### PR TITLE
Prevent uninstallation of active theme: Beta 2 milestone issue #522

### DIFF
--- a/web/concrete/single_pages/dashboard/pages/themes/view.php
+++ b/web/concrete/single_pages/dashboard/pages/themes/view.php
@@ -81,10 +81,10 @@ $alreadyActiveMessage = t('This theme is currently active on your site.');
                         <?//$bt->button_js(t("Preview"), "ccm_previewInternalTheme(1, " . intval($t->getThemeID()) . ",'" . addslashes(str_replace(array("\r","\n",'\n'),'',$t->getThemeDisplayName())) . "')", 'left');?>
                         <?=$bt->button(t("Inspect"), $view->url('/dashboard/pages/themes/inspect', $t->getThemeID()), 'left');?>
                         <?//$bt->button(t("Customize"), $view->url('/dashboard/pages/themes/customize', $t->getThemeID()), 'left');?>
-                     <? if ($siteThemeID == $t->getThemeID()) { ?>
+                    <? if ($siteThemeID == $t->getThemeID()) { ?>
                         <?=$bt->button(t("Remove"), $view->url('/dashboard/pages/themes', 'remove', $t->getThemeID(), $valt->generate('remove')), 'right', 'btn-danger', array('disabled'=>'disabled'));?>
                     <? } else { ?>
-						<?=$bt->button(t("Remove"), $view->url('/dashboard/pages/themes', 'remove', $t->getThemeID(), $valt->generate('remove')), 'right', 'btn-danger');?>	
+                        <?=$bt->button(t("Remove"), $view->url('/dashboard/pages/themes', 'remove', $t->getThemeID(), $valt->generate('remove')), 'right', 'btn-danger');?>	
 					<? } ?>
 					</div>
                     


### PR DESCRIPTION
This deactivates the remove button for the currently installed theme. Source not as tidy as I wanted despite two goes at it with tabs and spaces. 
