### PR TITLE
Some more multilingual fixes

### DIFF
--- a/web/concrete/config/concrete.php
+++ b/web/concrete/config/concrete.php
@@ -223,7 +223,8 @@ return array(
         'enabled' => false, // note this will automatically be set to true if needed
         'redirect_home_to_default_locale' => false,
         'use_browser_detected_locale' => false,
-        'default_locale' => false
+        'default_locale' => false,
+        'default_source_locale' => 'en_US'
     ),
 
     'design'            => array(

--- a/web/concrete/single_pages/dashboard/system/multilingual/setup.php
+++ b/web/concrete/single_pages/dashboard/system/multilingual/setup.php
@@ -161,19 +161,15 @@ if ($u->isSuperUser() && !$includesHome) { ?>
 		$defaultLocales[$pcl->getLocale()] = tc(/*i18n: %1$s is a page name, %2$s is a language name, %3$s is a locale identifier (eg en_US)*/'PageWithLocale', '%1$s (%2$s, %3$s)', $pc->getCollectionName(), $pcl->getLanguageText(), $pcl->getLocale());
 	}
 	$defaultLocalesSelect = $form->select('defaultLocale', $defaultLocales, $defaultLocale);
-	
-
 	?>
-
-    <fieldset>
-        <legend><?php echo t('Multilingual Settings')?></legend>
-
+   <legend><?php echo t('Multilingual Settings')?></legend>
+	<fieldset>
         <form method="post" action="<?php echo $this->action('set_default')?>">
             <div class="form-group">
                 <label class="control-label"><?php echo t('Default Locale');?></label>
                 <?php print $defaultLocalesSelect; ?>
             </div>
-
+            
             <div class="form-group">
                 <div class="checkbox">
                 <label>
@@ -190,10 +186,33 @@ if ($u->isSuperUser() && !$includesHome) { ?>
             </div>
 
             <div class="form-group">
+                <label class="control-label"><?php echo t('Site interface source locale');?></label>
+                <?php
+                echo $form->select('defaultSourceLanguage', array_merge(array('' => t('*** Unknown or mixed language')), $languages), $defaultSourceLanguage);
+                echo $form->select('defaultSourceCountry', array_merge(array('' => ''), $countries), $defaultSourceCountry);
+                ?>
+                <script>
+                $(document).ready(function() {
+                    function update() {
+                        if($('#defaultSourceLanguage').val()) {
+                        	$('#defaultSourceCountry').removeAttr('disabled');
+                        }
+                        else {
+                        	$('#defaultSourceCountry').attr('disabled', 'disabled');                        	
+                        }
+                    }
+                    update();
+                    $('#defaultSourceLanguage').on('change', function() {
+                        update();
+                    });
+                });
+                </script>
+            </div>
+            
+            <div class="form-group">
                 <?php echo Loader::helper('validation/token')->output('set_default')?>
                 <button class="btn btn-default pull-left" type="submit" name="save"><?=t('Save Settings')?></button>
             </div>
         </form>
-
     </fieldset>
 	<?php } ?>

--- a/web/concrete/single_pages/dashboard/system/multilingual/translate_interface.php
+++ b/web/concrete/single_pages/dashboard/system/multilingual/translate_interface.php
@@ -168,9 +168,10 @@ if ($this->controller->getTask() == 'translate_po') { ?>
 	$nav = Loader::helper('navigation');
 	Loader::model('section', 'multilingual');
 	$pages = \Concrete\Core\Multilingual\Page\Section\Section::getList();
-	$defaultLanguage = Config::get('concrete.multilingual.default_locale');
+	$defaultSourceLocale = Config::get('concrete.multilingual.default_source_locale');
 
 	$ch = Core::make('multilingual/interface/flag');
+	$dh = Core::make('helper/date');
 	if (count($pages) > 0) { ?>
 
 <div class="ccm-dashboard-content-full">
@@ -198,12 +199,12 @@ if ($this->controller->getTask() == 'translate_po') { ?>
                     </td>
                     <td style="white-space: nowrap">
                         <?php echo $pc->getLocale(); ?>
-                        <? if ($pc->getLocale() != $defaultLanguage) { ?>
+                        <? if ($pc->getLocale() != $defaultSourceLocale) { ?>
                             <a href="#" class="icon-link launch-tooltip" title="<?=REL_DIR_LANGUAGES_SITE_INTERFACE?>/<?=$pc->getLocale()?>.mo"><i class="fa fa-question-circle"></i></a>
                         <? } ?>
                     </td>
                     <td style="width: 40%">
-                        <? if ($pc->getLocale() != $defaultLanguage) { ?>
+                        <? if ($pc->getLocale() != $defaultSourceLocale) { ?>
                             <?
                             $data = $extractor->getSectionSiteInterfaceCompletionData($pc);
                             ?>
@@ -213,19 +214,21 @@ if ($this->controller->getTask() == 'translate_po') { ?>
                         <? } ?>
                     </td>
                     <td style="white-space: nowrap">
-                        <span class="percent"><?=$data['completionPercentage']?>%</span> - <span class="translated"><?=$data['translatedCount']?></span> <?=t('of')?> <span class="total"><?=$data['messageCount']?></span>
+                        <? if ($pc->getLocale() != $defaultSourceLocale) { ?>
+                            <span class="percent"><?=$data['completionPercentage']?>%</span> - <span class="translated"><?=$data['translatedCount']?></span> <?=t('of')?> <span class="total"><?=$data['messageCount']?></span>
+                        <? } ?>
                     </td>
                     <td>
-                        <? if ($pc->getLocale() != $defaultLanguage) {
+                        <? if ($pc->getLocale() != $defaultSourceLocale) {
                             if (file_exists(DIR_LANGUAGES_SITE_INTERFACE . '/' . $pc->getLocale() . '.mo'))
-                                print date('F d, Y g:i:s A', filemtime(DIR_LANGUAGES_SITE_INTERFACE . '/' . $pc->getLocale() . '.mo'));
+                                print $dh->formatDateTime(filemtime(DIR_LANGUAGES_SITE_INTERFACE . '/' . $pc->getLocale() . '.mo'), true);
                             else
                                 print t('File not found.');
                         }
                         else
                             echo t('N/A'); ?>
                     </td>
-                    <? if ($pc->getLocale() == $defaultLanguage) { ?>
+                    <? if ($pc->getLocale() == $defaultSourceLocale) { ?>
                         <td></td>
                     <? } else { ?>
                         <td><a href="<?=$this->action('translate_po', $pc->getCollectionID())?>" class="icon-link"><i class="fa fa-pencil"></i></a></td>


### PR DESCRIPTION
- add concrete.multilingual.default_source_locale configuration (defaulting to en_US)
- allow users to configure concrete.multilingual.default_source_locale
- localize dates in system/multilingual/translate_interface
- bugfix hide progress status of locale if it's the source one
