### PR TITLE
Turn request into a facade, make `->get`, `->post`, and `->request` work how they should

### DIFF
--- a/web/concrete/config/app.php
+++ b/web/concrete/config/app.php
@@ -11,7 +11,6 @@ return array(
      * Core Aliases
      */
     'aliases'             => array(
-        'Request'                              => '\Concrete\Core\Http\Request',
         'Environment'                          => '\Concrete\Core\Foundation\Environment',
         'Localization'                         => '\Concrete\Core\Localization\Localization',
         'Response'                             => '\Concrete\Core\Http\Response',
@@ -93,6 +92,7 @@ return array(
      * Core Providers
      */
     'providers'           => array(
+        'core_http'         => '\Concrete\Core\Http\HttpServiceProvider',
         'core_file'         => '\Concrete\Core\File\FileServiceProvider',
         'core_encryption'   => '\Concrete\Core\Encryption\EncryptionServiceProvider',
         'core_validation'   => '\Concrete\Core\Validation\ValidationServiceProvider',
@@ -106,7 +106,6 @@ return array(
         'core_database'     => '\Concrete\Core\Database\DatabaseServiceProvider',
         'core_form'         => '\Concrete\Core\Form\FormServiceProvider',
         'core_session'      => '\Concrete\Core\Session\SessionServiceProvider',
-        'core_http'         => '\Concrete\Core\Http\HttpServiceProvider',
         'core_events'       => '\Concrete\Core\Events\EventsServiceProvider',
         'core_whoops'       => '\Concrete\Core\Error\Provider\WhoopsServiceProvider',
         'core_logging'      => '\Concrete\Core\Logging\LoggingServiceProvider',
@@ -124,6 +123,7 @@ return array(
      */
     'facades'             => array(
         'Core'     => '\Concrete\Core\Support\Facade\Application',
+        'Request'  => '\Concrete\Core\Support\Facade\Request',
         'Session'  => '\Concrete\Core\Support\Facade\Session',
         'Database' => '\Concrete\Core\Support\Facade\Database',
         'Events'   => '\Concrete\Core\Support\Facade\Events',

--- a/web/concrete/src/Http/HttpServiceProvider.php
+++ b/web/concrete/src/Http/HttpServiceProvider.php
@@ -1,20 +1,28 @@
-<?php 
+<?php
 namespace Concrete\Core\Http;
-use \Concrete\Core\Foundation\Service\Provider as ServiceProvider;
 
-class HttpServiceProvider extends ServiceProvider {
+use Concrete\Core\Foundation\Service\Provider as ServiceProvider;
 
-	public function register() {
-		$singletons = array(
-			'helper/ajax' => '\Concrete\Core\Http\Service\Ajax',
-			'helper/json' => '\Concrete\Core\Http\Service\Json'
-		);
+class HttpServiceProvider extends ServiceProvider
+{
 
-		foreach($singletons as $key => $value) {
-			$this->app->singleton($key, $value);
-		}
+    public function register()
+    {
+        $this->app->bindShared(
+            'request',
+            function () {
+                return Request::createFromGlobals();
+            });
 
-	}
+        $singletons = array(
+            'helper/ajax' => '\Concrete\Core\Http\Service\Ajax',
+            'helper/json' => '\Concrete\Core\Http\Service\Json'
+        );
 
+        foreach ($singletons as $key => $value) {
+            $this->app->singleton($key, $value);
+        }
+
+    }
 
 }

--- a/web/concrete/src/Support/Facade/Request.php
+++ b/web/concrete/src/Support/Facade/Request.php
@@ -1,0 +1,17 @@
+<?php
+namespace Concrete\Core\Support\Facade;
+
+class Request extends Facade
+{
+
+    public static function getFacadeAccessor()
+    {
+        return 'request';
+    }
+
+    public static function getInstance()
+    {
+        return static::getFacadeRoot();
+    }
+
+}


### PR DESCRIPTION
We can now do `\Request::get('get_key', $default)` and `\Request::get('deeper[get][key]', $default, true)` with `\Request::get` `\Request::post` and `\Request::request`.

Previously `\Request::get` did not match the html form method, it checked $_GET, $_POST, and the path parameters. I've moved this functionality to `\Request::query`.

Moving forward, we should drop any usage of `$_GET`, `$_POST`, or `$_REQUEST` in favor of their respective `\Request` counterparts.
