### PR TITLE
make it possible to search for 0/1 and nothing

### DIFF
--- a/web/concrete/attributes/boolean/controller.php
+++ b/web/concrete/attributes/boolean/controller.php
@@ -11,7 +11,7 @@ class Controller extends AttributeTypeController  {
 	protected $searchIndexFieldDefinition = array('type' => 'boolean', 'options' => array('default' => 0, 'notnull' => false));
 	
 	public function searchForm($list) {
-		$list->filterByAttribute($this->attributeKey->getAttributeKeyHandle(), 1);
+		$list->filterByAttribute($this->attributeKey->getAttributeKeyHandle(), $this->request('value'));
 		return $list;
 	}	
 


### PR DESCRIPTION
it's currently not possible to filter for 0 which can be quite useful. You've got an attribute "great_cat" and you wish to search for great cats, possible, but if you want to filter for the not so great cats, you can't do that because the method will always filter for 1, no matter what.

I believe a boolean attribute needs three states, filter for true, false and don't filter anything (true+false).
