### PR TITLE
Make translation of facebook secret key easier

### DIFF
--- a/web/concrete/authentication/facebook/type_form.php
+++ b/web/concrete/authentication/facebook/type_form.php
@@ -9,7 +9,7 @@
     <div class="input-group">
       <?=$form->password('apisecret', $apisecret)?>
       <span class="input-group-btn">
-        <button id="showsecret" class="btn btn-warning" type="button"><?php echo t('Show secret')?></button>
+        <button id="showsecret" class="btn btn-warning" type="button"><?php echo t('Show secret key')?></button>
       </span>
     </div>
 </div>


### PR DESCRIPTION
As per discussion: https://github.com/concrete5/concrete5-5.7.0/commit/69df7c897da6529bdc757c26159eeaf82b6542fe#commitcomment-7818927
