### PR TITLE
Refactor permission assignments to use IoC container

### DIFF
--- a/web/concrete/core/Permission/Assignment/AreaAssignment.php
+++ b/web/concrete/core/Permission/Assignment/AreaAssignment.php
@@ -25,6 +25,11 @@ class AreaAssignment extends Assignment {
 		'add_stack_to_area' => 'add_stack'
 	);
 
+	public function __construct(Area $a)
+	{
+		$this->setPermissionObject($a);
+	}
+
 	public function setPermissionObject(Area $a) {
 		$ax = $a;
 		if ($a->isGlobalArea()) {

--- a/web/concrete/core/Permission/Assignment/Assignment.php
+++ b/web/concrete/core/Permission/Assignment/Assignment.php
@@ -8,6 +8,11 @@ class Assignment {
 	protected $pk; // permissionkey
 	protected $permissionObject;
 	
+	public function __construct($po)
+	{
+		$this->setPermissionObject($po);
+	}
+
 	public function setPermissionObject($po) {
 		$this->permissionObject = $po;
 	}

--- a/web/concrete/core/Permission/Assignment/BlockAssignment.php
+++ b/web/concrete/core/Permission/Assignment/BlockAssignment.php
@@ -29,6 +29,11 @@ class BlockAssignment extends Assignment {
 		'delete_block' => 'edit_page_contents'		
 	);
 	
+	public function __construct(Block $b)
+	{
+		$this->setPermissionObject($b);
+	}
+
 	public function setPermissionObject(Block $b) {
 		$this->permissionObject = $b;
 		

--- a/web/concrete/core/Permission/Assignment/FileAssignment.php
+++ b/web/concrete/core/Permission/Assignment/FileAssignment.php
@@ -18,6 +18,10 @@ class FileAssignment extends Assignment {
 		'delete_file' => 'delete_file_set_files'
 	);
 	
+	public function __construct(File $f)
+	{
+		$this->setPermissionObject($f);
+	}
 
 	public function getPermissionAccessObject() {
 		$db = Loader::db();

--- a/web/concrete/core/Permission/Assignment/FileSetAssignment.php
+++ b/web/concrete/core/Permission/Assignment/FileSetAssignment.php
@@ -5,6 +5,11 @@ use FileSet;
 use Loader;
 class FileSetAssignment extends Assignment {
 	
+	public function __construct(FileSet $fs)
+	{
+		$this->setPermissionObject($fs);
+	}
+
 	public function setPermissionObject(FileSet $fs) {
 		$this->permissionObject = $fs;
 		

--- a/web/concrete/core/Permission/Assignment/PageAssignment.php
+++ b/web/concrete/core/Permission/Assignment/PageAssignment.php
@@ -3,8 +3,14 @@ namespace Concrete\Core\Permission\Assignment;
 use PermissionAccess;
 use \Concrete\Core\Permission\Cache as PermissionCache;
 
+use Page;
 use Loader;
 class PageAssignment extends Assignment {
+
+	public function __construct(Page $p)
+	{
+		$this->setPermissionObject($p);
+	}
 
 	public function getPermissionAccessObject() {
 		$pa = PermissionCache::getAccessObject($this->pk, $this->getPermissionObject());

--- a/web/concrete/core/Permission/Assignment/TopicTreeNodeAssignment.php
+++ b/web/concrete/core/Permission/Assignment/TopicTreeNodeAssignment.php
@@ -9,6 +9,11 @@ class TopicTreeNodeAssignment extends TreeNodeAssignment {
 		'view_topic_tree_node' => 'view_topic_category_tree_node'
 	);
 
+	public function __construct(TopicTreeNode $node)
+	{
+		$this->setPermissionObject($node);
+	}
+
 	public function setPermissionObject(TopicTreeNode $node) {
 		$this->permissionObject = $node;
 		

--- a/web/concrete/core/Permission/Key/Key.php
+++ b/web/concrete/core/Permission/Key/Key.php
@@ -348,8 +348,7 @@ abstract class Key extends Object {
 	public function getPermissionAssignmentObject() {
 		if (is_object($this->permissionObject)) {
 			$className = $this->permissionObject->getPermissionAssignmentClassName();
-			$targ = Core::make($className);
-			$targ->setPermissionObject($this->permissionObject);
+			$targ = Core::make($className, array($this->permissionObject));
 		} else {
 			$targ = new PermissionAssignment();
 		}


### PR DESCRIPTION
Addresses [this issue](https://github.com/concrete5/concrete5-5.7.0/issues/186).

I modified all permission assignment classes having a _setPermissionObject()_ method with a type-hinted argument. However, I tested **ONLY** the PageAssignment and AreaAssignment classes.

-Steve
