### PR TITLE
Bugfix: Use default page template if available

### DIFF
--- a/web/concrete/src/Page/Page.php
+++ b/web/concrete/src/Page/Page.php
@@ -2449,14 +2449,17 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
                 $pkgID = $pt->getPackageID();
             }
 
+            // if we have a page type and we don't have a template,
+            // then we use the page type's default template
+            if (intval($pt->ptDefaultPageTemplateID)>0 && !$template) {
+                $template = \Concrete\Core\Page\Template::getByID($pt->ptDefaultPageTemplateID);
+            }
+
             $ptID = $pt->getPageTypeID();
             if ($template) {
                 $mc = $pt->getPageTypePageTemplateDefaultPageObject($template);
                 $masterCID = $mc->getCollectionID();
             }
-
-            // when provided a page type, use its default page template
-            $data['pTemplateID'] = $pt->ptDefaultPageTemplateID;
         }
 
         if ($template instanceof PageTemplate) {


### PR DESCRIPTION
When adding a page (probably only programmatically), the default page template was not respected. Adding a page of type 'X' would result in adding a page of type X with a blank/no template, which would in turn display as the default template. I added one line of code to resolve that, so it now uses the page type's default template if we know it. The template can still be overridden by manually providing the `$template` parameter.
