### PR TITLE
Fix for #52 (Community Points) 

### DIFF
--- a/web/concrete/controllers/single_page/dashboard/users/points/actions.php
+++ b/web/concrete/controllers/single_page/dashboard/users/points/actions.php
@@ -12,19 +12,22 @@ class Actions extends DashboardPageController {
 	public $upa;
 		
 	
-	public function on_start() {
+	public function on_start() 
+	{
 		$this->upa = new UserPointAction();
 	}
 	
 	
-	public function add() {
+	public function add() 
+	{
 		$this->set('add_edit',t('Add'));
 		$this->set('showForm',true);
 		$this->view();
 	}
 	
 	
-	public function view($upaID=NULL) {
+	public function view($upaID=NULL) 
+	{
 		
 		if(isset($upaID)) {
 			$this->set('add_edit',t('Edit'));
@@ -51,7 +54,8 @@ class Actions extends DashboardPageController {
 	}
 	
 	
-	public function getActionList() {
+	public function getActionList() 
+	{
 		$al = new UserPointActionList();
 		
 		switch($_REQUEST['ccm_order_by']) {
@@ -78,7 +82,8 @@ class Actions extends DashboardPageController {
 	}
 	
 	
-	protected function setAttribs($upa) {
+	protected function setAttribs($upa) 
+	{
 		$attribs = $upa->getAttributeNames();
 		foreach($attribs as $key) {
 			$this->set($key, $upa->$key);
@@ -86,7 +91,8 @@ class Actions extends DashboardPageController {
 	}
 	
 	
-	public function save() {
+	public function save() 
+	{
 		if($this->post('upaID') > 0) {
 			$this->upa->load($this->post('upaID'));
 			if (!$this->upa->hasCustomClass()) {
@@ -113,20 +119,23 @@ class Actions extends DashboardPageController {
 	}	
 	
 	
-	public function delete($upaID) {
+	public function delete($upaID) 
+	{
 		$this->upa->load($upaID);
 		$this->upa->delete();
 		$this->redirect('/dashboard/users/points/actions','action_deleted');
 	}
 	
 	
-	public function action_deleted() {
+	public function action_deleted() 
+	{
 		$this->set('message', t('Community Point Action Deleted'));
 		$this->view();
 	} 
 	
 	
-	public function action_saved() {
+	public function action_saved() 
+	{
 		$this->set('message', t('Community Point Action Saved'));
 		$this->view();
 	}

--- a/web/concrete/controllers/single_page/dashboard/users/points/assign.php
+++ b/web/concrete/controllers/single_page/dashboard/users/points/assign.php
@@ -4,8 +4,9 @@ namespace Concrete\Controller\SinglePage\Dashboard\Users\Points;
 use \Concrete\Core\Page\Controller\DashboardPageController;
 use Loader;
 use \Concrete\Core\User\Point\Entry as UserPointEntry;
+use \Concrete\Core\User\Point\Action\Action as UserPointAction;
 use \Concrete\Core\User\Point\Action\ActionList as UserPointActionList;
-use \Concrete\Core\User\Point\Action\Description as UserPointActionDescription;
+use \Concrete\Core\User\Point\Action\ActionDescription as UserPointActionDescription;
 use UserInfo;
 
 class Assign extends DashboardPageController {
@@ -42,7 +43,8 @@ class Assign extends DashboardPageController {
 		}
 	}
 
-	public function save() {
+	public function save() 
+	{
 
 		$user = $this->post('upUser');
 		if(is_numeric($user)) {

--- a/web/concrete/core/User/Point/Action/Action.php
+++ b/web/concrete/core/User/Point/Action/Action.php
@@ -3,6 +3,9 @@ namespace Concrete\Core\User\Point\Action;
 use Loader;
 use Environment;
 use \Concrete\Core\Package\PackageList;
+use Group;
+use UserInfo;
+use \Concrete\Core\User\Point\Entry as UserPointEntry;
 
 class Action {
 	
@@ -12,22 +15,26 @@ class Action {
 	public $upaDefaultPoints;
 	public $gBadgeID;
 	
-	public function load($upaID) {
+	public function load($upaID) 
+	{
 		$db = Loader::db();
 		$row = $db->GetRow('select * from UserPointActions where upaID = ?', array($upaID));
 		$this->setDataFromArray($row);
 	}
 	
-	public function delete() {
+	public function delete() 
+	{
 		$db = Loader::db();
 		$db->delete('UserPointActions', array('upaID' => $this->upaID));
 
 	}
+	
 	/**
 	 * @param $upaID
 	 * @return UserPointAction
 	 */
-	public static function getByID($upaID) {
+	public static function getByID($upaID) 
+	{
 		$db = Loader::db();
 		$row = $db->getRow("SELECT * FROM UserPointActions WHERE upaID = ?",array($upaID));
 		if ($row['upaID']) {
@@ -40,7 +47,7 @@ class Action {
 				
 				$class = Loader::helper('text')->camelcase($row['upaHandle']) . $class;
 			}
-			$upa = new $class();
+			$upa = new Action;
 			$upa->setDataFromArray($row);
 			return $upa;
 		}
@@ -51,7 +58,8 @@ class Action {
 	 * @param Package $pkg
 	 * @return array
  	 */
-	public static function getListByPackage($pkg) {
+	public static function getListByPackage($pkg) 
+	{
 		$db = Loader::db();
 		$upaIDs = $db->GetCol('select upaID from UserPointActions where pkgID = ? order by upaName asc', array($pkg->getPackageID()));
 		$actions = array();
@@ -68,7 +76,8 @@ class Action {
 	 * @param $upaHandle
 	 * @return UserPointAction
 	*/
-	public static function getByHandle($upaHandle) {
+	public static function getByHandle($upaHandle) 
+	{
 		$db = Loader::db();
 		$row = $db->getRow("SELECT * FROM UserPointActions WHERE upaHandle = ?",array($upaHandle));
 		if ($row['upaID']) {
@@ -81,13 +90,14 @@ class Action {
 				
 				$class = Loader::helper('text')->camelcase($row['upaHandle']) . $class;
 			}
-			$upa = new $class();
+			$upa = new Action;
 			$upa->setDataFromArray($row);
 			return $upa;
 		}
 	}
 
-	public static function add($upaHandle, $upaName, $upaDefaultPoints, $group, $upaIsActive = true, $pkg = false) {
+	public static function add($upaHandle, $upaName, $upaDefaultPoints, $group, $upaIsActive = true, $pkg = false) 
+	{
 		$upa = new static();
 		$upa->upaHandle = $upaHandle;
 		$upa->upaName = $upaName;
@@ -115,14 +125,15 @@ class Action {
 			$upa->upaHasCustomClass = 1;
 		}
 
-		//$upa->save();
+		$upa->save();
 	}
 
 	/**
 	 * @param array $data
 	 * @return boolean
 	 */
-	protected function setDataFromArray($data) {
+	protected function setDataFromArray($data) 
+	{
 		if(is_array($data) && count($data)) {
 			$this->upaID = $data['upaID'];
 			$this->upaHandle = $data['upaHandle'];
@@ -136,73 +147,89 @@ class Action {
 		}
 	}
 	
+	public function getAttributeNames()
+	{
+    	return array('upaID', 'upaHandle', 'upaName', 'upaDefaultPoints', 'gBadgeID', 'upaIsActive');
+	}
+	
 	/** 
 	 * @return boolean
 	 */
-	public function hasCustomClass() {
+	public function hasCustomClass() 
+	{
 		return $this->upaHasCustomClass;
 	}
 
-	public function getPackageHandle() {
+	public function getPackageHandle() 
+	{
 		return PackageList::getHandle($this->pkgID);
 	}
 
-	public function getPackageID() {
+	public function getPackageID() 
+	{
 		return $this->pkgID;
 	}
 
 	/**
 	 * @return string
 	*/
-	public function getUserPointActionHandle() {
+	public function getUserPointActionHandle() 
+	{
 		return $this->upaHandle;
 	}
 	
 	/**
 	 * @return string
 	*/
-	public function getUserPointActionName() {
+	public function getUserPointActionName() 
+	{
 		return $this->upaName;
 	}
 	
 	/**
 	 * @return int
 	 */
-	public function getUserPointActionID() {
+	public function getUserPointActionID() 
+	{
 		return $this->upaID;
 	}
 	
 	/**
 	 * @return int
 	 */
-	public function getUserPointActionDefaultPoints() {
+	public function getUserPointActionDefaultPoints() 
+	{
 		return $this->upaDefaultPoints;
 	}
 	
 	/**
 	 * @return int
 	 */
-	public function getUserPointActionBadgeGroupID() {
+	public function getUserPointActionBadgeGroupID() 
+	{
 		return $this->gBadgeID;
 	}
 
-	public function isUserPointActionActive() {
+	public function isUserPointActionActive() 
+	{
 		return $this->upaIsActive;
 	}
 
 	/**
 	 * @return Group
 	*/
-	public function getUserPointActionBadgeGroupObject() {
+	public function getUserPointActionBadgeGroupObject() 
+	{
 		return Group::getByID($this->getUserPointActionBadgeGroupID());
 	}
 	
-	public function addDetailedEntry($user, UserPointActionDescription $descr, $points = false, $date = null) {
+	public function addDetailedEntry($user, ActionDescription $descr, $points = false, $date = null) 
+	{
 		$this->addEntry($user, $descr, $points, $date);
 	}
 
-	public function addEntry($user, UserPointActionDescription $descr, $points = false, $date = null) {
-
+	public function addEntry($user, ActionDescription $descr, $points = false, $date = null) 
+	{
 		if (!$this->isUserPointActionActive()) {
 			return false;
 		}
@@ -252,16 +279,29 @@ class Action {
 		return true;
 	}
 
-	public function save() {
+	public function save() 
+	{
 		$db = Loader::db();
-		$db->update('UserPointActions', array(
-			'upaHandle' => $this->upaHandle,
-			'upaName' => $this->upaName,
-			'upaDefaultPoints' => $this->upaDefaultPoints,
-			'upaHasCustomClass' => $this->upaHasCustomClass,
-			'upaIsActive' => $this->upaIsActive,
-			'gBadgeID' => $this->gBadgeID
-		), array("upaID" => $this->upaID));
-	}
+		if($this->upaID) {
+    		$db->update('UserPointActions', array(
+    			'upaHandle' => $this->upaHandle,
+    			'upaName' => $this->upaName,
+    			'upaDefaultPoints' => $this->upaDefaultPoints,
+    			'upaHasCustomClass' => $this->upaHasCustomClass,
+    			'upaIsActive' => $this->upaIsActive,
+    			'gBadgeID' => $this->gBadgeID
+    		), array("upaID" => $this->upaID));
+		} else {
+    		$res = $db->insert('UserPointActions', array(
+    		    'upaHandle' => $this->upaHandle,
+    			'upaName' => $this->upaName,
+    			'upaDefaultPoints' => $this->upaDefaultPoints,
+    			'upaHasCustomClass' => $this->upaHasCustomClass,
+    			'upaIsActive' => $this->upaIsActive,
+    			'gBadgeID' => $this->gBadgeID
+    		));
+    		
+		}
 		
+	}		
 }

--- a/web/concrete/core/User/Point/Action/ActionDescription.php
+++ b/web/concrete/core/User/Point/Action/ActionDescription.php
@@ -2,15 +2,18 @@
 namespace Concrete\Core\User\Point\Action;
 class ActionDescription {
 
-	public function setComments($comments) {
+	public function setComments($comments) 
+	{
 		$this->comments = $comments;
 	}
 
-	public function getComments() {
+	public function getComments() 
+	{
 		return $this->comments;
 	}
 
-	public function getUserPointActionDescription() {
+	public function getUserPointActionDescription() 
+	{
 		return $this->getComments();
 	}
 

--- a/web/concrete/core/User/Point/Entry.php
+++ b/web/concrete/core/User/Point/Entry.php
@@ -1,6 +1,8 @@
 <?
 namespace Concrete\Core\User\Point;
 use Loader;
+use \Concrete\Core\User\UserInfo;
+use \Concrete\Core\User\Point\Action\Action as UserPointAction;
 class Entry {
 
 	public $upID;

--- a/web/concrete/core/User/Point/EntryList.php
+++ b/web/concrete/core/User/Point/EntryList.php
@@ -2,15 +2,20 @@
 namespace Concrete\Core\User\Point;
 use \Concrete\Core\Legacy\DatabaseItemList;
 use Loader;
+use \Concrete\Core\User\Point\Entry as UserPointEntry;
+use \Concrete\Core\User\UserInfo as UserInfo;
+
 class EntryList extends DatabaseItemList {
 
 	protected $autoSortColumns = array('uName', 'upaName', 'upPoints', 'timestamp');
 
-	public function __construct() {
+	public function __construct() 
+	{
 		$this->setBaseQuery();
 	}
 	
-	protected function setBaseQuery() {
+	protected function setBaseQuery() 
+	{
 		$this->setQuery('SELECT UserPointHistory.upID
 			FROM UserPointHistory
 			LEFT JOIN UserPointActions ON UserPointActions.upaID = UserPointHistory.upaID
@@ -24,7 +29,8 @@ class EntryList extends DatabaseItemList {
 	 * @param int $gID
 	 * @return void
 	 */
-	public function filterByGroupID($gID) {
+	public function filterByGroupID($gID) 
+	{
 		$this->filter('UserPointActions.gBadgeID',$gID);	
 	}
 	
@@ -32,12 +38,14 @@ class EntryList extends DatabaseItemList {
 	 * @param string $uName
 	 * @return void
 	 */
-	public function filterByUserName($uName) {
+	public function filterByUserName($uName) 
+	{
 		$this->filter('Users.uName',$uName);	
 	}
 
 	
-	public function filterByUserPointActionName($upaName) {
+	public function filterByUserPointActionName($upaName) 
+	{
 		$db = Loader::db();
 		$this->filter(false,"UserPointActions.upaName LIKE ".$db->quote('%'.$upaName.'%'));
 	}
@@ -46,11 +54,13 @@ class EntryList extends DatabaseItemList {
 	 * @param int $uID
 	 * @return void
 	 */
-	public function filterByUserID($uID) {
+	public function filterByUserID($uID) 
+	{
 		$this->filter('UserPointHistory.upuID',$upaTypeID);
 	}
 
-	public function get($items = 0, $offset = 0) {
+	public function get($items = 0, $offset = 0) 
+	{
 		$resp = parent::get($items, $offset);
 		$entries = array();
 		foreach($resp as $r) {

--- a/web/concrete/single_pages/dashboard/users/points/actions.php
+++ b/web/concrete/single_pages/dashboard/users/points/actions.php
@@ -1,73 +1,79 @@
-<?=Loader::helper('concrete/dashboard')->getDashboardPaneHeaderWrapper('Community Point Actions', false, false, false, array(), Page::getByPath('/dashboard/users/points', 'ACTIVE'))?>
+<? defined('C5_EXECUTE') or die("Access Denied.");
 
-<?php if($showForm) { ?>
-<form method="post" action="<?=$view->action('save')?>" id="ccm-community-points-action" class="form-horizontal">
-<div class="ccm-pane-body">
-	<?php 
-		echo $form->hidden('upaID',$upaID);
-	?>
-
-	<div class="control-group">
-		<label class="control-label"><?php echo t('Enabled');?></label>
-		<div class="controls">
-		<label class="checkbox">
-			<?=$form->checkbox('upaIsActive', 1, ($upaIsActive == 1 || (!$upaID)))?>
-		</label>
-		</div>
-	</div>
-	
-	<div class="control-group">
-		<label class="control-label"><?php echo t('Action Handle');?></label>
-		<div class="controls">
-		<? $args = array();
-		if ($upaHasCustomClass) { 
-			$args['disabled'] = 'disabled';
-		}
-		?>
-		<?php echo $form->text('upaHandle',$upaHandle, $args);?>
-		</div>
-	</div>
-	
-	<div class="control-group">
-		<label class="control-label"><?php echo t('Action Name');?></label>
-		<div class="controls">
-		<?php echo $form->text('upaName',$upaName);?>
-		</div>
-	</div>
-	
-	<div class="control-group">
-		<label class="control-label"><?php echo t('Default Points');?></label>
-		<div class="controls">
-		<?php echo $form->text('upaDefaultPoints',$upaDefaultPoints);?>
-		</div>
-	</div>
-	
-	<div class="control-group">
-		<!--  upaBadgeGroupID -->
-		<label class="control-label"><?php echo t('Badge Associated')?></label>
-		<div class="controls">
-			<?=$form->select('gBadgeID', $badges, $gBadgeID)?>
-			<i class="icon-question-sign launch-tooltip" title="<?=t('If a badge is assigned to this action, the first time this user performs this action they will be granted the badge.')?>"></i>
-		</div>
-	</div>
-</div>
-<? $label = t('Add');
-if ($upaID > 0) {
-	$label = t('Update');
-}
+    //$interface = Loader::helper('interface');
 ?>
 
-<div class="ccm-pane-footer">
-	<a href="<?=$view->url('/dashboard/users/points/actions')?>" class="btn btn-default pull-left"><?=t('Back to List')?></a>
-	<button type="submit" class="btn btn-primary pull-right"><?=$label?> <i class="icon-white icon-ok"></i></button>
-</div>
+<?php if($showForm) { ?>
+<form method="post" action="<?=$view->action('save')?>" id="ccm-community-points-action">
+    <div class="row">
+        <div class="col-md-12">
+    
+            <?php 
+        		echo $form->hidden('upaID',$upaID);
+        	?>               
+        	
+        	<div class="checkbox">
+                <label>
+                    <?=$form->checkbox('upaIsActive', 1, ($upaIsActive == 1 || (!$upaID)))?> <?=t('Enabled')?>
+                </label>
+            </div>
+	
+        	<div class="form-group">
+        	    <?=$form->label('upaHandle', t('Action Handle'));?>
+        		<div class="input">
+            		<? 
+                		$args = array();
+                		if ($upaHasCustomClass) { 
+                			$args['disabled'] = 'disabled';
+                		}
+            		?>
+                    <?php echo $form->text('upaHandle',$upaHandle, $args);?>
+        		</div>
+        	</div>
+	
+        	<div class="form-group">
+        	    <?=$form->label('upaName', t('Action Name'));?>
+        		<div class="input">
+        		    <?php echo $form->text('upaName',$upaName);?>
+        		</div>
+        	</div>
+	
+        	<div class="form-group">
+                <?=$form->label('upaDefaultPoints', t('Default Points'));?>
+        		<div class="input">
+        		    <?php echo $form->text('upaDefaultPoints',$upaDefaultPoints);?>
+        		</div>
+        	</div>
+	
+        	<div class="form-group">
+        	    <?=$form->label('gBadgeID', t('Badge Associated'));?>
+        		<div class="input">
+        			<?=$form->select('gBadgeID', $badges, $gBadgeID)?>
+        			<i class="icon-question-sign launch-tooltip" title="<?=t('If a badge is assigned to this action, the first time this user performs this action they will be granted the badge.')?>"></i>
+        		</div>
+        	</div>
+
+            <? 
+            $label = t('Add');
+            if ($upaID > 0) {
+            	$label = t('Update');
+            }
+            ?>
+    
+            <div class="ccm-dashboard-form-actions-wrapper">
+                <div class="ccm-dashboard-form-actions">
+                    <a href="<?=$view->url('/dashboard/users/points/actions')?>" class="btn btn-default pull-left"><?=t('Back to List')?></a>
+                    <button class="btn btn-primary pull-right" type="submit"><?=t($label . ' Action')?></button>
+                </div>
+            </div>
+        </div>
+    </div>
 </form>		
-<?php } else { ?>
-	<div class="ccm-pane-options ccm-pane-options-permanent-search">
-		<a href="<?=$view->action('add')?>" class="btn btn-primary"><?=t('Add Action')?></a>
+<?php } else { ?>	
+	<div class="ccm-dashboard-header-buttons">
+	    <a href="<?=$view->action('add')?>" class="btn btn-primary"><?=t('Add Action')?></a>
 	</div>
 	
-	<div class="ccm-pane-body">
 	<?
 		if (!$mode) {
 			$mode = $_REQUEST['mode'];
@@ -76,42 +82,35 @@ if ($upaID > 0) {
 		$keywords = $_REQUEST['keywords'];
 		
 		if (count($actions) > 0) { ?>	
-			<table border="0" cellspacing="0" cellpadding="0" class="ccm-results-list table">
-			<tr>
-				<th><?=t("Active")?></th>
-				<th class="<?=$actionList->getSearchResultsClass('upaName')?>"><a href="<?=$actionList->getSortByURL('upaName', 'asc')?>"><?=t('Action Name')?></a></th>
-				<th class="<?=$actionList->getSearchResultsClass('upaHandle')?>"><a href="<?=$actionList->getSortByURL('upaHandle', 'asc')?>"><?=t('Action Handle')?></a></th>
-				<th class="<?=$actionList->getSearchResultsClass('upaDefaultPoints')?>"><a href="<?=$actionList->getSortByURL('upaDefaultPoints', 'asc')?>"><?=t('Default Points')?></a></th>
-				<th class="<?=$actionList->getSearchResultsClass('upaBadgeGroupID')?>"><a href="<?=$actionList->getSortByURL('upaBadgeGroupID', 'asc')?>"><?=t('Group')?></a></th>
-				<th></th>
-			</tr>
-		<?php 
-		foreach($actions as $upa) { 
-			if (!isset($striped) || $striped == 'ccm-list-record-alt') {
-				$striped = '';
-			} else if ($striped == '') { 
-				$striped = 'ccm-list-record-alt';
-			} ?>
-			<tr class="">
-				<td style="text-align: center"><? if ($upa['upaIsActive']) { ?><i class="icon-ok"></i><? } ?></td>
-				<td><?= $upa['upaName']?></td>
-				<td><?= $upa['upaHandle']?></td>
-				<td><?= number_format($upa['upaDefaultPoints'])?></td>
-				<td><?php echo $upa['gName'];?></td>
-				<td style="text-align: right">
-					<?php echo $concrete_interface->button(t('Edit'),$view->action($upa['upaID']), '', 'btn btn-small')?>
-
-					<?php echo $concrete_interface->button(t('Delete'),$view->action('delete',$upa['upaID']),
-						'', 'btn btn-small', array(),"return confirm('<?=t('Are you sure?')?>')"); ?>	
-
-				</td>
-			</tr>
-		<?php } ?>
+			<table border="0" cellspacing="0" cellpadding="0" class="table table-striped">
+    			<tr>
+    				<th><?=t("Active")?></th>
+    				<th class="<?=$actionList->getSearchResultsClass('upaName')?>"><a href="<?=$actionList->getSortByURL('upaName', 'asc')?>"><?=t('Action Name')?></a></th>
+    				<th class="<?=$actionList->getSearchResultsClass('upaHandle')?>"><a href="<?=$actionList->getSortByURL('upaHandle', 'asc')?>"><?=t('Action Handle')?></a></th>
+    				<th class="<?=$actionList->getSearchResultsClass('upaDefaultPoints')?>"><a href="<?=$actionList->getSortByURL('upaDefaultPoints', 'asc')?>"><?=t('Default Points')?></a></th>
+    				<th class="<?=$actionList->getSearchResultsClass('upaBadgeGroupID')?>"><a href="<?=$actionList->getSortByURL('upaBadgeGroupID', 'asc')?>"><?=t('Group')?></a></th>
+    				<th></th>
+    			</tr>
+    			
+        		<?php 
+        		foreach($actions as $upa) { 
+                ?>
+        		<tr class="">
+        			<td style="text-align: center"><? if ($upa['upaIsActive']) { ?><i class="fa fa-check"></i><? } ?></td>
+        			<td><?=$upa['upaName']?></td>
+        			<td><?=$upa['upaHandle']?></td>
+        			<td><?=number_format($upa['upaDefaultPoints'])?></td>
+        			<td><?php echo $upa['gName'];?></td>
+        			<td style="text-align: right">
+        			    <a href="<?=$view->action($upa['upaID'])?>" class="btn btn-sm btn-default"><?=t('Edit')?></a>
+        			    <a href="<?=$view->action('delete',$upa['upaID'])?>" class="btn btn-sm btn-danger"><?=t('Delete')?></a>
+        			</td>
+        		</tr>
+        		<?php } ?>
 		</table>
 		<? } else { ?>
-			<div id="ccm-list-none"><?=t('No Actions found.')?></div>
+			<p><?=t('No Actions found.')?></p>
 		<? } ?>
-	</div>
 	
 <div class="ccm-pane-footer">
 <?=$actionList->displayPagingV2(); ?>

--- a/web/concrete/single_pages/dashboard/users/points/assign.php
+++ b/web/concrete/single_pages/dashboard/users/points/assign.php
@@ -1,50 +1,51 @@
 <?=Loader::helper('concrete/dashboard')->getDashboardPaneHeaderWrapper(t('Assign Community Points'), false, false, false, array(), Page::getByPath('/dashboard/users/points', 'ACTIVE'))?>
-<form method="post" action="<?=$view->action('save')?>" id="ccm-community-point-entry" class="form-horizontal">
-<div class="ccm-pane-body">
+<form method="post" action="<?=$view->action('save')?>" id="ccm-community-point-entry">
 	<?php if(isset($upID) && $upID > 0) {
 		echo $form->hidden('upID',$upID);
 	}?>
-	<div class="control-group">
-		<label class="control-label"><?php echo t('User');?></label>
-		<div class="controls">
+	<div class="form-group">
+	    <?=$form->label('upUser', t('User'))?>
+		<div class="input">
 			<?php echo $form_user_selector->quickSelect('upUser',$upUser);?>
 		</div>
 	</div>
 	
-	<div class="control-group">
-		<label class="control-label"><?php echo t('Action');?></label>
-		<div class="controls">
+	<div class="form-group">
+	    <?=$form->label('upaID', t('Action'))?>
+		<div class="input">
 			<?php echo $form->select('upaID',$userPointActions,$upaID,array('json-src'=>$view->action('getJsonDefaultPointAction'))); ?>
 		</div>
 	</div>
 	
-	<div class="control-group">
-		<label class="control-label"><?php echo t('Points');?></label>
-		<div class="controls">
+	<div class="form-group">
+	    <?=$form->label('upPoints', t('Points'))?>
+		<div class="input">
 			<?php echo $form->text('upPoints',$upPoints);?>
 		</div>
 	</div>
 	
-	<div class="control-group">
-		<label class="control-label"><?php echo t('Comments');?></label>
-		<div class="controls">
+	<div class="form-group">
+	    <?=$form->label('upComments', t('Comments'))?>
+		<div class="input">
 			<?php echo $form->textarea('upComments',$upComments);?>
 		</div>
 	</div>
 	
-	<div class="control-group">
-		<label class="control-label"><?php echo t('Override Timestamp');?></label>
-		<div class="controls">
-		<div class="checkbox">
-			<?php echo $form_date_time->datetime('dtoverride',$timestamp, true);?>
-		</div>
+	<div class="form-group">
+	    <?=$form->label('dtoverride', t('Override Timestamp'))?>
+		<div class="input">
+		    <div class="checkbox">
+			    <?php echo $form_date_time->datetime('dtoverride',$timestamp, true);?>
+            </div>
 		</div>
 	</div>
-</div>
-<div class="ccm-pane-footer">
-	<a href="<?=$view->url('/dashboard/users/points')?>" class="btn btn-default pull-left"><?=t('Back to List')?></a>
-	<button type="submit" class="btn btn-primary pull-right"><?=t('Assign')?> <i class="icon-white icon-ok"></i></button>
-</div>
+
+    <div class="ccm-dashboard-form-actions-wrapper">
+        <div class="ccm-dashboard-form-actions">
+            <a href="<?=$view->url('/dashboard/users/points')?>" class="btn btn-default pull-left"><?=t('Back to List')?></a>
+            <button type="submit" class="btn btn-primary pull-right"><?=t('Assign')?> <i class="icon-white icon-ok"></i></button>
+        </div>
+    </div>
 </form>
 
 <script type="text/javascript">
@@ -59,6 +60,4 @@ $(function() {
 
 	
 });
-
-</script>		
-<?=Loader::helper('concrete/dashboard')->getDashboardPaneFooterWrapper()?>
+</script>

--- a/web/concrete/single_pages/dashboard/users/points/view.php
+++ b/web/concrete/single_pages/dashboard/users/points/view.php
@@ -1,66 +1,56 @@
-<?php
-print
-Loader::helper('concrete/dashboard')->getDashboardPaneHeaderWrapper(t('Community Points'), false, false, false, array(
-	Page::getByPath('/dashboard/users/points/actions'),
-	Page::getByPath('/dashboard/users/points/assign')
-
-))?>
+<?php defined('C5_EXECUTE') or die("Access Denied."); ?>
 <form class="form-inline" action="<?php echo $view->action('view')?>" method="get">
-<div class="ccm-pane-options">
-<div class="ccm-pane-options-permanent-search">
-
-<label class="control-label"><?=t('User')?></label>
-<?php echo $form_user_selector->quickSelect('uName',$_GET['uName']);?>
-
+    <div class="ccm-dashboard-header-buttons">
+	    <a href="<?=View::url('/dashboard/users/points/assign')?>" class="btn btn-primary"><?=t('Add Points')?></a>
+	</div>
 	
-<input type="submit" value="<?=t('Search')?>" class="btn" />
-<a href="<?=View::url('/dashboard/users/points/assign')?>" class="btn btn-primary"><?=t('Add')?></a>
+    <div class="ccm-pane-options">
+        <div class="ccm-pane-options-permanent-search">
+            <?=$form->label('uName', t('User'))?>
+            <?php echo $form_user_selector->quickSelect('uName',$_GET['uName'],array('form-control'));?>
+            <input type="submit" value="<?=t('Search')?>" class="btn" />
 
-</div>
-</div>
 
+        </div>
+    </div>
 </form>
-<div class="ccm-pane-body ccm-pane-body-footer">
+<br />
+<?
+if (!$mode) {
+	$mode = $_REQUEST['mode'];
+}
+$txt = Loader::helper('text');
+$keywords = $_REQUEST['keywords'];
 
-	<?
-		if (!$mode) {
-			$mode = $_REQUEST['mode'];
-		}
-		$txt = Loader::helper('text');
-		$keywords = $_REQUEST['keywords'];
-		
-		if (count($entries) > 0) { ?>	
-			<table border="0" cellspacing="0" cellpadding="0" id="ccm-product-list" class="table table-condensed ccm-results-list">
-			<tr>
-				<th class="<?=$upEntryList->getSearchResultsClass('uName')?>"><a href="<?=$upEntryList->getSortByURL('uName', 'asc')?>"><?=t('User')?></a></th>
-				<th class="<?=$upEntryList->getSearchResultsClass('upaName')?>"><a href="<?=$upEntryList->getSortByURL('upaName', 'asc')?>"><?=t('Action')?></a></th>
-				<th class="<?=$upEntryList->getSearchResultsClass('upPoints')?>"><a href="<?=$upEntryList->getSortByURL('upPoints', 'asc')?>"><?=t('Points')?></a></th>
-				<th class="<?=$upEntryList->getSearchResultsClass('timestamp')?>"><a href="<?=$upEntryList->getSortByURL('timestamp', 'asc')?>"><?=t('Date Assigned')?></a></th>
-				<th><?=t("Details")?></th>
-				<th></th>
-			</tr>
-		<?php 
-		foreach($entries as $up) { ?>
-			<tr class="ccm-list-record <?=$striped?>">
-				<?
-				$ui = $up->getUserPointEntryUserObject();
-				$action = $up->getUserPointEntryActionObject();
-				?>
-				<td><? if (is_object($ui)) { ?><?php echo $ui->getUserName()?><? } ?></td>
-				<td><? if (is_object($action)) { ?><?=$action->getUserPointActionName()?><? } ?></td>
-				<td><?php echo number_format($up->getUserPointEntryValue())?></td>
-				<td><?php echo date(DATE_APP_GENERIC_MDYT, strtotime($up->getUserPointEntryTimestamp()));?></td>
-				<td><?=$up->getUserPointEntryDescription()?></td>
-				<td style="Text-align: right">
-					<?php echo $concrete_interface->button(t('Delete'),View::url('/dashboard/users/points/','deleteEntry',$up->getUserPointEntryID()),
-						'', 'btn btn-small', array(),"return confirm('<?=t('Are you sure?')?>')"); ?>
-				</td>
-			</tr>
-		<?php } ?>
-		</table>
-		<? } else { ?>
-			<div id="ccm-list-none"><?=t('No Entries found.')?></div>
-		<? } 
-		$upEntryList->displayPaging(); ?>
-</div>
-<? print Loader::helper('concrete/dashboard')->getDashboardPaneFooterWrapper(false)?>
+if (count($entries) > 0) { ?>	
+	<table border="0" cellspacing="0" cellpadding="0" id="ccm-product-list" class="table table-striped">
+	<tr>
+		<th class="<?=$upEntryList->getSearchResultsClass('uName')?>"><a href="<?=$upEntryList->getSortByURL('uName', 'asc')?>"><?=t('User')?></a></th>
+		<th class="<?=$upEntryList->getSearchResultsClass('upaName')?>"><a href="<?=$upEntryList->getSortByURL('upaName', 'asc')?>"><?=t('Action')?></a></th>
+		<th class="<?=$upEntryList->getSearchResultsClass('upPoints')?>"><a href="<?=$upEntryList->getSortByURL('upPoints', 'asc')?>"><?=t('Points')?></a></th>
+		<th class="<?=$upEntryList->getSearchResultsClass('timestamp')?>"><a href="<?=$upEntryList->getSortByURL('timestamp', 'asc')?>"><?=t('Date Assigned')?></a></th>
+		<th><?=t("Details")?></th>
+		<th></th>
+	</tr>
+    <?php 
+    foreach($entries as $up) { ?>
+    	<tr>
+    		<?
+        		$ui = $up->getUserPointEntryUserObject();
+        		$action = $up->getUserPointEntryActionObject();
+    		?>
+    		<td><? if (is_object($ui)) { ?><?php echo $ui->getUserName()?><? } ?></td>
+    		<td><? if (is_object($action)) { ?><?=$action->getUserPointActionName()?><? } ?></td>
+    		<td><?php echo number_format($up->getUserPointEntryValue())?></td>
+    		<td><?php echo date(DATE_APP_GENERIC_MDYT, strtotime($up->getUserPointEntryTimestamp()));?></td>
+    		<td><?=$up->getUserPointEntryDescription()?></td>
+    		<td style="Text-align: right">
+    		    <a href="<?=$view->action('deleteEntry', $up->getUserPointEntryID())?>" class="btn btn-sm btn-danger"><?=t('Delete')?></a>
+    		</td>
+    	</tr>
+    <?php } ?>
+</table>
+<? } else { ?>
+	<div id="ccm-list-none"><?=t('No entries found.')?></div>
+<? } 
+$upEntryList->displayPaging(); ?>


### PR DESCRIPTION
Damn, I was hoping all this would close more than one issue for us. Nevertheless....

Spent a few hours this afternoon fixing everything to do with Community Points.  Both functionality and 5.7 Styling, hense the large pull.

Current issues:

The user instant search on Viewing points (/users/points) and Adding points /users/points/assign doesnt work. This is due to errors in tools/required/users/autocomplete?key=uName&token=1404921021:25e2966daa7709725de7c2d5cd752dec&term=test

I did take a look but it was beyond me .. :(
Comments you enter never actually get saved anywhere. The table in the database doesn't event exist. I don't know the workflow for updating the Database, so I didn't. The code for this is \Concrete\Core\User\Point\Action\ActionDescription. 

How's it look?

Previews with nothing in the system:

Community Points    http://puu.sh/a3Kuw/09e7ec7970.png
Actions             http://puu.sh/a3Kw5/ab92e999ba.png
Adding an Actions   http://puu.sh/a3KxS/33b948e8f7.png
Viewing Actions     http://puu.sh/a3KAa/25e4076e9f.png
Assigning Points    http://puu.sh/a3KEF/f63b055560.png
Community Points 2  http://puu.sh/a3KH7/9641bd0622.png
