### PR TITLE
Introduce display names for log level/channel

### DIFF
--- a/web/concrete/controllers/single_page/dashboard/reports/logs.php
+++ b/web/concrete/controllers/single_page/dashboard/reports/logs.php
@@ -29,12 +29,12 @@ class Logs extends DashboardPageController {
 
         $levels = array();
         foreach(Log::getLevels() as $level) {
-            $levels[$level] = Log::getLevelName($level);
+            $levels[$level] = Log::getLevelDisplayName($level);
         }
         $this->set('levels', $levels);
         $channels = array('' => t('All Channels'));
         foreach(Log::getChannels() as $channel) {
-            $channels[$channel] = Core::make('helper/text')->unhandle($channel);
+            $channels[$channel] = Log::getChannelDisplayName($channel);
         }
         $r = Request::getInstance();
         if ($r->query->has('channel') && $r->query->get('channel') != '') {

--- a/web/concrete/core/Logging/LogEntry.php
+++ b/web/concrete/core/Logging/LogEntry.php
@@ -20,7 +20,7 @@ class LogEntry
 
     public function getLevelDisplayName()
     {
-        return ucfirst(strtolower(Logger::getLevelName($this->level)));
+        return Logger::getLevelDisplayName($this->level);
     }
 
     public function getMessage()
@@ -33,9 +33,9 @@ class LogEntry
         return $this->channel;
     }
 
-    public function getChannelDisplay()
+    public function getChannelDisplayName()
     {
-        return Core::make('helper/text')->unhandle($this->channel);
+        return Logger::getChannelDisplayName($this->channel);
     }
 
     public function getID()

--- a/web/concrete/core/Logging/Logger.php
+++ b/web/concrete/core/Logging/Logger.php
@@ -92,7 +92,7 @@ class Logger extends MonologLogger
      * @param  integer $level
      * @return string
      */
-    public static function getLevelName($level)
+    public static function getLevelDisplayName($level)
     {
         if (array_key_exists($level, static::$levels)) {
             switch (static::$levels[$level]) {
@@ -114,7 +114,19 @@ class Logger extends MonologLogger
                     return tc(/*i18n: Urgent alert */ 'Log level', 'Emergency');
             }
         }
-        return parent::getLevelName($level);
+        return tc(/*i18n: Urgent alert */ 'Log level', ucfirst(strtolower($level)));
     }
-
+    public static function getChannelDisplayName($channel)
+    {
+        switch ($channel) {
+            case 'application':
+                return tc('Log channel', 'Application');
+            case LOG_TYPE_EMAILS:
+                return tc('Log channel', 'Sent Emails');
+            case LOG_TYPE_EXCEPTIONS:
+                return tc('Log channel', 'Exceptions');
+            default:
+                return tc('Log channel', Core::make('helper/text')->unhandle($channel));
+        }
+    }
 }

--- a/web/concrete/single_pages/dashboard/reports/logs.php
+++ b/web/concrete/single_pages/dashboard/reports/logs.php
@@ -74,7 +74,7 @@ $th = Loader::helper('text');
                         print $ent->getDisplayTimestamp();
                     ?></td>
                     <td valign="top" style="text-align: center"><?=$ent->getLevelIcon()?></td>
-                    <td valign="top" style="white-space: nowrap"><?=$ent->getChannelDisplay()?></td>
+                    <td valign="top" style="white-space: nowrap"><?=$ent->getChannelDisplayName()?></td>
                     <td valign="top"><strong><?php
                     if($ent->getUserID() == NULL){
                         echo t("Guest");


### PR DESCRIPTION
- let's adopt `getLevelDisplayName` instead of `getLevelName`
- introduce `getChannelDisplayName` (supersedes `getChannelDisplay`)
