### PR TITLE
Fixed Composer's Url_slug to show a pencil icon.

### DIFF
--- a/concrete/elements/page_types/composer/controls/core_page_property/url_slug.php
+++ b/concrete/elements/page_types/composer/controls/core_page_property/url_slug.php
@@ -30,7 +30,7 @@ $resolverManager = app(ResolverManagerInterface::class);
         <?php
         if (is_object($draft) && !$draft->isPageDraft()) {
             ?>
-            <div><a href="#" class="icon-link" data-composer-field="edit_url_slug"><i class="fas fa-pencil"></i></a> <span><?= $control->getPageTypeComposerControlDraftValue() ?></span></div>
+            <div><a href="#" class="icon-link" data-composer-field="edit_url_slug"><i class="fas fa-pencil-alt"></i></a> <span><?= $control->getPageTypeComposerControlDraftValue() ?></span></div>
         <?php
         } else {
             echo $element;


### PR DESCRIPTION
The pencil icon for editing url_slug is not shown, so I added alt to the class name to make it show up.
![screenshot](https://user-images.githubusercontent.com/49182821/137627034-db05dc49-6b8f-439f-8f2c-788fa1c09441.png)

*Corrections to the following comments
https://github.com/concrete5/concrete5/issues/9774#issuecomment-922468795