### PR TITLE
[v9.0.2] Remove javascript page reload attribute from seo and attributes panels

### DIFF
--- a/concrete/views/dialogs/page/seo.php
+++ b/concrete/views/dialogs/page/seo.php
@@ -33,7 +33,7 @@ $form = $app->make(Form::class);
 
         <form method="post" action="<?php echo h($controller->action('submit')) ?>"
               class="pt-4 ccm-panel-detail-content-form"
-              data-dialog-form="seo" data-panel-detail-form="seo" data-action-after-save="reload">
+              data-dialog-form="seo" data-panel-detail-form="seo">
 
             <?php if ($allowEditName) { ?>
                 <div class="form-group">

--- a/concrete/views/panels/details/page/attributes.php
+++ b/concrete/views/panels/details/page/attributes.php
@@ -17,7 +17,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
 
     <section class="ccm-ui">
         <form method="post" action="<?= $controller->action('submit') ?>" data-dialog-form="attributes"
-              data-panel-detail-form="attributes" data-action-after-save="reload">
+              data-panel-detail-form="attributes">
 
             <?php if (isset($sitemap) && $sitemap) {
                 ?>

--- a/concrete/views/panels/details/page/seo.php
+++ b/concrete/views/panels/details/page/seo.php
@@ -5,7 +5,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 <div class="row">
     <section class="ccm-ui col-sm-9">
         <header><h3><?=t('SEO')?></h3></header>
-        <form method="post" action="<?=$controller->action('submit')?>" class="pt-4 ccm-panel-detail-content-form" data-dialog-form="seo" data-panel-detail-form="seo" data-action-after-save="reload">
+        <form method="post" action="<?=$controller->action('submit')?>" class="pt-4 ccm-panel-detail-content-form" data-dialog-form="seo" data-panel-detail-form="seo">
             <?php if ($allowEditName) {
             ?>
             <div class="form-group">


### PR DESCRIPTION
Hi,

The content creators from the agency I work for noticed some changes in comparison to concrete5 V8.
When working with nested sitemap pages, its very annoying to edit attributes or seo info from multiple pages.
After the page reload the whole sitemap is collapsed again which makes it quite annoying to work with.

This is because there is a page refresh after saving the attributes and seo information, caused by a attribute in the form tag.
I removed the tags and everything worked as expected, couldn't find any reason why it was there so I removed it.

If this is not the proper solution and this feature is required for some reason, please let me know. I also build a different solution where you are able to disable the automatic page reload which can be toggled in the dropdown above the sitemap.

![image](https://user-images.githubusercontent.com/22031710/158831282-75847453-fbf1-46a4-9831-d87910cebe81.png)

Kind regards,
Laurens van Strijland
