### PR TITLE
Add charset to emails' content types

### DIFF
--- a/web/concrete/src/Mail/Service.php
+++ b/web/concrete/src/Mail/Service.php
@@ -450,6 +450,7 @@ class Service
 
             $text = new MimePart($this->body);
             $text->type = "text/plain";
+            $text->charset = APP_CHARSET;
 
             $body = new MimeMessage();
             $body->setParts(array($text));
@@ -457,6 +458,7 @@ class Service
             if ($this->bodyHTML != false) {
                 $html = new MimePart($this->bodyHTML);
                 $html->type = "text/html";
+                $html->charset = APP_CHARSET;
                 $body->addPart($html);
             }
 


### PR DESCRIPTION
Currently encoding was set only to `Zend\Mail\Message`. Some email clients shows emails' content in wrong encoding if charset is not set to content type parts of header.
