### PR TITLE
'X' => text, 'X2' => longtext

### DIFF
--- a/web/concrete/src/Database/Schema/Parser/Axmls.php
+++ b/web/concrete/src/Database/Schema/Parser/Axmls.php
@@ -100,6 +100,14 @@ class Axmls extends XmlParser
                 $options['length'] = $size;
             }
         }
+        switch ($type) {
+            case 'X':
+                $options['length'] = 65535; // this means 'X' will result in a 'TEXT' column
+                break;
+            case 'X2':
+                // no length limitation -> this means 'X2' will result in a 'LONGTEXT' column
+                break;
+        }
         if ($column->unsigned || $column->UNSIGNED) {
             $options['unsigned'] = true;
         }


### PR DESCRIPTION
Adjusted so that columns of type "X" result in a mysql column of type "text", and that "X2" results in a a"longtext" column, to match the behavior of Concrete < 5.7

My application relies on detecting the difference between these two columns, and that's impossible with the current implementation. Also, it is in contradiction with your own documentation: http://www.concrete5.org/documentation/how-tos/developers/creating-and-working-with-db-xml-files/

Unfortunately, this change here _does_ fix the database side of things, but I am nevertheless still not able to discern between these two column types in my code. The Doctrine DBAL doesn't have the required functionality to do that. Newer versions do (the 2.5 release candidate does, see https://github.com/doctrine/dbal/blob/829eb1c8380ec7529d8efc7a970a0a8b4144b25c/lib/Doctrine/DBAL/Schema/MySqlSchemaManager.php), but that version can't be installed without creating conflicting requirements in Composer. So, I fixed that by manually replacing that one file (sigh), while I wait for the 2.5 Release Candidate to turn into an actual release...
