### PR TITLE
[8.5.x] Update from concrete5.org to concretecms.org

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -765,7 +765,7 @@ return [
         // Community Translation instance offering concrete5 translations
         'community_translation' => [
             // API entry point of the Community Translation instance
-            'entry_point' => 'https://translate.concreteorg.org/api',
+            'entry_point' => 'https://translate.concretecms.org/api',
             // API Token to be used for the Community Translation instance
             'api_token' => '',
             // Languages below this translation progress won't be considered
@@ -773,7 +773,7 @@ return [
             // Lifetime (in seconds) of the cache items associated to downloaded data
             'cache_lifetime' => 3600, // 1 hour
             // Base URI for package details
-            'package_url' => 'https://translate.concreteorg.org/translate/package',
+            'package_url' => 'https://translate.concretecms.org/translate/package',
         ],
     ],
     'urls' => [


### PR DESCRIPTION
Hi, I know 9.0rc branch already set new domain.

However, if there is another release of 8.5.x, I would like to include these change in 8.5.x branch

https://github.com/concrete5/concrete5/commit/4eff290b4b4d53bd955eba836c683f01084d3096
https://github.com/concrete5/concrete5/commit/95c88ad3d5af08384dfc69e65724adc4c6b3db00
https://github.com/concrete5/concrete5/commit/c330637b8ded85465bdfc5275faa431015a2f711
(not everything).

One of my client environment has tight restriction and had to set HTTP_PROXY.
Then, somehow it doesn't properly redirect, I had to point it to the new concretecms domains.