### PR TITLE
Don't call methods on undefined variables...

### DIFF
--- a/web/concrete/blocks/core_stack_display/controller.php
+++ b/web/concrete/blocks/core_stack_display/controller.php
@@ -66,7 +66,7 @@ class Controller extends BlockController {
 					}
 					$csr = $b->getCustomStyle();
 					if (is_object($csr)) {
-                        $styleHeader = '<style type="text/css" data-style-set="' . $st->getStyleSet()->getID() . '">' . $st->getCSS() . '</style>';
+                        $styleHeader = '<style type="text/css" data-style-set="' . $csr->getStyleSet()->getID() . '">' . $csr->getCSS() . '</style>';
 						$btc->addHeaderItem($styleHeader);
 					}
 					$btc->runTask('on_page_view', array($page));


### PR DESCRIPTION
The old code tried to invoke a method on an undefined variable. If I change it to '$csr', as seems to be the intention, the error message disappears and the page loads normally.
