### PR TITLE
Fix js assets not having the correct path

### DIFF
--- a/web/concrete/src/Html/Service/Html.php
+++ b/web/concrete/src/Html/Service/Html.php
@@ -91,7 +91,7 @@ class Html
         } else {
             if (substr($file, 0, 1) == '/') {
                 $asset->setAssetURL($file);
-                $asset->setAssetPath(DIR_APPLICATION . $file);
+                $asset->setAssetPath(DIR_BASE . $file);
             } else {
                 if (file_exists(DIR_APPLICATION . '/' . DIRNAME_JAVASCRIPT . '/' . $file)) {
                     $asset->setAssetURL(REL_DIR_APPLICATION . '/' . DIRNAME_JAVASCRIPT . '/' . $file);


### PR DESCRIPTION
Fixes: http://www.concrete5.org/index.php?cID=667692

original path had /application prepended to it, the CSS method had the correct constant, but the JS method did not.
