### PR TITLE
file manager permissions dashboard page styling and controller fixin #28...

### DIFF
--- a/web/concrete/controllers/single_page/dashboard/system/permissions/files.php
+++ b/web/concrete/controllers/single_page/dashboard/system/permissions/files.php
@@ -6,7 +6,8 @@ use Loader;
 use PermissionKey;
 use TaskPermission;
 use PermissionAccess;
-class Concrete5_Controller_Page_Dashboard_System_Permissions_Files extends DashboardPageController {
+use FileSet;
+class Files extends DashboardPageController {
 	
 	public function save() {
 		if (Loader::helper('validation/token')->validate('save_permissions')) {

--- a/web/concrete/single_pages/dashboard/system/permissions/files.php
+++ b/web/concrete/single_pages/dashboard/system/permissions/files.php
@@ -5,9 +5,7 @@
 	<? $help = ob_get_contents(); ?>
 	<? ob_end_clean(); ?>
 	<? $fs = FileSet::getGlobal(); ?>
-	
-	<?=Loader::helper('concrete/dashboard')->getDashboardPaneHeaderWrapper(t('File Permissions'), $help, 'span10 offset1', false)?>
-	<form method="post" action="<?=$view->action('save')?>" id="ccm-permission-list-form">
+		<form method="post" action="<?=$view->action('save')?>" id="ccm-permission-list-form">
 	
 	<?=Loader::helper('validation/token')->output('save_permissions')?>
 	<div class="ccm-pane-body">
@@ -19,9 +17,10 @@
 		<p><?=t('You cannot access task permissions.')?></p>
 	<? } ?>
 	</div>
-	<div class="ccm-pane-footer">
-		<a href="<?=$view->url('/dashboard/system/permissions/files')?>" class="btn btn-default pull-left"><?=t('Cancel')?></a>
-		<button type="submit" value="<?=t('Save')?>" class="btn btn-primary pull-right"><?=t('Save')?> <i class="icon-ok-sign icon-white"></i></button>
-	</div>
+	<div class="ccm-dashboard-form-actions-wrapper">
+        <div class="ccm-dashboard-form-actions">
+            <a href="<?=$view->url('/dashboard/system/permissions/files')?>" class="btn btn-default pull-left"><?=t('Cancel')?></a>
+            <button type="submit" value="<?=t('Save')?>" class="btn btn-primary pull-right"><?=t('Save')?> <i class="icon-ok-sign icon-white"></i></button>
+        </div>
+    </div>
 	</form>
-	<?=Loader::helper('concrete/dashboard')->getDashboardPaneFooterWrapper(false)?>


### PR DESCRIPTION
...5

Got bootstrap in there on the submit buttons, and updated controller so it was using the correct initial class declaration, so that got the page title appearing. Noticed it was erroring on save, so added the "use FileSet" and fixed it. I think that's correct? I also noticed this was in there:  $fs = FileSet::getGlobal(); Dunno if that's still needed or functioning, if it's notn functioning was why the error was occurring? 
