### PR TITLE
allow for Application/src directory autoloading

### DIFF
--- a/web/application/bootstrap/autoload.php
+++ b/web/application/bootstrap/autoload.php
@@ -8,3 +8,25 @@
 if (!@include(DIR_BASE_CORE . '/' . DIRNAME_VENDOR . '/autoload.php')) {
     die('Third party libraries not installed. Make sure that composer has required libraries in the concrete/ directory.');
 }
+
+/**
+* autoload Application\Core namespaced classes from the application/src/ directory
+*/
+spl_autoload_register(function($class){
+    $prefix = "Application\\Core";
+    // does the class use the Application\Core namespace prefix?
+    $len = strlen($prefix);
+
+    if (strncmp($prefix, $class, $len) !== 0) { // check if this is in our namespace or not
+        return;
+    }
+
+    $relative_class = substr($class, $len);
+    $base_dir = DIR_APPLICATION . "/src";
+    $file = $base_dir . str_replace('\\', '/', $relative_class) . '.php';
+
+    // if the file exists, require it
+    if (file_exists($file)) {
+        require $file;
+    }
+});


### PR DESCRIPTION
Unless I am missing something, it does not appear that the Application/src folder is autoloaded. This would allow for the following:

`$test = new Application\Core\Folder\File();`

which would autoload the File class from

`application/src/Folder/File.php`

Anything outside of the Application\Core namespace would be left alone. Again, I'm not sure if I wasn't namespacing, or loading the classes correctly if this functionality already exists. If I was trying to load files incorrectly, is there a preferred way to namespace fiels within the application/src directory?
