### PR TITLE
Adding a css class to the page wrapper for the page template in use.

### DIFF
--- a/web/concrete/src/Page/Page.php
+++ b/web/concrete/src/Page/Page.php
@@ -1541,10 +1541,15 @@ class Page extends Collection implements \Concrete\Core\Permission\ObjectInterfa
     public function getPageWrapperClass()
     {
         $pt = $this->getPageTypeObject();
+        $ptm = $this->getPageTemplateObject();
         $classes = array('ccm-page');
         if (is_object($pt)) {
             $classes[] = 'page-type-' . str_replace('_', '-', $pt->getPageTypeHandle());
         }
+        if (is_object($ptm)) {
+            $classes[] = 'page-template-' . str_replace('_', '-', $ptm->getPageTemplateHandle());
+        }
+
         return implode(' ', $classes);
     }
 


### PR DESCRIPTION
I separated this from the last pull as I thought it may be more controversial.

With the introduction of page templates focus has shifted from using page types for creating new 'layout' variations to the new templates. As such, for me (and no doubt many others) it makes sense to have the templates name defined on the wrapper rather than the page types. I feel that this makes CSS targeting much more relevant, I've added it alongside in this pull.
