### PR TITLE
Custom style presets revamp

### DIFF
--- a/web/concrete/core/Page/Style/CustomStyleRule.php
+++ b/web/concrete/core/Page/Style/CustomStyleRule.php
@@ -9,10 +9,10 @@ use Loader;
  * Class CustomStyleRule
  * @property int csrID
  * @property int|null cspID
- * @property string css_id
- * @property string css_class
- * @property string css_serialized
- * @property string css_custom
+ * @property string $css_id
+ * @property string $css_class
+ * @property string $css_serialized
+ * @property string $css_custom
  *
  * @package Concrete\Core\Page\Style
  */


### PR DESCRIPTION
PHPDoc'ed all the things

Got rid of Load function and integrated it straight into the getByID function since that's all it could ever really be used for anyway.

Changed getCustomStyleRule to use a cached copy instead of re-querying for the object every time it is accessed, with optional requery parameter in case one wanted to force this behavior.

Deprecated old functions in favor of new more abbreviated naming.

Added some TODO's for a future run through when we get around to redoing some of the database stuff
