### PR TITLE
Use grunt-newer instead of wasting time

### DIFF
--- a/build/Gruntfile.js
+++ b/build/Gruntfile.js
@@ -350,6 +350,7 @@ module.exports = function(grunt) {
     grunt.loadNpmTasks('grunt-contrib-cssmin');
     grunt.loadNpmTasks('grunt-contrib-less');
     grunt.loadNpmTasks('grunt-contrib-watch');
+    grunt.loadNpmTasks('grunt-newer');
 
     // Now let's build the final configuration for Grunt.
 
@@ -361,7 +362,7 @@ module.exports = function(grunt) {
     for(var concatKey in concat) {
         if(concat[concatKey].beforeJS) {
             jsTargets.release.push('concat:' + concatKey);
-            jsTargets.debug.push('concat:' + concatKey);
+            jsTargets.debug.push('newer:concat:' + concatKey);
         }
     }
 
@@ -391,7 +392,7 @@ module.exports = function(grunt) {
         target.options.sourceMapRoot = '<%= DIR_REL %>/';
         target.options.sourceMapPrefix = 1 + config.DIR_BASE.replace(/\/\/+/g, '/').replace(/[^\/]/g, '').length;
         config.uglify[key + '_debug'] = target;
-        jsTargets.debug.push('uglify:' + key + '_debug');
+        jsTargets.debug.push('newer:uglify:' + key + '_debug');
     }
 
     // Let's define the less section (for generating CSS files)

--- a/build/package.json
+++ b/build/package.json
@@ -1,18 +1,19 @@
 {
-	"name": "concrete5",
-	"version": "5.7.0",
-	"devDependencies": {
-		"grunt": "~0.4.1",
-		"temp": "~0.8.1",
-		"grunt-contrib-watch": "^0.6.1",
-		"grunt-contrib-concat": "~0.3.0",
-		"grunt-contrib-uglify": "~0.2.4",
-		"grunt-contrib-less": "~0.11.0",
-		"grunt-contrib-cssmin": "~0.6.2",
-		"shelljs": "0.2.6",
-		"download": "~0.1.18"
-	},
-	"scripts": {
-		"install": "grunt release"
-	}
+  "name": "concrete5",
+  "version": "5.7.0",
+  "devDependencies": {
+    "download": "~0.1.18",
+    "grunt": "~0.4.1",
+    "grunt-contrib-concat": "~0.3.0",
+    "grunt-contrib-cssmin": "~0.6.2",
+    "grunt-contrib-less": "~0.11.0",
+    "grunt-contrib-uglify": "~0.2.4",
+    "grunt-contrib-watch": "^0.6.1",
+    "grunt-newer": "^0.7.0",
+    "shelljs": "0.2.6",
+    "temp": "~0.8.1"
+  },
+  "scripts": {
+    "install": "grunt release"
+  }
 }


### PR DESCRIPTION
Use grunt-newer for js complilation instead of compiling every single
javascript file in the entire project every time you edit a line of
javascript code. AKA 1 second instead of 15.
