### PR TITLE
Fix for #286 (Dashboard Re-skin: System and Settings > Permissions and Access > Allowed File Types)

### DIFF
--- a/web/concrete/single_pages/dashboard/system/permissions/filetypes.php
+++ b/web/concrete/single_pages/dashboard/system/permissions/filetypes.php
@@ -1,25 +1,25 @@
 <? defined('C5_EXECUTE') or die("Access Denied."); ?>
 
-	<?=Loader::helper('concrete/dashboard')->getDashboardPaneHeaderWrapper(t('Allowed File Types'), false, 'span8 offset2', false)?>
+    <?=Loader::helper('concrete/dashboard')->getDashboardPaneHeaderWrapper(t('Allowed File Types'), false, 'span8 offset2', false)?>
 
-	<form method="post" id="file-access-extensions" action="<?=$view->url('/dashboard/system/permissions/filetypes', 'file_access_extensions')?>" role="form">
-		<?=$validation_token->output('file_access_extensions');?>
-		<p>
-		<?=t('Only files with the following extensions will be allowed. Separate extensions with commas. Periods and spaces will be ignored.')?>
-		</p>
-		<? if (UPLOAD_FILE_EXTENSIONS_CONFIGURABLE) { ?>
-		    <div class="form-group">
-		        <textarea name="file-access-file-types" class="form-control" rows="3"><?=$file_access_file_types?></textarea>
-		    </div>
-        <? } else { ?>
-			<?=$file_access_file_types?>
-		<? } ?>
-	
-    	<div class="ccm-dashboard-form-actions-wrapper">
-    	    <div class="ccm-dashboard-form-actions">
-    	        <button class="pull-right btn btn-success" type="submit" value="file-access-extensions"><?=t('Save')?></button>
+    <form method="post" id="file-access-extensions" action="<?=$view->url('/dashboard/system/permissions/filetypes', 'file_access_extensions')?>" role="form">
+        <?=$validation_token->output('file_access_extensions');?>
+        <p>
+            <?=t('Only files with the following extensions will be allowed. Separate extensions with commas. Periods and spaces will be ignored.')?>
+        </p>
+        <? if (UPLOAD_FILE_EXTENSIONS_CONFIGURABLE) { ?>
+            <div class="form-group">
+                <textarea name="file-access-file-types" class="form-control" rows="3"><?=$file_access_file_types?></textarea>
             </div>
-    	</div>	        
-	</form>
+        <? } else { ?>
+            <?=$file_access_file_types?>
+        <? } ?>
+	
+        <div class="ccm-dashboard-form-actions-wrapper">
+            <div class="ccm-dashboard-form-actions">
+                <button class="pull-right btn btn-success" type="submit" value="file-access-extensions"><?=t('Save')?></button>
+            </div>
+        </div>	        
+    </form>
 
-	<?=Loader::helper('concrete/dashboard')->getDashboardPaneFooterWrapper(false)?>
+    <?=Loader::helper('concrete/dashboard')->getDashboardPaneFooterWrapper(false)?>


### PR DESCRIPTION
app.css has the following rule:

.form-group .form-control {
    height:34px;
}

Preview with the above rule in place: http://puu.sh/9H0ax/6c09de82b1.png
Preview with the above rule disabled: http://puu.sh/9H0hy/3204c47faf.png

Preview if edits aren't enabled: http://puu.sh/9H0us/7b49eadef0.png

Bar, everything should be fixed and working.  I'll leave the app.css edits to you as I don't know what global effect changing these things will have!

Hope it's all OK. 
