### PR TITLE
add stack name to view_details page

### DIFF
--- a/web/concrete/single_pages/dashboard/blocks/stacks/view.php
+++ b/web/concrete/single_pages/dashboard/blocks/stacks/view.php
@@ -37,6 +37,8 @@ if ($controller->getTask() == 'view_details') {
         <a href="<?=URL::to('/dashboard/blocks/stacks')?>" data-dialog="add-stack" class="btn btn-default"><i class="fa fa-angle-double-left"></i> <?=t("Back to Stacks")?></a>
     </div>
 
+    <h3><?php echo $stack->getCollectionName()?></h3>
+
     <nav class="navbar navbar-default">
     <div class="container-fluid">
     <ul class="nav navbar-nav">


### PR DESCRIPTION
http://www.concrete5.org/developers/bugs/5-7-1/stack-name-missing-from-stack-edit-window/

![screen shot 2014-10-22 at 14 40 19](https://cloud.githubusercontent.com/assets/1431100/4736081/e53b60ba-59e8-11e4-9a8d-8f2b77600aff.png)
