### PR TITLE
Include required JS assets for core blocks (fixes elemental theme pages)

### DIFF
--- a/web/concrete/blocks/autonav/templates/responsive_header_navigation/view.php
+++ b/web/concrete/blocks/autonav/templates/responsive_header_navigation/view.php
@@ -1,6 +1,8 @@
 <? defined('C5_EXECUTE') or die("Access Denied."); ?>
 
-<? $navItems = $controller->getNavItems();
+<? View::getInstance()->requireAsset('javascript', 'jquery');
+
+$navItems = $controller->getNavItems();
 
 /**
  * The $navItems variable is an array of objects, each representing a nav menu item.

--- a/web/concrete/blocks/image/controller.php
+++ b/web/concrete/blocks/image/controller.php
@@ -76,6 +76,7 @@ class Controller extends BlockController {
 			$this->addHeaderItem('<style type="text/css"> img.ccm-image-block.alternate { display:none; } </style>');
 		}
 
+        $this->requireAsset('javascript', 'jquery');
 	}
 
 	


### PR DESCRIPTION
jQuery was being loaded **only on the home page** of the Elemental theme, resulting in some broken JS - including the mobile menu - on all other pages of the default installation. The **Image** block requires jQuery, as does the responsive template of the **Auto Nav** block.

The reason the home page worked is because jQuery was being included by the **Image Slider** block on the home page.

-Steve
