### PR TITLE
Removed non-needed trims

### DIFF
--- a/web/concrete/core/File/Type/Type.php
+++ b/web/concrete/core/File/Type/Type.php
@@ -114,10 +114,7 @@ class Type
         $stm = $db->query('select distinct fvExtension from FileVersions where fvIsApproved = 1 and fvExtension <> ""');
         $extensions = array();
         while ($row = $stm->fetch()) {
-            $fvExtension = trim($row['fvExtension']);
-            if (!in_array($fvExtension, $extensions)) {
-                $extensions[] = $fvExtension;
-            }
+            $extensions[] = $row['fvExtension'];
         }
         return $extensions;
     }
@@ -128,10 +125,7 @@ class Type
         $stm = $db->query('select distinct fvType from FileVersions where fvIsApproved = 1 and fvType <> 0');
         $types = array();
         while ($row = $stm->fetch()) {
-            $fvType = trim($row['fvType']);
-            if (!in_array($fvType, $types)) {
-                $types[] = $fvType;
-            }
+            $types[] = $row['fvType'];
         }
         return $types;
     }


### PR DESCRIPTION
I'll sleep easier at night knowing we're not trimming integer fields. And pretty sure we don't need to trim the extensions either (because why would there be spaces on an extension?)

Should properly address #460
