### PR TITLE
fixes getJSONObject call on file deletion

### DIFF
--- a/web/concrete/core/File/File.php
+++ b/web/concrete/core/File/File.php
@@ -97,9 +97,9 @@ class File implements \Concrete\Core\Permission\ObjectInterface
     public function __call($nm, $a)
     {
         $fv = $this->getApprovedVersion();
-		if(is_null($fv)) {
-			return null;
-		}
+        if(is_null($fv)) {
+            return null;
+        }
 		return call_user_func_array(array($fv, $nm), $a);
     }
 


### PR DESCRIPTION
So it seems like most of the other scenarios were cleared up at some point between last night and today via other fixes, however i'm still getting a "getJSONObject function not found" error when deleting files. Upon further investigation I found that the version is actually gone by the time the function gets called. Checking if we have any active versions on the file and returning null if not seems to fix the issue and so far I haven't found that it has broken anything else. 
