### PR TITLE
Fix force upgrade not working.

### DIFF
--- a/web/concrete/controllers/upgrade.php
+++ b/web/concrete/controllers/upgrade.php
@@ -76,6 +76,8 @@ class Upgrade extends BackendUserInterfaceController
 
         if (!$sav) {
             $message = t('Unable to determine your current version of concrete5. Upgrading cannot continue.');
+        }elseif($this->request->query->get('force', 0) == 1){
+            $this->set('do_upgrade', true);
         } else {
             if (version_compare($sav, APP_VERSION, '>')) {
                 $message = t('Upgrading from <b>%s</b>', $sav) . '<br/>';


### PR DESCRIPTION
I've noticed that the force upgrade option under /ccm/system/upgrade doesn't do anything, so I've modified the upgrade.php file to support re-running the upgrade process (this is pretty safe since it will only run un-applied migrations). 
