### PR TITLE
Fix translate problem on dashboard panel

### DIFF
--- a/web/concrete/blocks/autonav/controller.php
+++ b/web/concrete/blocks/autonav/controller.php
@@ -3,6 +3,7 @@ namespace Concrete\Block\Autonav;
 
 use Concrete\Core\Block\BlockController;
 use Loader;
+use Core;
 use Page;
 use Permissions;
 
@@ -266,7 +267,10 @@ class Controller extends BlockController
             //Package up all the data
             $navItem = new \stdClass();
             $navItem->url = $pageLink;
-            $navItem->name = $ni->getName();
+            $translate = $this->get('translate');
+            $name = (isset($translate) && $translate == true) ? t($ni->getName()) : $ni->getName();
+            $text = Core::make('helper/text');
+            $navItem->name = $text->entities($name);
             $navItem->target = $target;
             $navItem->level = $current_level + 1; //make this 1-based instead of 0-based (more human-friendly)
             $navItem->subDepth = $levels_between_this_and_next;

--- a/web/concrete/blocks/autonav/nav_item.php
+++ b/web/concrete/blocks/autonav/nav_item.php
@@ -104,7 +104,7 @@ use Loader;
 		 * @return string
 		 */
 		function getName() {
-			return Loader::helper('text')->entities($this->cvName);
+			return $this->cvName;
 		}
 
 		/**

--- a/web/concrete/blocks/autonav/view.php
+++ b/web/concrete/blocks/autonav/view.php
@@ -117,8 +117,7 @@ if (count($navItems) > 0) {
     foreach ($navItems as $ni) {
 
         echo '<li class="' . $ni->classes . '">'; //opens a nav item
-        $name = (isset($translate) && $translate == true) ? t($ni->name) : $ni->name;
-        echo '<a href="' . $ni->url . '" target="' . $ni->target . '" class="' . $ni->classes . '">' . $name . '</a>';
+        echo '<a href="' . $ni->url . '" target="' . $ni->target . '" class="' . $ni->classes . '">' . $ni->name . '</a>';
 
         if ($ni->hasSubmenu) {
             echo '<ul>'; //opens a dropdown sub-menu


### PR DESCRIPTION
Some pages in dashboard panel are not translated, because the character "&" in page names are escaped before translate.

Before
![concrete5_7 ____](https://cloud.githubusercontent.com/assets/514294/4321427/f68bf64a-3f3f-11e4-9b83-114cffe7f3af.png)

After
![concrete5_7 ____ 1](https://cloud.githubusercontent.com/assets/514294/4321426/f683d30c-3f3f-11e4-9f29-986e16ff30ff.png)

Thanks to bug report from... @ounziw @acliss19xx
