### PR TITLE
Fix npm install instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ This is a developer preview branch. This is intended for Add-On developers and c
 4. Use [npm](https://www.npmjs.org/) to install [grunt](http://gruntjs.com/) to the build directory and install the command line interface
 
         cd build
-        npm install grunt grunt-contrib-concat grunt-contrib-uglify grunt-contrib-cssmin grunt-contrib-less grunt-contrib-watch
-		npm install -g grunt-cli
+        npm install -g grunt-cli
+        npm install
 
 5. Build concrete5 sources with grunt
 


### PR DESCRIPTION
Not sure if we should make a note that "grunt release" gets run automatically after install so the initial "grunt release" technically isn't needed, but I feel like its probably better just to leave it.
