### PR TITLE
Addition of getPageTemplateObject() & getPageTemplateHandle().

### DIFF
--- a/web/concrete/src/Page/Page.php
+++ b/web/concrete/src/Page/Page.php
@@ -1071,6 +1071,26 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
     }
 
     /**
+     * Returns the Page Template Object
+     * @return PageTemplate
+     */
+    function getPageTemplateObject() {
+        return PageTemplate::getByID($this->getPageTemplateID());
+    }
+
+    /**
+     * Returns the Page Template handle
+     * @return string
+     */
+    function getPageTemplateHandle() {
+        $pt = $this->getPageTemplateObject();
+        if ($pt instanceof PageTemplate) {
+            return $pt->getPageTemplateHandle();
+        }
+        return false;
+    }
+
+    /**
      * Returns the Collection Type handle
      * @return string
      */


### PR DESCRIPTION
Adds the two utility methods above to the Concrete\Core\Page\Page class.
