### PR TITLE
rename "add page" button to "sitemap"

### DIFF
--- a/web/concrete/elements/page_controls_footer.php
+++ b/web/concrete/elements/page_controls_footer.php
@@ -287,7 +287,7 @@ if (isset($cp) && $canViewToolbar && (!$dh->inDashboard())) {
                                             data-launch-panel="sitemap">
                 <i class="fa fa-files-o"></i>
                 <span class="ccm-toolbar-accessibility-title ccm-toolbar-accessibility-title-add-page">
-                    <?= tc('toolbar', 'Add Page') ?>
+                    <?= tc('toolbar', 'Sitemap') ?>
                 </span>
             </a>
 

--- a/web/concrete/themes/dashboard/elements/header.php
+++ b/web/concrete/themes/dashboard/elements/header.php
@@ -87,7 +87,7 @@ $large_font = !!Config::get('concrete.accessibility.toolbar_large_font');
             <a href="#" data-panel-url="<?=URL::to('/system/panels/sitemap')?>" data-launch-panel="sitemap">
                 <i class="fa fa-files-o"></i>
                 <span class="ccm-toolbar-accessibility-title ccm-toolbar-accessibility-title-add-page">
-                    <?= tc('toolbar', 'Add Page') ?>
+                    <?= tc('toolbar', 'Sitemap') ?>
                 </span>
             </a>
         </li>


### PR DESCRIPTION
Maybe it's just me, but to me "sitemap" is the main functionality and not "add page". I know that add page gets a bit less visible due to that change, but so is sitemap.. "Add Page / Sitemap" is a bit too long, isn't it?

![image](https://cloud.githubusercontent.com/assets/129864/5068341/84f8216a-6e4d-11e4-8e26-68340ee84ac3.png)
