### PR TITLE
Add detach button to oauth authentication types

### DIFF
--- a/web/concrete/authentication/community/controller.php
+++ b/web/concrete/authentication/community/controller.php
@@ -15,8 +15,8 @@ class Controller extends GenericOauth2TypeController
     public function getAuthenticationTypeIconHTML()
     {
         return '<div class="ccm-concrete-authentication-type-svg" data-src="/concrete/images/authentication/community/concrete.svg">' .
-                    file_get_contents(DIR_BASE_CORE . '/images/authentication/community/concrete.svg') .
-               '</div>';
+        file_get_contents(DIR_BASE_CORE . '/images/authentication/community/concrete.svg') .
+        '</div>';
     }
 
     public function getHandle()
@@ -52,11 +52,13 @@ class Controller extends GenericOauth2TypeController
     /**
      * @return Array
      */
-    public function getAdditionalRequestParameters() {
+    public function getAdditionalRequestParameters()
+    {
         return array('state' => time());
     }
 
-    public function getExtractor() {
+    public function getExtractor()
+    {
         try {
             return parent::getExtractor();
         } catch (\Exception $e) {

--- a/web/concrete/authentication/community/hook.php
+++ b/web/concrete/authentication/community/hook.php
@@ -1,4 +1,3 @@
-
 <div class="form-group">
         <span>
             <?= t('Attach a community account') ?>
@@ -6,27 +5,48 @@
     <hr>
 </div>
 <div class="form-group">
-    <a href="<?= \URL::to('/system/authentication/community/attempt_attach'); ?>" class="btn btn-primary btn-community">
-        <img src="<?= BASE_URL . DIR_REL ?>/concrete/images/logo.png" class="concrete5-icon"></i>
-        <?= t('Attach a concrete5.org account') ?>
-    </a>
+    <?php
+    if ($attached) {
+        ?>
+        <div class="btn-group">
+            <a href="<?= \URL::to('/system/authentication/community/attempt_attach'); ?>"
+               class="btn btn-primary btn-community" target="_blank">
+                <img src="<?= BASE_URL . DIR_REL ?>/concrete/images/logo.png" class="concrete5-icon"></i>
+                <?= t('Attach a concrete5.org account') ?>
+            </a>
+            <a href="<?= \URL::to(
+                '/login/callback/community/handle_detach',
+                id(new \Concrete\Core\Validation\CSRF\Token)->generate('oauth_detach')); ?>"
+               class="btn btn-danger" target="_blank">
+                <?= t('Detach') ?>
+            </a>
+        </div>
+    <?php
+    } else {
+        ?>
+        <a href="<?= \URL::to('/system/authentication/community/attempt_attach'); ?>"
+           class="btn btn-primary btn-community" target="_blank">
+            <img src="<?= BASE_URL . DIR_REL ?>/concrete/images/logo.png" class="concrete5-icon"></i>
+            <?= t('Attach a concrete5.org account') ?>
+        </a>
+    <?php
+    }
+    ?>
 </div>
 
 <style>
     .ccm-ui .btn-community {
-        border-width: 0px;
-        background: rgb(31,186,232);
-        background: -moz-linear-gradient(top, rgba(31,186,232,1) 0%, rgba(18,155,211,1) 100%); /* FF3.6+ */
-        background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,rgba(31,186,232,1)), color-stop(100%,rgba(18,155,211,1)));
-        background: -webkit-linear-gradient(top, rgba(31,186,232,1) 0%,rgba(18,155,211,1) 100%);
-        background: -o-linear-gradient(top, rgba(31,186,232,1) 0%,rgba(18,155,211,1) 100%);
-        background: -ms-linear-gradient(top, rgba(31,186,232,1) 0%,rgba(18,155,211,1) 100%);
-        background: linear-gradient(to bottom, rgba(31,186,232,1) 0%,rgba(18,155,211,1) 100%);
-        filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#1fbae8', endColorstr='#129bd3',GradientType=0 );
+        border-color: transparent;
+        background: rgb(31, 186, 232);
+    }
+
+    .ccm-ui .btn-community:hover {
+        background: rgb(28, 163, 205);
+        border-color: transparent;
     }
 
     img.concrete5-icon {
-        width: 20px;
-        margin-right:5px;
+        height: 18px;
+        margin-right: 5px;
     }
 </style>

--- a/web/concrete/authentication/facebook/hook.php
+++ b/web/concrete/authentication/facebook/hook.php
@@ -7,17 +7,41 @@
     <hr>
 </div>
 <div class="form-group">
-    <a href="<?= \URL::to('/system/authentication/facebook/attempt_attach'); ?>" class="btn btn-primary btn-facebook">
-        <i class="fa fa-facebook"></i>
-        <?= t('Attach a %s account', t('facebook')) ?>
-    </a>
+    <?php
+    if ($attached) {
+        ?>
+        <div class="btn-group">
+            <a href="<?= \URL::to('/system/authentication/facebook/attempt_attach'); ?>"
+               class="btn btn-primary btn-facebook" target="_blank">
+                <i class="fa fa-facebook"></i>
+                <?= t('Attach a %s account', t('facebook')) ?>
+            </a>
+            <a href="<?= \URL::to(
+                '/login/callback/facebook/handle_detach',
+                id(new \Concrete\Core\Validation\CSRF\Token)->generate('oauth_detach')); ?>"
+               class="btn btn-danger" target="_blank">
+                <?= t('Detach') ?>
+            </a>
+        </div>
+    <?php
+    } else {
+        ?>
+        <a href="<?= \URL::to('/system/authentication/facebook/attempt_attach'); ?>"
+           class="btn btn-primary btn-facebook" target="_blank">
+            <i class="fa fa-facebook"></i>
+            <?= t('Attach a %s account', t('facebook')) ?>
+        </a>
+    <?php
+    }
+    ?>
 </div>
 
 <style>
     .ccm-ui .btn-facebook {
-        border-width: 0px;
+        border-color: transparent;
         background: #3b5998;
     }
