### PR TITLE
Translate tree names

### DIFF
--- a/web/concrete/attributes/topics/controller.php
+++ b/web/concrete/attributes/topics/controller.php
@@ -101,7 +101,7 @@ class Controller extends AttributeTypeController
         $node = Node::getByID($this->akTopicParentNodeID);
         $path = $node->getTreeNodeDisplayPath();
         $treeNode = $key->addChild('tree');
-        $treeNode->addAttribute('name', $tree->getTreeDisplayName());
+        $treeNode->addAttribute('name', $tree->getTreeName());
         $treeNode->addAttribute('path', $path);
 
         return $akey;

--- a/web/concrete/blocks/topic_list/controller.php
+++ b/web/concrete/blocks/topic_list/controller.php
@@ -94,7 +94,7 @@ class Controller extends BlockController
         if ($treeID > 0) {
             $tree = Tree::getByID($treeID);
             if (is_object($tree)) {
-                return '{ccm:export:tree:' . $tree->getTreeDisplayName() . '}';
+                return '{ccm:export:tree:' . $tree->getTreeName() . '}';
             }
         }
     }
@@ -106,7 +106,7 @@ class Controller extends BlockController
         $data->addChild('mode', $this->mode);
         $data->addChild('topicAttributeKeyHandle', $this->topicAttributeKeyHandle);
         if (is_object($tree)) {
-            $data->addChild('tree', $tree->getTreeDisplayName());
+            $data->addChild('tree', $tree->getTreeName());
         }
         $path = null;
         if ($this->cParentID) {

--- a/web/concrete/core/Tree/Tree.php
+++ b/web/concrete/core/Tree/Tree.php
@@ -12,6 +12,11 @@ abstract class Tree extends Object
 
     abstract protected function deleteDetails();
 
+    /** Returns the standard name for this tree
+     * @return string
+     */
+    abstract public function getTreeName();
+
     /** Returns the display name for this tree (localized and escaped accordingly to $format)
      * @param  string $format = 'html' Escape the result in html format (if $format is 'html'). If $format is 'text' or any other value, the display name won't be escaped.
      * @return string

--- a/web/concrete/core/Tree/Type/Group.php
+++ b/web/concrete/core/Tree/Type/Group.php
@@ -6,6 +6,14 @@ use GroupTreeNode;
 
 class Group extends Tree
 {
+    /** Returns the standard name for this tree
+     * @return string
+     */
+    public function getTreeName()
+    {
+        return 'Groups Tree';
+    }
+
     /** Returns the display name for this tree (localized and escaped accordingly to $format)
      * @param  string $format = 'html' Escape the result in html format (if $format is 'html'). If $format is 'text' or any other value, the display name won't be escaped.
      * @return string

--- a/web/concrete/core/Tree/Type/Topic.php
+++ b/web/concrete/core/Tree/Type/Topic.php
@@ -10,6 +10,14 @@ use PermissionAccess;
 
 class Topic extends Tree
 {
+    /** Returns the standard name for this tree
+     * @return string
+     */
+    public function getTreeName()
+    {
+    	return $this->topicTreeName;
+    }
+
     /** Returns the display name for this tree (localized and escaped accordingly to $format)
      * @param  string $format = 'html' Escape the result in html format (if $format is 'html'). If $format is 'text' or any other value, the display name won't be escaped.
      * @return string


### PR DESCRIPTION
Let's introduce translation contexts for tree names and adopt the standard approach for the `get...DisplayName` methods
