### PR TITLE
Unit Test: /core/utility/service/validation/strings

### DIFF
--- a/tests/tests/Core/Utility/Service/Validation/StringsTest.php
+++ b/tests/tests/Core/Utility/Service/Validation/StringsTest.php
@@ -1,0 +1,318 @@
+<?php
+
+class StringsTest extends ConcreteDatabaseTestCase
+{
+    /**
+     * @var \Concrete\Core\Utility\Service\Validation\Strings
+     */
+    protected $object;
+
+    protected $fixtures = array();
+    protected $tables = array();
+
+    /**
+     * Sets up the fixture, for example, opens a network connection.
+     * This method is called before a test is executed.
+     */
+    protected function setUp()
+    {
+        $this->object = new \Concrete\Core\Utility\Service\Validation\Strings();
+    }
+
+    /**
+     * Tears down the fixture, for example, closes a network connection.
+     * This method is called after a test is executed.
+     */
+    public function tearDown()
+    {
+        unset($this->object);
+        parent::tearDown();
+    }
+
+    public function emailDataProvider()
+    {
+        return array(
+            //no mx record validation
+            array(false, '', false),
+            array(false, 'Mmmmm Cookies', false),
+            array(false, 'example.com', false),
+            array(false, 'notvalid@', false),
+            array(false, 'A@b@c@example.com', false),
+            array(false,'a"b(c)d,e:f;g<h>i[j\k]l@example.com', false),
+            array(false, 'just"not"right@example.com', false),
+            array(false, 'this is"not\allowed@example.com', false),
+            array(false, 'this\ still\"not\\allowed@example.com', false),
+            array(false, 'notvalid..@example.com', false),
+            array(false, 'notvalid@..example.com', false),
+            array(true, 'is+valid@concrete5.org', false),
+            array(true, 'tld@international', false),
+            array(true, 'tld@international', false),
+            array(true, 'international@international', false),
+            array(true, 'a.little.lengthy.but.fine@dept.example.com', false),
+            array(true, 'other.email-with-dash@example.com', false),
+            array(true, 'test@concrete5.org', false),
+
+            //mx validation
+            array(true, 'test@concrete5.org', true),
+        );
+    }
+
+    public function alphanumDataProvider()
+    {
+        return array(
+            array(false, null, false, false),
+            array(false, true, false, false),
+            array(false, false, false, false),
+            array(false, 1.254, false, false),
+            array(false, '', false, false),
+            array(false, ' ', false, false),
+            array(false, ' ', true, false),
+            array(false, 'a  b--c', false, true),
+            array(false, 1, false, false),
+            array(false, 0, false, false),
+            array(false, array('testing'), false, false),
+            array(true, 'JustALongerStringForABasicTest', false, false),
+            array(true, 'Just A Longer String For A Basic Test', true, false),
+            array(true, 'Just-A-Longer-String-For-A-Basic-Test', false, true),
+            array(true, 'a ', true, false),
+            array(true, ' -', true, true),
+            array(true, 'a  b--c', true, true),
+            array(true, '1', false, false),
+            array(true, '0', false, false),
+        );
+    }
+
+    public function handleDataProvider()
+    {
+        return array(
+            array(false, null),
+            array(false, true),
+            array(false, false),
+            array(false, 1.254),
+            array(false, ''),
+            array(false, ' '),
+            array(false, 'a  b--c'),
+            array(false, 1),
+            array(false, 0),
+            array(false, 'Just A Longer String For A Basic Test'),
+            array(false, 'Just-A-Longer-String-For-A-Basic-Test'),
+            array(false, array('testing')),
+            array(true, 'JustALongerStringForABasicTest12'),
+            array(true, 'Just_A_Longer_String_For_1_Basic_Test2'),
+            array(true, '_1'),
+            array(true, '___'),
+        );
+    }
+
+    public function notEmptyDataProvider()
+    {
+        return array(
+            array(false, null),
+            array(false, true),
+            array(false, false),
+            array(false, 1.254),
+            array(false, ''),
+            array(false, ' '),
+            array(false, '     '),
+            array(false, 1),
+            array(false, 0),
+            array(false, array()),
+            array(false, new stdClass()),
+            array(false, array('testing')),
+            array(false, array()),
+            array(true, 'a  b--c'),
+            array(true, ' Just A Longer String For A Basic Test '),
+        );
+    }
+
+    public function minDataProvider()
+    {
+        return array(
+            array(false, null, 1),
+            array(false, true, 0),
+            array(false, false, 0),
+            array(false, 1.254, 1),
+            array(false, '', 0),
+            array(false, ' ', 0),
+            array(false, '     ', 0),
+            array(false, 't', 2),
+            array(false, ' t e ', 4),
+            array(false, array(), 1),
+            array(false, new stdClass(), 1),
+            array(true, ' super duper ', 11),
+            array(true, 'super duper ', 1),
+        );
+    }
+
+    public function maxDataProvider()
+    {
+        return array(
+            array(false, null, 1),
+            array(false, true, 0),
+            array(false, false, 0),
+            array(false, 1.254, 1),
+            array(false, '', 0),
+            array(false, ' ', 0),
+            array(false, '     ', 0),
+            array(false, 'fail test', 2),
+            array(false, ' t e ', 2),
+            array(false, array(), 1),
+            array(false, new stdClass(), 1),
+            array(false, ' super duper ', 10),
+            array(true, ' super duper ', 11),
+            array(true, 'super duper', 11),
+        );
+    }
+
+    public function containsNumberDataProvider()
+    {
+        return array(
+            array(0, null),
+            array(0, true),
+            array(0, false),
+            array(0, 1.254),
+            array(0, ''),
+            array(0, ' '),
+            array(0, ' t e '),
+            array(0, array()),
+            array(0, new stdClass()),
+            array(1, ' super_duper 1 '),
+            array(2, ' 2super_duper1 '),
+            array(18, '123456789abcdefghijklmnopqrstuvwxyz987654321'),
+        );
+    }
+
+    public function containsUpperCaseDataProvider()
+    {
+        return array(
+            array(0, null),
+            array(0, true),
+            array(0, false),
+            array(0, 1.254),
+            array(0, ''),
+            array(0, ' '),
+            array(0, ' t e '),
+            array(0, array()),
+            array(0, new stdClass()),
+            array(1, ' Super_duper 1 '),
+            array(2, ' 2Super_Duper1 '),
+            array(13, 'AbCdEfGhIjKlMnOpQrStUvWxYz123'),
+        );
+    }
+
+    public function containsLowerCaseDataProvider()
+    {
+        return array(
+            array(0, null),
+            array(0, true),
+            array(0, false),
+            array(0, 1.254),
+            array(0, ''),
+            array(0, ' '),
+            array(2, ' t e '),
+            array(0, array()),
+            array(0, new stdClass()),
+            array(0, ' SUPER_DUPER 1 '),
+            array(8, ' 2Super_Duper1 '),
+            array(13, 'AbCdEfGhIjKlMnOpQrStUvWxYz123'),
+        );
+    }
+
+    public function containsSymbolDataProvider()
+    {
+        return array(
+            array(0, null),
+            array(0, true),
+            array(0, false),
+            array(0, 1.254),
+            array(0, ''),
+            array(0, ' '),
+            array(0, ' t e '),
+            array(0, array()),
+            array(0, new stdClass()),
+            array(1, ' SUPER_DUPER 1 '),
+            array(3, ' !2Super Duper1@ '),
+            array(29, '!@#$%^&*()_-+=[]{};:\'"\\|?.,<>'),
+        );
+    }
+
+    /**
+     * @dataProvider emailDataProvider
+     */
+    public function testEmail($expected, $email, $mxValidation)
+    {
+        $this->assertEquals($expected, $this->object->email($email, $mxValidation));
+    }
+
+    /**
+     * @dataProvider alphanumDataProvider
+     */
+    public function testAlphaNum($expected, $value, $allowSpaces = false, $allowDashes = false)
+    {
+        $this->assertEquals($expected, $this->object->alphanum($value, $allowSpaces, $allowDashes));
+    }
+
+    /**
+     * @dataProvider handleDataProvider
+     */
+    public function testHandle($expected, $value)
+    {
+        $this->assertEquals($expected, $this->object->handle($value));
+    }
+
+    /**
+     * @dataProvider notEmptyDataProvider
+     */
+    public function testNotEmpty($expected, $value)
+    {
+        $this->assertEquals($expected, $this->object->notempty($value));
+    }
+
+    /**
+     * @dataProvider minDataProvider
+     */
+    public function testMin($expected, $string, $minLength)
+    {
+        $this->assertEquals($expected, $this->object->min($string, $minLength));
+    }
+
+    /**
+     * @dataProvider maxDataProvider
+     */
+    public function testMax($expected, $string, $maxLength)
+    {
+        $this->assertEquals($expected, $this->object->max($string, $maxLength));
+    }
+
+    /**
+     * @dataProvider containsNumberDataProvider
+     */
+    public function testContainsNumber($expected, $string)
+    {
+        $this->assertEquals($expected, $this->object->containsNumber($string));
+    }
+
+    /**
+     * @dataProvider containsUpperCaseDataProvider
+     */
+    public function testContainsUpperCase($expected, $string)
+    {
+        $this->assertEquals($expected, $this->object->containsUpperCase($string));
+    }
+
+    /**
+     * @dataProvider containsLowerCaseDataProvider
+     */
+    public function testContainsLowerCase($expected, $string)
+    {
+        $this->assertEquals($expected, $this->object->containsLowerCase($string));
+    }
+
+    /**
+     * @dataProvider containsSymbolDataProvider
+     */
+    public function testContainsSymbol($expected, $string)
+    {
+        $this->assertEquals($expected, $this->object->containsSymbol($string));
+    }
+}

