### PR TITLE
Remove icon_dashboard attribute from Stacks

### DIFF
--- a/web/concrete/config/install/base/dashboard.xml
+++ b/web/concrete/config/install/base/dashboard.xml
@@ -357,9 +357,6 @@
                 <attributekey handle="meta_keywords">
                     <value>stacks, reusable content, scrapbook, copy, paste, paste block, copy block, site name, logo</value>
                 </attributekey>
-                <attributekey handle="icon_dashboard">
-                    <value>fa fa-th</value>
-                </attributekey>
             </attributes>
 
         </page>


### PR DESCRIPTION
![2014-09-11_13-37-37](https://cloud.githubusercontent.com/assets/5735900/4229222/560c62f6-396b-11e4-8fa1-9f84afe01714.png)
