### PR TITLE
Fix errors logged during installation

### DIFF
--- a/web/concrete/bootstrap/start.php
+++ b/web/concrete/bootstrap/start.php
@@ -106,10 +106,11 @@ if (!$cms->isInstalled()) {
     if (!$cms->isRunThroughCommandLineInterface() && !$request->matches('/install/*') && $request->getPath(
         ) != '/install'
     ) {
-        Redirect::to('/install')->send();
+        $response = Redirect::to('/install');
     }
-
-    $response = $cms->dispatch($request);
+    else {
+        $response = $cms->dispatch($request);
+    }
     $response->send();
     $cms->shutdown();
 }
@@ -198,5 +199,3 @@ $response->send();
  * ----------------------------------------------------------------------------
  */
 return $cms;
-
-

--- a/web/concrete/core/Application/Application.php
+++ b/web/concrete/core/Application/Application.php
@@ -40,10 +40,12 @@ class Application extends Container
      */
     public function shutdown()
     {
-        $this->handleScheduledJobs();
-        $db = Database::get();
-        if ($db->isConnected()) {
-            $db->close();
+        if ($this->isInstalled()) {
+            $this->handleScheduledJobs();
+            $db = Database::get();
+            if ($db->isConnected()) {
+                $db->close();
+            }
         }
         if (defined('ENABLE_OVERRIDE_CACHE') && ENABLE_OVERRIDE_CACHE) {
             Environment::saveCachedEnvironmentObject();
@@ -61,7 +63,7 @@ class Application extends Container
      */
     protected function handleScheduledJobs()
     {
-        if ($this->isInstalled() && ENABLE_JOB_SCHEDULING) {
+        if (ENABLE_JOB_SCHEDULING) {
             $c = Page::getCurrentPage();
             if ($c instanceof Page && !$c->isAdminArea()) {
                 // check for non dashboard page


### PR DESCRIPTION
We had two problems:
1. `Redirect::to('/install')->send();` does not ends the execution, so the lines that follow are executed (so we had errors during the redirect to /install)
2. `Application->shutdown()` called `Database::get()`, which in turns try to open the default connection if it's not already open, so don't call `Database::get()` during the install process (this happened for every install step)
