### PR TITLE
adding namespaced repository class (mainly for packages)

### DIFF
--- a/web/concrete/src/Config/NamespacedRepository.php
+++ b/web/concrete/src/Config/NamespacedRepository.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace Concrete\Core\Config;
+use Concrete\Core\Config\Repository;
+use Package;
+
+class NamespacedRepository extends Repository
+{
+
+	/**
+	 * @var string
+	 */
+	protected $namespace;
+
+	public function getNamespace() { return $this->namespace; }
+	public function setNamespace($namespace) { $this->namespace = $namespace; }
+
+
+    /**
+     * Save a key (adding the internal namespace)
+     *
+     * @param $key
+     * @param $value
+     * @return bool
+     */
+    public function save($key, $value)
+	{
+		list($namespace, $group, $item) = $this->parseKey($key);
+		$nKey = $key;
+		if ( $namespace != $this->namespace ) $nKey = $this->namespace . "::$key";
+		parent::save($nKey, $value);
+	}
+
+	/**
+	 * Get the specified configuration value adding the namespace.
+	 *
+	 * @param  string  $key
+	 * @param  mixed   $default
+	 * @return mixed
+	 */
+	public function get($key, $default = null)
+	{
+		list($namespace, $group, $item) = $this->parseKey($key);
+		$nKey = $key;
+		if ( $namespace != $this->namespace ) $nKey = $this->namespace . "::$key";
+		return parent::get($nKey, $default);
+	}
+
+    /**
+     * Create a new configuration repository.
+     *
+	 * @param string		  $namespace
+     * @param LoaderInterface $loader
+     * @param SaverInterface  $saver
+     * @param                 $environment
+     */
+    public function __construct($namespace, LoaderInterface $loader, SaverInterface $saver, $environment)
+	{
+		$this->namespace = $namespace;
+		parent::__construct($loader, $saver, $environment);
+	}
+
+	public static function getDatabaseRepository( $namespace )
+	{
+		$loader = new DatabaseLoader();
+		$saver = new DatabaseSaver();
+		$cms = \Core::make( 'app' );
+		return new NamespacedRepository( $namespace, $loader, $saver, $cms->environment() );
+	}
+
+	public static function getFileRepository( $namespace )
+	{
+		$file_system = new Filesystem();
+		$loader = new FileLoader($file_system);
+		$saver = new FileSaver($file_system);
+		$cms = \Core::make( 'app' );
+		return new NamespacedRepository( $namespace, $loader, $saver, $cms->environment() );
+	}
+
+	public static function getRepositoryForPackage( $packageOrpackageIDorHandle )
+	{
+		$handle = $packageOrpackageIDorHandle;
+		if ( is_object( $packageOrpackageIDorHandle ) ) $handle = $packageOrpackageIDorHandle->getPackageHandle();
+		else if ( is_numeric( $packageOrpackageIDorHandle ) )
+		{
+			$package = Package::getByID( $packageOrpackageIDorHandle );
+			if ( !$package ) return null;
+			$handle = $package->getPackageHandle();
+		}
+		return self::getDatabaseRepository($handle);
+	
+	}
+}
+
+
+// vim: set noexpandtab ts=4 :

--- a/web/concrete/src/Package/Package.php
+++ b/web/concrete/src/Package/Package.php
@@ -57,6 +57,7 @@ use \Concrete\Core\Database\Schema\Schema;
 use Environment;
 use \Concrete\Core\Package\PackageList;
 use Localization;
+use \Concrete\Core\Config\NamespacedRepository;
 
 class Package extends Object
 {
@@ -65,6 +66,7 @@ class Package extends Object
     protected $REL_DIR_PACKAGES_CORE = REL_DIR_PACKAGES_CORE;
     protected $REL_DIR_PACKAGES = REL_DIR_PACKAGES;
     protected $backedUpFname = '';
+    protected $config = null;
 
     public function __construct()
     {
@@ -82,6 +84,12 @@ class Package extends Object
     public function getPackageName() {return t($this->pkgName);}
     public function getPackageDescription() {return t($this->pkgDescription);}
     public function getPackageHandle() {return $this->pkgHandle;}
+
+    public function getConfig()
+    {
+        if ( is_null( $this->config ) ) $this->config = NamespacedRepository::getRepositoryForPackage( $this->getPackageHandle() );
+        return $this->config;
+    }
 
     /**
 	 * Gets the date the package was added to the system,


### PR DESCRIPTION
Added Package::getConfig() and the appropriate NamespacedRepository class.

The latter class also have a convinience method getRepositoryForPackage() (used in Package).

Tested on last head, works as expected:

``` php
$pkg = Package::getByHandle('my_package');
$pkg->getConfig()->save('group.key', 'value'); // will add the namespace my_package automatically
$pkg->getConfig()->get('group.key');
```
