### PR TITLE
Allow user to override allowed filename extensions

### DIFF
--- a/web/concrete/src/File/ValidationService.php
+++ b/web/concrete/src/File/ValidationService.php
@@ -53,23 +53,30 @@ class ValidationService {
 
 	/**
 	* Parses the file extension for a given file name, checks it to see if it's in the the extension array if provided
-	* if not, it checks to see if it's in the UPLOAD_FILE_EXTENSIONS_ALLOWED constant
+	* if not, it checks to see if it's in the configuration, under the "upload.extensions" key
 	* @param string $filename
 	* @param array $extensions
 	* @return boolean
 	*/
-
 	public function extension($filename, $extensions = NULL) {
 		$f = Loader::helper('file');
 		$ext = strtolower($f->getExtension($filename));
 		if(isset($extensions) && is_array($extensions) && count($extensions)) {
 			$allowed_extensions = $extensions;
-		} else { // pull from constants
-			$extensions_string = strtolower(str_replace(array("*","."), "", Config::get('concrete.upload.extensions')));
+		} else { // pull from config
+			if (Config::get('app.upload.extensions')!==null) {
+				// user provided config exists - use that
+				$extensions = Config::get('app.upload.extensions');
+			} else {
+				// fall-back to default
+				$extensions = Config::get('concrete.upload.extensions');
+			}
+			$extensions_string = strtolower(str_replace(array("*","."), "", $extensions));
 			$allowed_extensions = explode(";",$extensions_string);
 		}
 		return in_array($ext,$allowed_extensions);
 	}
+
 
 	/**
 	 * @access private


### PR DESCRIPTION
The code and the comments here were wrong. It claimed to still look at the (5.6) UPLOAD_FILE_EXTENSIONS_ALLOWED constant, but it only looked at the 'concrete.upload.extensions' configuration. This basically means that you can't override it without editing the core.

I adjusted the code to first check if the user has provided an alternative list of allowed upload extensions, and to fall back to the default list if he/she hasn't. I also adjusted the documentation to match this behavior.
