### PR TITLE
Fix message when duplicating page version

### DIFF
--- a/web/concrete/controllers/panel/page/versions.php
+++ b/web/concrete/controllers/panel/page/versions.php
@@ -53,7 +53,7 @@ class Versions extends BackendInterfacePageController {
 			$nc = $this->page->cloneVersion(t('Copy of Version: %s', $this->page->getVersionID()));
 			$v = $nc->getVersionObject();
 			$r = new PageEditVersionResponse();
-			$r->setMessage(t('Version %s copied successfully into. New version %s.', $this->request->request->get('cvID'), $v->getVersionID()));
+			$r->setMessage(t('Version %s copied successfully. New version is %s.', $this->request->request->get('cvID'), $v->getVersionID()));
 			$r->addCollectionVersion($v);
 			$r->outputJSON();
 		}


### PR DESCRIPTION
`Version copied.` sounds better than `Version copied into.`
