### PR TITLE
finishing up elemental mobile nav, #364

### DIFF
--- a/web/concrete/blocks/autonav/templates/responsive_header_navigation/view.css
+++ b/web/concrete/blocks/autonav/templates/responsive_header_navigation/view.css
@@ -1,0 +1,3 @@
+.ccm-responsive-overlay  {
+    display: none;
+}

--- a/web/concrete/blocks/autonav/templates/responsive_header_navigation/view.js
+++ b/web/concrete/blocks/autonav/templates/responsive_header_navigation/view.js
@@ -1,8 +1,31 @@
 (function(global, $) {
-
-    alert('hi');
-
-
-
-
+    var originalNav = $('.ccm-responsive-navigation');
+    if(!($('.ccm-responsive-overlay').length)) {
+        $('body').append('<div class="ccm-responsive-overlay"></div>');
+    }
+    var clonedNavigation = originalNav.clone();
+    $(clonedNavigation).removeClass('original');
+    $('.ccm-responsive-overlay').append(clonedNavigation);
+    $('.ccm-responsive-menu-launch').click(function(){
+        $('.ccm-responsive-menu-launch').toggleClass('responsive-button-close');   // slide out mobile nav
+        $('.ccm-responsive-overlay').slideToggle();
+    });
+    $('.ccm-responsive-overlay ul li').children('ul').hide();
+    $('.ccm-responsive-overlay li').each(function(index) {
+        if($(this).children('ul').size() > 0) {
+            $(this).addClass('parent-ul');
+        } else {
+            $(this).addClass('last-li');
+        }
+    });
+    $('.ccm-responsive-overlay .parent-ul a').click(function(event) {
+        if(!($(this).parent('li').hasClass('last-li'))) {
+            $(this).parent('li').siblings().children('ul').hide();
+            if($(this).parent('li').children('ul').is(':visible')) {
+            } else {
+                $(this).next('ul').show();
+                event.preventDefault();
+            }
+        }
+    });
 })(window, $);

--- a/web/concrete/blocks/autonav/templates/responsive_header_navigation/view.php
+++ b/web/concrete/blocks/autonav/templates/responsive_header_navigation/view.php
@@ -1,40 +1,5 @@
 <? defined('C5_EXECUTE') or die("Access Denied."); ?>
 
-<script>
-    $(document).ready(function(){
-        var originalNav = $('.ccm-responsive-navigation');
-        var clonedNavigation = originalNav.clone();
-        $(originalNav).addClass('original');
-        $('.ccm-responsive-menu-overlay').append(clonedNavigation);
-        $('.ccm-responsive-menu-launch').click(function(){
-            $('.ccm-responsive-menu-launch').toggleClass('responsive-button-close');   // slide out mobile nav
-            $('.ccm-responsive-menu-overlay').slideToggle();
-        });
-        $('.ccm-responsive-menu-overlay ul li').children('ul').hide();
-        $('.ccm-responsive-menu-overlay li').each(function(index) {
-            if($(this).children('ul').size() > 0) {
-                $(this).addClass('parent-ul');
-            } else {
-                $(this).addClass('last-li');
-            }
-        });
-        $('.ccm-responsive-menu-overlay .parent-ul a').click(function(event) {
-            if(!($(this).parent('li').hasClass('last-li'))) {
-                $(this).parent('li').siblings().children('ul').hide();
-                if($(this).parent('li').children('ul').is(':visible')) {
-                } else {
-                    $(this).next('ul').show();
-                    event.preventDefault();
-                }
-            }
-        });
-    });
-</script>
-<style>
-    .ccm-responsive-mobile-menu-overlay {
-        display: none;
-    }
-</style>
 <? $navItems = $controller->getNavItems();
 
 /**
@@ -145,7 +110,7 @@ foreach ($navItems as $ni) {
 
 //*** Step 2 of 2: Output menu HTML ***/
 
