### PR TITLE
make uPreviousLogin nullable

### DIFF
--- a/web/concrete/config/db.xml
+++ b/web/concrete/config/db.xml
@@ -3619,7 +3619,6 @@
       <default value="0"/>
     </field>
     <field name="uPreviousLogin" type="I" size="10">
-      <notnull/>
       <default value="0"/>
       <unsigned/>
     </field>


### PR DESCRIPTION
I'm not sure how this could have worked for you guys, but if `recordLogin` is called for the first time, there's no previous login information which is why it can't be saved in a `notnull` column.
