### PR TITLE
Hide uploading dialog when upload fails

### DIFF
--- a/web/concrete/js/build/core/file-manager/search.js
+++ b/web/concrete/js/build/core/file-manager/search.js
@@ -53,6 +53,7 @@
                 dataType: 'json',
                 formData: {'ccm_token': CCM_SECURITY_TOKEN},
                 error: function(r) {
+                    jQuery.fn.dialog.closeTop();
                     var message = r.responseText;
                     try {
                         message = jQuery.parseJSON(message).errors.join('<br/>');


### PR DESCRIPTION
Automatically close the "Upload Progress" dialog when the upload fails (currently it's automatically closed only when the upload succeed)

![fix-uploaderror-dialog](https://cloud.githubusercontent.com/assets/928116/3843021/a0f8f9c2-1e3c-11e4-8142-cc96491c37c4.png)

Before this pull request, if we close the error dialog the Upload Progress dialog remains open:
![fix-uploaderror-dialog-2](https://cloud.githubusercontent.com/assets/928116/3843059/fabdadd6-1e3c-11e4-8ac8-ba09b75224f0.png)
