### PR TITLE
remove ComposerContentLayout reference

### DIFF
--- a/web/concrete/src/Block/Block.php
+++ b/web/concrete/src/Block/Block.php
@@ -1036,9 +1036,6 @@ class Block extends Object implements \Concrete\Core\Permission\ObjectInterface
             $q = "delete from CollectionVersionBlocks where bID = ?";
             $r = $db->query($q, array($bID));
 
-            $q = "delete from ComposerContentLayout where bID = ?";
-            $r = $db->query($q, array($bID));
-
             $q = "delete from BlockPermissionAssignments where bID = ?";
             $r = $db->query($q, array($bID));
 


### PR DESCRIPTION
That I can tell this is not need and gives errors on uninstall when working with packages that install defaultTemplate blocks.
