### PR TITLE
Remove country and script specifications from languages

### DIFF
--- a/web/concrete/src/Localization/Service/LanguageList.php
+++ b/web/concrete/src/Localization/Service/LanguageList.php
@@ -15,7 +15,7 @@ class LanguageList
      */
     public function getLanguageList()
     {
-        $languages = Language::getAll(false, false, Localization::activeLocale());
+        $languages = Language::getAll(true, true);
         return $languages;
     }
 


### PR DESCRIPTION
A language is only 'en', a locale is 'en_US': remove country codes from getLanguageList so that we have only languages and not locales.

Furthermore we don't need to tell Punic which is the active locale: Localization::changeLocale already sets the Punic default locale.
