### PR TITLE
Fix li in Image Slider

### DIFF
--- a/web/concrete/blocks/image_slider/view.css
+++ b/web/concrete/blocks/image_slider/view.css
@@ -13,7 +13,7 @@
     margin: 0;
 }
 
-.rslides li {
+.rslides > li {
     -webkit-backface-visibility: hidden;
     position: absolute;
     display: none;
@@ -22,7 +22,7 @@
     top: 0;
 }
 
-.rslides li:first-child {
+.rslides > li:first-child {
     position: relative;
     display: block;
     float: left;


### PR DESCRIPTION
Fixes issue with using li tags in the image slider text.

Fixes #1569 
