### PR TITLE
Fixed a validation issue when the URL slug property is required

### DIFF
--- a/concrete/src/Page/Type/Composer/Control/CorePageProperty/UrlSlugCorePageProperty.php
+++ b/concrete/src/Page/Type/Composer/Control/CorePageProperty/UrlSlugCorePageProperty.php
@@ -35,16 +35,29 @@ class UrlSlugCorePageProperty extends CorePageProperty
     public function validate()
     {
         $e = Loader::helper('validation/error');
-        $handle = $this->getPageTypeComposerControlDraftValue();
+        $val = $this->getRequestValue();
+        if ($val['url_slug']) {
+            $urlSlug = $val['url_slug'];
+        } else {
+            $urlSlug = $this->getPageTypeComposerControlDraftValue();
+        }
 
         /** @var \Concrete\Core\Utility\Service\Validation\Strings $stringValidator */
         $stringValidator = Core::make('helper/validation/strings');
-        if (!$stringValidator->notempty($handle)) {
+        if (!$stringValidator->notempty($urlSlug)) {
             $control = $this->getPageTypeComposerFormLayoutSetControlObject();
             $e->add(t('You haven\'t chosen a valid %s', $control->getPageTypeComposerControlDisplayLabel()));
 
             return $e;
         }
+    }
+
+    public function getRequestValue($args = false)
+    {
+        $data = parent::getRequestValue($args);
+        $data['url_slug'] = Core::make('helper/security')->sanitizeString($data['url_slug']);
+
+        return $data;
     }
 
     public function getPageTypeComposerControlDraftValue()


### PR DESCRIPTION
## Issue

#8987 

## Summary

As with other [CorePageProperty](https://github.com/concrete5/concrete5/blob/develop/concrete/src/Page/Type/Composer/Control/CorePageProperty/DescriptionCorePageProperty.php), I've changed to pass the value to the validation method if it exists in the request.