### PR TITLE
Allow to send option (preferredFormat, rgb or hex) to the method.

### DIFF
--- a/web/concrete/src/Form/Service/Widget/Color.php
+++ b/web/concrete/src/Form/Service/Widget/Color.php
@@ -31,7 +31,7 @@ class Color
         $options['showInput'] = true;
         $options['cancelText'] = t('Cancel');
         $options['chooseText'] = t('Choose');
-        $options['preferredFormat'] = 'rgb';
+        $options['preferredFormat'] = isset($options['preferredFormat'])?$options['preferredFormat']:'rgb';
         $options['clearText'] = t('Clear Color Selection');
         $strOptions = json_encode($options);
 


### PR DESCRIPTION
Allow to send option (preferredFormat, rgb or hex) to the method via output method:

```
$ch->output('color', $color, array('preferredFormat'=>'hex'));
```