-echo '<nav class="ccm-responsive-navigation"><ul>'; //opens the top-level menu
+echo '<nav class="ccm-responsive-navigation original"><ul>'; //opens the top-level menu
 
 foreach ($navItems as $ni) {
 
@@ -163,4 +128,3 @@ foreach ($navItems as $ni) {
 
 echo '</ul></nav>'; //closes the top-level menu
 echo '<div class="ccm-responsive-menu-launch"><i></i></div>'; // empty i tag for attaching :after or :before psuedos for things like FontAwesome icons.
-echo '<div class="ccm-responsive-menu-overlay"></div>';

--- a/web/concrete/themes/elemental/css/build/header.less
+++ b/web/concrete/themes/elemental/css/build/header.less
@@ -13,6 +13,27 @@ header {
     font-size: @header-brand-font-size;
   }
 
+  .ccm-search-block-form {
+    position: relative;
+    &:before {
+      content: "\f002";
+      font-family: FontAwesome;
+      font-weight: normal;
+      font-style: normal;
+      display: inline-block;
+      position: absolute;
+      left: 14px;
+      top: 9px;
+      text-decoration: inherit;
+      color: #d2d2d2;
+    }
+    .ccm-search-block-text {
+      border: 1px solid #e6e6e6;
+      border-radius: 30px;
+      padding: 10px 20px 10px 35px;
+    }
+  }
+
   nav {
     .dropdown{
       &:after {
@@ -24,6 +45,7 @@ header {
         }
       }
     }
+
     ul {
       a {
         padding-right: 40px;

--- a/web/concrete/themes/elemental/css/build/mobile/navigation.less
+++ b/web/concrete/themes/elemental/css/build/mobile/navigation.less
@@ -1,38 +1,101 @@
-.ccm-responsive-menu-overlay {
+.ccm-responsive-overlay {
+  background: white;
   display: none;
   position: absolute;
-  border-bottom: 5px solid #1b7bbc;
+  border-bottom: 5px solid @header-brand-color;
   width: 100%;
   z-index: 99;
-  top: 72px;
+  top: 147px;
   left: 0px;
+  padding-top: 15px;
+  padding-left: 20px;
+  -webkit-text-size-adjust: none;
+  ul {
+    padding-left: 0;
+    li {
+      list-style-type: none;
+      &.parent-ul {
+        a {
+          &:after {
+            padding-left: 7px;
+            padding-top: 3px;
+            font-size: 20px;
+            content: "\f107";
+            font-family: FontAwesome;
+            font-weight: normal;
+            font-style: normal;
+            display: inline-block;
+            cursor: pointer;
+            text-decoration: inherit;
+          }
+        }
+      }
+      a {
+        &:hover {
+          color: @header-navigation-hover-color;;
+        }
+        color: @header-navigation-text-color;
+        font-size: 18px;
+        display: inline-block;
+        width: 80%;
+        padding: 7px 5% 7px 0px;
+        margin: 0% 5% 0% 0;
+        padding-left: 15px;
+        height: 100%;
+        font-weight: 200;
+        text-decoration: none;
+      }
+      ul {
+        li {
+          &.last-li {
+            a{
+              padding-top: 0px;
+              font-size: 15px;
+              &:after {
+                content: '';
+              }
+            }
+          }
+          padding-left: 10px;
+        }
+      }
+      display: block;
+    }
+  }
 }
+
 
 .ccm-responsive-menu-launch {
   display: none;
-  width: 25px;
-  height: 25px;
   cursor: pointer;
+  margin-top: 10px;
+  float: right;
+  &.responsive-button-close {
+    i {
+      &:after {
+        font-size: 20px;
+        color: @header-navigation-text-color;
+        content: "\f077";
+        font-family: FontAwesome;
+        font-weight: normal;
+        font-style: normal;
+        display: inline-block;
+        cursor: pointer;
+        text-decoration: inherit;
+      }
+    }
+  }
   i {
     &:after {
-      content: "\f002";
+      font-size: 20px;
+      content: "\f0c9";
       font-family: FontAwesome;
+      color: @header-navigation-text-color;
       font-weight: normal;
       font-style: normal;
       display: inline-block;
       cursor: pointer;
       text-decoration: inherit;
-      &.responsive-button-close {
-        &:after {
-          content: "\f002";
-          font-family: FontAwesome;
-          font-weight: normal;
-          font-style: normal;
-          display: inline-block;
-          cursor: pointer;
-          text-decoration: inherit;
-        }
-      }
     }
   }
 }
@@ -47,4 +110,10 @@
     display: none;
   }
 
+}
+
+@media all and (min-width: @screen-xs-max) {
+  .ccm-responsive-overlay {
+    display: none !important;
+  }
 }

--- a/web/concrete/themes/elemental/css/main.less
+++ b/web/concrete/themes/elemental/css/main.less
@@ -13,7 +13,8 @@
 
 /* Our style rules - namespace so as not to collide with the core app styles */
 .ccm-page {
-  @import "build/mobile/navigation.less";
   @import "build/header.less";
   @import "build/content.less";
 }
+
+@import "build/mobile/navigation.less";

--- a/web/concrete/themes/elemental/elements/header.php
+++ b/web/concrete/themes/elemental/elements/header.php
@@ -34,15 +34,15 @@ $ag->requireAsset('css', 'font-awesome');
     <header>
         <div class="container">
             <div class="row">
-                <div class="col-md-4"><span id="header-brand">Elemental</span></div>
-                <div class="<? if ($displayThirdColumn) { ?>col-md-5<? } else { ?>col-md-8<? } ?>">
+                <div class="col-md-4 col-xs-6"><span id="header-brand">Elemental</span></div>
+                <div class="<? if ($displayThirdColumn) { ?>col-md-5 col-xs-6<? } else { ?>col-md-8 col-xs-6<? } ?>">
                     <?
                     $a = new GlobalArea('Header Navigation');
                     $a->display();
                     ?>
                 </div>
                 <? if ($displayThirdColumn) { ?>
-                    <div class="col-md-3"><? $as->display(); ?></div>
+                    <div class="col-md-3 col-xs-12"><? $as->display(); ?></div>
                 <? } ?>
             </div>
         </div>


### PR DESCRIPTION
This also includes styling for the search bar. Some notes on this one:
1.) Using view.js to append the mobile nav overlay to body tag. Since this is outside .ccm-page wrapper, had to place navigation.less import outside of the .ccm-page namespace. This approach is more theme agnostic (custom template can't really reference a class specific to the elemental theme). Within navigation.less, the mobile menu bars button is within .ccm-page namespacing, though. 

2.) Added some classes (col-sx-6) to the header divs for when they hit extra small town so that they stack side by side. Had to change the tertiary div that usually contains search to a col-sx-12, which makes it wrap under nicely, but it is a little snug against the site title div and the navigation button div. We could address that with a class on the tertiary div to give it some top margin in mobile town, or maybe there's some Bootstrap voodoo about mobile column stack spacing that I'm overlooking? 
![spacin](https://cloud.githubusercontent.com/assets/1302433/3517527/0ce12bb4-06f0-11e4-8839-d9a1a08e80db.jpg)
