### PR TITLE
Temporary fix for ZF1/ZF2 incompatibility

### DIFF
--- a/web/concrete/src/Localization/Localization.php
+++ b/web/concrete/src/Localization/Localization.php
@@ -191,7 +191,7 @@ class Localization {
 		} 
 		
 		$cacheLibrary = Cache::getLibrary();
-		if (is_object($cacheLibrary)) {
+		if (is_object($cacheLibrary) && is_a($cacheLibrary, '\\Zend_Cache_Core')) {
 			\Zend_Locale_Data::setCache($cacheLibrary);
 		}		
 		


### PR DESCRIPTION
I know we are in the middle of the progress to swap from ZF1 to ZF2, but right now we can't use concrete5 with locales.

Let's fix this with a temporary fix;)

PS: this fixes this critical error:

```
Argument 1 passed to Zend_Locale_Data::setCache() must be an instance of Zend_Cache_Core,
instance of Zend\Cache\Storage\Adapter\Filesystem given,
called in .../concrete/src/Localization/Localization.php on line 195
```
