### PR TITLE
Callback response honouring.

### DIFF
--- a/web/concrete/src/Routing/ClosureRouteCallback.php
+++ b/web/concrete/src/Routing/ClosureRouteCallback.php
@@ -10,8 +10,14 @@ class ClosureRouteCallback extends RouteCallback
     {
         $resolver = new HttpKernel\Controller\ControllerResolver();
         $arguments = $resolver->getArguments($request, $this->callback);
+        $callback_response = call_user_func_array($this->callback, $arguments);
+        
+        if ($callback_response instanceof \Concrete\Core\Http\Response) {
+            return $callback_response;
+        }
+
         $r = new Response();
-        $r->setContent(call_user_func_array($this->callback, $arguments));
+        $r->setContent($callback_response);
 
         return $r;
     }


### PR DESCRIPTION
Modifies the ClosureRouteCallback to properly honour responses from callbacks which are Response objects. At the moment they are cast to string and returned as a new Response objects content.
