### PR TITLE
Rename the conversation editor page

### DIFF
--- a/web/concrete/config/install/base/dashboard.xml
+++ b/web/concrete/config/install/base/dashboard.xml
@@ -706,7 +706,7 @@
 				</attributekey>
 			</attributes>
 		</page>
-		<page name="Editor" path="/dashboard/system/conversations/editor" filename="/dashboard/system/conversations/editor.php" pagetype="" description="" package="">
+		<page name="Conversations Editor" path="/dashboard/system/conversations/editor" filename="/dashboard/system/conversations/editor.php" pagetype="" description="" package="">
 			<attributes>
 				<attributekey handle="meta_keywords">
 					<value>conversations editor, editor</value>


### PR DESCRIPTION
`Editor` is too general.
Let's call the page that configures the editor for conversations as `Conversations Editor`