--- a/web/concrete/src/Utility/Service/Validation/Arrays.php
+++ b/web/concrete/src/Utility/Service/Validation/Arrays.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Concrete\Core\Utility\Service\Validation;
+
+use Core;
+
+class Arrays
+{
+
+    /**
+     * Returns true if any string in the "haystack" contains the "needle"
+     * @param string $needle The string to search for
+     * @param string|array $haystack An array of strings to be searched (Can also contain sub arrays)
+     * @param bool $recurse Defaults to true, when enabled this function will check any arrays inside the haystack for
+     * a containing value when false it will only check the first level
+     * @return bool
+     */
+    public function containsString($needle, $haystack = array(), $recurse = true)
+    {
+        /** @var \Concrete\Core\Utility\Service\Validation\Strings $stringHelper */
+        $stringHelper = Core::make('helper/validation/strings');
+        if (!$stringHelper->notempty($needle)) {
+            return false;
+        }
+        $arr = (!is_array($haystack)) ? array($haystack) : $haystack; // turn the string into an array
+        foreach ($arr as $item) {
+            if ($stringHelper->notempty($item) && strstr($item, $needle) !== false) {
+                return true;
+            } elseif ($recurse && is_array($item) && $this->containsString($needle, $item)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+} 

--- a/web/concrete/src/Utility/Service/Validation/Strings.php
+++ b/web/concrete/src/Utility/Service/Validation/Strings.php
@@ -11,10 +11,10 @@ class Strings
 {
 
     /**
-     * Validates an email address
-     * @param $em
-     * @param bool $testMXRecord
-     * @return bool $isvalid
+     * Returns true if the provided email is valid
+     * @param string $em The email address to be tested
+     * @param bool $testMXRecord Set to true if you want to perform dns record validation for the domain, defaults to false
+     * @return bool
      */
     public function email($em, $testMXRecord = false)
     {
@@ -23,40 +23,35 @@ class Strings
     }
 
     /**
-     * Returns true on whether the passed field is completely alpha-numeric
-     * @param string $field
-     * @param bool $allow_spaces whether or not spaces are permitted in the field contents
-     * @param bool $allow_dashes whether or not dashes (-) are permitted in the field contents
+     * Returns true on whether the passed string is completely alpha-numeric, if the value is not a string or is an
+     * empty string false will be returned.
+     * @param string $value
+     * @param bool $allowSpaces whether or not spaces are permitted in the field contents
+     * @param bool $allowDashes whether or not dashes (-) are permitted in the field contents
      * @return bool
      */
-    public function alphanum($field, $allow_spaces = false, $allow_dashes = false)
+    public function alphanum($value, $allowSpaces = false, $allowDashes = false)
     {
-        if ($allow_spaces && $allow_dashes) {
-            return !preg_match("/[^A-Za-z0-9 \-]/", $field);
-        } else {
-            if ($allow_spaces) {
-                return !preg_match("/[^A-Za-z0-9 ]/", $field);
-            } else {
-                if ($allow_dashes) {
-                    return !preg_match("/[^A-Za-z0-9\-]/", $field);
-                } else {
-                    return !preg_match('/[^A-Za-z0-9]/', $field);
-                }
-            }
+
+        $allowedCharsRegex = 'A-Za-z0-9';
+        if ($allowSpaces) {
+            $allowedCharsRegex .= ' ';
         }
+        if ($allowDashes) {
+            $allowedCharsRegex .= '\-';
+        }
+        return $this->notempty($value) && !preg_match('/[^' . $allowedCharsRegex . ']/', $value);
     }
 
     /**
-     * Returns true if the passed field is a valid "handle" (e.g. only letters, numbers, or a _ symbol
+     * Returns true if the passed string is a valid "handle" (e.g. only letters, numbers, or a _ symbol)
+     * @param string $handle
+     * @return bool
      */
     public function handle($handle)
     {
-        if (!$handle) {
-            return false;
-        }
-        return !preg_match("/[^A-Za-z0-9\_]/", $handle);
+        return $this->notempty($handle) && !preg_match("/[^A-Za-z0-9\_]/", $handle);
     }
-
 
     /**
      * Returns false if the string is empty (including trim())
@@ -65,7 +60,7 @@ class Strings
      */
     public function notempty($field)
     {
-        return ((is_array($field) && count($field) > 0) || (is_string($field) && trim($field) != ''));
+        return is_string($field) && trim($field) !== '';
     }
 
     /**
@@ -76,7 +71,7 @@ class Strings
      */
     public function min($str, $length)
     {
-        return strlen(trim($str)) >= $length;
+        return $this->notempty($str) && strlen(trim($str)) >= $length;
     }
 
     /**
@@ -87,7 +82,7 @@ class Strings
      */
     public function max($str, $length)
     {
-        return strlen(trim($str)) <= $length;
+        return $this->notempty($str) && strlen(trim($str)) <= $length;
     }
 
     /**
@@ -97,7 +92,10 @@ class Strings
      */
     public function containsNumber($str)
     {
-        return strlen(trim(preg_replace('/([^0-9]*)/', '', $str)));
+        if (!$this->notempty($str)) {
+            return 0;
+        }
+        return strlen(preg_replace('/([^0-9]*)/', '', $str));
     }
 
     /**
@@ -107,7 +105,10 @@ class Strings
      */
     public function containsUpperCase($str)
     {
-        return strlen(trim(preg_replace('/([^A-Z]*)/', '', $str)));
+        if (!$this->notempty($str)) {
+            return 0;
+        }
+        return strlen(preg_replace('/([^A-Z]*)/', '', $str));
     }
 
     /**
@@ -117,7 +118,10 @@ class Strings
      */
     public function containsLowerCase($str)
     {
-        return strlen(trim(preg_replace('/([^a-z]*)/', '', $str)));
+        if (!$this->notempty($str)) {
+            return 0;
+        }
+        return strlen(preg_replace('/([^a-z]*)/', '', $str));
     }
 
     /**
@@ -127,25 +131,9 @@ class Strings
      */
     public function containsSymbol($str)
     {
-        return strlen(
-            trim(preg_replace('/([a-zA-Z0-9]*)/', '', $str))
-        ); //we replace a-z and numbers and see if there is anything left.
-    }
-
-    /**
-     * Returns true if the string contains another string
-     * @param string $str
-     * @param array $cont
-     * @return bool
-     */
-    public function containsString($str, $cont = array())
-    {
-        $arr = (!is_array($cont)) ? array($cont) : $cont; // turn the string into an array
-        foreach ($arr as $item) {
-            if (strstr($str, $item) !== false) {
-                return true;
-            }
+        if (!$this->notempty($str)) {
+            return 0;
         }
-        return false;
+        return strlen(trim(preg_replace('/([a-zA-Z0-9]*)/', '', $str)));
     }
 }


### PR DESCRIPTION
Modified behaviors of functions to ensure they are dealing with strings when strings are expected.

Moved the containsString function into an Arrays validation class, and added the ability for this to now handle nested arrays by default, with an option to only search the first level of an array.

Wrote up unit tests for all of the Strings functions.

Fixed up the PHPDocs so they better describe what each function does more accurately where appropriate

Also closes #740, thanks for the help guys.
