### PR TITLE
Fix for #48 (Dashboard Re-Skin: Users > Groups > Edit Group)

### DIFF
--- a/web/concrete/single_pages/dashboard/users/groups.php
+++ b/web/concrete/single_pages/dashboard/users/groups.php
@@ -1,215 +1,199 @@
 <?
 defined('C5_EXECUTE') or die("Access Denied.");
+
 $valt = Loader::helper('validation/token');
 $ih = Loader::helper('concrete/ui');
+$form = Loader::helper('form');
+$date = Loader::helper('form/date_time');
+
 if (isset($group)) { ?>
 
-<form method="post"  class="form-horizontal" id="update-group-form" action="<?=$view->url('/dashboard/users/groups/', 'update_group')?>">
-<?=$valt->output('add_or_update_group')?>
-<div class="ccm-pane-body">
+<form method="post" id="update-group-form" action="<?=$view->url('/dashboard/users/groups/', 'update_group')?>" role="form">
+    <?=$valt->output('add_or_update_group')?>
 	<?
-	$form = Loader::helper('form');
-	$date = Loader::helper('form/date_time');
-	$u=new User();
+	    $u = new User();
 
 	$delConfirmJS = t('Are you sure you want to permanently remove this group?');
 	if($u->isSuperUser() == false){ ?>
 		<?=t('You must be logged in as %s to remove groups.', USER_SUPER)?>			
 	<? }else{ ?>   
 
-		<script type="text/javascript">
-		deleteGroup = function() {
-			if (confirm('<?=$delConfirmJS?>')) { 
-				location.href = "<?=$view->url('/dashboard/users/groups', 'delete', $group->getGroupID(), $valt->generate('delete_group_' . $group->getGroupID() ))?>";				
-			}
+	<script type="text/javascript">
+	deleteGroup = function() {
+		if (confirm('<?=$delConfirmJS?>')) { 
+			location.href = "<?=$view->url('/dashboard/users/groups', 'delete', $group->getGroupID(), $valt->generate('delete_group_' . $group->getGroupID() ))?>";				
 		}
-		</script>
+	}
+	</script>
 
 	<? } ?>
 
-	<fieldset>
-		<legend><?=t('Group Details')?></legend>
-	<div class="control-group">
-	<?=$form->label('gName', t('Name'))?>
-	<div class="controls">
-		<input type="text" name="gName" class="span6" value="<?=Loader::helper('text')->entities($gName)?>" />
-	</div>
-	</div>
-	
-	<div class="control-group">
-	<?=$form->label('gDescription', t('Description'))?>
-	<div class="controls">
-		<textarea name="gDescription" rows="6" class="span6"><?=Loader::helper("text")->entities($gDescription)?></textarea>
-	</div>
-	</div>
-	</fieldset>
+    <fieldset>
+	    <legend><?=t('Group Details')?></legend>
+	    <div class="form-group">
+	        <label for="gName"><?=t('Name')?></label>
+	        <input type="text" name="gName" id="gName" class="form-control" value="<?=Loader::helper('text')->entities($gName)?>" />
+	    </div>
+	    
+	    <div class="form-group">
+	        <label for="gDescription"><?=t('Description')?></label>	        
+	        <textarea name="gDescription" id="gDescription" rows="6" class="form-control"><?=Loader::helper("text")->entities($gDescription)?></textarea>
+	    </div>
+    </fieldset>
 
 	<? if (ENABLE_USER_PROFILES) { ?>
+	
 	<fieldset>
 		<legend><?=t('Badge Details')?></legend>
-		<div class="control-group">
-		<div class="controls">
-		<label class="checkbox">
-		<?=$form->checkbox('gIsBadge', 1, $group->isGroupBadge())?>
-		<span><?=t('This group is a badge.')?> <i class="icon-question-sign" title="<?=t('Badges are publicly viewable in user profiles, and display pictures and a custom description. Badges can be automatically assigned or given out by administrators.')?>"></i> </span>
-		</label>
-		</div>
-		</div>
+
+        <div class="form-group">
+            <label class="checkbox">
+                <?=$form->checkbox('gIsBadge', 1, $group->isGroupBadge())?>	
+                <span><?=t('This group is a badge.')?> <i class="icon-question-sign" title="<?=t('Badges are publicly viewable in user profiles, and display pictures and a custom description. Badges can be automatically assigned or given out by administrators.')?>"></i> </span>
+            </label>
+        </div>
 		
-	<div id="gUserBadgeOptions" style="display: none">
-		<div class="control-group">
-			<label class="control-label"><?=t('Image')?></label>
-			<div class="controls">
-				<?
+        <div id="gUserBadgeOptions" style="display: none">
+		    <div class="form-group">
+			    <label for="gBadgeFID"><?=t('Image')?></label>
+                
+                    <?
+                        $af = Loader::helper('concrete/asset_library');
+        				print $af->image('gBadgeFID', 'gBadgeFID', t('Choose Badge Image'), $group->getGroupBadgeImageObject());
+                    ?>
+                
+            </div>
 
-				$af = Loader::helper('concrete/asset_library');
-				print $af->image('gBadgeFID', 'gBadgeFID', t('Choose Badge Image'), $group->getGroupBadgeImageObject());
-				?>
+            <div class="form-group">
+                <label for="gBadgeDescription"><?=t('Badge Description')?></label>
+                <?=$form->textarea('gBadgeDescription', $group->getGroupBadgeDescription(), array('rows' => 6, 'class' =>'form-control'))?>
+            </div>
 
-			</div>
+            <div class="form-group">
+                <label for="gBadgeCommunityPointValue"><?=t('Community Points')?></label>
+                <?=$form->text('gBadgeCommunityPointValue', $group->getGroupBadgeCommunityPointValue(), array('class' => 'form-control'))?>
+            </div>
 		</div>
-
-		<div class="control-group">
-		<?=$form->label('gBadgeDescription', t('Badge Description'))?>
-		<div class="controls">
-			<?=$form->textarea('gBadgeDescription', $group->getGroupBadgeDescription(), array('rows' => 6, 'class' =>'span6'))?>
-		</div>
-		</div>
-
-		<div class="control-group">
-		<?=$form->label('gBadgeCommunityPointValue', t('Community Points'))?>
-		<div class="controls">
-			<?=$form->text('gBadgeCommunityPointValue', $group->getGroupBadgeCommunityPointValue(), array('class' => 'span1'))?>
-		</div>
-		</div>
-
-
-	</div>
-
 	</fieldset>
 	<? } ?>
 
 	<fieldset>
 		<legend><?=t('Automation')?></legend>
-		<div class="control-group">
-		<div class="controls">
-		<label class="checkbox">
-		<?=$form->checkbox('gIsAutomated', 1, $group->isGroupAutomated())?>
-		<span><?=t('This group is automatically entered.')?> <i class="icon-question-sign" title="<?=t("Automated Groups aren't assigned by administrators. They are checked against code at certain times that determines whether users should enter them.")?>"></i> </span>
-		</label>
-		</div>
+		<div class="form-group">
+            <label class="checkbox">
+                <?=$form->checkbox('gIsAutomated', 1, $group->isGroupAutomated())?>
+                <span><?=t('This group is automatically entered.')?> <i class="icon-question-sign" title="<?=t("Automated Groups aren't assigned by administrators. They are checked against code at certain times that determines whether users should enter them.")?>"></i> </span>
+            </label>
+		
 		</div>
 		
-	<div id="gAutomationOptions" style="display: none">
-		<div class="control-group">
-		<label class="control-label"><?=t('Check Group')?></label>
-		<div class="controls">
-			<label class="checkbox">
-				<?=$form->checkbox('gCheckAutomationOnRegister', 1, $group->checkGroupAutomationOnRegister())?>
-				<span><?=t('When a user registers.')?></span>
-			</label>
-			<label class="checkbox">
-				<?=$form->checkbox('gCheckAutomationOnLogin', 1, $group->checkGroupAutomationOnLogin())?>
-				<span><?=t('When a user signs in.')?></span>
-			</label>
-			<label class="checkbox">
-				<?=$form->checkbox('gCheckAutomationOnJobRun', 1, $group->checkGroupAutomationOnJobRun())?>
-				<span><?=t('When the "Check Automated Groups" Job runs.')?></span>
-			</label>
-		</div>
-		</div>
+    	<div id="gAutomationOptions" style="display: none">
+    		<div class="form-group">
+    		    <label><?=t('Check Group')?></label>
+    		    
+    		    <label class="checkbox">
+    				<?=$form->checkbox('gCheckAutomationOnRegister', 1, $group->checkGroupAutomationOnRegister())?>
+    				<span><?=t('When a user registers.')?></span>
+    			</label>
+    			
+    			<label class="checkbox">
+    				<?=$form->checkbox('gCheckAutomationOnLogin', 1, $group->checkGroupAutomationOnLogin())?>
+    				<span><?=t('When a user signs in.')?></span>
+    			</label>
+    			
+    			<label class="checkbox">
+    				<?=$form->checkbox('gCheckAutomationOnJobRun', 1, $group->checkGroupAutomationOnJobRun())?>
+    				<span><?=t('When the "Check Automated Groups" Job runs.')?></span>
+    			</label>
+    		</div>
+    
+    		<div class="alert alert-info">
+    			<?
+    			$path = $group->getGroupAutomationControllerFile();
+    			print t('Make sure a code file exists at %s', str_replace(array(DIR_APPLICATION, DIR_BASE_CORE), '', $path));
+    			?>
+    		</div>
+    	</div>
 
-		<div class="alert alert-info">
-			<?
-			$path = $group->getGroupAutomationControllerFile();
-			print t('Make sure a code file exists at %s', str_replace(array(DIR_APPLICATION, DIR_BASE_CORE), '', $path));
-			?>
-		</div>
-	</div>
-
-	<div class="control-group">
-	<div class="controls">
-
-		<label class="checkbox">
-		<?=$form->checkbox('gUserExpirationIsEnabled', 1, $group->isGroupExpirationEnabled())?>
-		<span><?=t('Automatically remove users from this group')?></span></label>
-		
-	</div>
+    	<div class="form-group">
+            <label class="checkbox">
+    		<?=$form->checkbox('gUserExpirationIsEnabled', 1, $group->isGroupExpirationEnabled())?>
+    		<span><?=t('Automatically remove users from this group')?></span></label>
+    	</div>
 	
-	<div class="controls" style="">
-		<?=$form->select("gUserExpirationMethod", array(
-			'SET_TIME' => t('at a specific date and time'),
-				'INTERVAL' => t('once a certain amount of time has passed')
-			
-		), $group->getGroupExpirationMethod(), array('disabled' => true));?>	
-	</div>	
-	</div>
+    	<div class="form-group">
+    		<?=$form->select("gUserExpirationMethod", array(
+    		    'SET_TIME' => t('at a specific date and time'),
+    			'INTERVAL' => t('once a certain amount of time has passed')
+            ), $group->getGroupExpirationMethod(), array('disabled' => true, 'class' => 'form-control'));?>	
+    	</div>	
 	
+    	<div id="gUserExpirationSetTimeOptions" style="display: none">
+    	    <div class="form-group">
+    	        <label for="gUserExpirationSetDateTime"><?=t('Expiration Date')?></label>
+                <?=$date->datetime('gUserExpirationSetDateTime', $group->getGroupExpirationDateTime())?>
+            </div>
+    	</div>
 	
-	<div id="gUserExpirationSetTimeOptions" style="display: none">
-	<div class="control-group">
-	<?=$form->label('gUserExpirationSetDateTime', t('Expiration Date'))?>
-	<div class="controls">
-	<?=$date->datetime('gUserExpirationSetDateTime', $group->getGroupExpirationDateTime())?>
-	</div>
-	</div>
-	</div>
-	<div id="gUserExpirationIntervalOptions" style="display: none">
-	<div class="control-group">
-	<label class="control-label"><?=t('Accounts expire after')?></label>
-	<div class="controls">
-	<table class="table" style="width: auto">
-	<tr>
-		<th><?=t('Days')?></th>
-		<th><?=t('Hours')?></th>
-		<th><?=t('Minutes')?></th>
-	</tr>
-
-	<tr>
-
-	<?
-	$days = $group->getGroupExpirationIntervalDays();
-	$hours = $group->getGroupExpirationIntervalHours();
-	$minutes = $group->getGroupExpirationIntervalMinutes();
-	$style = 'width: 60px';
-	?>
-	<td valign="top">
-	<?=$form->text('gUserExpirationIntervalDays', $days, array('style' => $style, 'class' => 'span1'))?>
-	</td>
-	<td valign="top">
-	<?=$form->text('gUserExpirationIntervalHours', $hours, array('style' => $style, 'class' => 'span1'))?>
-	</td>
-	<td valign="top">
-	<?=$form->text('gUserExpirationIntervalMinutes', $minutes, array('style' => $style, 'class' => 'span1'))?>
-	</td>
-	</tr>
-	</table>
-	</div>
-	</div>
-	</div>
+    	<div id="gUserExpirationIntervalOptions" style="display: none">
+    	    <div class="form-group">
+                <label for=""><?=t('Accounts expire after')?></label>
+                <div>
+                	<table class="table" style="width: auto">
+                    	<tr>
+                    		<th><?=t('Days')?></th>
+                    		<th><?=t('Hours')?></th>
+                    		<th><?=t('Minutes')?></th>
+                    	</tr>
+    
+                        <tr>
+                            <?
+                            	$days = $group->getGroupExpirationIntervalDays();
+                            	$hours = $group->getGroupExpirationIntervalHours();
+                            	$minutes = $group->getGroupExpirationIntervalMinutes();
+                            	$style = 'width: 60px';
+                        	?>
+                        	
+                        	<td valign="top">
+                        	    <?=$form->text('gUserExpirationIntervalDays', $days, array('style' => $style))?>
+                        	</td>
+                        	<td valign="top">
+                        	    <?=$form->text('gUserExpirationIntervalHours', $hours, array('style' => $style))?>
+                        	</td>
+                        	<td valign="top">
+                        	    <?=$form->text('gUserExpirationIntervalMinutes', $minutes, array('style' => $style))?>
+                        	</td>
+                        </tr>
+                    </table>
+                </div>
+            </div>
+    	</div>
 	
-	<div id="gUserExpirationAction" style="display: none">
-	<div class="control-group">
-	<?=$form->label('gUserExpirationAction', t('Expiration Action'))?>
-	<div class="controls">
-	<?=$form->select("gUserExpirationAction", array(
-	'REMOVE' => t('Remove the user from this group'),
-		'DEACTIVATE' => t('Deactivate the user account'),
-		'REMOVE_DEACTIVATE' => t('Remove the user from the group and deactivate the account')
-	), $group->getGroupExpirationAction());?>	
-	</div>
-	</div>
-	</div>
-	<input type="hidden" name="gID" value="<?=$group->getGroupID()?>" />
+    	<div id="gUserExpirationAction" style="display: none">
+    	    <div class="form-group">
+    	        <label for="gUserExpirationAction"><?=t('Expiration Action')?></label>
+                <?=$form->select("gUserExpirationAction", array(
+                        'REMOVE' => t('Remove the user from this group'),
+                        'DEACTIVATE' => t('Deactivate the user account'),
+                        'REMOVE_DEACTIVATE' => t('Remove the user from the group and deactivate the account')
+                ), $group->getGroupExpirationAction(), 
+                array('class' => 'form-control'));?>	
+            </div>
+    	</div>
+	
+        <input type="hidden" name="gID" value="<?=$group->getGroupID()?>" />
 	</fieldset>
-</div>
-<div class="ccm-pane-footer">
-	<button class="btn pull-right btn-primary" style="margin-left: 10px" type="submit"><?=t('Update Group')?></button>
-	<a href="<?=$view->url('/dashboard/users/groups')?>" class="btn btn-default pull-left"><?=t('Cancel')?></a>
-	<? if ($u->isSuperUser()) { ?>
-		<? print $ih->button_js(t('Delete'), "deleteGroup()", 'right', 'error');?>
-		<? } ?>
-</div>
+	
+	<div class="ccm-dashboard-form-actions-wrapper">
+        <div class="ccm-dashboard-form-actions">    
+            <a href="<?=$view->url('/dashboard/users/groups')?>" class="btn btn-default pull-left"><?=t('Cancel')?></a>
+            <button class="btn pull-right btn-primary" style="margin-left: 10px" type="submit"><?=t('Update Group')?></button>
+            
+            <?php if ($u->isSuperUser()) { ?>
+                <?php print $ih->button_js(t('Delete'), "deleteGroup()", 'right', 'error');?>
+            <?php } ?>
+        </div>
+    </div>
 </form>
 
 <script type="text/javascript">


### PR DESCRIPTION
Graphical fixes only. There are still functionality errors. Was a larger form, so I may have messed up somewhere. (Sorry for going full retard Korvin LOL). 

Functionality issues that I've seen: 
- Loader class cannot be found
- Doesn't load the values of the group you're editing ($gName, $gDescription). $group seems to load fine and have the values, but previously it's clearly used $gName and $gDescription but I didn't want to remove them. 

Hopefully someone more versed with the backend can take a look at the functionality problems here. 
