### PR TITLE
Concrete5 5.7.0 1069

### DIFF
--- a/web/concrete/config/concrete.php
+++ b/web/concrete/config/concrete.php
@@ -45,14 +45,19 @@ return array(
      * ------------------------------------------------------------------------
      */
     'debug'             => array(
+        /**
+         * Display errors
+         *
+         * @var bool
+         */
+        'display_errors' => false,
 
         /**
          * Site debug level
          *
-         * @var int
+         * @var string (message|debug)
          */
-        'level' => 0
-
+        'details'        => 'message'
     ),
 
     /**

--- a/web/concrete/controllers/single_page/dashboard/system/environment/debug.php
+++ b/web/concrete/controllers/single_page/dashboard/system/environment/debug.php
@@ -9,18 +9,20 @@ class Debug extends DashboardPageController
 
     public function view()
     {
+        $enabled = Config::get('concrete.debug.display_errors');
+        $detail = Config::get('concrete.debug.detail');
 
-        $debug_level = Config::get('concrete.debug.level');
-        $this->set('debug_level', $debug_level);
+        $this->set('debug_enabled', $enabled);
+        $this->set('debug_detail', $detail);
     }
 
     public function update_debug()
     {
         if ($this->token->validate("update_debug")) {
             if ($this->isPost()) {
-                Config::save('concrete.debug.level', $this->post('debug_level'));
+                Config::save('concrete.debug.detail', $this->post('debug_detail'));
+                Config::save('concrete.debug.display_errors', !!$this->post('debug_enabled'));
                 $this->redirect('/dashboard/system/environment/debug', 'debug_saved');
-
             }
         } else {
             $this->set('error', array($this->token->getErrorMessage()));
@@ -32,5 +34,38 @@ class Debug extends DashboardPageController
         $this->set('message', t('Debug configuration saved.'));
         $this->view();
     }
+
+    public function debug_example()
+    {
+        \Config::set('concrete.debug.display_errors', true);
+        \Config::set('concrete.debug.detail', 'debug');
+
+        $_SERVER['HTTP_X_REQUESTED_WITH'] = 'debug_example';
+
+        throw new ExampleException('Sample Debug Output!');
+    }
+
+    public function message_example()
+    {
+        \Config::set('concrete.debug.display_errors', true);
+        \Config::set('concrete.debug.detail', 'message');
+
+        $_SERVER['HTTP_X_REQUESTED_WITH'] = 'debug_example';
+
+        throw new ExampleException('Sample Message Output!');
+    }
+
+    public function disabled_example()
+    {
+        \Config::set('concrete.debug.display_errors', false);
+        $_SERVER['HTTP_X_REQUESTED_WITH'] = 'debug_example';
+
+        throw new ExampleException('Sample Disabled Output!');
+    }
+
+}
+
+class ExampleException extends \Exception
+{
 
 }

--- a/web/concrete/single_pages/dashboard/system/environment/debug.php
+++ b/web/concrete/single_pages/dashboard/system/environment/debug.php
@@ -1,32 +1,89 @@
-<?php defined('C5_EXECUTE') or die("Access Denied.") ?>
+<?php defined('C5_EXECUTE') or die("Access Denied.");
+$view = View::getInstance();
+?>
 
 <form method="post" id="debug-form"
       action="<?php echo $view->url('/dashboard/system/environment/debug', 'update_debug') ?>">
     <?php echo $this->controller->token->output('update_debug') ?>
 
-    <div class="form-group">
-        <div class="radio">
-            <label>
-                <input type="radio" name="debug_level"
-                       value="<?php echo DEBUG_DISPLAY_PRODUCTION ?>" <?php if ($debug_level == DEBUG_DISPLAY_PRODUCTION) { ?> checked <?php } ?> />
-                <span><?php echo t('Hide errors from site visitors.') ?> </span>
-            </label>
+    <fieldset>
+        <legend><?= t('Display Errors') ?></legend>
+        <div class="form-group">
+
+            <div class="checkbox">
+                <label>
+                    <input data-sample='<?= $view->action('disabled_example') ?>' type="checkbox" name="debug_enabled"
+                           value="1" <?= $debug_enabled ? 'checked' : '' ?> />
+                    <span><?php echo t('Output error information to site users') ?></span>
+                    <span class="help-block"><?= t('Disable to show a generic error message') ?></span>
+                </label>
+            </div>
+
         </div>
-        <div class="radio">
-            <label>
-                <input type="radio" name="debug_level"
-                       value="<?php echo DEBUG_DISPLAY_ERRORS ?>" <?php if ($debug_level == DEBUG_DISPLAY_ERRORS) { ?> checked <?php } ?> />
-                <span><?php echo t('Show errors in page.') ?></span>
-            </label>
+    </fieldset>
+
+    <fieldset>
+        <legend><?= t('Error detail') ?></legend>
+        <div class="form-group">
+
+            <div class="radio">
+                <label>
+                    <input data-sample='<?= $view->action('message_example') ?>' type="radio" name="debug_detail"
+                           value="message" <?= $debug_detail != 'debug' ? 'checked' : '' ?> />
+                    <span><?php echo t('Show the error message but nothing else') ?></span>
+                </label>
+            </div>
+            <div class="radio">
+                <label>
+                    <input data-sample='<?= $view->action('debug_example') ?>' type="radio" name="debug_detail"
+                           value="debug" <?= $debug_detail == 'debug' ? 'checked' : '' ?> />
+                    <span><?php echo t('Show the debug error output') ?></span>
+
+                    <p class="help-block">
+                        <span class='text-danger'>
+                            <?php echo t('May disclose sensitive information, use only for development.') ?>
+                        </span>
+                    </p>
+                </label>
+            </div>
+
         </div>
-    </div>
+    </fieldset>
+
+    <fieldset>
+        <legend><?= t('Example') ?></legend>
+        <iframe class="sample" style="display:none"></iframe>
+    </fieldset>
 
     <div class="ccm-dashboard-form-actions-wrapper">
         <div class="ccm-dashboard-form-actions">
-            <?
-            print $interface->submit(t('Save'), 'debug-form', 'right', 'btn-primary');
+            <?php
+            echo $interface->submit(t('Save'), 'debug-form', 'right', 'btn-primary');
             ?>
         </div>
     </div>
 
 </form>
+
+<script>
+    (function () {
+        var iframe = $('.sample'),
+            enabled = $('input[name=debug_enabled]'),
+            detail = $('input[name=debug_detail]'),
+            inputs = $('input');
+
+        inputs.change(function () {
+            var url;
+            if (enabled.is(':checked')) {
+                url = detail.filter(':checked').data('sample');
+            } else {
+                url = enabled.data('sample');
+            }
+            iframe.css({
+                width: '100%',
+                height: 600,
+                border: 'none'
+            }).show().attr('src', url);
+        }).change();
+    }());
+</script>

--- a/web/concrete/src/Page/Controller/DashboardPageController.php
+++ b/web/concrete/src/Page/Controller/DashboardPageController.php
@@ -1,24 +1,34 @@
 <?php
 namespace Concrete\Core\Page\Controller;
+
+use Concrete\Core\Error\Error;
+use Concrete\Core\Validation\CSRF\Token;
 use Loader;
-class DashboardPageController extends PageController {
 
-	protected $error;
-	public $token;
-	protected $helpers = array('form');
+class DashboardPageController extends PageController
+{
 
-	public function enableNativeMobile() {
-		$md = new \Mobile_Detect();
-		if ($md->isMobile()) {
-			$this->addHeaderItem('<meta name="viewport" content="width=device-width,initial-scale=1"/>');
-		}
-	}
+    /** @var Error */
+    protected $error;
 
-	public function on_start() {
-		$this->token = Loader::helper('validation/token');
-		$this->error = Loader::helper('validation/error');
-		$this->set('interface', Loader::helper('concrete/ui'));
-		$this->set('dashboard', Loader::helper('concrete/dashboard'));
+    /** @var Token */
+    public $token;
+    protected $helpers = array('form');
+
+    public function enableNativeMobile()
+    {
+        $md = new \Mobile_Detect();
+        if ($md->isMobile()) {
+            $this->addHeaderItem('<meta name="viewport" content="width=device-width,initial-scale=1"/>');
+        }
+    }
+
+    public function on_start()
+    {
+        $this->token = Loader::helper('validation/token');
+        $this->error = Loader::helper('validation/error');
+        $this->set('interface', Loader::helper('concrete/ui'));
+        $this->set('dashboard', Loader::helper('concrete/dashboard'));
 
         $hideDashboardPanel = false;
         if (\Cookie::has('panels/dashboard/closed') && intval(\Cookie::get('panels/dashboard/closed')) == 1) {
@@ -27,14 +37,14 @@ class DashboardPageController extends PageController {
         $this->set('hideDashboardPanel', $hideDashboardPanel);
     }
 
-	public function on_before_render() {
-		$pageTitle = $this->get('pageTitle');
-		if (!$pageTitle) {
-			$this->set('pageTitle', $this->c->getCollectionName());
-		}
-		$this->set('token', $this->token);
-		$this->set('error', $this->error);
-	}
-
+    public function on_before_render()
+    {
+        $pageTitle = $this->get('pageTitle');
+        if (!$pageTitle) {
+            $this->set('pageTitle', $this->c->getCollectionName());
+        }
+        $this->set('token', $this->token);
+        $this->set('error', $this->error);
+    }
 
 }


### PR DESCRIPTION
This adds the following config settings:

| Item | Type | Default |
| --- | --- | --- |
| `config.debug.display_errors` | `bool` | `false` |
| `config.debug.detail` | `string (message / debug)` | `message` |

I also added a quick preview iframe to the dashboard page.
