### PR TITLE
Avoid scrolling to top when removing attributes

### DIFF
--- a/web/concrete/views/panels/details/page/attributes.php
+++ b/web/concrete/views/panels/details/page/attributes.php
@@ -4,7 +4,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 
 <script type="text/template" class="attribute">
 	<div class="form-group <% if (pending) { %>ccm-page-attribute-adding<% } %>" data-attribute-key-id="<%=akID%>">
-		<a href="#" data-remove-attribute-key="<%=akID%>"><i class="fa fa-minus-circle"></i></a>
+		<a href="javascript:void(0)" data-remove-attribute-key="<%=akID%>"><i class="fa fa-minus-circle"></i></a>
 		<label class="control-label"><%=label%></label>
 		<div>
 			<%=content%>


### PR DESCRIPTION
When removing a page attribute the web page scrolls to top: let's avoid that.
