### PR TITLE
fix akID doesn't exist in BlockTypeSetBlockTypes table

### DIFF
--- a/web/concrete/core/Block/BlockType/Set.php
+++ b/web/concrete/core/Block/BlockType/Set.php
@@ -177,7 +177,7 @@ class Set extends Object {
 	
 	public function contains($bt) {
 		$db = Loader::db();
-		$r = $db->GetOne('select count(akID) from BlockTypeSetBlockTypes where btsID = ? and btID = ?', array($this->getBlockTypeSetID(), $bt->getBlockTypeID()));
+		$r = $db->GetOne('select count(*) from BlockTypeSetBlockTypes where btsID = ? and btID = ?', array($this->getBlockTypeSetID(), $bt->getBlockTypeID()));
 		return $r > 0;
 	}	
 	


### PR DESCRIPTION
akID doesn't exist in this table, just switched it out for *, not sure what the intended behavior was or if this function is even used anymore
