### PR TITLE
Update Package.php

### DIFF
--- a/web/concrete/core/Package/Package.php
+++ b/web/concrete/core/Package/Package.php
@@ -394,7 +394,7 @@ class Package extends Object {
 			return t('%s (%s)', $item->getAttributeSetDisplayName(), $txt->unhandle($at->getAttributeKeyCategoryHandle()));
 		} else if ($item instanceof GroupSet) {
 			return $item->getGroupSetDisplayName();
-		} else if (is_a($item, 'AttributeKey')) {
+		} else if ($item instanceof AttributeKey) {
 			$akc = AttributeKeyCategory::getByID($item->getAttributeKeyCategoryID());
 			return t(' %s (%s)', $txt->unhandle($item->getAttributeKeyHandle()), $txt->unhandle($akc->getAttributeKeyCategoryHandle()));
 		} else if ($item instanceof ConfigValue) {


### PR DESCRIPTION
Attribute keys were not displaying on the uninstall screen. There wasn't an error, they just didn't show.
