### PR TITLE
Display attribute placeholder text on stack page

### DIFF
--- a/web/concrete/blocks/page_attribute_display/controller.php
+++ b/web/concrete/blocks/page_attribute_display/controller.php
@@ -75,7 +75,8 @@ class Controller extends BlockController
                 break;
         }
 
-        if (!strlen($content) && $c->isMasterCollection()) {
+        $is_stack = $c->getController() instanceof \Concrete\Controller\SinglePage\Dashboard\Blocks\Stacks;
+        if (!strlen(trim(strip_tags($content))) && ($c->isMasterCollection() || $is_stack)) {
             $content = $this->getPlaceHolderText($this->attributeHandle);
         }
         return $content;


### PR DESCRIPTION
If you add an attribute block to a stack it will render as an empty block. I adjusted to code so it behaves like it does when displaying an attribute block on a page defaults page: it shows a placeholder text.
