### PR TITLE
Fix getIntelligentSearchMenu cache

### DIFF
--- a/web/concrete/core/Application/Service/Dashboard.php
+++ b/web/concrete/core/Application/Service/Dashboard.php
@@ -232,8 +232,10 @@ class Dashboard {
 	}
 
 	public function getIntelligentSearchMenu() {
-		if (Session::has('dashboardMenus')) {
-			return Session::get('dashboardMenus/' . Localization::activeLocale());
+		$dashboardMenus = Session::get('dashboardMenus', array());
+		$dashboardMenusKey = Localization::activeLocale();
+		if (array_key_exists($dashboardMenusKey, $dashboardMenus)) {
+			return $dashboardMenus[$dashboardMenusKey];
 		}			
 
 		ob_start(); ?>
@@ -351,8 +353,9 @@ class Dashboard {
 		<?
 			$html = ob_get_contents();
 			ob_end_clean();
-			
-		return str_replace(array("\n", "\r", "\t"), "", $html);
+		$dashboardMenus[$dashboardMenusKey] = str_replace(array("\n", "\r", "\t"), "", $html);
+		Session::set('dashboardMenus', $dashboardMenus);
+		return $dashboardMenus[$dashboardMenusKey];
 	}	
 
 

--- a/web/concrete/core/Application/Service/UserInterface.php
+++ b/web/concrete/core/Application/Service/UserInterface.php
@@ -184,15 +184,14 @@ class UserInterface {
 	public function clearInterfaceItemsCache() {
 		$u = new ConcreteUser();
 		if ($u->isRegistered()) {
-			Session::remove('dashboardMenus/' . Localization::activeLocale());
+			Session::remove('dashboardMenus');
 		}
 	}
 	
 	public function cacheInterfaceItems() {
 		$u = new ConcreteUser();
 		if ($u->isRegistered()) {
-			$ch = Loader::helper('concrete/dashboard');
-			Session::set('dashboardMenus/' . Localization::activeLocale(), $ch->getIntelligentSearchMenu());
+			Loader::helper('concrete/dashboard')->getIntelligentSearchMenu();
 		}
 	}
 	


### PR DESCRIPTION
`getIntelligentSearchMenu` checks if a value called `dashboardMenus` exists in cache, but if it does not exists it caches the value `dashboardMenus/locale`.
This causes `getIntelligentSearchMenu` to not use cache.

Let's fix this, by using an _array_ with key `dashboardMenus`: so, clearing the cache simply requires to remove the `dashboardMenus` array from the cache (instead of removing all the possible `dashboardMenus/locale` keys).

Furthermore, `getIntelligentSearchMenu` itself put in the cache its result, so that `cacheInterfaceItems` simply have to call `getIntelligentSearchMenu` without worrying about where to store its result.
