### PR TITLE
Make the text next to the back chevron clickable

### DIFF
--- a/web/concrete/views/panels/page/attributes.php
+++ b/web/concrete/views/panels/page/attributes.php
@@ -3,7 +3,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 ?>
 
 <section id="ccm-menu-page-attributes">
-	<header><a href="" data-panel-navigation="back" class="ccm-panel-back"><span class="fa fa-chevron-left"></span></a> <?=t('Attributes')?></header>
+	<header><a href="" data-panel-navigation="back" class="ccm-panel-back"><span class="fa fa-chevron-left"></span></a> <a href="" data-panel-navigation="back"><?=t('Attributes')?></a></header>
 	<div class="ccm-menu-page-attributes-search">
 		<i class="fa fa-search"></i>
 		<input type="text" name="" id="ccm-menu-page-attributes-search-input" placeholder="<?=t('Search')?>" autocomplete="false" />

--- a/web/concrete/views/panels/page/design.php
+++ b/web/concrete/views/panels/page/design.php
@@ -7,7 +7,8 @@ defined('C5_EXECUTE') or die("Access Denied.");
     <input type="hidden" name="processCollection" value="1">
 
 
-    <header><a href="" data-panel-navigation="back" class="ccm-panel-back"><span class="fa fa-chevron-left"></span></a> <?=t('Design')?></header>
+    <header><a href="" data-panel-navigation="back" class="ccm-panel-back"><span class="fa fa-chevron-left"></span></a> <a href="" data-panel-navigation="back"><?=t('Design')?></a></header>
+
 
     <div class="ccm-panel-content-inner">
 

--- a/web/concrete/views/panels/page/design/customize.php
+++ b/web/concrete/views/panels/page/design/customize.php
@@ -6,7 +6,7 @@ $pk = PermissionKey::getByHandle('customize_themes');
 
 <section id="ccm-panel-page-design-customize">
     <form data-form="panel-page-design-customize" target="ccm-page-preview-frame" method="post" action="<?=$controller->action("preview", $theme->getThemeID())?>">
-    <header><a href="" data-panel-navigation="back" class="ccm-panel-back"><span class="fa fa-chevron-left"></span></a> <?=t('Customize Theme')?></header>
+    <header><a href="" data-panel-navigation="back" class="ccm-panel-back"><span class="fa fa-chevron-left"></span></a> <a href="" data-panel-navigation="back"><?=t('Customize Theme')?></a></header>
 
     <div class="ccm-panel-content-inner">
 

--- a/web/concrete/views/panels/page/preview_as/form.php
+++ b/web/concrete/views/panels/page/preview_as/form.php
@@ -6,7 +6,9 @@ $fdh = Core::make('helper/form/date_time'); /* @var $fdh \Concrete\Core\Form\Ser
         <a href="" data-panel-navigation="back" class="ccm-panel-back">
             <span class="fa fa-chevron-left"></span>
         </a>
-        <?=t('View as User')?>
+        <a href="" data-panel-navigation="back">
+          <?=t('View as User')?>
+        </a>
     </header>
     <form class="preview-panel-form form-horizontal">
         <div class="ccm-panel-content-inner" id="ccm-menu-page-attributes-list">
@@ -57,7 +59,7 @@ $fdh = Core::make('helper/form/date_time'); /* @var $fdh \Concrete\Core\Form\Ser
 			e.preventDefault();
 			return false;
 		});
-	 
+
 	});
 }(jQuery));
 </script>

--- a/web/concrete/views/panels/page/versions.php
+++ b/web/concrete/views/panels/page/versions.php
@@ -2,7 +2,7 @@
 defined('C5_EXECUTE') or die("Access Denied.");
 ?>
 <script type="text/javascript">
-	
+
 </script>
 <script type="text/template" class="tbody">
 <% _.each(cv.versions, function(cv) { %>
@@ -279,11 +279,11 @@ $(function() {
 
 });
 
-</script>				
+</script>
 
 
 <section id="ccm-panel-page-versions" class="ccm-ui">
-	<header><a href="" data-panel-navigation="back" class="ccm-panel-back"><span class="fa fa-chevron-left"></span></a> <?=t('Versions')?></header>
+	<header><a href="" data-panel-navigation="back" class="ccm-panel-back"><span class="fa fa-chevron-left"></span></a> <a href="" data-panel-navigation="back"><?=t('Versions')?></a></header>
 	<table class="table">
 		<thead>
 			<tr>


### PR DESCRIPTION
So the text next to the chevron in panels is just text, which really annoys me.

Screenshot of what im talking about: http://screencast.com/t/cBunzw8dKZ

this makes the text clickable without changing any of the styling.
