### PR TITLE
Area Design Dialog fix

### DIFF
--- a/web/concrete/views/dialogs/area/design.php
+++ b/web/concrete/views/dialogs/area/design.php
@@ -7,8 +7,17 @@ $pt = $c->getCollectionThemeObject();
 
 $areaClasses = $pt->getThemeAreaClasses();
 $customClasses = array();
-if (isset($areaClasses[$a->getAreaHandle()])) {
-    $customClasses = $areaClasses[$a->getAreaHandle()];
+
+// Use the area handle as the key to map against area classes
+$areaHandle = $a->getAreaHandle();
+
+// If its a SubArea, find the parent handle and use that
+if( $a instanceof \Concrete\Core\Area\SubArea ){
+    $areaHandle = \Concrete\Core\Area\Area::getAreaHandleFromID($a->getAreaParentID());
+}
+
+if (isset($areaClasses[$areaHandle])) {
+    $customClasses = $areaClasses[$areaHandle];
 }
 
 Loader::element("custom_style", array(


### PR DESCRIPTION
When using Grid layouts, after you create a new child area in the grid - class SubArea - and you click the area and choose "Edit Area Design" on the pop-up menu, the classes specified in page_theme.php for the parent area should be available. Since the SubArea instance appends a separator ":" to the area name/handle, the array keys returned by getAreaThemeClasses in page_theme.php can't match up.

Fixed area design dialog so that if its a SubArea type, it'll use the parent area handle to match against the classes from page_theme.php's getAreaBlocks method
