### PR TITLE
Fix opacity on inline block style design

### DIFF
--- a/web/concrete/js/build/core/app/edit-mode/editmode.js
+++ b/web/concrete/js/build/core/app/edit-mode/editmode.js
@@ -100,8 +100,8 @@
 //            ConcreteMenuManager.disable();
                 ConcreteToolbar.disable();
                 $('div.ccm-area').addClass('ccm-area-inline-edit-disabled');
+                block.getElem().addClass('ccm-block-edit-inline-active');
 
-                $container.addClass('ccm-block-edit-inline-active');
 
                 $.ajax({
                     type: 'GET',
@@ -109,7 +109,10 @@
                     data: postData,
                     success: function (r) {
                         var elem = $(r);
-                        $container.empty().append(elem);
+                        $container.empty()
+                                  .append(elem)
+                                  .find('.ccm-block-edit')
+                                  .addClass('ccm-block-edit-inline-active');
                         my.loadInlineEditModeToolbars($container);
                         $.fn.dialog.hideLoader();
                         Concrete.event.fire('EditModeInlineEditLoaded', {


### PR DESCRIPTION
Add `ccm-block-edit-inline-active` to set opacity to 1 while in inline
edit mode for block style design
