### PR TITLE
Fix variable check for white label background on login page

### DIFF
--- a/web/concrete/single_pages/login.php
+++ b/web/concrete/single_pages/login.php
@@ -189,7 +189,7 @@ $attribute_mode = (isset($required_attributes) && count($required_attributes));
             }, 0);
 
 
-            <?php if(!Config::get('concrete.white_label.background_image') !== 'none') { ?>
+            <?php if(Config::get('concrete.white_label.background_image') !== 'none') { ?>
             $(function () {
                 var shown = false, info;
                 $.getJSON('<?= BASE_URL . DIR_REL . '/' . DISPATCHER_FILENAME . '/tools/required/dashboard/get_image_data' ?>', { image: '<?= $image ?>' }, function (data) {


### PR DESCRIPTION
Remove redundant exclamation mark from variable check. Causes unwanted behavior, see e.g. http://3v4l.org/fUMr4
