### PR TITLE
Fixed modifying the page output through the on_page_output event.

### DIFF
--- a/web/concrete/src/Block/BlockController.php
+++ b/web/concrete/src/Block/BlockController.php
@@ -263,7 +263,7 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
         $event->setArgument('record', $this->record);
         $event->setArgument('btHandle', $this->btHandle);
         $event->setArgument('bID', $this->bID);
-        $ret = Events::dispatch('on_page_output', $event);
+        $ret = Events::dispatch('on_block_load', $event);
         $this->record = $ret->getArgument('record');
 
         if (is_object($this->record)) {

--- a/web/concrete/src/Page/View/PageView.php
+++ b/web/concrete/src/Page/View/PageView.php
@@ -2,6 +2,7 @@
 namespace Concrete\Core\Page\View;
 
 use Environment;
+use Events;
 use Loader;
 use PageCache;
 use PageTemplate;
@@ -170,6 +171,12 @@ class PageView extends View
     public function finishRender($contents)
     {
         $contents = parent::finishRender($contents);
+
+        $event = new \Symfony\Component\EventDispatcher\GenericEvent();
+        $event->setArgument('contents', $contents);
+        Events::dispatch('on_page_output', $event);
+        $contents = $event->getArgument('contents');
+
         $cache = PageCache::getLibrary();
         $shouldAddToCache = $cache->shouldAddToCache($this);
         if ($shouldAddToCache) {

--- a/web/concrete/src/View/View.php
+++ b/web/concrete/src/View/View.php
@@ -162,11 +162,6 @@ class View extends AbstractView {
 
     public function finishRender($contents) {
         $event = new \Symfony\Component\EventDispatcher\GenericEvent();
-        $event->setArgument('contents', $contents);
-        Events::dispatch('on_page_output', $event);
-        $contents = $event->getArgument('contents');
-
-        $event = new \Symfony\Component\EventDispatcher\GenericEvent();
         $event->setArgument('view', $this);
         Events::dispatch('on_render_complete', $event);
 


### PR DESCRIPTION
As discussed with @aembler here:
http://www.concrete5.org/community/forums/5-7-discussion/how-to-modify-page-contents-within-a-package/#688821

I'm not sure whether the own event class would be required here but on the other hand, I don't really see any benefits in that either. Maybe checking the event class' type during the event callback but we can also check `if ($ev->hasArgument('contents'))`.
