### PR TITLE
Remove formatting by getDate... methods

### DIFF
--- a/web/concrete/single_pages/account/messages/inbox.php
+++ b/web/concrete/single_pages/account/messages/inbox.php
@@ -1,4 +1,7 @@
-<? defined('C5_EXECUTE') or die("Access Denied."); ?>
+<? defined('C5_EXECUTE') or die("Access Denied.");
+
+$dh = Core::make('helper/date'); /* @var $dh \Concrete\Core\Localization\Service\Date */
+?>
 
 <div class="row">
 <div class="span10 offset1">
@@ -94,7 +97,7 @@
 						<a href="<?=$view->url('/account/profile/public_profile', 'view', $msg->getMessageRelevantUserID())?>"><?=$msg->getMessageRelevantUserName()?></a>
 						</td>
 						<td class="ccm-profile-messages-item-name"><a href="<?=$view->url('/account/messages/inbox', 'view_message', $mailbox, $msg->getMessageID())?>"><?=$msg->getFormattedMessageSubject()?></a></td>
-						<td style="white-space: nowrap"><?=$msg->getMessageDateAdded('user', t('F d, Y \a\t g:i A'))?></td>
+						<td style="white-space: nowrap"><?=$dh->formatDateTime($msg->getMessageDateAdded(), true)?></td>
 						<td><?=$msg->getMessageStatus()?></td>
 					</tr>
 
@@ -204,7 +207,7 @@
     				<td class="ccm-profile-mailbox-last-message"><?
     				$msg = $inbox->getLastMessageObject();
     				if (is_object($msg)) {
-    					print t('<strong>%s</strong>, sent by %s on %s', $msg->getFormattedMessageSubject(), $msg->getMessageAuthorName(), $msg->getMessageDateAdded('user', t('F d, Y \a\t g:i A')));
+    					print t('<strong>%s</strong>, sent by %s on %s', $msg->getFormattedMessageSubject(), $msg->getMessageAuthorName(), $dh->formatDateTime($msg->getMessageDateAdded(), true));
     				}
     				?></td>
     			</tr>
@@ -214,7 +217,7 @@
     				<td class="ccm-profile-mailbox-last-message"><?
      				$msg = $sent->getLastMessageObject();
     				if (is_object($msg)) {
-    					print t('<strong>%s</strong>, sent by %s on %s', $msg->getFormattedMessageSubject(), $msg->getMessageAuthorName(), $msg->getMessageDateAdded('user', t('F d, Y \a\t g:i A')));
+    					print t('<strong>%s</strong>, sent by %s on %s', $msg->getFormattedMessageSubject(), $msg->getMessageAuthorName(), $dh->formatDateTime($msg->getMessageDateAdded(), true));
     				}
     				?>
    				</td>

--- a/web/concrete/src/Block/Block.php
+++ b/web/concrete/src/Block/Block.php
@@ -921,19 +921,11 @@ class Block extends Object implements \Concrete\Core\Permission\ObjectInterface
 
     /**
      * Gets the date the block was added
-     * if user is specified, returns in the current user's timezone
-     *
-     * @param string $type (system || user)
      * @return string date formated like: 2009-01-01 00:00:00
      */
-    function getBlockDateAdded($type = 'system')
+    function getBlockDateAdded()
     {
-        if (ENABLE_USER_TIMEZONES && $type == 'user') {
-            $dh = Loader::helper('date');
-            return $dh->getLocalDateTime($this->bDateAdded);
-        } else {
-            return $this->bDateAdded;
-        }
+        return $this->bDateAdded;
     }
 
     function getBlockDateLastModified()

--- a/web/concrete/src/File/Version.php
+++ b/web/concrete/src/File/Version.php
@@ -348,18 +348,11 @@ class Version
 
     /**
      * Gets the date a file version was added
-     * if user is specified, returns in the current user's timezone
-     * @param string $type (system || user)
      * @return string date formated like: 2009-01-01 00:00:00
      */
-    function getDateAdded($type = 'system')
+    function getDateAdded()
     {
-        if (ENABLE_USER_TIMEZONES && $type == 'user') {
-            $dh = Loader::helper('date');
-            return $dh->getLocalDateTime($this->fvDateAdded);
-        } else {
-            return $this->fvDateAdded;
-        }
+        return $this->fvDateAdded;
     }
 
     public function getExtension()

