### PR TITLE
Setting the responsive nav dropdown zindex to be equal to the editbar so...

### DIFF
--- a/web/concrete/css/build/core/app/toolbar.less
+++ b/web/concrete/css/build/core/app/toolbar.less
@@ -335,7 +335,7 @@ div#ccm-toolbar-disabled {
   position: fixed;
   border-bottom: 5px solid #4674a1;
   width: 100%;
-  z-index: 99;
+  z-index: @index-level-main-bar;
   top: 49px;
   left: 0px;
   &.ccm-mobile-menu-overlay-dashboard {


### PR DESCRIPTION
... checkboxes don't crash its partay. #566
