### PR TITLE
Avoid (and disable) code coverage in forks

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -9,7 +9,7 @@ jobs:
     name: "PHPUnit"
     env:
       LC_ALL: en_US.UTF-8
-      CODE_COVERAGE: n
+      CODE_COVERAGE: none
     continue-on-error: ${{ matrix.php-version == '8.1' }}
 
     runs-on: ${{ matrix.operating-system }}
@@ -50,6 +50,10 @@ jobs:
             dependencies: "locked"
 
     steps:
+      - name: Enable code coverage
+        if: matrix.php-version == '7.4' && startsWith(matrix.operating-system, 'ubuntu') && matrix.dependencies == 'locked' && github.repository_owner == 'concrete5'
+        run: printf 'CODE_COVERAGE=pcov\n' >> "$GITHUB_ENV"
+
       - name: "Checkout"
         uses: "actions/checkout@v2"
         with:
@@ -60,7 +64,7 @@ jobs:
         with:
           php-version: "${{ matrix.php-version }}"
           extensions: mbstring, xml, ctype, iconv, intl, pdo_mysql, mysql
-          coverage: pcov
+          coverage: ${{ env.CODE_COVERAGE }}
           ini-values: memory_limit=-1, pcov.directory=concrete, pcov.exclude="~(vendor|tests|js|css|config)~"
           tools: ${{matrix.composer}}
 
@@ -68,10 +72,6 @@ jobs:
         run: |
           mysql -h127.0.0.1 -uroot -proot -e "CREATE USER 'travis'@'%' IDENTIFIED BY '';"
           mysql -h127.0.0.1 -uroot -proot -e "GRANT ALL PRIVILEGES ON *.* TO 'travis'@'%' WITH GRANT OPTION; FLUSH PRIVILEGES;"
-
-      - name: Enable code coverage
-        if: matrix.php-version == '7.4' && startsWith(matrix.operating-system, 'ubuntu') && matrix.dependencies == 'locked'
-        run: printf 'CODE_COVERAGE=y\n' >> "$GITHUB_ENV"
 
       - name: "Install lowest dependencies"
         if: ${{ matrix.dependencies == 'lowest' }}
@@ -96,17 +96,17 @@ jobs:
 
 
       - name: "Tests"
-        if: env.CODE_COVERAGE == 'n'
+        if: env.CODE_COVERAGE == 'none'
         run: php ./concrete/vendor/phpunit/phpunit/phpunit
         # Same as above
         continue-on-error: ${{ matrix.php-version == '8.1' }}
 
       - name: "Tests with coverage"
-        if: env.CODE_COVERAGE == 'y'
+        if: env.CODE_COVERAGE != 'none'
         run: php ./concrete/vendor/phpunit/phpunit/phpunit --coverage-clover=coverage.clover
 
       - name: "Upload coverage"
-        if: env.CODE_COVERAGE == 'y'
+        if: env.CODE_COVERAGE != 'none'
         run: |
           wget --tries=5 https://scrutinizer-ci.com/ocular.phar
           php ocular.phar code-coverage:upload --format=php-clover coverage.clover


### PR DESCRIPTION
While developing for Concrete, contributors publish their changes to their own forks on GitHub.

In those cases, uploading the code coverage doesn't work (since contributors don't have write rights to scrutinizer).

So, what about skipping the code coverage in forks?

PS: to speed up tests a bit, here I also disable installing pcov if it won't be used.