### PR TITLE
Use Text helper instead of htmlentities function

### DIFF
--- a/web/concrete/single_pages/dashboard/users/add_group.php
+++ b/web/concrete/single_pages/dashboard/users/add_group.php
@@ -22,7 +22,7 @@ $registeredGroupNode = GroupTreeNode::getTreeNodeByGroupID(REGISTERED_GROUP_ID);
 	<legend><?=t('Group Details')?></legend>
 <div class="form-group">
 <?=$form->label('gName', t('Name'))?>
-	<input type="text" class="form-control" name="gName" value="<?=htmlentities($_POST['gName'])?>" />
+	<input type="text" class="form-control" name="gName" value="<?=Core::make('helper/text')->entities($_POST['gName'])?>" />
 </div>
 
 <div class="form-group">

--- a/web/concrete/src/Conversation/Editor/MarkdownEditor.php
+++ b/web/concrete/src/Conversation/Editor/MarkdownEditor.php
@@ -2,6 +2,7 @@
 namespace Concrete\Core\Conversation\Editor;
 
 use \Michelf\Markdown;
+use Core;
 
 class MarkdownEditor extends Editor
 {
@@ -18,7 +19,7 @@ class MarkdownEditor extends Editor
 
     public function formatConversationMessageBody($cnv, $cnvMessageBody, $config = array())
     {
-        $md = Markdown::defaultTransform(htmlentities($cnvMessageBody));
+        $md = Markdown::defaultTransform(Core::make('helper/text')->entities($cnvMessageBody));
         $formatted = str_replace(array('&amp;lt', '&amp;gt'), array('&lt', '&gt'), $md);
         return parent::formatConversationMessageBody($cnv, $formatted, $config);
     }

--- a/web/concrete/src/Gathering/Item/Template/Template.php
+++ b/web/concrete/src/Gathering/Item/Template/Template.php
@@ -222,7 +222,7 @@ abstract class Template extends Object {
 		$agt = $axml->addChild('gatheringitemtemplate');
 		$type = $this->getGatheringItemTemplateTypeObject();
 		$agt->addAttribute('handle',$this->getGatheringItemTemplateHandle());
-		$agt->addAttribute('name', htmlentities($this->getGatheringItemTemplateName()));
+		$agt->addAttribute('name', Core::make('helper/text')->entities($this->getGatheringItemTemplateName()));
 		$agt->addAttribute('type', $type->getGatheringItemTemplateTypeHandle());
 		if ($this->gatheringItemTemplateHasCustomClass()) {
 			$agt->addAttribute('has-custom-class', true);

--- a/web/concrete/src/Page/Template.php
+++ b/web/concrete/src/Page/Template.php
@@ -37,7 +37,7 @@ class Template
         foreach ($list as $pt) {
             $type = $nxml->addChild('pagetemplate');
             $type->addAttribute('icon', $pt->getPageTemplateIcon());
-            $type->addAttribute('name', htmlentities($pt->getPageTemplateName()));
+            $type->addAttribute('name', Core::make('helper/text')->entities($pt->getPageTemplateName()));
             $type->addAttribute('handle', $pt->getPageTemplateHandle());
             $type->addAttribute('package', $pt->getPackageHandle());
             $type->addAttribute('internal', $pt->isPageTemplateInternal());


### PR DESCRIPTION
Do not use `htmlentities()` function without encoding option for multibyte support.

![concrete5_7 ____home](https://cloud.githubusercontent.com/assets/514294/5137765/1924a97a-7183-11e4-8a4f-ff6dc3c5382e.png)
