### PR TITLE
Why use fprintf?

### DIFF
--- a/web/concrete/jobs/generate_sitemap.php
+++ b/web/concrete/jobs/generate_sitemap.php
@@ -79,7 +79,7 @@ class GenerateSitemap extends AbstractJob {
 			if(!$hFile = @fopen($osName, 'w')) {
 				throw new \Exception(t('Cannot open file %s', $osName));
 			}
-			if(!@fprintf($hFile, $dom->saveXML())) {
+			if(!@fwrite($hFile, $dom->saveXML())) {
 				throw new \Exception(t('Error writing to file %s', $osName));
 			}
 			@fflush($hFile);


### PR DESCRIPTION
fprintf call error because url encoding string have "%".
