### PR TITLE
Conversations Formatting

### DIFF
--- a/web/concrete/src/Conversation/Editor/Editor.php
+++ b/web/concrete/src/Conversation/Editor/Editor.php
@@ -239,7 +239,7 @@ abstract class Editor extends Object
         $cnvMessageBody = $htmlHelper->noFollowHref($cnvMessageBody);
         if (isset($config['htmlawed'])) {
 
-            $default = array('safe' => 1, 'elements' => 'strong, em, strike, a');
+            $default = array('safe' => 1, 'elements' => 'p, br, strong, em, strike, a');
             $conf = array_merge($default, (array)$config['htmlawed']);
             $lawed = htmLawed($cnvMessageBody, $conf);
         } else {


### PR DESCRIPTION
The redactor editor on the conversations block allowed for a different set of tags than configured in the filter.
