### PR TITLE
Use URL for Inline Images in Content Block

### DIFF
--- a/web/concrete/blocks/content/controller.php
+++ b/web/concrete/blocks/content/controller.php
@@ -239,19 +239,20 @@ use \Concrete\Core\Block\BlockController;
 		
 		private function replaceFileID($match) {
 			$fID = $match[1];
-			if ($fID > 0) {
-				$path = File::getRelativePathFromID($fID);
-				return $path;
+			$file = File::getByID($fID);
+			if (!$file) {
+				return '';
 			}
+			return $file->getURL();
 		}
-		
+
 		private function replaceImageID($match) {
 			$fID = $match[1];
 			if ($fID > 0) {
 				preg_match('/width\s*="([0-9]+)"/',$match[0],$matchWidth);
 				preg_match('/height\s*="([0-9]+)"/',$match[0],$matchHeight);
 				$file = File::getByID($fID);
-				if (is_object($file) && (!$file->isError())) {
+				if ($file) {
 					$imgHelper = Loader::helper('image');
 					$maxWidth = ($matchWidth[1]) ? $matchWidth[1] : $file->getAttribute('width');
 					$maxHeight = ($matchHeight[1]) ? $matchHeight[1] : $file->getAttribute('height');
@@ -285,7 +286,11 @@ use \Concrete\Core\Block\BlockController;
 		
 		private function replaceFileIDInEditMode($match) {
 			$fID = $match[1];
-			return URL::to('/download_file', 'view_inline', $fID);
+			$file = File::getByID($fID);
+			if (!$file) {
+				return '';
+			}
+			return $file->getURL();
 		}
 		
 		private function replaceCollectionID($match) {

--- a/web/concrete/js/build/vendor/redactor/redactor.js
+++ b/web/concrete/js/build/vendor/redactor/redactor.js
@@ -6856,7 +6856,7 @@
                         ConcreteFileManager.getFileDetails(data.fID, function(r) {
                             jQuery.fn.dialog.hideLoader();
                             var file = r.files[0];
-                            $('#redactor_file_link').val(file.urlInline);
+                            $('#redactor_file_link').val(file.url);
                         });
                     });
                 });


### PR DESCRIPTION
When other storage locations are used, for example AWS S3, serving the
`/download_file/inline/1` link causes the server to download the file
from S3 then serve the file to the client.
- Change redactor link insert to use `url` not `urlInline`
- Change content block replacement methods to use url instead of inline