+
     .btn-facebook .fa-facebook {
         margin: 0 6px 0 3px;
     }

--- a/web/concrete/authentication/twitter/hook.php
+++ b/web/concrete/authentication/twitter/hook.php
@@ -8,15 +8,42 @@ defined('C5_EXECUTE') or die('Access Denied');
     <hr>
 </div>
 <div class="form-group">
-    <a href="<?= \URL::to('/system/authentication/twitter/attempt_attach'); ?>"
-       class="btn btn-primary btn-twitter">
-        <i class="fa fa-twitter"></i>
-        <?= t('Attach a %s account', t('twitter')) ?>
-    </a>
 </div>
+
+
+<div class="form-group">
+    <?php
+    if ($attached) {
+        ?>
+        <div class="btn-group">
+            <a href="<?= \URL::to('/system/authentication/twitter/attempt_attach'); ?>"
+               class="btn btn-primary btn-twitter target="_blank"">
+                <i class="fa fa-twitter"></i>
+                <?= t('Attach a %s account', t('twitter')) ?>
+            </a>
+            <a href="<?= \URL::to(
+                '/login/callback/twitter/handle_detach',
+                id(new \Concrete\Core\Validation\CSRF\Token)->generate('oauth_detach')); ?>"
+               class="btn btn-danger" target="_blank">
+                <?= t('Detach') ?>
+            </a>
+        </div>
+    <?php
+    } else {
+        ?>
+        <a href="<?= \URL::to('/system/authentication/twitter/attempt_attach'); ?>"
+           class="btn btn-primary btn-twitter" target="_blank">
+            <i class="fa fa-twitter"></i>
+            <?= t('Attach a %s account', t('twitter')) ?>
+        </a>
+    <?php
+    }
+    ?>
+</div>
+
 <style>
     .ccm-ui .btn-twitter {
-        border-width: 0px;
+        border-color: transparent;
         background: #00aced;
     }
 

