### PR TITLE
Fix reports logs

### DIFF
--- a/web/concrete/single_pages/dashboard/reports/logs.php
+++ b/web/concrete/single_pages/dashboard/reports/logs.php
@@ -76,12 +76,18 @@ $th = Loader::helper('text');
                     <td valign="top" style="text-align: center"><?=$ent->getLevelIcon()?></td>
                     <td valign="top" style="white-space: nowrap"><?=$ent->getChannelDisplayName()?></td>
                     <td valign="top"><strong><?php
-                    if($ent->getUserID() == NULL){
+                    $uID = $ent->getUserID();
+                    if(empty($uID)) {
                         echo t("Guest");
                     }
-                    else{
-                        $u = User::getByUserID($ent->getUserID());
-                        echo $u->getUserName();
+                    else {
+                        $u = User::getByUserID($uID);
+                        if(is_object($u)) {
+                            echo $u->getUserName();
+                        }
+                        else {
+                            echo tc('Deleted user', 'Deleted (id: %s)', $uID);
+                        }
                     }
                     ?></strong></td>
                     <td style="width: 100%"><?=$th->makenice($ent->getMessage())?></td>


### PR DESCRIPTION
- If a user is deleted, we call `getUserName` method on a NULL: let's avoid it :wink:
- `$ent->getUserID` may return `'0'`: [comparing it with NULL returns false](http://mlocati.github.io/php-comparisions/), and the previous code considers `'0'` as a valid user id: let's avoid this by using `empty()` instead of `== NULL`
