### PR TITLE
Allow for custom error reporting

### DIFF
--- a/web/concrete/bootstrap/configure.php
+++ b/web/concrete/bootstrap/configure.php
@@ -588,7 +588,11 @@ define('LOG_TYPE_EXCEPTIONS', 'exceptions');
  * concrete5 depends on some more forgiving error handling.
  * ----------------------------------------------------------------------------
  */
-error_reporting(E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED);
+if (defined('CUSTOM_ERROR_REPORTING')) {
+	error_reporting(CUSTOM_ERROR_REPORTING);
+} else {
+	error_reporting(E_ALL & ~E_NOTICE & ~E_STRICT & ~E_DEPRECATED);
+}
 
 
 


### PR DESCRIPTION
Allow custom error reporting to be set for testing and other uses

An example would be setting this in `config/site.php`

`define('CUSTOM_ERROR_REPORTING', E_ALL & ~E_NOTICE & ~E_DEPRECATED);`
