### PR TITLE
Fix Page::getDrafts() declaration

### DIFF
--- a/web/concrete/core/Page/Page.php
+++ b/web/concrete/core/Page/Page.php
@@ -460,7 +460,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
 
 	}
 
-	public function getDrafts() {
+	public static function getDrafts() {
 		$db = Loader::db();
 		$u = new User();
 		$nc = Page::getByPath(PAGE_DRAFTS_PAGE_PATH);


### PR DESCRIPTION
- Add `static` declaration to `Page::getDrafts()`

`Page::getDrafts()` is called statically.

If it is not defined `static` and is called statically it will inherit
`$this` from the calling methods object. This also causes issues with
the `static` keyword as this will also inherit in the same way.
