### PR TITLE
Date localization fixes

### DIFF
--- a/web/concrete/src/Localization/Service/Date.php
+++ b/web/concrete/src/Localization/Service/Date.php
@@ -600,8 +600,7 @@ class Date
      */
     public function getTimeFormat()
     {
-        /*i18n: can be 12 or 24 */
-        $timeFormat = tc('Time format', '12');
+        $timeFormat = tc(/*i18n: can be 12 or 24 */'Time format', '12');
         switch ($timeFormat) {
             case '24':
                 return 24;


### PR DESCRIPTION
Removed duplicate array key and I think I "fixed" the behavior of one of the timezone case statements

Perhaps someone more knowledgable could indicate if my tweak to the case statement is proper. It seemed odd to define the `$city` var then overwrite it immediately, assumed a break belonged.
