### PR TITLE
Convert config renderer to single quotes rather than double

### DIFF
--- a/web/concrete/src/Config/Renderer.php
+++ b/web/concrete/src/Config/Renderer.php
@@ -51,7 +51,7 @@ class Renderer {
             list($key, $value) = $scalar;
 
             if (is_string($value)) {
-                $clean_value = '"' . addcslashes($value, '"\\') . '"';
+                $clean_value = "'" . addcslashes($value, "'\\") . "'";
             } elseif (is_bool($value)) {
                 $clean_value = $value ? 'true' : 'false';
             } elseif (is_null($value)) {
@@ -61,7 +61,7 @@ class Renderer {
             }
 
             if ($associative) {
-                $results[] = $space . '"' . addcslashes($key, '"\\') . '" => ' . $clean_value;
+                $results[] = $space . "'" . addcslashes($key, "'\\") . "' => " . $clean_value;
             } else {
                 $results[] = $space . $clean_value;
             }
@@ -72,7 +72,7 @@ class Renderer {
             $rendered = $this->renderRecursive($value, $eol, $spacer, $depth + 1);
 
             if ($associative) {
-                $results[] = $space . '"' . addcslashes($key, '"\\') . '" => ' . $rendered;
+                $results[] = $space . "'" . addcslashes($key, "'\\") . "' => " . $rendered;
             } else {
                 $results[] = $space . $rendered;
             }


### PR DESCRIPTION
Prevents accidental variable injection

Fixes #1074
