### PR TITLE
Fixed "ccm-area-footer-handle losing it's clickable capability #77"

### DIFF
--- a/web/concrete/js/build/core/app/edit-mode.js
+++ b/web/concrete/js/build/core/app/edit-mode.js
@@ -137,6 +137,7 @@
             Concrete.event.bind('EditModeExitInline', function () {
                 $('#a' + area.getId() + '-bt' + btID).remove();
                 my.destroyInlineEditModeToolbars();
+                ConcreteEvent.fire('EditModeExitInlineComplete');
             });
             $.ajax({
                 type: 'GET',


### PR DESCRIPTION
The "EditModeExitInlineComplete" event (referenced on line 89 of layouts.js) was not being fired.
(However, just discovered a related bug: "Bug when trying to add layout twice #453" :(
