### PR TITLE
Multibyte PagePath (URL) support

### DIFF
--- a/web/concrete/core/Http/Request.php
+++ b/web/concrete/core/Http/Request.php
@@ -51,7 +51,8 @@ class Request extends SymfonyRequest {
 	 * Returns the full path for a request
 	 */
 	public function getPath() {
-		$path = '/' . trim($this->getPathInfo(), '/');
+	    $pathInfo = rawurldecode($this->getPathInfo());
+		$path = '/' . trim($pathInfo, '/');
 		return ($path == '/') ? '' : $path;
 	}
 

--- a/web/concrete/core/Page/Page.php
+++ b/web/concrete/core/Page/Page.php
@@ -904,7 +904,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
      * @return string
      */
     function getCollectionPath() {
-        return $this->cPath;
+		return self::getEncodePath($this->cPath);
     }
 
     /**
@@ -919,6 +919,24 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
         ));
         return $path;
     }
+
+	/**
+	 * Returns the urlencode path for a page from path string
+	 * @param string $path
+	 * @return string $path
+	 */	
+	public static function getEncodePath($path){
+	    if(mb_strpos($path,"/") !== false){
+	      $path = explode("/",$path);
+	      $path = array_map("rawurlencode",$path);
+	      $newPath = implode("/",$path);
+	    }else if(is_null($path)){
+          $newPath = NULL;
+	    }else{
+	      $newPath = rawurlencode($path);
+	    } 
+	    return str_replace('%21','!',$newPath);
+	}
 
     /**
      * Adds a non-canonical page path to the current page.
@@ -995,7 +1013,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
     public static function getCollectionPathFromID($cID) {
         $db = Loader::db();
         $path = $db->GetOne("select cPath from PagePaths inner join CollectionVersions on (PagePaths.cID = CollectionVersions.cID and CollectionVersions.cvIsApproved = 1) where PagePaths.cID = ? order by PagePaths.ppIsCanonical desc", array($cID));
-        return $path;
+        return self::getEncodePath($path);
     }
 
     /**


### PR DESCRIPTION
concrete5 Japan team is taking a look at multibyte issues now.

Multibyte URL is very important to us
Therefore, we have made the pull request to meet the followings:
1. Sanitization.

We can use Japanese (and other multibyte characters) for URL slug, but there is no sanitization on both way (enter and output). What's your plan in the future?
1. Decode page path

We need to decode the page path URL at Request class in order to be able to use multibyte characters. Otherwise, it would return 404. Can we do it?
1. When printing out the page path in <a>, we need to encode the page path.
2. Are you still planning to use PagePath object when handling Page object? Or getCollectionPath() would be obsolete?
