### PR TITLE
Translations are included in release by default if at least 90%, not 95%

### DIFF
--- a/build/Gruntfile.parameters-sample.js
+++ b/build/Gruntfile.parameters-sample.js
@@ -23,7 +23,7 @@ module.exports = {
 	// A list of locales. If empty then all the Transifex locales are retrieved.
 	txLocales: [],
 	// The minimum translation progress of locales (percentage).
-	// Default value: 95%
-	txProgressLimit: 95
+	// Default value: 90%
+	txProgressLimit: 90
 
 };


### PR DESCRIPTION
See https://github.com/concrete5/concrete5-5.7.0/blob/master/build/tasks/translations.js#L141
