### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/concrete5/concrete5-5.7.0.png?label=ready&title=Ready)](https://waffle.io/concrete5/concrete5-5.7.0)
 [![Build Status](https://travis-ci.org/concrete5/concrete5-5.7.0.png?branch=master)](https://travis-ci.org/concrete5/concrete5-5.7.0)
 
 # concrete5 5.7.0 Developer Repository


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/concrete5/concrete5-5.7.0

This was requested by a real person (user KorvinSzanto) on waffle.io, we're not trying to spam you.
