### PR TITLE
Add public key to the BearerTokenValidator if it has a setPublicKey method

### DIFF
--- a/concrete/src/Api/ApiServiceProvider.php
+++ b/concrete/src/Api/ApiServiceProvider.php
@@ -17,6 +17,7 @@ use Concrete\Core\Foundation\Service\Provider as ServiceProvider;
 use Concrete\Core\Routing\Router;
 use Doctrine\ORM\EntityManagerInterface;
 use League\OAuth2\Server\AuthorizationServer;
+use League\OAuth2\Server\AuthorizationValidators\BearerTokenValidator;
 use League\OAuth2\Server\Grant\AuthCodeGrant;
 use League\OAuth2\Server\Grant\PasswordGrant;
 use League\OAuth2\Server\Grant\RefreshTokenGrant;


### PR DESCRIPTION
Newer versions of league/oauth-server require the public key be provided to the bearer token validator. 