### PR TITLE
Unlikely infinite recusion fix in authenticiation

### DIFF
--- a/web/concrete/authentication/concrete/controller.php
+++ b/web/concrete/authentication/concrete/controller.php
@@ -65,7 +65,7 @@ class Controller extends AuthenticationTypeController
                array($token, $u->getUserID(), $validThrough));
         } catch (\Exception $e) {
             // HOLY CRAP.. SERIOUSLY?
-            $this->buildHash($u, $test++);
+            $this->buildHash($u, ++$test);
         }
         return $token;
     }


### PR DESCRIPTION
Fixed very very very unlikely infinite recursion loop in token generation. $test++ would mean test gets incremented afterwards, so it just keeps passing 1 back into the recursive function. ++$test increments, then passes it in.
