### PR TITLE
Pile namespace so add from clipboard works

### DIFF
--- a/web/concrete/controllers/panel/add.php
+++ b/web/concrete/controllers/panel/add.php
@@ -5,6 +5,7 @@ use BlockTypeList;
 use Loader;
 use Session;
 use BlockType;
+use \Concrete\Core\Page\Stack\Pile\Pile;
 
 class Add extends BackendInterfacePageController {
 
@@ -33,8 +34,11 @@ class Add extends BackendInterfacePageController {
 			$tab = $_REQUEST['tab'];
 		} else {
 			$tab = Session::get('panels_page_add_block_tab');
-		}
+    }
+    $sp = Pile::getDefault();
+    $contents = $sp->getPileContentObjects('date_desc');
 
+		$this->set('contents', $contents);
 		$this->set('tab', $tab);
 		$this->set('blockTypes', $blockTypes);
 		$this->set('ih', Loader::helper('concrete/ui'));

--- a/web/concrete/core/Page/Stack/Pile/Pile.php
+++ b/web/concrete/core/Page/Stack/Pile/Pile.php
@@ -2,6 +2,7 @@
 namespace Concrete\Core\Page\Stack\Pile;
 use Loader;
 use \Concrete\Core\Foundation\Object;
+use \Concrete\Core\User\User;
 /**
 *
 * Essentially a user's scrapbook, a pile is an object used for clumping bits of content together around a user account.

--- a/web/concrete/views/panels/add.php
+++ b/web/concrete/views/panels/add.php
@@ -39,8 +39,6 @@ switch($tab) {
 <div id="ccm-panel-add-block-clipboard-list">
 <?
 
-$sp = Pile::getDefault();
-$contents = $sp->getPileContentObjects('date_desc');
 foreach($contents as $obj) { 
 	$item = $obj->getObject();
 	if (is_object($item)) {


### PR DESCRIPTION
Was getting errors finding the Pile in the view. Moved loading the $contents to the controller, to simplify view and as a better home for the necessary 'use'.
