### PR TITLE
tweaking responsive breakpoints in dashboard to prevent right hand dashb...

### DIFF
--- a/web/concrete/css/build/themes/dashboard/main.less
+++ b/web/concrete/css/build/themes/dashboard/main.less
@@ -162,6 +162,12 @@ div#ccm-dashboard-content {
 
 @media (max-width: @screen-md) {
   div#ccm-dashboard-content {
+    padding-left: 20px;
+  }
+}
+
+@media (max-width: @screen-sm) {
+  div#ccm-dashboard-content {
     margin-right: 0px !important;
 
     div.ccm-dashboard-form-actions-wrapper {


### PR DESCRIPTION
...oard pane from overlapping dashboard page content. I also tweaked it so that at the small breakpoint, the 320px left padding goes away, gives the dashboard pages a little more breathing room just before the dashboard pane disappears. #347
