### PR TITLE
[trivial] adding gVim temporary files to the ignore list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 thumbs.db
 __MACOSX
 ._*
+.*swp
+.*swo
 
 # ignore composer files
 composer.phar


### PR DESCRIPTION
Well this is just a little dev fix, since I am using gVim I am trying to get my repo clean.

Could you allow to ignore .sw\* files generated from Vim in the main .gitignore please?
