### PR TITLE
Hande multiple fonts in style customizer

### DIFF
--- a/web/concrete/js/build/core/style-customizer/typography.js
+++ b/web/concrete/js/build/core/style-customizer/typography.js
@@ -87,7 +87,7 @@
 
             my.setValue('font-family', my.fonts[fontFamilyName].css);
             my.$fontMenu.val(fontFamilyName);
-            my.$fontMenu.css('font-family', my.font[fontFamilyName].css);
+            my.$fontMenu.css('font-family', my.fonts[fontFamilyName].css);
         } else {
             my.$widget.find('[data-wrapper=fontFamily]').remove();
             my.$element.find('[data-wrapper=fontFamily]').remove();


### PR DESCRIPTION
The style customizer did not handle multiple fonts.

When multiple fonts as set in css use the first defined font as the
display name.
Use the full css string for saving.
