### PR TITLE
Fixing Surveys page and date time helper for calculating delta days

### DIFF
--- a/web/concrete/src/Localization/Service/Date.php
+++ b/web/concrete/src/Localization/Service/Date.php
@@ -354,10 +354,12 @@ class Date
         if (is_null($dtFrom) || is_null($dtTo)) {
             return null;
         }
-        $dtFrom->setTimezone('GMT');
-        $dtFrom = new \DateTime($dtFrom->format('Y-m-d'), 'UTC');
-        $dtTo->setTimezone('GMT');
-        $dtTo = new \DateTime($dtTo->format('Y-m-d'), 'UTC');
+        $gmt = new \DateTimeZone('GMT');
+        $utc = new \DateTimeZone('UTC');
+        $dtFrom->setTimezone($gmt);
+        $dtFrom = new \DateTime($dtFrom->format('Y-m-d'), $utc);
+        $dtTo->setTimezone($gmt);
+        $dtTo = new \DateTime($dtTo->format('Y-m-d'), $utc);
         
         $seconds = $dtTo->getTimestamp() - $dtFrom->getTimestamp();
 


### PR DESCRIPTION
This should fix that issue on the survey page and in the helper. I think we just need to fetch DateTimeZone objects for these rather than try to make setTimezone cast them (as it might have previously worked in PHP of yore). However, I am lightyears away from a localization dynamo, so @mlocati would you mind double checking that this is sane? I'm not sure if 'GMT' is deprecated or whatnot. Thanks!). Re: #760
