### PR TITLE
Normalize default locale text

### DIFF
--- a/web/concrete/controllers/single_page/dashboard/users/search.php
+++ b/web/concrete/controllers/single_page/dashboard/users/search.php
@@ -354,7 +354,7 @@ class Search extends DashboardPageController {
 		$languages = Localization::getAvailableInterfaceLanguages();
 		array_unshift($languages, 'en_US');
 		$obj = new stdClass;
-		$obj->text = t('** Default');
+		$obj->text = tc('Default locale', '** Default');
 		$obj->value = '';
 		$result = array($obj);
 		


### PR DESCRIPTION
Let's adopt the same translation as we have in the [login page](https://github.com/concrete5/concrete5-5.7.0/blob/master/web/concrete/controllers/single_page/login.php#L60).
