### PR TITLE
increase mail length

### DIFF
--- a/web/concrete/config/db.xml
+++ b/web/concrete/config/db.xml
@@ -3514,7 +3514,7 @@
       <default value="0"/>
       <unsigned/>
     </field>
-    <field name="email" type="C" size="255">
+    <field name="email" type="C" size="254">
       <notnull/>
     </field>
     <field name="mHash" type="C" size="128">
@@ -3554,7 +3554,7 @@
     <field name="uName" type="C" size="64">
       <notnull/>
     </field>
-    <field name="uEmail" type="C" size="64">
+    <field name="uEmail" type="C" size="254">
       <notnull/>
     </field>
     <field name="uPassword" type="C" size="255">


### PR DESCRIPTION
according to RFC 5321, the maximum length of an email address is 256 (http://tools.ietf.org/html/rfc5321#section-4.5.3.1.3). This includes angle brackets which is why the maximum length of the actual address has to be 254 or shorter.
