### PR TITLE
Background should be transparent instead of white

### DIFF
--- a/web/concrete/css/build/vendor/redactor/redactor.less
+++ b/web/concrete/css/build/vendor/redactor/redactor.less
@@ -41,7 +41,7 @@
 .redactor_box {
   position: relative;
   overflow: visible;
-  background: #fff;
+  background: transparent;
 }
 .redactor_box iframe {
   display: block;


### PR DESCRIPTION
When using a black background with white text the user cannot see the text in the editor if the background is white.
