### PR TITLE
Correct use of t2

### DIFF
--- a/web/concrete/views/panels/add.php
+++ b/web/concrete/views/panels/add.php
@@ -74,7 +74,7 @@ switch ($tab) {
                     </div>
                     <div class="blocks">
                         <div class="block-count">
-                            <?= $block_count ?> <?= t2('Block', 'Blocks', $block_count) ?>
+                            <?= t2('%d Block', '%d Blocks', $block_count) ?>
                         </div>
                         <?php
 


### PR DESCRIPTION
Don't suppose that numbers always come before the text in strings like `3 Blocks`.
As a general rule, string concatenation should be always avoided when dealing with translations.
