### PR TITLE
Fix to remove the closing link tag that was causing pages to fail HTML5 W3C validation.

### DIFF
--- a/web/concrete/src/Asset/CssAsset.php
+++ b/web/concrete/src/Asset/CssAsset.php
@@ -1,6 +1,8 @@
 <?php
 namespace Concrete\Core\Asset;
+
 use HtmlObject\Element;
+use Concrete\Core\Html\Object\HeadLink;
 use Config;
 
 class CssAsset extends Asset {
@@ -132,8 +134,7 @@ class CssAsset extends Asset {
 	}
 
 	public function __toString() {
-        $e = new Element('link');
-        $e->rel('stylesheet')->type('text/css')->href($this->getAssetURL());
+        $e = new HeadLink($this->getAssetURL(), 'stylesheet', 'text/css', 'all');
         if (count($this->combinedAssetSourceFiles)) {
             $source = '';
             foreach($this->combinedAssetSourceFiles as $file) {

--- a/web/concrete/src/Html/Object/HeadLink.php
+++ b/web/concrete/src/Html/Object/HeadLink.php
@@ -1,0 +1,57 @@
+<?php
+namespace Concrete\Core\Html\Object;
+
+use HtmlObject\Element;
+
+class HeadLink extends Element
+{
+    /**
+     * Default element
+     *
+     * @var string
+     */
+    protected $element = 'link';
+
+    /**
+     * Whether the element is self closing
+     *
+     * @var boolean
+     */
+    protected $isSelfClosing = true;
+
+    /**
+     * Create a new Link
+     *
+     * @param string $href  Link url
+     * @param string $rel   Link relation (stylesheet)
+     * @param string $type  Link type (text/css)
+     * @param string $media Link media (screen, print, etc)
+     *
+     * @return HeadLink
+     */
+    public function __construct($href = '#', $rel = null, $type = null, $media = null)
+    {
+        $attributes = array();
+        foreach (array('href', 'rel', 'type', 'media') as $k) {
+            if (!is_null($$k)) {
+                $attributes[$k] = $$k;
+            }
+        }
+        $this->setTag('link', $value, $attributes);
+    }
+
+    /**
+     * Static alias for constructor
+     *
+     * @param string $href  Link url
+     * @param string $rel   Link relation (stylesheet)
+     * @param string $type  Link type (text/css)
+     * @param string $media Link media (screen, print, etc)
+     *
+     * @return HeadLink
+     */
+    public static function create($href = '#', $rel = null, $type = null, $media = null)
+    {
+        return new static($href, $rel, $type, $media);
+    }
+}


### PR DESCRIPTION
Links generated by the asset pipeline (in specific by CssAsset) currently look like this:

`<link rel="stylesheet" type="text/css" href="/path/to/where/ever/styles.css"></link>`

To conform with [the HTML5 spec](http://www.w3.org/html/wg/drafts/html/master/document-metadata.html#attr-link-type) they should omit the trailing `</link>` which is currently causing documents to fail validation. 

I've implemented a new `HeadLink` HTMLObject to achieve this as the protected method `$isSelfClosing` needed setting. I've also created as static creator and fixed up a constructor with the ability to also easily set the 'media' attribute, hopefully this could be implemented when registering assets down the line as it would be helpful to be able to control this when attaching CSS assets.

The links now look like this:
`<link href="/path/to/where/ever/styles.css" rel="stylesheet" type="text/css" media="all">`
