### PR TITLE
Package Tools Files Are Broken

### DIFF
--- a/web/concrete/src/Legacy/Controller/ToolController.php
+++ b/web/concrete/src/Legacy/Controller/ToolController.php
@@ -40,6 +40,7 @@ class ToolController extends Controller {
 			if ($r->exists()) {
 				$v = new DialogView($btHandle . '/' . DIRNAME_TOOLS . '/' . $tool);
 				$v->setViewRootDirectoryName(DIRNAME_BLOCKS);
+				$v->setInnerContentFile($r->file);
 				$this->setViewObject($v);		
 			}
 		}

--- a/web/concrete/src/View/View.php
+++ b/web/concrete/src/View/View.php
@@ -100,7 +100,9 @@ class View extends AbstractView {
         // programmatically we already have a theme.
         $this->loadViewThemeObject();
         $env = Environment::get();
-        $this->setInnerContentFile($env->getPath($this->viewRootDirectoryName . '/' . trim($this->viewPath, '/') . '.php', $this->themePkgHandle));
+        if (!$this->innerContentFile) { // will already be set in a legacy tools file
+	        $this->setInnerContentFile($env->getPath($this->viewRootDirectoryName . '/' . trim($this->viewPath, '/') . '.php', $this->themePkgHandle));
+        }
         if ($this->themeHandle) {
             if (file_exists(DIR_FILES_THEMES_CORE . '/' . DIRNAME_THEMES_CORE . '/' . $this->themeHandle . '.php')) {
                 $this->setViewTemplate($env->getPath(DIRNAME_THEMES . '/' . DIRNAME_THEMES_CORE . '/' . $this->themeHandle . '.php'));


### PR DESCRIPTION
Legacy tools files within a packaged block are broken. The call to `$env->getPath()` on line 103 of **view.php** was returning a path relative to the **concrete** directory instead of the **packages** directory. I think this is because nothing was being passed in for `$this->themePkgHandle` (which makes sense if the package is not a theme). This fix was simple to implement, appears to work, and doesn't seem to break anything, but a core member should make the call as to whether this is the right way to go about it.

-Steve
