### PR TITLE
Fix Block Custom Style Edit Mode Breaking

### DIFF
--- a/web/concrete/js/build/core/style-customizer/inline-toolbar.js
+++ b/web/concrete/js/build/core/style-customizer/inline-toolbar.js
@@ -114,9 +114,6 @@
             arEnableGridContainer = area.getEnableGridContainer() ? 1 : 0,
             action = CCM_DISPATCHER_FILENAME + '/ccm/system/block/render';
 
-        if (block.getId() != parseInt(resp.bID)) {
-            block.id = parseInt(resp.bID);
-        }
         $.get(action, {
             arHandle: area.getHandle(),
             cID: resp.cID,


### PR DESCRIPTION
After adding a custom style to a block the edit mode interface no longer
functions properly until the page is refreshed.

Change event to `EditModeExitInline`
Remove `destroyInlineEditModeToolbars` called down the even chain

Closes #1219
