### PR TITLE
make it possible for google to render site

### DIFF
--- a/web/robots.txt
+++ b/web/robots.txt
@@ -1,7 +1,6 @@
 User-agent: *
 Disallow: /application/attributes
 Disallow: /application/authentication
-Disallow: /application/blocks
 Disallow: /application/bootstrap
 Disallow: /application/config
 Disallow: /application/controllers


### PR DESCRIPTION
It seems that google needs access to JavaScript and CSS files in order to properly index a page. That's because it uses a headless browser to fetch the content of a website.

You can see the discussion about 5.6 here https://github.com/concrete5/concrete5/pull/1865

Seems to hurt your SEO ranking!
