### PR TITLE
Localize name of FormLayoutSet

### DIFF
--- a/web/concrete/core/Page/Type/Composer/FormLayoutSet.php
+++ b/web/concrete/core/Page/Type/Composer/FormLayoutSet.php
@@ -10,7 +10,20 @@ class FormLayoutSet extends Object {
 	public function getPageTypeComposerFormLayoutSetDisplayOrder() {return $this->ptComposerFormLayoutSetDisplayOrder;}
 	public function getPageTypeID() {return $this->ptID;}
 	public function getPageTypeObject() {return PageType::getByID($this->ptID);}
-
+	/** Returns the display name for this instance (localized and escaped accordingly to $format)
+	* @param string $format = 'html' Escape the result in html format (if $format is 'html'). If $format is 'text' or any other value, the display name won't be escaped.
+	* @return string
+	*/
+	public function getPageTypeComposerFormLayoutSetDisplayName($format = 'html') {
+		$value = tc('PageTypeComposerFormLayoutSetName', $this->ptComposerFormLayoutSetName);
+		switch ($format) {
+			case 'html':
+				return h($value);
+			case 'text':
+			default:
+				return $value;
+		}
+	}
 	public static function getList(PageType $pagetype) {
 		$db = Loader::db();
 		$ptComposerFormLayoutSetIDs = $db->GetCol('select ptComposerFormLayoutSetID from PageTypeComposerFormLayoutSets where ptID = ? order by ptComposerFormLayoutSetDisplayOrder asc', array($pagetype->getPageTypeID()));

--- a/web/concrete/elements/page_types/composer/form/output/form.php
+++ b/web/concrete/elements/page_types/composer/form/output/form.php
@@ -13,8 +13,8 @@ $cmp = new Permissions($pagetype);
 
 <? foreach($fieldsets as $cfl) { ?>
 	<fieldset>
-		<? if ($cfl->getPageTypeComposerFormLayoutSetName()) { ?>
-			<legend><?=$cfl->getPageTypeComposerFormLayoutSetName()?></legend>
+		<? if ($cfl->getPageTypeComposerFormLayoutSetDisplayName()) { ?>
+			<legend><?=$cfl->getPageTypeComposerFormLayoutSetDisplayName()?></legend>
 		<? } ?>
 		<? $controls = PageTypeComposerFormLayoutSetControl::getList($cfl);
 

--- a/web/concrete/single_pages/dashboard/pages/types/form.php
+++ b/web/concrete/single_pages/dashboard/pages/types/form.php
@@ -44,7 +44,7 @@ use \Concrete\Core\Page\Type\Composer\FormLayoutSet as PageTypeComposerFormLayou
 					<li><a href="#" data-edit-set="<?=$set->getPageTypeComposerFormLayoutSetID()?>"><i class="glyphicon glyphicon-pencil"></i></a></li>
 					<li><a href="#" data-delete-set="<?=$set->getPageTypeComposerFormLayoutSetID()?>"><i class="glyphicon glyphicon-trash"></i></a></li>
 				</ul>
-				<div class="ccm-page-type-composer-form-layout-control-set-name" ><? if ($set->getPageTypeComposerFormLayoutSetName()) { ?><?=$set->getPageTypeComposerFormLayoutSetName()?><? } else { ?><?=t('(No Name)')?><? } ?></div>
+				<div class="ccm-page-type-composer-form-layout-control-set-name" ><? if ($set->getPageTypeComposerFormLayoutSetDisplayName()) { ?><?=$set->getPageTypeComposerFormLayoutSetDisplayName()?><? } else { ?><?=t('(No Name)')?><? } ?></div>
 				<div style="display: none">
 					<div data-delete-set-dialog="<?=$set->getPageTypeComposerFormLayoutSetID()?>">
 						<form data-delete-set-form="<?=$set->getPageTypeComposerFormLayoutSetID()?>" action="<?=$view->action('delete_set', $set->getPageTypeComposerFormLayoutSetID())?>" method="post">


### PR DESCRIPTION
Let's adopt `getPageTypeComposerFormLayoutSetDisplayName` instead of `getPageTypeComposerFormLayoutSetName`
