### PR TITLE
Config Indexes

### DIFF
--- a/web/concrete/config/db.xml
+++ b/web/concrete/config/db.xml
@@ -2068,27 +2068,21 @@
     </index>
   </table>
 
-
-
     <table name="Config">
+        <field name="configNamespace" type="C" size="255" >
+            <key/>
+        </field>
+        <field name="configGroup" type="C" size="255" >
+            <key/>
+        </field>
         <field name="configItem" type="C" size="255">
             <key/>
         </field>
         <field name="configValue" type="X2" />
-        <field name="configGroup" type="C" size="255" />
-        <field name="configNamespace" type="C" size="255" />
-
-        <index name="configItem">
-            <col>configItem</col>
-        </index>
         <index name="configGroup">
             <col>configGroup</col>
         </index>
-        <index name="configNamespace">
-            <col>configNamespace</col>
-        </index>
     </table>
-
 
   <table name="ConfigStore">
     <field name="cfKey" type="C" size="64">


### PR DESCRIPTION
Added appropriate primary key for uniqueness constraint and searching, left group index for searching, removed item index and namespace index as they aren't used or were replaced by the new PK.

Fixes #1210 
