### PR TITLE
Fix Duplicate Attribute Render In Composer

### DIFF
--- a/web/concrete/core/Attribute/Key/Key.php
+++ b/web/concrete/core/Attribute/Key/Key.php
@@ -13,6 +13,7 @@ use Database;
 use AttributeSet;
 use \Concrete\Core\Attribute\Value\Value as AttributeValue;
 use \Concrete\Core\Package\PackageList;
+use Environment;
 
 
 class Key extends Object {
@@ -599,6 +600,13 @@ class Key extends Object {
 	 * is printed in the corresponding $view function in the attribute's controller is printed out.
 	 */
 	public function render($view = 'view', $value = false, $return = false) {
+		if ($view === 'composer') {
+			$env = Environment::get();
+			$r = $env->getRecord(DIRNAME_ATTRIBUTES . '/' . $this->getAttributeTypeHandle() . '/' . 'composer.php', $this->getPackageHandle());
+			if (!$r->exists()) {
+				$view = 'form';
+			}
+		}
 		$at = AttributeType::getByHandle($this->atHandle);
 		$resp = $at->render($view, $this, $value, $return);
 		if ($return) {

--- a/web/concrete/core/Attribute/View.php
+++ b/web/concrete/core/Attribute/View.php
@@ -59,12 +59,8 @@ class View extends AbstractView {
 		$atHandle = $this->attributeType->getAttributeTypeHandle();
 		$env = Environment::get();
 		$r = $env->getRecord(DIRNAME_ATTRIBUTES . '/' . $atHandle . '/' . $this->viewToRender . '.php', $this->attributePkgHandle);
-		if ($this->viewToRender == 'composer' && !$r->exists()) {
-			$this->render('form');
-		} else {
-			$file = $r->file;
-			$this->setViewTemplate($file);
-		}
+		$file = $r->file;
+		$this->setViewTemplate($file);
 	}
 
 	public function setupController() {


### PR DESCRIPTION
Some attribute forms are displayed twice in composer
These attribtutes do not have a `composer.php`

If view was set to 'composer' the render method was called twice.
- Move 'composer' view checkout to
  Core\Attribute\Key\Key::render()`
- Check if `$view` is composer then check if `composer.php` file exists.
  If so set `$view` from 'composer' to 'form'
