### PR TITLE
Remove inspect page template button from theme dashboard page

### DIFF
--- a/web/concrete/single_pages/dashboard/pages/themes/view.php
+++ b/web/concrete/single_pages/dashboard/pages/themes/view.php
@@ -49,7 +49,7 @@ if (isset($activate_confirm)) {
                             } else {
                                 echo $bt->button(t('Activate'), $view->url('/dashboard/pages/themes','activate', $t->getThemeID()), 'left', 'primary');
                             }
-                            echo $bt->button(t('Page Templates'), $view->url('/dashboard/pages/themes/inspect', $t->getThemeID()), 'left');
+
                             if ($siteThemeID == $t->getThemeID()) {
                                 echo $bt->button(t('Remove'), $view->url('/dashboard/pages/themes', 'remove', $t->getThemeID(), $valt->generate('remove')), 'right', 'btn-danger', array('disabled'=>'disabled'));
                             } else {


### PR DESCRIPTION
Hello,

I've noticed that on the /dashboard/pages/themes/ the "page templates" button doesn't work due to a change that happened in 5.7.1 removing the page /dashboard/pages/themes/inspect 

https://github.com/concrete5/concrete5-5.7.0/blob/develop/web/concrete/src/Updater/Migrations/Migrations/Version571.php#L86 

I'm assuming (because of the above change) that this button shouldn't still be in the interface, so this is the pull request to remove it.

If this is an incorrect assumption let me know.

Thanks
