### PR TITLE
Change all area effects to a blue shade if the area is global.

### DIFF
--- a/web/concrete/css/build/core/app/page-areas.less
+++ b/web/concrete/css/build/core/app/page-areas.less
@@ -69,6 +69,12 @@ div.ccm-block-edit.ccm-menu-item-hover, div.ccm-block-edit.ccm-block-highlight {
   }
 }
 
+div.ccm-global-area {
+  div.ccm-block-edit.ccm-menu-item-hover, div.ccm-block-edit.ccm-block-highlight {
+    outline: 1px solid #80d0ec;
+  }
+}
+
 /**
  * Areas
   */
@@ -180,6 +186,13 @@ div.ccm-area[data-total-blocks="0"].ccm-area-drag-block-type-over, div.ccm-area[
     }
   }
 
+  &.ccm-global-area {
+    outline-color: #80d0ec;
+    div.ccm-area-footer-handle {
+      border-color: #80d0ec;
+
+    }
+  }
 }
 
 /**
@@ -199,15 +212,36 @@ div.ccm-area.ccm-area-highlight {
       color: #000;
     }
   }
+
+  &.ccm-global-area-highlight {
+    outline: 1px solid #80d0ec;
+
+    > div.ccm-area-footer {
+
+      div.ccm-area-footer-handle {
+        border-left: 1px solid #80d0ec;
+        border-bottom: 1px solid #80d0ec;
+        border-right: 1px solid #80d0ec;
+        color: #000;
+      }
+    }
+  }
 }
 
 div.ccm-area[data-total-blocks="0"].ccm-area-highlight {
   outline: 1px solid #59ec59;
+  &.ccm-global-area-highlight {
+    outline-color: #80d0ec;
+  }
 }
 
 div#ccm-menu-highlighter.ccm-area-highlight {
   background-color: #ffff76;
   opacity: 0.1;
+
+  &.ccm-global-area-highlight {
+    background-color: #93ffdb;
+  }
 }
 
 /**
@@ -241,7 +275,13 @@ div.ccm-area.ccm-area-inline-edit-disabled {
 div#ccm-menu-highlighter.ccm-block-highlight {
   background-color: #59ec59;
   opacity: 0.4;
+
+  &.ccm-global-area-block-highlight {
+    outline: 1px solid #80d0ec;
+    background-color: rgb(128, 208, 236);
+  }
 }
+
 
 /**
  * Inline commands
@@ -391,6 +431,19 @@ div.ccm-area-drag-area {
   &.ccm-area-drag-area-selectable {
     outline-color: rgb(170, 255, 170);
     outline-width: 10px;
+  }
+}
+
+/* Global area color */
+div.ccm-global-area {
+
+  div.ccm-area-drag-area {
+    &.ccm-area-drag-area-selectable {
+      // 105 206 65
+      //outline-color: rgb(255, 165, 91);
+      border: rgb(128, 208, 236);
+      outline-color: rgb(203, 234, 255);
+    }
   }
 }
 

--- a/web/concrete/js/build/core/app/edit-mode/area.js
+++ b/web/concrete/js/build/core/app/edit-mode/area.js
@@ -112,12 +112,20 @@
             if (my.getAttr('menu')) {
                 my.getAttr('menu').destroy();
             }
-            my.setAttr('menu', new ConcreteMenu(elem, {
+
+            var menu_config = {
                 'handle': menuHandle,
                 'highlightClassName': 'ccm-area-highlight',
                 'menuActiveClass': 'ccm-area-highlight',
                 'menu': $('[data-area-menu=' + elem.attr('data-launch-area-menu') + ']')
-            }));
+            };
+
+            if (my.getElem().hasClass('ccm-global-area')) {
+                menu_config.menuActiveClass += " ccm-global-area-highlight";
+                menu_config.highlightClassName += " ccm-global-area-highlight";
+            }
+
+            my.setAttr('menu', new ConcreteMenu(elem, menu_config));
 
             $menuElem.find('a[data-menu-action=add-inline]')
                 .off('click.edit-mode')

--- a/web/concrete/js/build/core/app/edit-mode/block.js
+++ b/web/concrete/js/build/core/app/edit-mode/block.js
@@ -65,8 +65,6 @@
                 place: false
             });
 
-            my.bindMenu();
-
             my.bindEvent('EditModeSelectableContender', function (e, data) {
                 if (my.getDragging() && data instanceof Concrete.DragArea) {
                     my.setSelected(data);
@@ -135,10 +133,7 @@
                 drag_area.getArea().addBlockToIndex(my, 0);
             }
             my.getPeper().pep(my.getPepSettings());
-            if (targetArea.getTotalBlocks() === 1) {
-                // we have to destroy the old menu and create it anew
-                targetArea.bindMenu();
-            }
+
             my.getEditMode().scanBlocks();
             Concrete.event.fire('EditModeBlockMove', {
                 block: my,
@@ -233,11 +228,18 @@
 
             if (menuHandle !== 'none') {
 
-                my.setAttr('menu', new ConcreteMenu(elem, {
+                var menu_config = {
                     'highlightClassName': 'ccm-block-highlight',
                     'menuActiveClass': 'ccm-block-highlight',
                     'menu': $menuElem
-                }));
+                };
+
+                if (my.getArea() && my.getArea().getElem().hasClass('ccm-global-area')) {
+                    menu_config.menuActiveClass += " ccm-global-area-block-highlight";
+                    menu_config.highlightClassName += " ccm-global-area-block-highlight";
+                }
+
+                my.setAttr('menu', new ConcreteMenu(elem, menu_config));
 
                 $menuElem.find('a[data-menu-action=edit_inline]').unbind('click.core').on('click.core', function (event) {
                     Concrete.event.fire('EditModeBlockEditInline', {block: my, event: event});
@@ -274,6 +276,8 @@
                 href += '&arHandle=' + encodeURIComponent(area.getHandle()) + '&bID=' + my.getId();
                 $(this).attr('href', href).dialog();
             });
+
+            my.bindMenu();
         },
 
         /**

--- a/web/concrete/js/build/core/app/in-context-menu.js
+++ b/web/concrete/js/build/core/app/in-context-menu.js
@@ -257,6 +257,7 @@
             _.defer(function () {
                 my.$element.removeClass(my.options.menuActiveClass);
                 my.$element.parents('*').slice(0, 3).removeClass(my.options.menuActiveParentClass);
+                global.$highlighter.removeClass();
                 global.$container.removeClass().addClass('ccm-ui').html('');
             });
 


### PR DESCRIPTION
Fix for #1137

I worked with Franz and Robert to decide on a blue highlight rather than a darker green.
I had to move the `block.bindMenu` call to the  `block.setArea` method rather than in the block constructor function because we needed to have access to the area in the bindMenu function.