--- a/web/concrete/src/Package/Package.php
+++ b/web/concrete/src/Package/Package.php
@@ -78,17 +78,10 @@ class Package extends Object {
 	
 	/**
 	 * Gets the date the package was added to the system, 
-	 * if user is specified, returns in the current user's timezone
-	 * @param string $type (system || user)
 	 * @return string date formated like: 2009-01-01 00:00:00 
 	*/
-	function getPackageDateInstalled($type = 'system') {
-		if(ENABLE_USER_TIMEZONES && $type == 'user') {
-			$dh = Loader::helper('date');
-			return $dh->getLocalDateTime($this->pkgDateInstalled);
-		} else {
-			return $this->pkgDateInstalled;
-		}
+	function getPackageDateInstalled() {
+		return $this->pkgDateInstalled;
 	}
 	
 	public function getPackageVersion() {return $this->pkgVersion;}

--- a/web/concrete/src/Page/Collection/Collection.php
+++ b/web/concrete/src/Page/Collection/Collection.php
@@ -515,19 +515,9 @@ class Collection extends Object
         return false;
     }
 
-    function getCollectionDateLastModified($mask = null, $type = "system")
+    function getCollectionDateLastModified()
     {
-        $dh = Loader::helper('date');
-        if (ENABLE_USER_TIMEZONES && $type == 'user') {
-            $cDateModified = $dh->getLocalDateTime($this->cDateModified);
-        } else {
-            $cDateModified = $this->cDateModified;
-        }
-        if ($mask == null) {
-            return $cDateModified;
-        } else {
-            return $dh->date($mask, strtotime($cDateModified));
-        }
+        return $this->cDateModified;
     }
 
     function getCollectionHandle()
@@ -535,19 +525,9 @@ class Collection extends Object
         return $this->cHandle;
     }
 
-    function getCollectionDateAdded($mask = null, $type = 'system')
+    function getCollectionDateAdded()
     {
-        $dh = Loader::helper('date');
-        if (ENABLE_USER_TIMEZONES && $type == 'user') {
-            $cDateAdded = $dh->getLocalDateTime($this->cDateAdded);
-        } else {
-            $cDateAdded = $this->cDateAdded;
-        }
-        if ($mask == null) {
-            return $cDateAdded;
-        } else {
-            return $dh->date($mask, strtotime($cDateAdded));
-        }
+        return $this->cDateAdded;
     }
 
     public function __destruct()

--- a/web/concrete/src/Page/Collection/Version/Version.php
+++ b/web/concrete/src/Page/Collection/Version/Version.php
@@ -140,17 +140,10 @@ class Version extends Object implements \Concrete\Core\Permission\ObjectInterfac
 
 	/**
 	 * Gets the date the collection version was created
-	 * if user is specified, returns in the current user's timezone
-	 * @param string $type (system || user)
 	 * @return string date formated like: 2009-01-01 00:00:00
 	*/
