### PR TITLE
fixed missing loader that broke my first login

### DIFF
--- a/web/concrete/authentication/concrete/controller.php
+++ b/web/concrete/authentication/concrete/controller.php
@@ -2,6 +2,7 @@
 namespace Concrete\Authentication\Concrete;
 use \Concrete\Core\Authentication\AuthenticationTypeController;
 use User;
+use Loader;
 class Controller extends AuthenticationTypeController {
 
 	public $apiMethods = array('forgot_password', 'change_password');


### PR DESCRIPTION
My first login attempt after install (logging in from a new browser -- the auto-login after install was okay) failed with:
 Fatal error: Class 'Concrete\Authentication\Concrete\Loader' not found in /home/jkoudys/Work/concrete5-5.7.0/web/concrete/authentication/concrete/controller.php on line 82
