### PR TITLE
Add missing support for boostrap5 guides

### DIFF
--- a/build/assets/cms.scss
+++ b/build/assets/cms.scss
@@ -1,7 +1,6 @@
 @import 'bootstrap/scss/functions';
 @import 'bootstrap/scss/variables';
 @import 'bootstrap/scss/mixins';
-@import "bootstrap/scss/popover";
 
 @import "@concretecms/bedrock/assets/cms/scss/variables";
 @import "@fortawesome/fontawesome-free/scss/variables";

--- a/concrete/controllers/frontend/assets_localization.php
+++ b/concrete/controllers/frontend/assets_localization.php
@@ -293,7 +293,7 @@ var ccmi18n_tree = ' . json_encode([
         ]) . ';
 var ccmi18n_tourist = ' . json_encode([
             'template' => implode('', [
-                '<div class="popover ccm-help-tour" role="tooltip">',
+                '<div class="popover ccm-ui ccm-help-tour" role="tooltip">',
                 '<div class="popover-arrow"></div>',
                 '<a class="ccm-help-tour-close fas fa-times" href="#" data-role="end"></a>',
                 '<div class="popover-body"></div>',

--- a/concrete/single_pages/dashboard/system/seo/urls.php
+++ b/concrete/single_pages/dashboard/system/seo/urls.php
@@ -91,7 +91,7 @@ $(function () {
     var tour = new Tour({
         name: 'dashboard-system-urls',
         steps: steps,
-        framework: 'bootstrap4',
+        framework: 'bootstrap5',
         template: ccmi18n_tourist.template,
         localization: ccmi18n_tourist.localization,
         storage: false,


### PR DESCRIPTION
Requires update of bedrock https://github.com/concrete5/bedrock/pull/175
