### PR TITLE
Composer UserCorePageProperty Bug fix

### DIFF
--- a/web/concrete/src/Page/Type/Composer/Control/CorePageProperty/UserCorePageProperty.php
+++ b/web/concrete/src/Page/Type/Composer/Control/CorePageProperty/UserCorePageProperty.php
@@ -2,6 +2,7 @@
 namespace Concrete\Core\Page\Type\Composer\Control\CorePageProperty;
 use Loader;
 use UserInfo;
+use Concrete\Core\Page\Page;
 
 class UserCorePageProperty extends CorePageProperty {
 	


### PR DESCRIPTION
Argument 1 passed to Concrete\Core\Page\Type\Composer\Control\CorePageProperty\UserCorePageProperty::publishToPage() must be an instance of Concrete\Core\Page\Type\Composer\Control\CorePageProperty\Page, instance of Concrete\Core\Page\Page given, called in /var/www/clients/planitagency.com/dev3_html/concrete/src/Page/Type/Type.php on line 877 and defined

http://screencast.com/t/RwLUbBWi
