### PR TITLE
escape $uID parameter in PageList::filterByUserID()

### DIFF
--- a/web/concrete/core/Page/PageList.php
+++ b/web/concrete/core/Page/PageList.php
@@ -299,7 +299,9 @@ class PageList extends DatabaseItemList {
 	 */
 	public function filterByUserID($uID) {
 		if ($this->includeAliases) {
-			$this->filter(false, "(p1.uID = $uID or p2.uID = $uID)");
+			$db = Loader::db();
+			$quID = $db->quote($uID);
+			$this->filter(false, "(p1.uID = {$quID} or p2.uID = {$quID})");
 		} else {
 			$this->filter('p1.uID', $uID);
 		}


### PR DESCRIPTION
Avoid SQL Injection in case a developer passes a user-provided ID directly to this function.
