### PR TITLE
Fix redactor dropdowns loose focus before the click event is fired when embedded into a non inline block dialog.

### DIFF
--- a/web/concrete/js/build/vendor/redactor/redactor.js
+++ b/web/concrete/js/build/vendor/redactor/redactor.js
@@ -2648,6 +2648,10 @@
                     /* concrete5 */
                     //$item = $('<a href="#" class="' + btnObject.className + ' redactor_dropdown_' + btnName + '">' + btnObject.title + '</a>');
                     $item = $('<li><a href="#" class="' + btnObject.className + ' redactor_dropdown_' + btnName + '">' + btnObject.title + '</a></li>');
+                    $item.on('mousedown', function(e){ // Prevent focus loss on mousedown before the click event has a chance to fire.
+                        e.preventDefault();
+                        e.stopPropagation();
+                    });
                     /* end concrete5 */
                     $item.on('click', $.proxy(function(e)
                     {


### PR DESCRIPTION
Hi,

I've found an issue when you have a block edit dialog (non inline) and a reactor editor within that dialog, when you select some text within the reactor editor and click a dropdown open (for example "Insert Link") then on mousedown the focus will switch to the top most input within the dialog, losing your text selection.

Steps to reproduce:
- Install my test block https://github.com/mlabrum/test-block/tree/master/test 
- Add the test block to an area
- when the option dialog displays select the text within the reactor edit
- click the Link button
- click "Insert Link" and notice the focus swaps to the top input and you lose your text selection.

Stopping propagation from the dropdown item prevents the focus loss.

Cheers,
