### PR TITLE
Add parameters to route closures

### DIFF
--- a/web/concrete/src/Routing/ClosureRouteCallback.php
+++ b/web/concrete/src/Routing/ClosureRouteCallback.php
@@ -4,24 +4,28 @@ use Symfony\Component\HttpKernel;
 use Response;
 use Request;
 
-class ClosureRouteCallback extends RouteCallback {
+class ClosureRouteCallback extends RouteCallback
+{
+    public function execute(Request $request, \Concrete\Core\Routing\Route $route, $parameters)
+    {
+        $resolver = new HttpKernel\Controller\ControllerResolver();
+        $arguments = $resolver->getArguments($request, $this->callback);
+        $r = new Response();
+        $r->setContent(call_user_func_array($this->callback, $arguments));
 
-	public function execute(Request $request, \Concrete\Core\Routing\Route $route, $parameters) {
-		$resolver = new HttpKernel\Controller\ControllerResolver();
-		$arguments = $resolver->getArguments($request, $this->callback);
-		$r = new Response();
-		$r->setContent(call_user_func_array($this->callback, $arguments));
-		return $r;
-	}
+        return $r;
+    }
 
-	public function __sleep() {
-		unset($this->callback);
-	}
+    public function __sleep()
+    {
+        unset($this->callback);
+    }
 
-	public static function getRouteAttributes($callback) {
-		$callback = new static($callback);
-		return array('callback' => $callback);
-	}
+    public static function getRouteAttributes($callback)
+    {
+        $callback = new static($callback);
 
+        return array('callback' => $callback);
+    }
 
 }


### PR DESCRIPTION
Use 'HttpKernel\Controller\ControllerResolver::getArguments' to get the
parameter arguments mapped properly to the closure function arguments

Function arguments must have the same name as the route parameters but
can be in any order.
