### PR TITLE
Added separator argument to getContainerClass

### DIFF
--- a/web/concrete/src/Area/CustomStyle.php
+++ b/web/concrete/src/Area/CustomStyle.php
@@ -19,7 +19,7 @@ class CustomStyle extends AbstractCustomStyle
     public function getCSS()
     {
         $set = $this->set;
-        $css = '.' . $this->getContainerClass() . '{';
+        $css = '.' . $this->getContainerClass('.') . '{';
         if ($set->getBackgroundColor()) {
             $css .= 'background-color:' . $set->getBackgroundColor() . ';';
         }
@@ -84,13 +84,13 @@ class CustomStyle extends AbstractCustomStyle
         return $css;
     }
 
-    public function getContainerClass()
+    public function getContainerClass($separator = ' ')
     {
         $class = 'ccm-custom-style-';
         $txt = Core::make('helper/text');
         $class .= strtolower($txt->filterNonAlphaNum($this->arHandle));
         if (is_object($this->set) && $this->set->getCustomClass()) {
-            $class .= ' ' . $this->set->getCustomClass();
+            $class .= $separator . $this->set->getCustomClass();
         }
         return $class;
     }


### PR DESCRIPTION
(default separator is ' ' when setting the class attribute, but needs to be changed to '.' when printing inline CSS).
This fixes an issue when adding both custom styles and a custom class to an area. The resulting class attribute was ok ("ccm-custom-style-area custom-class") but the inline CSS was wrong (".ccm-custom-style-area custom-class" instead of ".ccm-custom-style-area.custom-class"). 
