### PR TITLE
CLI: change config to new location so re-install works

### DIFF
--- a/cli/install-concrete5.php
+++ b/cli/install-concrete5.php
@@ -103,10 +103,10 @@ if (!file_exists($corePath . '/config/concrete.php')) {
 	die("ERROR: Invalid concrete5 core.\n");
 }
 
-if ($cliconfig['reinstall'] === 'yes' && is_file(DIR_BASE . '/config/site.php')) {
-	unlink(DIR_BASE . '/config/site.php');
+if ($cliconfig['reinstall'] === 'yes' && is_file(DIR_BASE . '/application/config/database.php')) {
+	unlink(DIR_BASE . '/application/config/database.php');
 }
-if (file_exists(DIR_BASE . '/config/site.php')) {
+if (file_exists(DIR_BASE . '/application/config/database.php')) {
 	die("ERROR: concrete5 is already installed.\n");
 }
 


### PR DESCRIPTION
the installer referenced the old config file, so the --reinstall flag didn't work.
