### PR TITLE
Avoid downloading VCS data when building release

### DIFF
--- a/build/tasks/build-release/build.js
+++ b/build/tasks/build-release/build.js
@@ -34,7 +34,7 @@ module.exports = function(grunt, config, parameters, done) {
 						process.stdout.write('done.\n');
 						process.stdout.write('Installng PHP dependencies with Composer... ');
 						exec(
-							'composer install',
+							'composer install --prefer-dist',
 							{
 								cwd: path.join(workFolder, 'web/concrete')
 							},


### PR DESCRIPTION
Calling `composer install --prefer-dist` will speed up operations, since we don't download .git folders and after delete them.
