### PR TITLE
Fix handleURLSlashes() so that it's pretty-URLs-aware

### DIFF
--- a/web/concrete/core/Application/Application.php
+++ b/web/concrete/core/Application/Application.php
@@ -218,8 +218,9 @@ class Application extends Container
                 $redirect .= '/';
             }
             if ($pathInfo != $redirect) {
+                $dispatcher = URL_REWRITING || URL_REWRITING_ALL ? '' : '/' . DISPATCHER_FILENAME;
                 Redirect::url(
-                        BASE_URL . DIR_REL . '/' . DISPATCHER_FILENAME . '/' . $path . ($r->getQueryString(
+                        BASE_URL . DIR_REL . $dispatcher . '/' . $path . ($r->getQueryString(
                         ) ? '?' . $r->getQueryString() : '')
                 )->send();
             }


### PR DESCRIPTION
Fixes the **handleURLSlashes()** method of the **Application** class so that with pretty URLs enabled, going to...

&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mydomain.com/about/

...will properly redirect to...

&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mydomain.com/about

...instead of...

&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mydomain.com/index.php/about

-Steve
