### PR TITLE
Session fixation IP address check

### DIFF
--- a/web/concrete/src/Session/Session.php
+++ b/web/concrete/src/Session/Session.php
@@ -1,7 +1,6 @@
 <?php
 namespace Concrete\Core\Session;
 
-use Concrete\Core\Permission\IPService;
 use Concrete\Core\Utility\IPAddress;
 use Config;
 use \Symfony\Component\HttpFoundation\Session\Session as SymfonySession;


### PR DESCRIPTION
I changed the session fixation test to use the IP service. It was only checking REMOTE_ADDR which would remove the protection if the server is behind a reverse proxy.
