### PR TITLE
Fixed Collection CustomStyleRule namespacing issue

### DIFF
--- a/web/concrete/core/Page/Collection/Collection.php
+++ b/web/concrete/core/Page/Collection/Collection.php
@@ -14,6 +14,7 @@ use User;
 use Block;
 use \Concrete\Core\Page\Collection\Version\VersionList;
 use \Concrete\Core\Feature\Assignment\CollectionVersionAssignment as CollectionVersionFeatureAssignment;
+use \Concrete\Core\Page\Style\CustomStyleRule;
 
 	class Collection extends Object {
 


### PR DESCRIPTION
Added a namespace to the collection object to fix a namespacing issue that was caused by including the CustomStyleRule in a namespace over in issue #78.
