### PR TITLE
Check for Doc Comments on Install

### DIFF
--- a/web/concrete/controllers/install.php
+++ b/web/concrete/controllers/install.php
@@ -23,6 +23,13 @@ if (!ini_get('safe_mode')) {
 class Install extends Controller
 {
 
+    /**
+     * This is to check if comments are being stripped
+     * Doctrine ORM depends on comments not being stripped
+     * @var int
+     */
+    protected $docCommentCanary = 1;
+
     protected $fp;
     protected $fpu;
 
@@ -178,6 +185,9 @@ class Install extends Controller
         $this->set('xmlTest', function_exists('xml_parse') && function_exists('simplexml_load_file'));
         $this->set('fileWriteTest', $this->testFileWritePermissions());
         $this->set('finfoTest', function_exists('finfo_open'));
+        $rf = new \ReflectionObject($this);
+        $rp = $rf->getProperty('docCommentCanary');
+        $this->set('docCommentTest', (bool) $rp->getDocComment());
 
         $val = $this->getBytes(ini_get('memory_limit'));
         $this->set('memoryBytes', $val);
@@ -234,7 +244,7 @@ class Install extends Controller
     {
         if ($this->get('imageTest') && $this->get('mysqlTest') && $this->get('fileWriteTest') && $this->get(
                 'xmlTest') && $this->get('phpVtest') && $this->get('i18nTest') && $this->get('finfoTest')
-            && $this->get('memoryTest') !== -1
+            && $this->get('memoryTest') !== -1 && $this->get('docCommentTest')
         ) {
             return true;
         }

--- a/web/concrete/views/frontend/install.php
+++ b/web/concrete/views/frontend/install.php
@@ -406,6 +406,11 @@ $(function() {
     </td>
     <td><? if (!$i18nTest) { ?><i class="fa fa-question-circle launch-tooltip" title="<?=t('You must enable ctype support in your copy of PHP.')?>"></i><? } ?></td>
 </tr>
+<tr>
+    <td><? if ($docCommentTest) { ?><i class="fa fa-check"></i><? } else { ?><i class="fa fa-excalmation-circle"></i><? } ?></td>
+    <td width="100%"><?=t('Doc Comment Support')?>
+    <td><? if (!$docCommentTest) { ?><i class="fa fa-question-circle launch-tooltip" title="<?=t('concrete5 is not compatible with opcode caches that strip PHP comments. Older versions of eAccelerator can have this issue.')?>"></td><? } ?></td>
+</tr>
 </table>
 
 </div>


### PR DESCRIPTION
Check for doc comments on install as Doctrine ORM depends on them for
annotations.

Older veresions of eAccelerator would strip comments.
