### PR TITLE
Fix Error on Stack GlobalArea delete

### DIFF
--- a/web/concrete/src/Page/Stack/Stack.php
+++ b/web/concrete/src/Page/Stack/Stack.php
@@ -2,6 +2,7 @@
 namespace Concrete\Core\Page\Stack;
 
 use Area;
+use GlobalArea;
 use CacheLocal;
 use Config;
 use Loader;


### PR DESCRIPTION
When deleting a stack from GlobalArea stack section of the dashboard the
deletion will fail with the error
`Class 'Concrete\Core\Page\Stack\GlobalArea' not found`

Add `use Global` statement
