### PR TITLE
Remove "Events" from aliases

### DIFF
--- a/web/concrete/config/aliases.php
+++ b/web/concrete/config/aliases.php
@@ -3,7 +3,6 @@ return array(
     'Request' => '\Concrete\Core\Http\Request',
     'Environment' => '\Concrete\Core\Foundation\Environment',
     'Localization' => '\Concrete\Core\Localization\Localization',
-    'Events' => '\Concrete\Core\Events\Events',
     'Response' => '\Concrete\Core\Http\Response',
     'Redirect' => '\Concrete\Core\Routing\Redirect',
     'URL' => '\Concrete\Core\Routing\URL',


### PR DESCRIPTION
This alias references a non-existent class. Events, instead, appear to have been implemented as a service provider with a facade.

-Steve
