### PR TITLE
Use captcha label from provider

### DIFF
--- a/web/concrete/blocks/form/view.php
+++ b/web/concrete/blocks/form/view.php
@@ -119,7 +119,7 @@ $translatedSubmitLabel = t('Submit');
 			$captchaLabel = $captcha->label();
 			if (!empty($captchaLabel)) {
 				?>
-				<label class="control-label"><?php $captchaLabel; ?></label>
+				<label class="control-label"><?php echo $captchaLabel; ?></label>
 				<?php
 			}
 			?>


### PR DESCRIPTION
The captcha label was set to a fixed label and did not use the one from the captcha controller. This is a problem for some other captcha services like reCAPTCHA that use a different form of verification.
