### PR TITLE
Make block.js resolve the block correctly when added to grid areas

### DIFF
--- a/web/concrete/js/build/core/app/ajax-request/block.js
+++ b/web/concrete/js/build/core/app/ajax-request/block.js
@@ -54,7 +54,18 @@
 
                 if (my.options.task == 'add') {
                     var $area = area.getElem(), $elem = $(r);
-                    block = new Concrete.Block($elem, Concrete.getEditMode());
+
+
+                    if (!$elem.hasClass('ccm-block-edit')) {
+                        var found = $elem.find('.ccm-block-edit');
+                        if (found.length) {
+                            block = new Concrete.Block(found, Concrete.getEditMode());
+                        }
+                    }
+
+                    if (!block) {
+                        block = new Concrete.Block($elem, Concrete.getEditMode());
+                    }
 
                     if (my.options.btHandle === 'core_area_layout') {
                         $area.children('.ccm-area-block-list').append($elem);


### PR DESCRIPTION
Since render responds with a container div when a block is in a area with grid enabled, we previously would fail to create a valid block object when a block was added to that area. Now we always resolve the block correctly.
