### PR TITLE
[V9] Cache response of $cp->canViewToolbar()

### DIFF
--- a/concrete/src/Permission/Response/Response.php
+++ b/concrete/src/Permission/Response/Response.php
@@ -4,7 +4,7 @@ namespace Concrete\Core\Permission\Response;
 use Exception;
 use Concrete\Core\User\User;
 use Concrete\Core\Support\Facade\Application;
-use PermissionKeyCategory;
+use Concrete\Core\Permission\Category as PermissionKeyCategory;
 use Core;
 
 class Response


### PR DESCRIPTION
See #10333

Additionally, I've checked PageResponse class and marked two methods as deprecated.
These methods were added while developing 5.7.0 but I think @aembler forgot to remove them.

https://github.com/concrete5/concrete5/commit/90af51f70d7278ff13d0e25013dd50f0da454dc2
https://github.com/concrete5/concrete5/commit/886b7d3eb1532f45a0042fd736f0a4988a2931a9