### PR TITLE
Set `$dashboard` in `DashboardPageController`

### DIFF
--- a/web/concrete/core/Page/Controller/DashboardPageController.php
+++ b/web/concrete/core/Page/Controller/DashboardPageController.php
@@ -18,6 +18,7 @@ class DashboardPageController extends PageController {
 		$this->token = Loader::helper('validation/token');
 		$this->error = Loader::helper('validation/error');
 		$this->set('interface', Loader::helper('concrete/ui'));
+		$this->set('dashboard', Loader::helper('concrete/dashboard'));
 	}
 	
 	public function on_before_render() {


### PR DESCRIPTION
Set `$dashboard` in `DashboardPageController`

Avoid a fair amount of boilerplate in dashboard page views as almost all
of them contain
`Loader::helper('dashboard')->getDashboardPageHeaderWrapper()` etc
