### PR TITLE
Clear translations cache when installing/updating/removing packages

### DIFF
--- a/web/concrete/controllers/single_page/dashboard/extend/install.php
+++ b/web/concrete/controllers/single_page/dashboard/extend/install.php
@@ -130,13 +130,6 @@ class Install extends DashboardPageController
                             if ($currentLocale != 'en_US') {
                                 Localization::changeLocale($currentLocale);
                             }
-                            $translate = Localization::getTranslate();
-                            if(is_object($translate)) {
-                                $cache = $translate->getCache();
-                                if(is_object($cache) && method_exists($cache, 'flush')) {
-                                    $cache->flush();
-                                }
-                            }
                             $pkg = Package::getByHandle($p->getPackageHandle());
                             $this->redirect('/dashboard/extend/install', 'package_installed', $pkg->getPackageID());
                         } catch (Exception $e) {

--- a/web/concrete/single_pages/dashboard/extend/install.php
+++ b/web/concrete/single_pages/dashboard/extend/install.php
@@ -122,13 +122,7 @@ if ($this->controller->getTask() == 'install_package' && $showInstallOptionsScre
             $pkgAvailableArray[] = $_pkg;
         }
         if(count($pkgAvailableArray) > 0) {
-            $translate = Localization::getTranslate();
-            if(is_object($translate)) {
-                $cache = $translate->getCache();
-                if(is_object($cache) && method_exists($cache, 'flush')) {
-                    $cache->flush();
-                }
-            }
+            Localization::clearCache();
         }
     }
 

--- a/web/concrete/src/Localization/Localization.php
+++ b/web/concrete/src/Localization/Localization.php
@@ -10,6 +10,10 @@ use \Punic\Data as PunicData;
 class Localization
 {
     private static $loc = null;
+    /**
+     * @var ZendCacheDriver|null
+     */
+    private static $cache = null;
 
     public static function getInstance()
     {
@@ -69,7 +73,7 @@ class Localization
         $this->translate = new Translator();
         $this->translate->addTranslationFilePattern('gettext', $languageDir, 'LC_MESSAGES/messages.mo');
         $this->translate->setLocale($locale);
-        $this->translate->setCache(new ZendCacheDriver('cache/expensive'));
+        $this->translate->setCache(self::getCache());
         PunicData::setDefaultLocale($locale);
 
         $event = new \Symfony\Component\EventDispatcher\GenericEvent();
@@ -91,7 +95,7 @@ class Localization
     {
         if (!is_object($this->translate)) {
             $this->translate = new Translator();
-            $this->translate->setCache(new ZendCacheDriver('cache/expensive'));
+            $this->translate->setCache(self::getCache());
         }
         $this->translate->addTranslationFilePattern('gettext', DIR_LANGUAGES_SITE_INTERFACE, $language . '.mo');
     }
@@ -171,4 +175,23 @@ class Localization
         return \Punic\Language::getName($locale, is_null($displayLocale) ? $locale : $displayLocale);
     }
 
+    /**
+     * @return ZendCacheDriver
+     */
+    protected static function getCache()
+    {
+        if (is_null(self::$cache)) {
+            self::$cache = new ZendCacheDriver('cache/expensive');
+        }
+
+        return self::$cache;
+    }
+
+    /**
+     * Clear the translations cache
+     */
+    public static function clearCache()
+    {
+        self::getCache()->flush();
+    }
 }

--- a/web/concrete/src/Package/Package.php
+++ b/web/concrete/src/Package/Package.php
@@ -516,13 +516,7 @@ class Package extends Object
         \Core::make('config/database')->clearNamespace($this->getPackageHandle());
 
         $db->Execute("delete from Packages where pkgID = ?", array($this->pkgID));
-        $translate = Localization::getTranslate();
-        if(is_object($translate)) {
-            $cache = $translate->getCache();
-            if(is_object($cache) && method_exists($cache, 'flush')) {
-                $cache->flush();
-            }
-        }
+        Localization::clearCache();
     }
 
     protected function validateClearSiteContents($options)
@@ -771,6 +765,7 @@ class Package extends Object
         Package::installDB($pkg->getPackagePath() . '/' . FILENAME_PACKAGE_DB);
         $env = Environment::get();
         $env->clearOverrideCache();
+        Localization::clearCache();
 
         return $pkg;
     }
@@ -800,13 +795,7 @@ class Package extends Object
                 $item->refresh();
             }
         }
-        $translate = Localization::getTranslate();
-        if(is_object($translate)) {
-            $cache = $translate->getCache();
-            if(is_object($cache) && method_exists($cache, 'flush')) {
-                $cache->flush();
-            }
-        }
+        Localization::clearCache();
     }
 
     public static function getInstalledHandles()


### PR DESCRIPTION
I added a new static method `Localization::clearCache` that flushes the translations cache when packages get installed/upgraded/removed.

PS: the changes to `web/concrete/controllers/single_page/dashboard/extend/install.php` are mostly indentation fixes.
