### PR TITLE
Translate login texts

### DIFF
--- a/web/concrete/authentication/concrete/form.php
+++ b/web/concrete/authentication/concrete/form.php
@@ -27,5 +27,5 @@ $form = Loader::helper('form');
 	</div>
 </div>
 <div class='actions'>
-	<button class='btn primary'>Sign In</button>
+	<button class='btn primary'><?=t('Sign In')</button>
 </div>


### PR DESCRIPTION
`Remain logged in to website` and `Sign In` need `t()`