-	function getVersionDateCreated($type = 'system') {
-		if(ENABLE_USER_TIMEZONES && $type == 'user') {
-			$dh = Loader::helper('date');
-			return $dh->getLocalDateTime($this->cvDateCreated);
-		} else {
-			return $this->cvDateCreated;
-		}
+	function getVersionDateCreated() {
+		return $this->cvDateCreated;
 	}
 
 	function canWrite() {return $this->cvCanWrite;}

--- a/web/concrete/src/Page/Page.php
+++ b/web/concrete/src/Page/Page.php
@@ -1193,23 +1193,10 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
 
     /**
      * Gets the date a the current version was made public,
-     * if user is specified, returns in the current user's timezone
-     * @param string $mask
-     * @param string $type (system || user)
      * @return string date formated like: 2009-01-01 00:00:00
-    */
-    function getCollectionDatePublic($mask = null, $type='system') {
-        $dh = Loader::helper('date');
-        if(ENABLE_USER_TIMEZONES && $type == 'user') {
-            $cDatePublic = $dh->getLocalDateTime($this->vObj->cvDatePublic);
-        } else {
-            $cDatePublic = $this->vObj->cvDatePublic;
-        }
-        if ($mask == null) {
-            return $cDatePublic;
-        } else {
-            return $dh->date($mask, strtotime($cDatePublic));
-        }
+     */
+    function getCollectionDatePublic() {
+        return $this->vObj->cvDatePublic;
     }
 
     /**

--- a/web/concrete/src/Page/Statistics.php
+++ b/web/concrete/src/Page/Statistics.php
@@ -45,16 +45,10 @@ class Statistics {
 
 	/**
 	 * Returns the datetime of the last edit to the site. Used in the dashboard
-	 * @return datetime
+	 * @return string date formated like: 2009-01-01 00:00:00
 	 */
 	public static function getSiteLastEdit($type = 'system') {
-		$db = Loader::db();
-		$cDateModified = $db->GetOne("select max(Collections.cDateModified) from Collections");
-		if(ENABLE_USER_TIMEZONES && $type == 'user') {
-			$dh = Loader::helper('date');
-			return $dh->getLocalDateTime($cDateModified);
-		}
-		return $cDateModified;
+		return Loader::db()->GetOne("select max(Collections.cDateModified) from Collections");
 	}
 
 	/**

--- a/web/concrete/src/User/Group/Group.php
+++ b/web/concrete/src/User/Group/Group.php
@@ -266,32 +266,18 @@ class Group extends Object implements \Concrete\Core\Permission\ObjectInterface 
 
 	/**
 	 * Gets the group start date
-	 * if user is specified, returns in the current user's timezone
-	 * @param string $type (system || user)
 	 * @return string date formated like: 2009-01-01 00:00:00
-	*/
-	function getGroupStartDate($type = 'system') {
-		if(ENABLE_USER_TIMEZONES && $type == 'user') {
-			$dh = Loader::helper('date');
-			return $dh->getLocalDateTime($this->cgStartDate);
-		} else {
-			return $this->cgStartDate;
-		}
+	 */
+	function getGroupStartDate() {
+		return $this->cgStartDate;
 	}
 
 	/**
 	 * Gets the group end date
-	 * if user is specified, returns in the current user's timezone
-	 * @param string $type (system || user)
 	 * @return string date formated like: 2009-01-01 00:00:00
 	*/
-	function getGroupEndDate($type = 'system') {
-		if(ENABLE_USER_TIMEZONES && $type == 'user') {
-			$dh = Loader::helper('date');
-			return $dh->getLocalDateTime($this->cgEndDate);
-		} else {
-			return $this->cgEndDate;
-		}
+	function getGroupEndDate() {
+		return $this->cgEndDate;
 	}
 
 	public function isGroupBadge() {

--- a/web/concrete/src/User/PrivateMessage/PrivateMessage.php
+++ b/web/concrete/src/User/PrivateMessage/PrivateMessage.php
@@ -146,13 +146,8 @@ class PrivateMessage extends Object {
 		return $this->authorName;
 	}
 	
-	public function getMessageDateAdded($type = 'system', $mask = false) {
-		if($type == 'user') {
-			$dh = Loader::helper('date');
-			return $dh->getLocalDateTime($this->msgDateCreated, $mask);
-		} else {
-			return $this->msgDateCreated;
-		}
+	public function getMessageDateAdded() {
+		return $this->msgDateCreated;
 	}
 	
 	public function getMessageSubject() {return $this->msgSubject;}

--- a/web/concrete/src/User/UserInfo.php
+++ b/web/concrete/src/User/UserInfo.php
@@ -784,58 +784,30 @@ class UserInfo extends Object implements \Concrete\Core\Permission\ObjectInterfa
 
     /**
      * Gets the date a user was added to the system,
-     * if user is specified, returns in the current user's timezone
-     * @param string $type (system || user)
      * @return string date formated like: 2009-01-01 00:00:00
      */
-    public function getUserDateAdded($type = 'system', $datemask = 'Y-m-d H:i:s')
+    public function getUserDateAdded()
     {
-        $dh = Loader::helper('date');
-        if (ENABLE_USER_TIMEZONES && $type == 'user') {
-            return $dh->getLocalDateTime($this->uDateAdded, $datemask);
-        } else {
-            return $dh->date($datemask, strtotime($this->uDateAdded));
-        }
+        return $this->uDateAdded;
     }
 
-    public function getUserStartDate($type = 'system')
+    public function getUserStartDate()
     {
-        // time-release permissions for users
-        if (ENABLE_USER_TIMEZONES && $type == 'user') {
-            $dh = Loader::helper('date');
-
-            return $dh->getLocalDateTime($this->upStartDate);
-        } else {
-            return $this->upStartDate;
-        }
+        return $this->upStartDate;
     }
 
     /**
      * Gets the date a user was last active on the site
-     * if user is specified, returns in the current user's timezone
-     * @param string $type (system || user)
      * @return string date formated like: 2009-01-01 00:00:00
      */
-    public function getLastOnline($type = 'system')
+    public function getLastOnline()
     {
-        if (ENABLE_USER_TIMEZONES && $type == 'user') {
-            $dh = Loader::helper('date');
-
-            return $dh->getLocalDateTime($this->uLastOnline);
-        } else {
-            return $this->uLastOnline;
-        }
+        return $this->uLastOnline;
     }
 
-    public function getUserEndDate($type = 'system')
+    public function getUserEndDate()
     {
-        if (ENABLE_USER_TIMEZONES && $type == 'user') {
-            $dh = Loader::helper('date');
-
-            return $dh->getLocalDateTime($this->upEndDate);
-        } else {
-            return $this->upEndDate;
-        }
+        return $this->upEndDate;
     }
 
 }

--- a/web/concrete/tools/panels/details/page/properties.php
+++ b/web/concrete/tools/panels/details/page/properties.php
@@ -27,7 +27,7 @@ if (is_object($c) && !$c->isError()) {
 			<div class="form-group">
 				<label for="cName" class="control-label"><?=t('Created Time')?></label>
 				<div>
-					<? print $dt->datetime('cDatePublic', $c->getCollectionDatePublic(null, 'user')); ?>
+					<? print $dt->datetime('cDatePublic', $c->getCollectionDatePublic()); ?>
 				</div>
 			</div>
 			<? } ?>

--- a/web/concrete/views/panels/details/page/attributes.php
+++ b/web/concrete/views/panels/details/page/attributes.php
@@ -32,7 +32,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 		<div class="form-group">
 			<label for="cName" class="control-label"><?=t('Created Time')?></label>
 			<div>
-				<? print $dt->datetime('cDatePublic', $c->getCollectionDatePublic(null, 'user')); ?>
+				<? print $dt->datetime('cDatePublic', $c->getCollectionDatePublic()); ?>
 			</div>
 		</div>
 		<? } ?>


### PR DESCRIPTION
Some (but not all) of the model methods that return a date/time try to format the timestamp and to handle the timezone.
Let's keep this in a central place (the DateHelper).

Supersedes #684
