### PR TITLE
When you save a content block, we run "this.destroy()" to remove the redactor instance

### DIFF
--- a/web/concrete/js/build/core/redactor/plugin.js
+++ b/web/concrete/js/build/core/redactor/plugin.js
@@ -21,7 +21,6 @@ RedactorPlugins.concrete5inline = {
             toolbar.hide();
             ConcreteEvent.fire('EditModeExitInlineSaved');
             ConcreteEvent.fire('EditModeExitInline');
-            obj.destroy();
             $('#ccm-block-form').submit();
         });
 


### PR DESCRIPTION
This doesn't seem to be necessary, it just flashes the otherwise hidden textarea. Removing this function call prevents this flash and still allows the block to function.
Pull request, because I don't know if there was a reason for this.
