### PR TITLE
Overlay class does not exist. Changed to lightbox.

### DIFF
--- a/web/concrete/src/Html/HtmlServiceProvider.php
+++ b/web/concrete/src/Html/HtmlServiceProvider.php
@@ -7,7 +7,7 @@ class HtmlServiceProvider extends ServiceProvider {
     public function register() {
         $singletons = array(
             'helper/html' => '\Concrete\Core\Html\Service\Html',
-            'helper/overlay' => '\Concrete\Core\Html\Service\Overlay',
+            'helper/lightbox' => '\Concrete\Core\Html\Service\Lightbox',
             'helper/navigation' => '\Concrete\Core\Html\Service\Navigation',
         );
 


### PR DESCRIPTION
Noticed this one through #1657. `\Concrete\Core\Html\Service\Overlay` does not exist. There's a Lightbox class in the package that's not used so I changed it to use that. I'm assuming this got renamed sometime and was never changed here.
