### PR TITLE
make the Axmls parser type case insensitive

### DIFF
--- a/web/concrete/src/Database/Schema/Parser/Axmls.php
+++ b/web/concrete/src/Database/Schema/Parser/Axmls.php
@@ -81,7 +81,7 @@ class Axmls extends XmlParser
 
     protected function _getColumnOptions(\Concrete\Core\Database\Connection $db, \SimpleXMLElement $column)
     {
-        $type = (string)$column['type'];
+        $type = strtoupper((string)$column['type']);
         $size = (string)$column['size'];
         $options = array();
         if ($size) {
@@ -130,7 +130,7 @@ class Axmls extends XmlParser
 
     protected function _getColumnType(\SimpleXMLElement $column)
     {
-        $type = (string)$column['type'];
+        $type = strtoupper((string)$column['type']);
         $size = (string)$column['size'];
         if ($type == 'L') {
             return 'boolean';


### PR DESCRIPTION
Fixed #1086 (strtoupper all type names)
