### PR TITLE
Give an error on when package's controller file is not found.

### DIFF
--- a/web/concrete/controllers/single_page/dashboard/extend/install.php
+++ b/web/concrete/controllers/single_page/dashboard/extend/install.php
@@ -138,6 +138,9 @@ class Install extends DashboardPageController {
 					$this->set('showInstallOptionsScreen', true);
 					$this->set('pkg', $p);
 				}
+			} else {
+				$this->error->add(t('Package controller file not found.'));
+				$this->set('error', $this->error);
 			}
 		} else {
 			$this->error->add(t('You do not have permission to install add-ons.'));


### PR DESCRIPTION
I made own package and it did not install. So I ended up with this that the packages controller file was not found but installer didn't say anything to tell what is wrong. This will help if one types wrong folder name or package name. 