--- a/web/concrete/src/Authentication/Type/OAuth/GenericOauthTypeController.php
+++ b/web/concrete/src/Authentication/Type/OAuth/GenericOauthTypeController.php
@@ -2,6 +2,7 @@
 namespace Concrete\Core\Authentication\Type\OAuth;
 
 use Concrete\Core\Authentication\AuthenticationTypeController;
+use Concrete\Core\Validation\CSRF\Token;
 use OAuth\Common\Exception\Exception;
 use OAuth\Common\Service\AbstractService;
 use OAuth\Common\Token\TokenInterface;
@@ -10,7 +11,7 @@ use OAuth\UserData\Extractor\Extractor;
 abstract class GenericOauthTypeController extends AuthenticationTypeController
 {
 
-    public $apiMethods = array('handle_error', 'handle_success');
+    public $apiMethods = array('handle_error', 'handle_success', 'handle_detach');
 
     /**
      * @var \OAuth\Common\Service\AbstractService
@@ -65,6 +66,59 @@ abstract class GenericOauthTypeController extends AuthenticationTypeController
         return array();
     }
 
+    public function hook()
+    {
+        $this->set('attached', $this->isBoundUser(new \User()));
+    }
+
+    /**
+     * @param \User $user
+     * @return bool
+     */
+    public function isBoundUser(\User $user)
+    {
+        return $this->isBoundUserID($user->getUserID());
+    }
+
+    public function isBoundUserID($user_id)
+    {
+
+        $qb = \Database::connection()->createQueryBuilder();
+
+        $and = $qb->expr()->andX();
+        $and->add($qb->expr()->comparison('namespace', '=', ':namespace'));
+        $and->add($qb->expr()->eq('user_id', intval($user_id, 10)));
+
+        $result = $qb->select('count(binding)')->from('OauthUserMap', 'map')
+                     ->where($and)
+                     ->setParameter(':namespace', $this->getHandle())
+                     ->execute();
+
+        foreach ($result as $row) {
+            return !!intval(array_shift($row), 10);
+        }
+
+        return false;
+    }
+
+    public function unbindUser(\User $user)
+    {
+        $this->unbindUserID($user->getUserID());
+    }
+
+    public function unbindUserID($user_id)
+    {
+        $qb = \Database::connection()->createQueryBuilder();
+
+        $and = $qb->expr()->andX();
+        $and->add($qb->expr()->comparison('namespace', '=', ':namespace'));
+        $and->add($qb->expr()->eq('user_id', intval($user_id, 10)));
+
+        $qb->delete('OauthUserMap')->where($and)
+           ->setParameter(':namespace', $this->getHandle())
+           ->execute();
+    }
+
     /**
      * @param \User $user
      * @param       $binding
@@ -82,10 +136,10 @@ abstract class GenericOauthTypeController extends AuthenticationTypeController
      */
     public function bindUserID($user_id, $binding)
     {
-
         if (!$binding || !$user_id) {
             return null;
         }
+
         $qb = \Database::connection()->createQueryBuilder();
 
         $or = $qb->expr()->orX();
@@ -324,6 +378,15 @@ abstract class GenericOauthTypeController extends AuthenticationTypeController
         }
 
         $this->set('error', $error);
+    }
+
+    public function handle_detach($token=null) {
+        if (!id(new Token)->validate('oauth_detach', $token)) {
+            $this->showError('Invalid token.');
+        } else {
+            $this->unbindUser(new \User);
+            $this->showSuccess('Successfully detached user.');
+        }
     }
 
     public function showError($error = null)


### PR DESCRIPTION
This presents a pretty serious issue: if a user creates an account with facebook login, then detaches, it will cause the user to lose the ability to log in.  
After completing it, I'd much rather leave this for the next point release accompanied by something like `$user->getRegisteredAuthTypeHandle()` to prevent detaching the auth type you registered with.
