### PR TITLE
Fix assets minification and combination

### DIFF
--- a/web/concrete/core/Asset/CssAsset.php
+++ b/web/concrete/core/Asset/CssAsset.php
@@ -120,7 +120,7 @@ class CssAsset extends Asset {
 
 	public function minify($assets) {
 		return self::process($assets, function($css, $assetPath, $targetPath) {
-			return CssMin::minify($css);
+			return \CssMin::minify($css);
 		});
 	}
 

--- a/web/concrete/core/Html/Service/Html.php
+++ b/web/concrete/core/Html/Service/Html.php
@@ -31,7 +31,7 @@ class Html {
 			$asset->setAssetIsLocal(false);
 		} else if (substr($file, 0, 1) == '/') {
 			$asset->setAssetURL($file);
-			$asset->setAssetPath(DIR_APPLICATION . $file);
+			$asset->setAssetPath(DIR_BASE . $file);
 		} else {
 			$v = View::getInstance();
 			// checking the theme directory for it. It's just in the root.

--- a/web/concrete/core/View/View.php
+++ b/web/concrete/core/View/View.php
@@ -1,5 +1,6 @@
 <?
 namespace Concrete\Core\View;
+
 use Concrete\Core\Asset\Asset;
 use Concrete\Core\Http\ResponseAssetGroup;
 use Environment;
@@ -238,10 +239,10 @@ class View extends AbstractView {
         foreach($groupedAssets as $segment => $assets) {
             if ($assets[0] instanceof Asset && $assets[0]->assetSupportsMinification()) {
                 // this entire segment can be post processed together
-                $class = Loader::helper('text')->camelcase($assets[0]->getAssetType()) . 'Asset';
+                $class = get_class($assets[0]);
                 $assets = call_user_func(array($class, 'minify'), $assets);
             } else if ($assets[0] instanceof Asset && $assets[0]->assetSupportsCombination()) {
-                $class = Loader::helper('text')->camelcase($assets[0]->getAssetType()) . 'Asset';
+                $class = get_class($assets[0]);
                 $assets = call_user_func(array($class, 'combine'), $assets);
             }
             $return = array_merge($return, $assets);


### PR DESCRIPTION
- set correct namespace for CssMin (it's \CssMin)
- assets with urls starting with / are relative to DIR_BASE, not to DIR_APPLICATION
- to retrieve the class of an asset: let's use get_class, since concatenating AssetType + 'Asset' does not contain the class namespace
