### PR TITLE
File manager should always return a value when form is submitted

### DIFF
--- a/web/concrete/js/build/core/file-manager/selector.js
+++ b/web/concrete/js/build/core/file-manager/selector.js
@@ -39,7 +39,8 @@
     ConcreteFileSelector.prototype = {
 
 
-        chooseTemplate: '<div class="ccm-file-selector-choose-new"><%=options.chooseText%></div>',
+        chooseTemplate: '<div class="ccm-file-selector-choose-new">' +
+            '<input type="hidden" name="<%=options.inputName%>" value="0" /><%=options.chooseText%></div>',
         loadingTemplate: '<div class="ccm-file-selector-loading"><img src="' + CCM_IMAGE_PATH + '/throbber_white_16.gif" /></div>',
         fileLoadedTemplate: '<div class="ccm-file-selector-file-selected"><input type="hidden" name="<%=inputName%>" value="<%=file.fID%>" />' +
             '<div class="ccm-file-selector-file-selected-thumbnail"><%=file.resultsThumbnailImg%></div>' +


### PR DESCRIPTION
If you would clear a file from the file manager popup, it would not get saved. If you would reload the page and edit the block, the file would still be there. The reason for that is that the file manager would return no value when no file is present. I think it's better to change that, so you can add the file manager to a block and have the 'clear' functionality work out of the box.
