### PR TITLE
Fix class loading

### DIFF
--- a/web/concrete/core/Foundation/ClassLoader.php
+++ b/web/concrete/core/Foundation/ClassLoader.php
@@ -81,6 +81,7 @@ class ClassLoader  {
 		$symfonyLoader->addPrefix(NAMESPACE_SEGMENT_APPLICATION . '\\Theme', DIR_APPLICATION . '/' . DIRNAME_THEMES);
 		$symfonyLoader->addPrefix(NAMESPACE_SEGMENT_APPLICATION . '\\Controller', DIR_APPLICATION . '/' . DIRNAME_CONTROLLERS);
 		$symfonyLoader->addPrefix(NAMESPACE_SEGMENT_APPLICATION . '\\Job', DIR_APPLICATION . '/' . DIRNAME_JOBS);
+		$symfonyLoader->addPrefix(NAMESPACE_SEGMENT_APPLICATION . '\\Core', DIR_APPLICATION . '/' . DIRNAME_CLASSES);
 
 		$symfonyLoader->register();
 	}


### PR DESCRIPTION
The following example given in the comments of app.php...

// Register a class override.
Core::bind('helper/feed', function() {
    return new \Application\Core\CustomFeedHelper();
});

...will not work without this change. See the following forum post...

http://www.concrete5.org/index.php?cID=627470

-Steve
