### PR TITLE
Fix verifyAuthTypeCookie

### DIFF
--- a/web/concrete/core/User/User.php
+++ b/web/concrete/core/User/User.php
@@ -334,7 +334,7 @@ class User extends Object {
 			list($_uID, $authType, $uHash) = explode(':', $_COOKIE['ccmAuthUserHash']);
 			$at = AuthenticationType::getByHandle($authType);
 			$u = User::getByUserID($_uID);
-			if ($u->isError()) {
+			if ((!is_object($u)) || $u->isError()) {
 				return;
 			}
 			if ($at->controller->verifyHash($u, $uHash)) {


### PR DESCRIPTION
`User::getByUserID` returns null if user wasn't found, so `isError` is called on a non-object.

Let's fix this....
