### PR TITLE
Fix t without strings

### DIFF
--- a/web/concrete/bootstrap/helpers.php
+++ b/web/concrete/bootstrap/helpers.php
@@ -62,6 +62,7 @@ function t2($singular, $plural, $number)
     if ($arg) {
         return vsprintf($translated, $arg);
     }
+
     return vsprintf($translated, $number);
 }
 
@@ -97,6 +98,7 @@ function tc($context, $text)
     for ($i = 2; $i < func_num_args(); $i++) {
         $arg[] = func_get_arg($i);
     }
+
     return vsprintf($text, $arg);
 }
 
@@ -108,7 +110,7 @@ function tc($context, $text)
  */
 function h($input)
 {
-    return id(new Text)->specialchars($input);
+    return id(new Text())->specialchars($input);
 }
 
 /**
@@ -150,6 +152,7 @@ function core_class($class, $prefix = false)
     }
 
     $class = '\\' . $prefix . '\\' . $class;
+
     return $class;
 }
 
@@ -158,6 +161,7 @@ function overrideable_core_class($class, $path, $pkgHandle = null)
     $env = \Environment::get();
     $r = $env->getRecord($path);
     $prefix = $r->override ? true : $pkgHandle;
+
     return core_class($class, $prefix);
 }
 
@@ -214,6 +218,7 @@ function uncamelcase($string)
             }
         }
     }
+
     return str_replace('__', '_', implode('_', $a));
 }
 
@@ -230,5 +235,6 @@ function array_to_object($o, $array)
     foreach ($array as $property => $value) {
         $o->$property = $value;
     }
+
     return $o;
 }


### PR DESCRIPTION
Let's be sure that the t() functions receive a string.

This is mandatory because if we call t() with an undefined value, and if the current locale is not en_US, the execution halts with the error message `Illegal offset type`.

I encountered this while browsing to http://mysite/index.php/dashboard/system/basics/editor, where `$pageTitle` is undefined in [concrete/themes/dashboard/view.php](https://github.com/concrete5/concrete5-5.7.0/blob/93336287feb651792ec3d3c83229719ae550a172/web/concrete/themes/dashboard/view.php#L6) (and that's another problem :wink:)
