### PR TITLE
Fix for #284 (Dashboard Re-skin: System and Settings > Permissions and Access > Site Access)

### DIFF
--- a/web/concrete/controllers/single_page/dashboard/system/permissions/site.php
+++ b/web/concrete/controllers/single_page/dashboard/system/permissions/site.php
@@ -9,6 +9,8 @@ use PermissionAccess;
 use GroupList;
 use Cache;
 use Page;
+use Group;
+use \Concrete\Core\Permission\Access\Entity\GroupEntity as GroupPermissionAccessEntity;
 
 class Site extends DashboardPageController {
 	public function view() {

--- a/web/concrete/single_pages/dashboard/system/permissions/site.php
+++ b/web/concrete/single_pages/dashboard/system/permissions/site.php
@@ -40,16 +40,12 @@ $form = Loader::helper('form');
     <legend style="margin-bottom: 0px"><?=t('Edit Access')?></legend>
         <span class="help-block"><?=t('Choose which users and groups may edit your site. Note: These settings can be overridden on specific pages.')?></span>
         <div class="form-group">
-			<ul class="checkbox">
-				<?foreach($gArray as $g):?>
-				<li>
-					<label>
-						<?=$form->checkbox('gID[]', $g->getGroupID(), in_array($g->getGroupID(), $editAccess))?>
-						<span><?=$g->getGroupDisplayName()?></span>
-					</label>
-				</li>
-				<?endforeach?>
-			</ul>
+			<?foreach($gArray as $g):?>
+				<label class="checkbox">
+					<?=$form->checkbox('gID[]', $g->getGroupID(), in_array($g->getGroupID(), $editAccess))?>
+					<span><?=$g->getGroupDisplayName()?></span>
+				</label>
+			<?endforeach?>
         </div>
     </fieldset>
     


### PR DESCRIPTION
Reskin for #284
Preview of changes here: http://puu.sh/9ErMR/5ce0d51dae.png

Any feedback?

I did wonder if the descriptions of what each viewing permission level should be a tooltip but I'll let someone else make that call. 

As with previous app.css has a .ccm-ui label rule making the labels bold. 

J. 
