### PR TITLE
Convert custom block class selection into a select2 tag selection field ...

### DIFF
--- a/web/concrete/elements/custom_style.php
+++ b/web/concrete/elements/custom_style.php
@@ -82,9 +82,8 @@ $alignmentOptions = array(
 );
 
 
-$customClassesSelect = array(
-    '' => t('None')
-);
+$customClassesSelect = array();
+
 if (is_array($customClasses)) {
     foreach($customClasses as $class) {
         $customClassesSelect[$class] = $class;
@@ -302,7 +301,7 @@ $form = Core::make('helper/form');
 
             <div>
                 <?=t('Custom Class')?>
-                <?=$form->select('customClass', $customClassesSelect, $customClass);?>
+                <?= $form->text('customClass', $customClass);?>
             </div>
             <hr/>
 
@@ -337,4 +336,5 @@ $form = Core::make('helper/form');
 
 <script type="text/javascript">
     $('#ccm-inline-design-form').<?=$method?>();
+    $("#customClass").select2({tags:<?= json_encode(array_values($customClassesSelect)); ?>, separator: " "});
 </script>


### PR DESCRIPTION
Hi,

Concrete 5.6 allowed you to add any custom css class to a block, Concrete 5.7 improved on this functionality allowing themes to define css classes for the block but to me the implementation was missing two things:
- The ability to select multiple custom classes
- The ability to input your own custom classes (not bound by what the theme defines)

So in this pull request I've modified the class selection drop down and replaced it with a select2 tag selection list.

![class selection](https://cloud.githubusercontent.com/assets/296106/5118033/13b6c8a6-70ac-11e4-9fee-6e8436563072.png)

![class selection - list](https://cloud.githubusercontent.com/assets/296106/5118032/138c4356-70ac-11e4-8a94-35ea18325141.png)

Thanks,
