### PR TITLE
Remove `Router` singleton in favor of a facade.

### DIFF
--- a/web/application/config/app.php
+++ b/web/application/config/app.php
@@ -7,8 +7,7 @@
  *
  * ## Set a theme by route:
  *
- * $router = Router::getInstance();
- * $router->setThemeByRoute('/login', 'greek_yogurt');
+ * Route::setThemeByRoute('/login', 'greek_yogurt');
  *
  *
  * ## Register a class override.
@@ -30,13 +29,12 @@
  *
  * ## Register some custom MVC Routes
  *
- * $router = Router::getInstance();
- * $router->register('/test', function() {
+ * Route::register('/test', function() {
  * 	print 'This is a contrived example.';
  * });
  *
- * $router->register('/custom/view', '\My\Custom\Controller::view');
- * $router->register('/custom/add', '\My\Custom\Controller::add');
+ * Route::register('/custom/view', '\My\Custom\Controller::view');
+ * Route::register('/custom/add', '\My\Custom\Controller::add');
  *
  * ----------------------------------------------------------------------------
  */

--- a/web/concrete/config/aliases.php
+++ b/web/concrete/config/aliases.php
@@ -1,5 +1,4 @@
-<?
-defined('C5_EXECUTE') or die("Access Denied.");
+<?php defined('C5_EXECUTE') or die("Access Denied.");
 return array(
 	'Request' => '\Concrete\Core\Http\Request',
 	'Environment' => '\Concrete\Core\Foundation\Environment',

--- a/web/concrete/config/facades.php
+++ b/web/concrete/config/facades.php
@@ -1,8 +1,8 @@
-<?
-defined('C5_EXECUTE') or die("Access Denied.");
+<?php defined('C5_EXECUTE') or die("Access Denied.");
 return array(
-	'Core' => '\Concrete\Core\Support\Facade\Application',
-	'Session' => '\Concrete\Core\Support\Facade\Session',
+	'Core'     => '\Concrete\Core\Support\Facade\Application',
+	'Session'  => '\Concrete\Core\Support\Facade\Session',
 	'Database' => '\Concrete\Core\Support\Facade\Database',
-	'Events' => '\Concrete\Core\Support\Facade\Events'
+	'Events'   => '\Concrete\Core\Support\Facade\Events',
+	'Route'    => '\Concrete\Core\Support\Facade\Route'
 );

--- a/web/concrete/config/routes.php
+++ b/web/concrete/config/routes.php
@@ -1,158 +1,155 @@
-<?
-defined('C5_EXECUTE') or die("Access Denied.");
-
-$rl = Router::getInstance();
+<?php defined('C5_EXECUTE') or die("Access Denied.");
 
 /**
  * Install
  */
-$rl->register('/install', '\Concrete\Controller\Install::view');
-$rl->register('/install/select_language', '\Concrete\Controller\Install::select_language');
-$rl->register('/install/setup', '\Concrete\Controller\Install::setup');
-$rl->register('/install/test_url/{num1}/{num2}', '\Concrete\Controller\Install::test_url');
-$rl->register('/install/configure', '\Concrete\Controller\Install::configure');
-$rl->register('/install/run_routine/{pkgHandle}/{routine}', '\Concrete\Controller\Install::run_routine');
+Route::register('/install', '\Concrete\Controller\Install::view');
+Route::register('/install/select_language', '\Concrete\Controller\Install::select_language');
+Route::register('/install/setup', '\Concrete\Controller\Install::setup');
+Route::register('/install/test_url/{num1}/{num2}', '\Concrete\Controller\Install::test_url');
+Route::register('/install/configure', '\Concrete\Controller\Install::configure');
+Route::register('/install/run_routine/{pkgHandle}/{routine}', '\Concrete\Controller\Install::run_routine');
 
 
 /**
  * Tools - legacy
  */
-$rl->register('/tools/blocks/{btHandle}/{tool}', '\Concrete\Core\Legacy\Controller\ToolController::displayBlock', 'blockTool', array('tool' => '[A-Za-z0-9_/.]+'));
-$rl->register('/tools/{tool}', '\Concrete\Core\Legacy\Controller\ToolController::display', 'tool', array('tool' => '[A-Za-z0-9_/.]+'));
+Route::register('/tools/blocks/{btHandle}/{tool}', '\Concrete\Core\Legacy\Controller\ToolController::displayBlock', 'blockTool', array('tool' => '[A-Za-z0-9_/.]+'));
+Route::register('/tools/{tool}', '\Concrete\Core\Legacy\Controller\ToolController::display', 'tool', array('tool' => '[A-Za-z0-9_/.]+'));
 
 /**
  * Dialog
  */
 
-$rl->register('/ccm/system/dialogs/page/delete/', '\Concrete\Controller\Dialog\Page\Delete::view');
-$rl->register('/ccm/system/dialogs/page/delete/submit', '\Concrete\Controller\Dialog\Page\Delete::submit');
-$rl->register('/ccm/system/dialogs/area/layout/presets/submit/{arLayoutID}', '\Concrete\Controller\Dialog\Area\Layout\Presets::submit');
-$rl->register('/ccm/system/dialogs/area/layout/presets/{arLayoutID}/{token}', '\Concrete\Controller\Dialog\Area\Layout\Presets::view');
-$rl->register('/ccm/system/dialogs/page/bulk/properties', '\Concrete\Controller\Dialog\Page\Bulk\Properties::view');
-$rl->register('/ccm/system/dialogs/page/bulk/properties/update_attribute', '\Concrete\Controller\Dialog\Page\Bulk\Properties::updateAttribute');
-$rl->register('/ccm/system/dialogs/page/bulk/properties/clear_attribute', '\Concrete\Controller\Dialog\Page\Bulk\Properties::clearAttribute');
-$rl->register('/ccm/system/dialogs/page/design', '\Concrete\Controller\Dialog\Page\Design::view');
-$rl->register('/ccm/system/dialogs/page/design/submit', '\Concrete\Controller\Dialog\Page\Design::submit');
-$rl->register('/ccm/system/dialogs/user/search', '\Concrete\Controller\Dialog\User\Search::view');
-$rl->register('/ccm/system/dialogs/group/search', '\Concrete\Controller\Dialog\Group\Search::view');
-$rl->register('/ccm/system/dialogs/file/search', '\Concrete\Controller\Dialog\File\Search::view');
-$rl->register('/ccm/system/dialogs/page/search', '\Concrete\Controller\Dialog\Page\Search::view');
-$rl->register('/ccm/system/dialogs/page/attributes', '\Concrete\Controller\Dialog\Page\Attributes::view');
-$rl->register('/ccm/system/dialogs/user/bulk/properties', '\Concrete\Controller\Dialog\User\Bulk\Properties::view');
-$rl->register('/ccm/system/dialogs/user/bulk/properties/update_attribute', '\Concrete\Controller\Dialog\User\Bulk\Properties::updateAttribute');
-$rl->register('/ccm/system/dialogs/user/bulk/properties/clear_attribute', '\Concrete\Controller\Dialog\User\Bulk\Properties::clearAttribute');
-$rl->register('/ccm/system/dialogs/file/properties', '\Concrete\Controller\Dialog\File\Properties::view');
-$rl->register('/ccm/system/dialogs/file/properties/save', '\Concrete\Controller\Dialog\File\Properties::save');
-$rl->register('/ccm/system/dialogs/file/properties/update_attribute', '\Concrete\Controller\Dialog\File\Properties::update_attribute');
-$rl->register('/ccm/system/dialogs/file/properties/clear_attribute', '\Concrete\Controller\Dialog\File\Properties::clear_attribute');
-$rl->register('/ccm/system/dialogs/file/bulk/properties', '\Concrete\Controller\Dialog\File\Bulk\Properties::view');
-$rl->register('/ccm/system/dialogs/file/bulk/properties/update_attribute', '\Concrete\Controller\Dialog\File\Bulk\Properties::updateAttribute');
-$rl->register('/ccm/system/dialogs/file/bulk/properties/clear_attribute', '\Concrete\Controller\Dialog\File\Bulk\Properties::clearAttribute');
-$rl->register('/ccm/system/dialogs/page/add_block', '\Concrete\Controller\Dialog\Page\AddBlock::view');
-$rl->register('/ccm/system/dialogs/page/add_block/submit', '\Concrete\Controller\Dialog\Page\AddBlock::submit');
-$rl->register('/ccm/system/dialogs/page/search/customize', '\Concrete\Controller\Dialog\Page\Search\Customize::view');
-$rl->register('/ccm/system/dialogs/page/search/customize/submit', '\Concrete\Controller\Dialog\Page\Search\Customize::submit');
-$rl->register('/ccm/system/dialogs/file/search/customize', '\Concrete\Controller\Dialog\File\Search\Customize::view');
-$rl->register('/ccm/system/dialogs/file/search/customize/submit', '\Concrete\Controller\Dialog\File\Search\Customize::submit');
-$rl->register('/ccm/system/dialogs/user/search/customize', '\Concrete\Controller\Dialog\User\Search\Customize::view');
-$rl->register('/ccm/system/dialogs/user/search/customize/submit', '\Concrete\Controller\Dialog\User\Search\Customize::submit');
+Route::register('/ccm/system/dialogs/page/delete/', '\Concrete\Controller\Dialog\Page\Delete::view');
+Route::register('/ccm/system/dialogs/page/delete/submit', '\Concrete\Controller\Dialog\Page\Delete::submit');
+Route::register('/ccm/system/dialogs/area/layout/presets/submit/{arLayoutID}', '\Concrete\Controller\Dialog\Area\Layout\Presets::submit');
+Route::register('/ccm/system/dialogs/area/layout/presets/{arLayoutID}/{token}', '\Concrete\Controller\Dialog\Area\Layout\Presets::view');
+Route::register('/ccm/system/dialogs/page/bulk/properties', '\Concrete\Controller\Dialog\Page\Bulk\Properties::view');
+Route::register('/ccm/system/dialogs/page/bulk/properties/update_attribute', '\Concrete\Controller\Dialog\Page\Bulk\Properties::updateAttribute');
+Route::register('/ccm/system/dialogs/page/bulk/properties/clear_attribute', '\Concrete\Controller\Dialog\Page\Bulk\Properties::clearAttribute');
+Route::register('/ccm/system/dialogs/page/design', '\Concrete\Controller\Dialog\Page\Design::view');
+Route::register('/ccm/system/dialogs/page/design/submit', '\Concrete\Controller\Dialog\Page\Design::submit');
+Route::register('/ccm/system/dialogs/user/search', '\Concrete\Controller\Dialog\User\Search::view');
+Route::register('/ccm/system/dialogs/group/search', '\Concrete\Controller\Dialog\Group\Search::view');
+Route::register('/ccm/system/dialogs/file/search', '\Concrete\Controller\Dialog\File\Search::view');
+Route::register('/ccm/system/dialogs/page/search', '\Concrete\Controller\Dialog\Page\Search::view');
+Route::register('/ccm/system/dialogs/page/attributes', '\Concrete\Controller\Dialog\Page\Attributes::view');
+Route::register('/ccm/system/dialogs/user/bulk/properties', '\Concrete\Controller\Dialog\User\Bulk\Properties::view');
+Route::register('/ccm/system/dialogs/user/bulk/properties/update_attribute', '\Concrete\Controller\Dialog\User\Bulk\Properties::updateAttribute');
+Route::register('/ccm/system/dialogs/user/bulk/properties/clear_attribute', '\Concrete\Controller\Dialog\User\Bulk\Properties::clearAttribute');
+Route::register('/ccm/system/dialogs/file/properties', '\Concrete\Controller\Dialog\File\Properties::view');
+Route::register('/ccm/system/dialogs/file/properties/save', '\Concrete\Controller\Dialog\File\Properties::save');
+Route::register('/ccm/system/dialogs/file/properties/update_attribute', '\Concrete\Controller\Dialog\File\Properties::update_attribute');
+Route::register('/ccm/system/dialogs/file/properties/clear_attribute', '\Concrete\Controller\Dialog\File\Properties::clear_attribute');
+Route::register('/ccm/system/dialogs/file/bulk/properties', '\Concrete\Controller\Dialog\File\Bulk\Properties::view');
+Route::register('/ccm/system/dialogs/file/bulk/properties/update_attribute', '\Concrete\Controller\Dialog\File\Bulk\Properties::updateAttribute');
+Route::register('/ccm/system/dialogs/file/bulk/properties/clear_attribute', '\Concrete\Controller\Dialog\File\Bulk\Properties::clearAttribute');
+Route::register('/ccm/system/dialogs/page/add_block', '\Concrete\Controller\Dialog\Page\AddBlock::view');
+Route::register('/ccm/system/dialogs/page/add_block/submit', '\Concrete\Controller\Dialog\Page\AddBlock::submit');
+Route::register('/ccm/system/dialogs/page/search/customize', '\Concrete\Controller\Dialog\Page\Search\Customize::view');
+Route::register('/ccm/system/dialogs/page/search/customize/submit', '\Concrete\Controller\Dialog\Page\Search\Customize::submit');
+Route::register('/ccm/system/dialogs/file/search/customize', '\Concrete\Controller\Dialog\File\Search\Customize::view');
+Route::register('/ccm/system/dialogs/file/search/customize/submit', '\Concrete\Controller\Dialog\File\Search\Customize::submit');
+Route::register('/ccm/system/dialogs/user/search/customize', '\Concrete\Controller\Dialog\User\Search\Customize::view');
+Route::register('/ccm/system/dialogs/user/search/customize/submit', '\Concrete\Controller\Dialog\User\Search\Customize::submit');
 
 /**
  * Files
  */
-$rl->register('/ccm/system/file/star', '\Concrete\Controller\Backend\File::star');
-$rl->register('/ccm/system/file/rescan', '\Concrete\Controller\Backend\File::rescan');
-$rl->register('/ccm/system/file/approve_version', '\Concrete\Controller\Backend\File::approveVersion');
-$rl->register('/ccm/system/file/delete_version', '\Concrete\Controller\Backend\File::deleteVersion');
-$rl->register('/ccm/system/file/get_json', '\Concrete\Controller\Backend\File::getJSON');
-$rl->register('/ccm/system/file/duplicate', '\Concrete\Controller\Backend\File::duplicate');
-$rl->register('/ccm/system/file/upload', '\Concrete\Controller\Backend\File::upload');
+Route::register('/ccm/system/file/star', '\Concrete\Controller\Backend\File::star');
+Route::register('/ccm/system/file/rescan', '\Concrete\Controller\Backend\File::rescan');
+Route::register('/ccm/system/file/approve_version', '\Concrete\Controller\Backend\File::approveVersion');
+Route::register('/ccm/system/file/delete_version', '\Concrete\Controller\Backend\File::deleteVersion');
+Route::register('/ccm/system/file/get_json', '\Concrete\Controller\Backend\File::getJSON');
+Route::register('/ccm/system/file/duplicate', '\Concrete\Controller\Backend\File::duplicate');
+Route::register('/ccm/system/file/upload', '\Concrete\Controller\Backend\File::upload');
 
 
 /**
  * Users
  */
-$rl->register('/ccm/system/user/add_group', '\Concrete\Controller\Backend\User::addGroup');
-$rl->register('/ccm/system/user/remove_group', '\Concrete\Controller\Backend\User::removeGroup');
+Route::register('/ccm/system/user/add_group', '\Concrete\Controller\Backend\User::addGroup');
+Route::register('/ccm/system/user/remove_group', '\Concrete\Controller\Backend\User::removeGroup');
 
 /**
  * Page actions - non UI
  */
-$rl->register('/ccm/system/page/check_in/{cID}/{token}', '\Concrete\Controller\Panel\Page\CheckIn::exitEditMode');
-$rl->register('/ccm/system/page/create/{ptID}', '\Concrete\Controller\Backend\Page::create');
-$rl->register('/ccm/system/page/arrange_blocks/', '\Concrete\Controller\Backend\Page\ArrangeBlocks::arrange');
+Route::register('/ccm/system/page/check_in/{cID}/{token}', '\Concrete\Controller\Panel\Page\CheckIn::exitEditMode');
+Route::register('/ccm/system/page/create/{ptID}', '\Concrete\Controller\Backend\Page::create');
+Route::register('/ccm/system/page/arrange_blocks/', '\Concrete\Controller\Backend\Page\ArrangeBlocks::arrange');
 
 
 /**
  * Misc
  */
-$rl->register('/ccm/system/css/page/{cID}/{cvID}/{stylesheet}', '\Concrete\Controller\Frontend\Stylesheet::page');
-$rl->register('/ccm/system/css/layout/{bID}', '\Concrete\Controller\Frontend\Stylesheet::layout');
+Route::register('/ccm/system/css/page/{cID}/{cvID}/{stylesheet}', '\Concrete\Controller\Frontend\Stylesheet::page');
+Route::register('/ccm/system/css/layout/{bID}', '\Concrete\Controller\Frontend\Stylesheet::layout');
 
 /**
  * Search Routes
  */
-$rl->register('/ccm/system/search/pages/submit', '\Concrete\Controller\Search\Pages::submit');
-$rl->register('/ccm/system/search/pages/field/{field}', '\Concrete\Controller\Search\Pages::field');
-$rl->register('/ccm/system/search/files/submit', '\Concrete\Controller\Search\Files::submit');
-$rl->register('/ccm/system/search/files/field/{field}', '\Concrete\Controller\Search\Files::field');
-$rl->register('/ccm/system/search/users/submit', '\Concrete\Controller\Search\Users::submit');
-$rl->register('/ccm/system/search/users/field/{field}', '\Concrete\Controller\Search\Users::field');
-$rl->register('/ccm/system/search/groups/submit', '\Concrete\Controller\Search\Groups::submit');
+Route::register('/ccm/system/search/pages/submit', '\Concrete\Controller\Search\Pages::submit');
+Route::register('/ccm/system/search/pages/field/{field}', '\Concrete\Controller\Search\Pages::field');
+Route::register('/ccm/system/search/files/submit', '\Concrete\Controller\Search\Files::submit');
+Route::register('/ccm/system/search/files/field/{field}', '\Concrete\Controller\Search\Files::field');
+Route::register('/ccm/system/search/users/submit', '\Concrete\Controller\Search\Users::submit');
+Route::register('/ccm/system/search/users/field/{field}', '\Concrete\Controller\Search\Users::field');
+Route::register('/ccm/system/search/groups/submit', '\Concrete\Controller\Search\Groups::submit');
 
 
 /**
  * Panels - top level
  */
-$rl->register('/ccm/system/panels/dashboard', '\Concrete\Controller\Panel\Dashboard::view');
-$rl->register('/ccm/system/panels/sitemap', '\Concrete\Controller\Panel\Sitemap::view');
-$rl->register('/ccm/system/panels/add', '\Concrete\Controller\Panel\Add::view');
-$rl->register('/ccm/system/panels/page', '\Concrete\Controller\Panel\Page::view');
-$rl->register('/ccm/system/panels/page/attributes', '\Concrete\Controller\Panel\Page\Attributes::view');
-$rl->register('/ccm/system/panels/page/design', '\Concrete\Controller\Panel\Page\Design::view');
-$rl->register('/ccm/system/panels/page/design/preview_contents', '\Concrete\Controller\Panel\Page\Design::preview_contents');
-$rl->register('/ccm/system/panels/page/design/submit', '\Concrete\Controller\Panel\Page\Design::submit');
-$rl->register('/ccm/system/panels/page/design/customize/preview/{pThemeID}', '\Concrete\Controller\Panel\Page\Design\Customize::preview');
-$rl->register('/ccm/system/panels/page/design/customize/apply_to_page/{pThemeID}', '\Concrete\Controller\Panel\Page\Design\Customize::apply_to_page');
-$rl->register('/ccm/system/panels/page/design/customize/apply_to_site/{pThemeID}', '\Concrete\Controller\Panel\Page\Design\Customize::apply_to_site');
-$rl->register('/ccm/system/panels/page/design/customize/reset_page_customizations', '\Concrete\Controller\Panel\Page\Design\Customize::reset_page_customizations');
-$rl->register('/ccm/system/panels/page/design/customize/reset_site_customizations/{pThemeID}', '\Concrete\Controller\Panel\Page\Design\Customize::reset_site_customizations');
-$rl->register('/ccm/system/panels/page/design/customize/{pThemeID}', '\Concrete\Controller\Panel\Page\Design\Customize::view');
-$rl->register('/ccm/system/panels/page/check_in', '\Concrete\Controller\Panel\Page\CheckIn::__construct');
-$rl->register('/ccm/system/panels/page/check_in/submit', '\Concrete\Controller\Panel\Page\CheckIn::submit');
-$rl->register('/ccm/system/panels/page/versions', '\Concrete\Controller\Panel\Page\Versions::view');
-$rl->register('/ccm/system/panels/page/versions/get_json', '\Concrete\Controller\Panel\Page\Versions::get_json');
-$rl->register('/ccm/system/panels/page/versions/duplicate', '\Concrete\Controller\Panel\Page\Versions::duplicate');
-$rl->register('/ccm/system/panels/page/versions/new_page', '\Concrete\Controller\Panel\Page\Versions::new_page');
-$rl->register('/ccm/system/panels/page/versions/delete', '\Concrete\Controller\Panel\Page\Versions::delete');
-$rl->register('/ccm/system/panels/page/versions/approve', '\Concrete\Controller\Panel\Page\Versions::approve');
+Route::register('/ccm/system/panels/dashboard', '\Concrete\Controller\Panel\Dashboard::view');
+Route::register('/ccm/system/panels/sitemap', '\Concrete\Controller\Panel\Sitemap::view');
+Route::register('/ccm/system/panels/add', '\Concrete\Controller\Panel\Add::view');
+Route::register('/ccm/system/panels/page', '\Concrete\Controller\Panel\Page::view');
+Route::register('/ccm/system/panels/page/attributes', '\Concrete\Controller\Panel\Page\Attributes::view');
+Route::register('/ccm/system/panels/page/design', '\Concrete\Controller\Panel\Page\Design::view');
+Route::register('/ccm/system/panels/page/design/preview_contents', '\Concrete\Controller\Panel\Page\Design::preview_contents');
+Route::register('/ccm/system/panels/page/design/submit', '\Concrete\Controller\Panel\Page\Design::submit');
+Route::register('/ccm/system/panels/page/design/customize/preview/{pThemeID}', '\Concrete\Controller\Panel\Page\Design\Customize::preview');
+Route::register('/ccm/system/panels/page/design/customize/apply_to_page/{pThemeID}', '\Concrete\Controller\Panel\Page\Design\Customize::apply_to_page');
+Route::register('/ccm/system/panels/page/design/customize/apply_to_site/{pThemeID}', '\Concrete\Controller\Panel\Page\Design\Customize::apply_to_site');
+Route::register('/ccm/system/panels/page/design/customize/reset_page_customizations', '\Concrete\Controller\Panel\Page\Design\Customize::reset_page_customizations');
+Route::register('/ccm/system/panels/page/design/customize/reset_site_customizations/{pThemeID}', '\Concrete\Controller\Panel\Page\Design\Customize::reset_site_customizations');
+Route::register('/ccm/system/panels/page/design/customize/{pThemeID}', '\Concrete\Controller\Panel\Page\Design\Customize::view');
+Route::register('/ccm/system/panels/page/check_in', '\Concrete\Controller\Panel\Page\CheckIn::__construct');
+Route::register('/ccm/system/panels/page/check_in/submit', '\Concrete\Controller\Panel\Page\CheckIn::submit');
+Route::register('/ccm/system/panels/page/versions', '\Concrete\Controller\Panel\Page\Versions::view');
+Route::register('/ccm/system/panels/page/versions/get_json', '\Concrete\Controller\Panel\Page\Versions::get_json');
+Route::register('/ccm/system/panels/page/versions/duplicate', '\Concrete\Controller\Panel\Page\Versions::duplicate');
+Route::register('/ccm/system/panels/page/versions/new_page', '\Concrete\Controller\Panel\Page\Versions::new_page');
+Route::register('/ccm/system/panels/page/versions/delete', '\Concrete\Controller\Panel\Page\Versions::delete');
+Route::register('/ccm/system/panels/page/versions/approve', '\Concrete\Controller\Panel\Page\Versions::approve');
 
 /**
  * Panel Details
  */
 
-$rl->register('/ccm/system/panels/details/page/versions', '\Concrete\Controller\Panel\Detail\Page\Versions::view');
-$rl->register('/ccm/system/panels/details/page/seo', '\Concrete\Controller\Panel\Detail\Page\Seo::view');
-$rl->register('/ccm/system/panels/details/page/seo/submit', '\Concrete\Controller\Panel\Detail\Page\Seo::submit');
-$rl->register('/ccm/system/panels/details/page/location', '\Concrete\Controller\Panel\Detail\Page\Location::view');
-$rl->register('/ccm/system/panels/details/page/location/submit', '\Concrete\Controller\Panel\Detail\Page\Location::submit');
-$rl->register('/ccm/system/panels/details/page/preview', '\Concrete\Controller\Panel\Page\Design::preview');
-$rl->register('/ccm/system/panels/details/page/composer', '\Concrete\Controller\Panel\Detail\Page\Composer::view');
-$rl->register('/ccm/system/panels/details/page/composer/autosave', '\Concrete\Controller\Panel\Detail\Page\Composer::autosave');
-$rl->register('/ccm/system/panels/details/page/composer/publish', '\Concrete\Controller\Panel\Detail\Page\Composer::publish');
-$rl->register('/ccm/system/panels/details/page/composer/discard', '\Concrete\Controller\Panel\Detail\Page\Composer::discard');
-$rl->register('/ccm/system/panels/details/page/attributes', '\Concrete\Controller\Panel\Detail\Page\Attributes::view');
-$rl->register('/ccm/system/panels/details/page/attributes/submit', '\Concrete\Controller\Panel\Detail\Page\Attributes::submit');
-$rl->register('/ccm/system/panels/details/page/attributes/add_attribute', '\Concrete\Controller\Panel\Detail\Page\Attributes::add_attribute');
-$rl->register('/ccm/system/panels/details/page/caching', '\Concrete\Controller\Panel\Detail\Page\Caching::view');
-$rl->register('/ccm/system/panels/details/page/caching/submit', '\Concrete\Controller\Panel\Detail\Page\Caching::submit');
-$rl->register('/ccm/system/panels/details/page/caching/purge', '\Concrete\Controller\Panel\Detail\Page\Caching::purge');
-$rl->register('/ccm/system/panels/details/page/permissions', '\Concrete\Controller\Panel\Detail\Page\Permissions::view');
-$rl->register('/ccm/system/panels/details/page/permissions/save_simple', '\Concrete\Controller\Panel\Detail\Page\Permissions::save_simple');
+Route::register('/ccm/system/panels/details/page/versions', '\Concrete\Controller\Panel\Detail\Page\Versions::view');
+Route::register('/ccm/system/panels/details/page/seo', '\Concrete\Controller\Panel\Detail\Page\Seo::view');
+Route::register('/ccm/system/panels/details/page/seo/submit', '\Concrete\Controller\Panel\Detail\Page\Seo::submit');
+Route::register('/ccm/system/panels/details/page/location', '\Concrete\Controller\Panel\Detail\Page\Location::view');
+Route::register('/ccm/system/panels/details/page/location/submit', '\Concrete\Controller\Panel\Detail\Page\Location::submit');
+Route::register('/ccm/system/panels/details/page/preview', '\Concrete\Controller\Panel\Page\Design::preview');
+Route::register('/ccm/system/panels/details/page/composer', '\Concrete\Controller\Panel\Detail\Page\Composer::view');
+Route::register('/ccm/system/panels/details/page/composer/autosave', '\Concrete\Controller\Panel\Detail\Page\Composer::autosave');
+Route::register('/ccm/system/panels/details/page/composer/publish', '\Concrete\Controller\Panel\Detail\Page\Composer::publish');
+Route::register('/ccm/system/panels/details/page/composer/discard', '\Concrete\Controller\Panel\Detail\Page\Composer::discard');
+Route::register('/ccm/system/panels/details/page/attributes', '\Concrete\Controller\Panel\Detail\Page\Attributes::view');
+Route::register('/ccm/system/panels/details/page/attributes/submit', '\Concrete\Controller\Panel\Detail\Page\Attributes::submit');
+Route::register('/ccm/system/panels/details/page/attributes/add_attribute', '\Concrete\Controller\Panel\Detail\Page\Attributes::add_attribute');
+Route::register('/ccm/system/panels/details/page/caching', '\Concrete\Controller\Panel\Detail\Page\Caching::view');
+Route::register('/ccm/system/panels/details/page/caching/submit', '\Concrete\Controller\Panel\Detail\Page\Caching::submit');
+Route::register('/ccm/system/panels/details/page/caching/purge', '\Concrete\Controller\Panel\Detail\Page\Caching::purge');
+Route::register('/ccm/system/panels/details/page/permissions', '\Concrete\Controller\Panel\Detail\Page\Permissions::view');
+Route::register('/ccm/system/panels/details/page/permissions/save_simple', '\Concrete\Controller\Panel\Detail\Page\Permissions::save_simple');
 
 /**
  * Special Dashboard
  */
-$rl->register('/dashboard/blocks/stacks/list', function() {
+Route::register('/dashboard/blocks/stacks/list', function() {
 	return Redirect::to('/');
 });

--- a/web/concrete/config/theme_paths.php
+++ b/web/concrete/config/theme_paths.php
@@ -1,16 +1,14 @@
-<?
-defined('C5_EXECUTE') or die("Access Denied.");
+<?php defined('C5_EXECUTE') or die("Access Denied.");
 
-$l = Router::getInstance();
-$l->setThemeByRoute('/dashboard', 'dashboard');
-$l->setThemeByRoute('/dashboard/*', 'dashboard');
-$l->setThemeByRoute('/account', VIEW_CORE_THEME);
-$l->setThemeByRoute('/account/*', VIEW_CORE_THEME);
+Route::setThemeByRoute('/dashboard', 'dashboard');
+Route::setThemeByRoute('/dashboard/*', 'dashboard');
+Route::setThemeByRoute('/account', VIEW_CORE_THEME);
+Route::setThemeByRoute('/account/*', VIEW_CORE_THEME);
 
-$l->setThemeByRoute('/page_forbidden', VIEW_CORE_THEME);
-$l->setThemeByRoute('/page_not_found', VIEW_CORE_THEME);
-$l->setThemeByRoute('/install', VIEW_CORE_THEME);
-$l->setThemeByRoute('/login', VIEW_CORE_THEME);
-$l->setThemeByRoute('/register', VIEW_CORE_THEME);
-$l->setThemeByRoute('/maintenance_mode', VIEW_CORE_THEME);
-$l->setThemeByRoute('/upgrade', VIEW_CORE_THEME);
+Route::setThemeByRoute('/page_forbidden', VIEW_CORE_THEME);
+Route::setThemeByRoute('/page_not_found', VIEW_CORE_THEME);
+Route::setThemeByRoute('/install', VIEW_CORE_THEME);
+Route::setThemeByRoute('/login', VIEW_CORE_THEME);
+Route::setThemeByRoute('/register', VIEW_CORE_THEME);
+Route::setThemeByRoute('/maintenance_mode', VIEW_CORE_THEME);
+Route::setThemeByRoute('/upgrade', VIEW_CORE_THEME);

--- a/web/concrete/core/Controller/Controller.php
+++ b/web/concrete/core/Controller/Controller.php
@@ -1,10 +1,10 @@
 <?
 
 namespace Concrete\Core\Controller;
-use Router;
 use Request;
 use PageTheme;
 use View;
+use Route;
 
 class Controller extends AbstractController {
 
@@ -27,8 +27,7 @@ class Controller extends AbstractController {
 
 	public function getTheme() {
 		if (is_object($this->view)) {
-			$rl = Router::getInstance();
-			$tmpTheme = $rl->getThemeByRoute($this->view->getViewPath());
+			$tmpTheme = Route::getThemeByRoute($this->view->getViewPath());
 			if ($tmpTheme) {
 				return $tmpTheme[0];
 			}

--- a/web/concrete/core/Routing/Router.php
+++ b/web/concrete/core/Routing/Router.php
@@ -1,4 +1,4 @@
-<?
+<?php
 namespace Concrete\Core\Routing;
 use \Symfony\Component\Routing\RouteCollection as SymfonyRouteCollection;
 use Request;
@@ -6,32 +6,21 @@ use Loader;
 
 class Router {
 
-	static $instance = null;
 	protected $collection;
 	protected $request;
+	protected $themePaths = array();
 	public $routes = array();
 
-	protected function __construct() {
+	public function __construct() {
 		$this->collection = new SymfonyRouteCollection();
 	}
 
 	public function getList() {
 		return $this->collection;
 	}
-	
+
 	public function setRequest(Request $req) {
 		$this->request = $req;
-	}
-	
-	/** 
-	 * Returns an instance of the Router object
-	 * @return Router
-	 */
-	public static function getInstance() {
-		if (null === static::$instance) {
-			static::$instance = new static;
-		}
-		return static::$instance;
 	}
 
 	public function register($rtPath, $callback, $rtHandle = null, $additionalAttributes = array()) {
@@ -75,7 +64,7 @@ class Router {
 	}
 
 	/**
-	 * This grabs the theme for a particular path, if one exists in the themePaths array 
+	 * This grabs the theme for a particular path, if one exists in the themePaths array
 	 * @param string $path
 	 * @return string|boolean
 	*/

--- a/web/concrete/core/Support/Facade/Route.php
+++ b/web/concrete/core/Support/Facade/Route.php
@@ -1,0 +1,10 @@
+<?php
+namespace Concrete\Core\Support\Facade;
+
+class Route extends Facade {
+
+  public static function getFacadeAccessor() {
+    return '\Concrete\Core\Routing\Router';
+  }
+
+}


### PR DESCRIPTION
Singletons make it difficult to test / extend code, facades remove these concerns while still providing a global instance that can be replaced.

Old syntax:

```
$router = Router::getInstance();
$router->register(...);
```

New syntax:

```
Route::register(...);
```
