### PR TITLE
Allow full urls for relative path in local storage location

### DIFF
--- a/web/concrete/src/File/StorageLocation/Configuration/LocalConfiguration.php
+++ b/web/concrete/src/File/StorageLocation/Configuration/LocalConfiguration.php
@@ -46,7 +46,11 @@ class LocalConfiguration extends Configuration implements ConfigurationInterface
 
     public function getPublicURLToFile($file)
     {
-        return BASE_URL . $this->getRelativePathToFile($file);
+        $rel = $this->getRelativePathToFile($file);
+        if(strpos($rel, '://')) {
+            return $rel;
+        }
+        return BASE_URL . $rel;
     }
 
     public function loadFromRequest(\Concrete\Core\Http\Request $req)


### PR DESCRIPTION
Lets say I want to serve my files from the same server but a different domain, with this you can... its kinda hacky, but it works... and its not really relative... but it works...
