### PR TITLE
IE9 window.console bugfix

### DIFF
--- a/web/concrete/js/build/core/events.js
+++ b/web/concrete/js/build/core/events.js
@@ -1,6 +1,7 @@
 var eventing = (function (global, $) {
     'use strict';
     global.c5 = global.c5 || {};
+    global.console = global.console || {};
 
     global.ConcreteEvent = (function (ns, $) {
         var target = $('<span />'), debug = false;


### PR DESCRIPTION
Fixed one of many javascript bugs in <IE10, this one pertaining to an error thrown when the window.console doesn't exist which doesn't happen unless developer tools are open
