### PR TITLE
Fix login when LANGUAGE_CHOOSE_ON_LOGIN is on

### DIFF
--- a/web/concrete/controllers/single_page/login.php
+++ b/web/concrete/controllers/single_page/login.php
@@ -13,6 +13,7 @@ use Permissions;
 use UserInfo;
 use UserAttributeKey;
 use Session;
+use Cache;
 
 class Login extends PageController {
 


### PR DESCRIPTION
When `LANGUAGE_CHOOSE_ON_LOGIN` is set to true, we have a call to `Cache::getLibrary()`: let's declare that we want to use the `Cache` namespace...
