### PR TITLE
Use "static" so that overrides work

### DIFF
--- a/web/concrete/core/Http/Request.php
+++ b/web/concrete/core/Http/Request.php
@@ -38,10 +38,10 @@ class Request extends SymfonyRequest {
 	}
 
 	public static function getInstance() {
-		if (null === self::$_request) {
-			self::$_request = Request::createFromGlobals();
+		if (null === static::$_request) {
+			static::$_request = static::createFromGlobals();
 		}
-		return self::$_request;
+		return static::$_request;
 	}
 
 	/** 


### PR DESCRIPTION
I was extending the core **Request** class to override one of its methods, and this eliminates an error when getting the instance (in _start.php_ around line 100). The most critical change was from _Request::createFromGlobals()_ to _static::createFromGlobals()_.

-Steve
