### PR TITLE
on_page_add should have access to the newly created page

### DIFF
--- a/web/concrete/src/Page/Page.php
+++ b/web/concrete/src/Page/Page.php
@@ -2491,7 +2491,7 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
             $pc = Page::getByID($newCID, 'RECENT');
 
             // run any internal event we have for page addition
-            $pe = new Event($this);
+            $pe = new Event($pc);
             Events::dispatch('on_page_add', $pe);
 
             $pc->rescanCollectionPath();


### PR DESCRIPTION
When the `on_page_add` event is called, it should pass in a reference to the _new_ page instead of to `$this` (which in my case resolved to the "drafts" system page). Otherwise there is no way to get to the newly created page, since not even the cID of the new page is stored... Also, I can't think of a situation where it is useful to get a link to the "drafts" page when you're adding a new page. Therefore, I think this is/was probably a bug.
