### PR TITLE
Add ability to preview Mobile Theme

### DIFF
--- a/web/concrete/controllers/panel/page/preview_as_user.php
+++ b/web/concrete/controllers/panel/page/preview_as_user.php
@@ -11,6 +11,7 @@ use UserInfo;
 use View;
 use Core;
 use Config;
+use Concrete\Core\Page\Theme\Theme;
 
 class PreviewAsUser extends Controller
 {
@@ -50,6 +51,13 @@ class PreviewAsUser extends Controller
 
             $controller = $page->getPageController();
             $view = $controller->getViewObject();
+            
+            if ($request->request('emulateMobile') == 1) {
+                $mobileTheme = Theme::getByID(Config::get('concrete.misc.mobile_theme_id'));
+                if($mobileTheme instanceof Theme) {
+                    $view->setViewTheme($mobileTheme);
+                }
+            }
 
             $response = new \Response();
             $response->setContent($view->render());

--- a/web/concrete/views/panels/page/preview_as/form.php
+++ b/web/concrete/views/panels/page/preview_as/form.php
@@ -10,23 +10,38 @@ $fdh = Core::make('helper/form/date_time'); /* @var $fdh \Concrete\Core\Form\Ser
           <?=t('View as User')?>
         </a>
     </header>
-    <form class="preview-panel-form form-horizontal">
+    <form class="preview-panel-form">
         <div class="ccm-panel-content-inner" id="ccm-menu-page-attributes-list">
 
-            <label class="label"><?= t('Date / time') ?></label>
-            <div>
+            <h5><?= t('Date / time') ?></h5>
+            <div class="form-group">
             	<?php echo $fdh->datetime('preview_as_user_datetime'); ?>
             </div>
 
-            <label class="label"><?= t('View As') ?></label>
-            <div>
+            <h5><?= t('View As') ?></h5>
+            <div class="form-group">
                 <div class="btn-group">
                     <button class="guest-button btn btn-default active"><?= t('Guest') ?></button>
                     <button class="user-button btn btn-default"><?= t('Site User') ?></button>
                 </div>
                 <div class="site-user" style="display:none">
-                    <label for="user" class="label"><?= t('User') ?></label>
-                    <input class="form-control custom-user" name="user" />
+                    <label for="user"><?= t('Username') ?></label>
+                    <input class="form-control input-sm custom-user" type="text" name="user" />
+                </div>
+            </div>
+            
+            <h5><?= t('Emulate Mobile') ?></h5>
+            <div class="form-group">
+                <div class="btn-group">
+                    <button class="disable-mobile-button btn btn-default active"><?= t('Disable') ?></button>
+                    <button class="enable-mobile-button btn btn-default"><?= t('Enable') ?></button>
+                </div>
+                <div class="resolution" style="display:none">
+                    <label for="resolution-width"><?= t('Width') ?></label>
+                    <div class="input-group">
+                        <input class="form-control input-sm resolution-width" type="text" name="resolution-width" />
+                        <div class="input-group-addon"><?= t('px') ?></div>
+                    </div>
                 </div>
             </div>
 
@@ -39,7 +54,10 @@ $fdh = Core::make('helper/form/date_time'); /* @var $fdh \Concrete\Core\Form\Ser
 	$(function() {
 		var user_input = $('div.site-user'),
 			guest_button = $('button.guest-button'),
-			user_button = $('button.user-button');
+			user_button = $('button.user-button'),
+			disable_mobile_button = $('button.disable-mobile-button'),
+			enable_mobile_button = $('button.enable-mobile-button'),
+			resolution_input = $('div.resolution');
 		// user
 		guest_button.click(function(e) {
 			if (!guest_button.hasClass('active')) {
@@ -55,6 +73,25 @@ $fdh = Core::make('helper/form/date_time'); /* @var $fdh \Concrete\Core\Form\Ser
 				user_input.slideDown();
 				guest_button.removeClass('active');
 				user_button.addClass('active');
+			}
+			e.preventDefault();
+			return false;
+		});
+		// mobile
+		disable_mobile_button.click(function(e) {
+			if (!disable_mobile_button.hasClass('active')) {
+				resolution_input.slideUp();
+				enable_mobile_button.removeClass('active');
+				disable_mobile_button.addClass('active');
+			}
+			e.preventDefault();
+			return false;
+		});
+		enable_mobile_button.click(function(e) {
+			if (!enable_mobile_button.hasClass('active')) {
+				resolution_input.slideDown();
+				disable_mobile_button.removeClass('active');
+				enable_mobile_button.addClass('active');
 			}
 			e.preventDefault();
 			return false;

--- a/web/concrete/views/panels/page/preview_as/frame.php
+++ b/web/concrete/views/panels/page/preview_as/frame.php
@@ -1,8 +1,8 @@
 <div class="preview-frame-container">
     <iframe
         style="display:none"
-        src="<?= URL::to('/ccm/system/panels/page/preview_as_user/render') . '?&cID=' . Request::request('cID') ?>"
-        data-src="<?= URL::to('/ccm/system/panels/page/preview_as_user/render') ?>">></iframe>
+        src="<?= URL::to('/ccm/system/panels/page/preview_as_user/render') . '?cID=' . Request::request('cID') ?>"
+        data-src="<?= URL::to('/ccm/system/panels/page/preview_as_user/render') ?>"></iframe>
     <div class="cover"></div>
     <div class="loader">
         <div class="icon">
@@ -51,11 +51,20 @@
         function handleChange() {
             var guest_button = form.find('button.guest-button'),
                 user_input = form.find('input.custom-user'),
+                mobile_button = form.find('button.enable-mobile-button'),
+                container_width = form.find('input.resolution-width'),
                 query = {
                     cID: CCM_CID,
-                    customUser: guest_button.hasClass('active') ? 0 : user_input.val()
+                    customUser: guest_button.hasClass('active') ? 0 : user_input.val(),
+                    emulateMobile: mobile_button.hasClass('active') ? 1 : 0
                 };
 
+            if (mobile_button.hasClass('active')) {
+                container.css('max-width', container_width.val());
+            } else {
+                container.css('max-width', 'none');
+            }
+            
             form.find('input[name],select[name]').each(function() {
                 var $me = $(this), name = $me.attr('name');
                 if(name && (name.indexOf('preview_as_user_datetime_') === 0)) {


### PR DESCRIPTION
- Add an Emulate Mobile section on the Preview as User panel.
- If enabled, set the mobile theme to the View object.
- Add a `resolution-width` input to change the `max-width` value of the container.

![emulate_mobile](https://cloud.githubusercontent.com/assets/514294/5514034/cb745e4c-8860-11e4-88ed-026312fc99b2.png)
