### PR TITLE
Fix typo in loging page causing fatal error

### DIFF
--- a/web/concrete/authentication/concrete/form.php
+++ b/web/concrete/authentication/concrete/form.php
@@ -27,5 +27,5 @@ $form = Loader::helper('form');
 	</div>
 </div>
 <div class='actions'>
-	<button class='btn primary'><?=t('Sign In')</button>
+	<button class='btn primary'><?=t('Sign In')?></button>
 </div>


### PR DESCRIPTION
Fix typo in loging page causing fatal error
- Close `?>`
