### PR TITLE
The root user is called admin in concrete5

### DIFF
--- a/web/concrete/controllers/single_page/login.php
+++ b/web/concrete/controllers/single_page/login.php
@@ -146,7 +146,7 @@ class Login extends PageController {
 		$u = new User();
 		if ($u->getUserID() == 1 && $type->getAuthenticationTypeHandle() != 'concrete') {
 			$u->logout();
-			throw new \Exception(t('You can only identify as the root user using the concrete login.'));
+			throw new \Exception(t('You can only identify as the admin user using the concrete login.'));
 		}
 
 		$ui = UserInfo::getByID($u->getUserID());


### PR DESCRIPTION
For uniformity, let's call "admin" the concrete5 root user
