### PR TITLE
Make Advanced search text tell what it actually does

### DIFF
--- a/web/concrete/elements/files/search.php
+++ b/web/concrete/elements/files/search.php
@@ -46,7 +46,7 @@ $req = $flr->getSearchRequest();
             </div>
         </div>
         <ul class="ccm-search-form-advanced list-inline">
-            <li><a href="#" data-search-toggle="advanced"><?=t('Advanced Search')?></a>
+            <li><a href="#" data-search-toggle="advanced"><?=t('Add Advanced Search Filter')?></a>
             <li><a href="#" data-search-toggle="customize" data-search-column-customize-url="<?=URL::to('/ccm/system/dialogs/file/search/customize')?>"><?=t('Customize Results')?></a>
             <?php
             $fp = FilePermissions::getGlobal();

--- a/web/concrete/elements/pages/search.php
+++ b/web/concrete/elements/pages/search.php
@@ -54,7 +54,7 @@ $req = $flr->getSearchRequest();
 		</div>
 	</div>
 	<ul class="ccm-search-form-advanced list-inline">
-		<li><a href="#" data-search-toggle="advanced"><?=t('Advanced Search')?></a>
+		<li><a href="#" data-search-toggle="advanced"><?=t('Add Advanced Search Filter')?></a>
 		<li><a href="#" data-search-toggle="customize" data-search-column-customize-url="<?=URL::to('/ccm/system/dialogs/page/search/customize')?>"><?=t('Customize Results')?></a>
 	</ul>
 	</div>

--- a/web/concrete/elements/users/search.php
+++ b/web/concrete/elements/users/search.php
@@ -56,7 +56,7 @@ $searchRequest = $flr->getSearchRequest();
 		</div>
 	</div>
 	<ul class="ccm-search-form-advanced list-inline">
-		<li><a href="#" data-search-toggle="advanced"><?=t('Advanced Search')?></a>
+		<li><a href="#" data-search-toggle="advanced"><?=t('Add Advanced Search Filter')?></a>
 		<li><a href="#" data-search-toggle="customize" data-search-column-customize-url="<?=URL::to('/ccm/system/dialogs/user/search/customize')?>"><?=t('Customize Results')?></a>
 	</ul>
 	</div>


### PR DESCRIPTION
Formerly the advanced search text opened another section with all the options with a separate add button

now, it just adds the fields underneath, so I though we should clarify what that link actually does.
