### PR TITLE
Contextualize "By <author>"

### DIFF
--- a/web/concrete/elements/gathering/templates/tile/image_byline_description_center/view.php
+++ b/web/concrete/elements/gathering/templates/tile/image_byline_description_center/view.php
@@ -12,7 +12,7 @@ $ownerName = $u->getUserName();
 		<img src="<?=$image->getPath()?>" alt="<?php echo t('Preview Image') ?>" />
 	</a>
 	<div class="ccm-gathering-tile-title-description">
-		<div class="ccm-gathering-tile-byline"><?php echo t('By '). '<span class="author-name">' .$ownerName. '</span>' ?></div>
+		<div class="ccm-gathering-tile-byline"><?php echo tc(/*i18n: %s is the name of the author */ 'Authored', 'By %s', '<span class="author-name">' . $ownerName . '</span>'); ?></div>
 		<div class="ccm-gathering-tile-description">
 		<?=$description?>
 		</div>

--- a/web/concrete/elements/gathering/templates/tile/image_overlay_headline/view.php
+++ b/web/concrete/elements/gathering/templates/tile/image_overlay_headline/view.php
@@ -9,7 +9,7 @@ if (is_array($image)) {
 		<img src="<?=$image->getPath()?>" alt="<?php echo t('Preview Image') ?>" />
 	<div class="ccm-gathering-tile-image-overlay-headline-byline-description">
 		<p class="overlay-title"><?=$title; ?></p>
-		<p class="overlay-byline"><?= t('by ') . $author ?></p>
+		<p class="overlay-byline"><?php echo tc(/*i18n: %s is the name of the author */ 'Authored', 'by %s', $author); ?></p>
 	</div>
 	<div class="clearfix" style="clear: both;"></div>
 </div>

--- a/web/concrete/elements/gathering/templates/tile/masthead_byline_description/view.php
+++ b/web/concrete/elements/gathering/templates/tile/masthead_byline_description/view.php
@@ -7,7 +7,7 @@ $nh = Loader::helper('navigation');
 <div class="ccm-gathering-masthead-byline-description">
 	<div class="ccm-gathering-tile-title-description">
 		<div class="ccm-gathering-tile-headline"><a href="<?=$link?>"><?=$title?></a></div>
-		<div class="ccm-gathering-tile-byline"><?php echo t('by '). '<span class="author-name">' .$ownerName. '</span>' ?></div>
+		<div class="ccm-gathering-tile-byline"><?php echo tc(/*i18n: %s is the name of the author */ 'Authored', 'by %s', '<span class="author-name">' . $ownerName . '</span>'); ?></div>
 		<div class="ccm-gathering-tile-description">
 		<?=$description?>
 		</div>

--- a/web/concrete/elements/gathering/templates/tile/masthead_image_byline_left/view.php
+++ b/web/concrete/elements/gathering/templates/tile/masthead_image_byline_left/view.php
@@ -13,7 +13,7 @@ $ownerName = $u->getUserName();
 	</a>
 	<div class="ccm-gathering-tile-title-description float-left">
 		<div class="ccm-gathering-tile-headline"><a href="<?=$link?>"><?=$title?></a></div>
-		<div class="ccm-gathering-tile-byline"><?php echo t('By '). '<span class="author-name">' .$ownerName. '</span>' ?></div>
+		<div class="ccm-gathering-tile-byline"><?php echo tc(/*i18n: %s is the name of the author */ 'Authored', 'By %s', '<span class="author-name">' . $ownerName . '</span>'); ?></div>
 		<div class="ccm-gathering-tile-description">
 		<?=$description?>
 		</div>

--- a/web/concrete/elements/gathering/templates/tile/masthead_image_byline_right/view.php
+++ b/web/concrete/elements/gathering/templates/tile/masthead_image_byline_right/view.php
@@ -10,7 +10,7 @@ $ownerName = $u->getUserName();
 <div class="ccm-gathering-masthead-image-right ccm-gathering-masthead-image ccm-gathering-scaled-image">
 	<div class="ccm-gathering-tile-title-description float-left">
 		<div class="ccm-gathering-tile-headline"><a href="<?=$link?>"><?=$title?></a></div>
-		<div class="ccm-gathering-tile-byline"><?php echo t('By '). '<span class="author-name">' .$ownerName. '</span>' ?></div>
+		<div class="ccm-gathering-tile-byline"><?php echo tc(/*i18n: %s is the name of the author */ 'Authored', 'By %s', '<span class="author-name">' . $ownerName . '</span>'); ?></div>
 		<div class="ccm-gathering-tile-description">
 		<?=$description?>
 		</div>

--- a/web/concrete/single_pages/dashboard/conversations/messages.php
+++ b/web/concrete/single_pages/dashboard/conversations/messages.php
@@ -155,7 +155,13 @@ $ip = Loader::helper('validation/ip'); ?>
 		</td>
 		<td>
 			<?=$msg->getConversationMessageDateTimeOutput(array(DATE_APP_GENERIC_MDY_FULL . ' H:i:s'));?> 
-			<p><?=t('By')?> <? if (!is_object($ui)) { ?><?=t('Anonymous')?><? } else { ?><?=$ui->getUserDisplayName()?><? } ?></p>
+			<p><?
+				if(is_object($ui)) {
+					echo tc(/*i18n: %s is the name of the author */ 'Authored', 'By %s', $ui->getUserDisplayName());
+				} else {
+					echo t(/*i18n: when the author of a message is anonymous */ 'By Anonymous');
+				}
+			?></p>
 
 			<?
 			$cnv = $msg->getConversationObject();


### PR DESCRIPTION
Concatenating strings makes translators work very hard.
Let's state that "By" in these cases stands for "By <author>"
