### PR TITLE
Always use strings when using getNodeByKey() with fancytree

### DIFF
--- a/concrete/js/build/core/sitemap/menu.js
+++ b/concrete/js/build/core/sitemap/menu.js
@@ -23,7 +23,7 @@
 	ConcretePageMenu.prototype = Object.create(ConcreteMenu.prototype);
 
 	ConcretePageMenu.prototype.setupMenuOptions = function($menu) {
-		var my = this, 
+		var my = this,
 			parent = ConcreteMenu.prototype,
 			cID = $menu.attr('data-search-page-menu');
 
@@ -33,13 +33,13 @@
 		}
 		$menu.find('a[data-action=delete-forever]').on('click', function() {
 			ccm_triggerProgressiveOperation(
-				CCM_TOOLS_PATH + '/dashboard/sitemap_delete_forever', 
+				CCM_TOOLS_PATH + '/dashboard/sitemap_delete_forever',
 				[{'name': 'cID', 'value': cID}],
 				ccmi18n_sitemap.deletePages,
 				function() {
 					if (my.options.sitemap) {
 						var tree = my.options.sitemap.getTree(),
-							node = tree.getNodeByKey(cID);
+							node = tree.getNodeByKey(String(cID));
 
 						node.remove();
 					}
@@ -52,13 +52,13 @@
 		});
 		$menu.find('a[data-action=empty-trash]').on('click', function() {
 			ccm_triggerProgressiveOperation(
-				CCM_TOOLS_PATH + '/dashboard/sitemap_delete_forever', 
+				CCM_TOOLS_PATH + '/dashboard/sitemap_delete_forever',
 				[{'name': 'cID', 'value': cID}],
 				ccmi18n_sitemap.deletePages,
 				function() {
 					if (my.options.sitemap) {
 						var tree = my.options.sitemap.getTree(),
-							node = tree.getNodeByKey(cID);
+							node = tree.getNodeByKey(String(cID));
 
 						node.removeChildren();
 					}

--- a/concrete/js/build/core/sitemap/sitemap.js
+++ b/concrete/js/build/core/sitemap/sitemap.js
@@ -406,7 +406,7 @@
 			});
 			ConcreteEvent.unsubscribe('SitemapAddPageRequestComplete.sitemap');
 			ConcreteEvent.subscribe('SitemapAddPageRequestComplete.sitemap', function(e, data) {
-				var node = my.getTree().getNodeByKey(data.cParentID);
+				var node = my.getTree().getNodeByKey(String(data.cParentID));
 				if (node) {
 					my.reloadNode(node);
 				}
@@ -414,7 +414,7 @@
 			});
 			ConcreteEvent.subscribe('SitemapUpdatePageRequestComplete.sitemap', function(e, data) {
 				try {
-					var node = my.getTree().getNodeByKey(data.cID);
+					var node = my.getTree().getNodeByKey(String(data.cID));
 					var parent = node.parent;
 					if (parent) {
 						my.reloadNode(parent);
@@ -486,7 +486,7 @@
 							node.remove();
 						}
 						reloadNode.removeChildren();
-		
+
 						my.reloadNode(reloadNode, function() {
 							if (!destNode.bExpanded) {
 								destNode.setExpanded(true, {noAnimation: true});
@@ -608,7 +608,7 @@
 		},
 
 		reloadSelfNodeByCID: function(cID, onComplete) {
-			var node = cID ? this.getTree().getNodeByKey(cID.toString()) : null;
+			var node = cID ? this.getTree().getNodeByKey(String(cID)) : null;
 			if (node) {
 				this.reloadSelfNode(node, onComplete);
 			}

--- a/concrete/js/build/core/tree.js
+++ b/concrete/js/build/core/tree.js
@@ -159,7 +159,7 @@
 					if (options.removeNodesByKey.length) {
 						for (var i = 0; i < options.removeNodesByKey.length; i++) {
 							var nodeID = options.removeNodesByKey[i];
-							var node = $tree.fancytree('getTree').getNodeByKey(nodeID);
+							var node = $tree.fancytree('getTree').getNodeByKey(String(nodeID));
 							if (node) {
 								node.remove();
 							}
@@ -327,7 +327,7 @@
 						ConcreteAlert.dialog(ccmi18n.error, r.errors.join("<br>"));
 					} else {
 						jQuery.fn.dialog.closeTop();
-						var node = $tree.fancytree('getTree').getNodeByKey(r.treeNodeParentID);
+						var node = $tree.fancytree('getTree').getNodeByKey(String(r.treeNodeParentID));
 						jQuery.fn.dialog.showLoader();
 						my.reloadNode(node, function() {
 							jQuery.fn.dialog.hideLoader();
@@ -402,23 +402,23 @@
 				node;
 			if (nodes.length) {
 				for (var i = 0; i < nodes.length; i++) {
-					node = $tree.fancytree('getTree').getNodeByKey(nodes[i].treeNodeParentID);
+					node = $tree.fancytree('getTree').getNodeByKey(String(nodes[i].treeNodeParentID));
 					node.addChildren(nodes);
 				}
 			} else {
-				node = $tree.fancytree('getTree').getNodeByKey(nodes.treeNodeParentID);
+				node = $tree.fancytree('getTree').getNodeByKey(String(nodes.treeNodeParentID));
 				node.addChildren(nodes);
 			}
 		});
 		ConcreteEvent.subscribe('ConcreteTreeUpdateTreeNode.concreteTree', function(e, r) {
 			var $tree = $('[data-tree=' + my.options.treeID + ']'),
-				node = $tree.fancytree('getTree').getNodeByKey(r.node.key);
+				node = $tree.fancytree('getTree').getNodeByKey(String(r.node.key));
 			node.fromDict(r.node);
 			node.render();
 		});
 		ConcreteEvent.subscribe('ConcreteTreeDeleteTreeNode.concreteTree', function(e, r) {
 			var $tree = $('[data-tree=' + my.options.treeID + ']'),
-				node = $tree.fancytree('getTree').getNodeByKey(r.node.treeNodeID);
+				node = $tree.fancytree('getTree').getNodeByKey(String(r.node.treeNodeID));
 			node.remove();
 		});
 	};


### PR DESCRIPTION
Since #7266 and #7272, `getCollectionID()` and `getCollectionParentID()` return an integer, but fancytree's `getNodeByKey()` function uses strings to retrieve nodes and sometimes can't find the nodes.

**Steps to reproduce :**
- Go to the **Full Sitemap** page
- Change the name of a page
- When the page is saved the node is not updated in the sitemap

PS : I used `String()` to avoid **TypeError** if the key is null as explained [here](https://stackoverflow.com/a/3945236).