### PR TITLE
Fix so icons don't overlap text in accessibility mode

### DIFF
--- a/web/concrete/css/build/core/app/toolbar.less
+++ b/web/concrete/css/build/core/app/toolbar.less
@@ -26,6 +26,9 @@ div#ccm-toolbar {
       width: auto !important;
       padding: 16px;
     }
+    li > a i{
+      position: static;
+    }
   }
 
   .ccm-launch-panel-loading {


### PR DESCRIPTION
Not sure if this completes #568 or what is left to do there. This tweak sure didn't feel like "significant work" so I might be missing something.
