### PR TITLE
Addition of attribute handles as link titles

### DIFF
--- a/web/concrete/elements/dashboard/attributes_table.php
+++ b/web/concrete/elements/dashboard/attributes_table.php
@@ -50,7 +50,7 @@ if (count($attribs) > 0) { ?>
 			<?
 			foreach($setattribs as $ak) { ?>
                 <li class="ccm-attribute" id="akID_<?=$ak->getAttributeKeyID()?>">
-                    <a href="<?=URL::to($editURL, 'edit', $ak->getAttributeKeyID())?>">
+                    <a href="<?=URL::to($editURL, 'edit', $ak->getAttributeKeyID())?>" title="<?php echo t('Handle')?>: <?php echo $ak->getAttributeKeyHandle(); ?>">
                         <img class="ccm-attribute-icon" src="<?=$ak->getAttributeKeyIconSRC()?>" width="16" height="16" />
                         <?=$ak->getAttributeKeyDisplayName()?>
                     </a>
@@ -74,7 +74,7 @@ if (count($attribs) > 0) { ?>
 				<?
 				foreach($unsetattribs as $ak) { ?>
                     <li class="ccm-attribute">
-                        <a href="<?=URL::to($editURL, 'edit', $ak->getAttributeKeyID())?>">
+                        <a href="<?=URL::to($editURL, 'edit', $ak->getAttributeKeyID())?>" title="<?php echo t('Handle')?>: <?php echo $ak->getAttributeKeyHandle(); ?>">
                             <img class="ccm-attribute-icon" src="<?=$ak->getAttributeKeyIconSRC()?>" width="16" height="16" />
                             <?=$ak->getAttributeKeyDisplayName()?>
                         </a>
@@ -92,7 +92,7 @@ if (count($attribs) > 0) { ?>
 		<?
         foreach($attribs as $ak) { ?>
             <li class="ccm-attribute" id="akID_<?=$ak->getAttributeKeyID()?>">
-			    <a href="<?=URL::to($editURL, 'edit', $ak->getAttributeKeyID())?>"><img class="ccm-attribute-icon" src="<?=$ak->getAttributeKeyIconSRC()?>" width="16" height="16" /> <?=$ak->getAttributeKeyDisplayName()?></a>
+			    <a href="<?=URL::to($editURL, 'edit', $ak->getAttributeKeyID())?>" title="<?php echo t('Handle')?>: <?php echo $ak->getAttributeKeyHandle(); ?>"><img class="ccm-attribute-icon" src="<?=$ak->getAttributeKeyIconSRC()?>" width="16" height="16" /> <?=$ak->getAttributeKeyDisplayName()?></a>
                 <? if($sortable) { ?><i class="ccm-item-select-list-sort"></i><? } ?>
 		    </li>
 		


### PR DESCRIPTION
When developing with attributes a common task is to look up for
existing attributes their handles for use in code.

This change adds to the lists of attributes within the dashboard, the
attribute handle as a title attribute.

This means that instead of a developer having to repeatedly view the
edit page an attribute just to see the handle, they can mouse-over the
links to see this.
