### PR TITLE
Escape conversation message body in dashboard

### DIFF
--- a/web/concrete/src/Conversation/Message/Message.php
+++ b/web/concrete/src/Conversation/Message/Message.php
@@ -139,7 +139,7 @@ class Message extends Object implements \Concrete\Core\Permission\ObjectInterfac
         /** @var \Concrete\Core\Conversation\Editor\Editor $editor */
         $editor = ConversationEditor::getActive();
         if ($dashboardOverride) {
-            return h($this->cnvMessageBody);
+            return $editor->formatConversationMessageBody($this->getConversationObject(),$this->cnvMessageBody);
         } elseif ($this->cnvIsMessageDeleted) {
             return $editor->formatConversationMessageBody($this->getConversationObject(),t('This message has been deleted.'));
             //return t('This message has been deleted.');


### PR DESCRIPTION
This is a temporary fix. I had not checked about this issue with front-end conversation block.
