### PR TITLE
fix empty areaToModify variable if block is added to a global area

### DIFF
--- a/web/concrete/controllers/dialog/page/add_block.php
+++ b/web/concrete/controllers/dialog/page/add_block.php
@@ -34,7 +34,7 @@ class AddBlock extends BackendInterfacePageController
         $this->areaToModify = $this->area;
         if ($this->area->isGlobalArea()) {
             $this->pageToModify = Stack::getByName($_REQUEST['arHandle']);
-            $this->areaToModify = Area::get($this->page, STACKS_AREA_NAME);
+            $this->areaToModify = Area::get($this->pageToModify, STACKS_AREA_NAME);
         }
         $this->areaPermissions = new Permissions($this->areaToModify);
         $cnt = $this->blockType->getController();


### PR DESCRIPTION
Fixes http://www.concrete5.org/developers/bugs/5-7-2/concretecorepermissionkeyaddblockblocktypekey-does-not-have-a-me/

The error occurred when a block was being added to a global area. The $this-> areaToModify variable remained empty if the default Area name "Main" also didn't exist in the template.
