### PR TITLE
Deal with FileSet::getByName() ambiguity

### DIFF
--- a/web/concrete/src/File/Set/Set.php
+++ b/web/concrete/src/File/Set/Set.php
@@ -20,6 +20,7 @@ class Set implements \Concrete\Core\Permission\ObjectInterface
     const TYPE_PUBLIC = 1;
     const TYPE_STARRED = 2;
     const TYPE_SAVED_SEARCH = 3;
+    const GLOBAL_FILESET_USER_ID = 0;
     protected $fileSetFiles;
 
     /**
@@ -36,7 +37,7 @@ class Set implements \Concrete\Core\Permission\ObjectInterface
 
     public static function getMySets($u = false)
     {
-        if ($u == false) {
+        if ($u === false) {
             $u = new User();
         }
         $db = Loader::db();
@@ -70,7 +71,7 @@ class Set implements \Concrete\Core\Permission\ObjectInterface
      */
     public static function createAndGetSet($fs_name, $fs_type, $fs_uid = false)
     {
-        if (!$fs_uid) {
+        if ($fs_uid === false) {
             $u = new User();
             $fs_uid = $u->uID;
         }
@@ -162,13 +163,14 @@ class Set implements \Concrete\Core\Permission\ObjectInterface
     /**
      * Static method to return an array of File objects by the set name
      *
-     * @param  string $fsName
+     * @param  string   $fsName
+     * @param  int|bool $uID
      * @return array
      */
-    public static function getFilesBySetName($fsName)
+    public static function getFilesBySetName($fsName, $uID = false)
     {
         if (!empty($fsName)) {
-            $fileset = self::getByName($fsName);
+            $fileset = self::getByName($fsName, $uID);
             if ($fileset instanceof \Concrete\Core\File\Set\Set) {
                 return $fileset->getFiles();
             }
@@ -178,13 +180,18 @@ class Set implements \Concrete\Core\Permission\ObjectInterface
     /**
      * Get a file set object by a file name
      *
-     * @param string $fsName
+     * @param  string   $fsName
+     * @param  int|bool $uID
      * @return FileSet
      */
-    public static function getByName($fsName)
+    public static function getByName($fsName, $uID = false)
     {
         $db = Loader::db();
-        $row = $db->GetRow('SELECT * FROM FileSets WHERE fsName = ?', array($fsName));
+        if ($uID !== false) {
+            $row = $db->GetRow('SELECT * FROM FileSets WHERE fsName = ? AND uID = ?', array($fsName, $uID));
+        } else {
+            $row = $db->GetRow('SELECT * FROM FileSets WHERE fsName = ?', array($fsName));
+        }
         if (is_array($row) && count($row)) {
             $fs = new static();
             $fs = array_to_object($fs, $row);


### PR DESCRIPTION
`FileSet::getByName()` gets the first row matching fsName from the FileSets table
https://github.com/concrete5/concrete5-5.7.0/blob/develop/web/concrete/src/File/Set/Set.php#L187

This is regardless of which uID the file set is attached to. This gets a little awkward because you can have many file sets with the same name.
https://github.com/concrete5/concrete5-5.7.0/blob/develop/web/concrete/src/File/Set/Set.php#L69
Someone was even nice enough to  put a note about that :wink: 

Which makes me wonder what this will end up returning
https://github.com/concrete5/concrete5-5.7.0/blob/develop/web/concrete/tools/conversations/add_file.php#L156

So I used to use a "global" file set with a uID of 0 in own projects and write a few helper methods to get  around the issue. This pull request attempts to come up with a backwards compatible way to deal with the issue. An alternative implementation would be to add a `FileSet::setUserID()` method and use that instead of the additional function parameter. I wasn't quite sure which pattern was currently preferred.

---
- Add global uID for global file sets not owned by any user
- Add strict check to `FileSet::getMySets() and
  `FileSet::createAndGetSet()`
- Add optional parameters for uID to `FileSet::getByName()` and
  `FileSet::getFilesBySetName()`
