### PR TITLE
Fix access to protected fID

### DIFF
--- a/web/concrete/core/File/Set/Set.php
+++ b/web/concrete/core/File/Set/Set.php
@@ -225,7 +225,7 @@ class Set implements \Concrete\Core\Permission\ObjectInterface {
 	public function removeFileFromSet($f_id){
 
 		if (is_object($f_id)) {
-			$f_id = $f_id->fID;
+			$f_id = $f_id->getFileID();
 		}
 
 		$file_set_file = File::createAndGetFile($f_id,$this->fsID);


### PR DESCRIPTION
Unstarring a file didn't work because the removeFileFromSet method tries to access a protected fID.

![screen shot 2014-07-24 at 14 05 44](https://cloud.githubusercontent.com/assets/1431100/3687664/5d298520-132b-11e4-9025-122172fd3f55.png)
