### PR TITLE
Credit bar always at the bottom of the page

### DIFF
--- a/web/concrete/css/build/themes/concrete/main.less
+++ b/web/concrete/css/build/themes/concrete/main.less
@@ -78,7 +78,7 @@ div#ccm-account-menu {
         cursor: auto;
     }
     .background-credit {
-        position:absolute;
+        position: fixed;
         bottom:0;
         left:0;
         right:0;


### PR DESCRIPTION
Fix the credit-bar position when the page is scrolled down:

![creditbar-bug](https://cloud.githubusercontent.com/assets/928116/3854126/6a0e6b2c-1ed2-11e4-829d-b573f4226a6f.png)
