### PR TITLE
rename site settings to dashboard

### DIFF
--- a/web/concrete/elements/page_controls_footer.php
+++ b/web/concrete/elements/page_controls_footer.php
@@ -254,7 +254,7 @@ if (isset($cp) && $canViewToolbar && (!$dh->inDashboard())) {
                                              title="<?= t('Dashboard – Change Site-wide Settings') ?>">
                 <i class="fa fa-sliders"></i>
                 <span class="ccm-toolbar-accessibility-title ccm-toolbar-accessibility-title-site-settings">
-                    <?= tc('toolbar', 'Site Settings') ?>
+                    <?= tc('toolbar', 'Dashboard') ?>
                 </span>
 
             </a>

--- a/web/concrete/themes/dashboard/elements/header.php
+++ b/web/concrete/themes/dashboard/elements/header.php
@@ -78,7 +78,7 @@ $large_font = !!Config::get('concrete.accessibility.toolbar_large_font');
                 data-panel-url="<?=URL::to('/system/panels/dashboard')?>">
                 <i class="fa fa-sliders"></i>
                 <span class="ccm-toolbar-accessibility-title ccm-toolbar-accessibility-title-site-settings">
-                    <?= tc('toolbar', 'Site Settings') ?>
+                    <?= tc('toolbar', 'Dashboard') ?>
                 </span>
             </a>
         </li>


### PR DESCRIPTION
it feels strange to call this `Site Settings`, we can get to the file manager, the sitemap  and lots of things which aren't settings at all.
