### PR TITLE
Autoincrement compatibilty fix for Windows

### DIFF
--- a/web/concrete/src/Legacy/Model.php
+++ b/web/concrete/src/Legacy/Model.php
@@ -53,8 +53,10 @@ class Model {
 				$data[$key] = $value;
 			}
 		}
+
+		$columnName = $this->getAutoIncrementColumnName();
 		$db->Replace($this->_table, $data, $primaryKeys);
-		$this->setAutoincrementColumn();
+		$this->setAutoincrementColumn($columnName);
 		return 1;
 	}
 
@@ -70,19 +72,28 @@ class Model {
 		}
 		return $primaryKeys;
 	}
-	
-	protected function setAutoIncrementColumn() {
+
+	protected function getAutoIncrementColumnName() {
 		$db = Loader::db();
 		$sm = $db->getSchemaManager();
 		$details = $sm->listTableDetails($this->_table);
 		foreach($details->getColumns() as $name => $column) {
-			if($column->getAutoincrement() &&
-				property_exists($this, $name) &&
-				empty($this->$name)
-			) {
-				$this->$name = $db->lastInsertId();
+			if($column->getAutoincrement()) {
+				return $name;
 			}
-		}		
+		}
+		return null;
+	}
+	
+	protected function setAutoIncrementColumn($name) {
+		if(empty($name)) {
+			return;
+		}
+
+		if(property_exists($this, $name) && empty($this->$name)) {
+			$db = Loader::db();
+			$this->$name = $db->lastInsertId();
+		}
 	}
 
 	public function Insert() {
@@ -94,8 +105,10 @@ class Model {
 				$data[$key] = $value;
 			}
 		}
+
+		$columnName = $this->getAutoIncrementColumnName();
 		$db->insert($this->_table, $data);
-		$this->setAutoincrementColumn();
+		$this->setAutoincrementColumn($columnName);
 	}
 
 	public function Delete() {


### PR DESCRIPTION
I made this patch before that set an auto-increment column on the Model to the last inserted id. Having tested it on Windows now, it unfortunately failed there since there were some SELECTs made to detect the auto-increment column directly after the INSERT. For some reason the last insert id could be retrieved even after a SELECT on Linux (or possibly an older Mysql version.)

So here's a patched version that works on both Linux and Windows.
