### PR TITLE
Fix results sent to select2 for user timezones

### DIFF
--- a/web/concrete/controllers/single_page/dashboard/users/search.php
+++ b/web/concrete/controllers/single_page/dashboard/users/search.php
@@ -360,9 +360,8 @@ class Search extends DashboardPageController
         foreach ($timezones as $timezoneID => $timezoneName) {
             if(($query === '') || (stripos($timezoneName, $query) !== false)) {
                 $obj = new stdClass();
-                $obj->value = $timezoneID;
+                $obj->id = $timezoneID;
                 $obj->text = $timezoneName;
-                $obj->id = $timezoneName;
                 $result[] = $obj;
             }
         }


### PR DESCRIPTION
We need to save the timezone id to the database, not their name.
