### PR TITLE
Adds Default Theme option to page types.

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -8,7 +8,7 @@ return [
      */
     'version' => '9.1.0RC4',
     'version_installed' => '9.1.0RC4',
-    'version_db' => '20220503000000', // the key of the latest database migration
+    'version_db' => '20220507000000', // the key of the latest database migration
 
     /*
      * Installation status

--- a/concrete/config/db.xml
+++ b/concrete/config/db.xml
@@ -21,6 +21,9 @@
     <field name="ptDefaultPageTemplateID" type="integer" size="10">
       <unsigned/>
     </field>
+    <field name="ptDefaultThemeID" type="integer" size="10">
+      <unsigned/>
+    </field>
     <field name="ptAllowedPageTemplates" type="string" size="1">
       <default value="A"/>
     </field>

--- a/concrete/controllers/single_page/dashboard/pages/themes.php
+++ b/concrete/controllers/single_page/dashboard/pages/themes.php
@@ -235,6 +235,11 @@ class Themes extends DashboardSitePageController
             if ($localUninstall) {
                 $pl->uninstall();
             }
+
+            // clean up a page types that are pointing to this deleted theme as the default
+            $db = $this->app->make('database')->connection();
+            $db->query('update PageTypes set ptDefaultThemeID = null where ptDefaultThemeID = ?', [$pThemeID]);
+
             $this->set('message', t('Theme uninstalled.'));
         } catch (Exception $e) {
             $this->error->add($e);

--- a/concrete/controllers/single_page/dashboard/pages/types.php
+++ b/concrete/controllers/single_page/dashboard/pages/types.php
@@ -5,6 +5,7 @@ use Concrete\Controller\Element\Dashboard\Pages\Types\Header;
 use Concrete\Core\Error\ErrorList\ErrorList;
 use Concrete\Core\Page\Controller\DashboardPageController;
 use Concrete\Core\Page\Controller\DashboardSitePageController;
+use Concrete\Core\Page\Theme\Theme;
 use PageType;
 use Loader;
 use PageTemplate;
@@ -156,6 +157,16 @@ class Types extends DashboardPageController
         if (!is_object($defaultTemplate)) {
             $this->error->add(t('You must choose a valid default page template.'));
         }
+
+        $defaultTheme = null;
+
+        if ($this->post('ptDefaultThemeID')) {
+            $defaultTheme = Theme::getByID($this->post('ptDefaultThemeID'));
+            if (!is_object($defaultTheme)) {
+                $this->error->add(t('You must choose a valid theme.'));
+            }
+        }
+
         $templates = array();
         if (isset($_POST['ptPageTemplateID']) && is_array($_POST['ptPageTemplateID'])) {
             foreach ($this->post('ptPageTemplateID') as $pageTemplateID) {
@@ -183,6 +194,7 @@ class Types extends DashboardPageController
                 'handle' => $handle,
                 'name' => $name,
                 'defaultTemplate' => $defaultTemplate,
+                'defaultTheme' => $defaultTheme,
                 'ptLaunchInComposer' => $this->post('ptLaunchInComposer'),
                 'ptIsFrequentlyAdded' => $this->post('ptIsFrequentlyAdded'),
                 'allowedTemplates' => $this->post('ptAllowedPageTemplates'),

--- a/concrete/controllers/single_page/dashboard/pages/types/add.php
+++ b/concrete/controllers/single_page/dashboard/pages/types/add.php
@@ -3,6 +3,7 @@ namespace Concrete\Controller\SinglePage\Dashboard\Pages\Types;
 
 use Concrete\Core\Error\ErrorList\ErrorList;
 use Concrete\Core\Page\Controller\DashboardPageController;
+use Concrete\Core\Page\Theme\Theme;
 use PageType;
 use PageTemplate;
 use Concrete\Core\Page\Type\PublishTarget\Type\Type as PageTypePublishTargetType;
@@ -49,6 +50,15 @@ class Add extends DashboardPageController
         if (!is_object($defaultTemplate)) {
             $this->error->add(t('You must choose a valid default page template.'));
         }
+
+        $defaultTheme = null;
+        if ($post->get('ptDefaultThemeID')) {
+            $defaultTheme = Theme::getByID($post->get('ptDefaultThemeID'));
+            if (!is_object($defaultTheme)) {
+                $this->error->add(t('You must choose a valid theme.'));
+            }
+        }
+
         $templates = array();
         if (is_array($post->get('ptPageTemplateID'))) {
             foreach ($post->get('ptPageTemplateID') as $pageTemplateID) {
@@ -84,6 +94,7 @@ class Add extends DashboardPageController
                 'handle' => $handle,
                 'name' => $name,
                 'defaultTemplate' => $defaultTemplate,
+                'defaultTheme' => $defaultTheme,
                 'ptLaunchInComposer' => $post->get('ptLaunchInComposer'),
                 'ptIsFrequentlyAdded' => $post->get('ptIsFrequentlyAdded'),
                 'allowedTemplates' => $post->get('ptAllowedPageTemplates'),

--- a/concrete/elements/page_types/form/base.php
+++ b/concrete/elements/page_types/form/base.php
@@ -8,6 +8,13 @@ $pagetemplates = PageTemplate::getList();
 foreach ($pagetemplates as $pt) {
     $templates[$pt->getPageTemplateID()] = $pt->getPageTemplateDisplayName();
 }
+
+$themes = [''=>t('Active Theme')];
+$siteThemes = Concrete\Core\Page\Theme\Theme::getList();
+foreach ($siteThemes as $theme) {
+    $themes[$theme->getThemeID()] = $theme->getThemeName();
+}
+
 $targetTypes = PageTypePublishTargetType::getList();
 
 $ptName = '';
@@ -15,6 +22,7 @@ $ptHandle = '';
 $ptPageTemplateID = [];
 $ptAllowedPageTemplates = 'A';
 $ptDefaultPageTemplateID = 0;
+$ptDefaultThemeID = 0;
 $ptLaunchInComposer = 0;
 $ptIsFrequentlyAdded = 1;
 $token = 'add_page_type';
@@ -25,6 +33,7 @@ if (isset($pagetype) && is_object($pagetype)) {
     $ptHandle = $pagetype->getPageTypeHandle();
     $ptLaunchInComposer = $pagetype->doesPageTypeLaunchInComposer();
     $ptDefaultPageTemplateID = $pagetype->getPageTypeDefaultPageTemplateID();
+    $ptDefaultThemeID = $pagetype->getPageTypeDefaultThemeID();
     $ptAllowedPageTemplates = $pagetype->getPageTypeAllowedPageTemplates();
     $ptIsFrequentlyAdded = $pagetype->isPageTypeFrequentlyAdded();
     $selectedtemplates = $pagetype->getPageTypeSelectedPageTemplateObjects();
@@ -54,6 +63,11 @@ if (isset($pagetype) && is_object($pagetype)) {
 		<?= $form->label('ptDefaultPageTemplateID', t('Default Page Template')) ?>
 		<?= $form->select('ptDefaultPageTemplateID', $templates, $ptDefaultPageTemplateID) ?>
 	</div>
+
+    <div class="form-group">
+        <?= $form->label('ptDefaultThemeID', t('Default Theme')) ?>
+        <?= $form->select('ptDefaultThemeID', $themes, $ptDefaultThemeID) ?>
+    </div>
 
 	<div class="form-group">
 		<?= $form->label('ptLaunchInComposer', t('Launch in Composer?')) ?>

--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -3485,6 +3485,8 @@ EOT
         $db = Database::connection();
         $txt = Core::make('helper/text');
 
+        $theme = false;
+
         // the passed collection is the parent collection
         $cParentID = $this->getCollectionID();
 
@@ -3547,6 +3549,10 @@ EOT
             // then we use the page type's default template
             if ($pt->getPageTypeDefaultPageTemplateID() > 0 && !$template) {
                 $template = $pt->getPageTypeDefaultPageTemplateObject();
+            }
+
+            if ($pt->getPageTypeDefaultThemeID()) {
+                $theme = $pt->getPageTypeDefaultThemeObject();
             }
 
             $ptID = $pt->getPageTypeID();
@@ -3626,6 +3632,10 @@ EOT
         }
         if (!$hasAuthor) {
             $u->refreshUserGroups();
+        }
+
+        if ($theme) {
+            $pc->setTheme($theme);
         }
 
         return $pc;

--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -1946,7 +1946,7 @@ class Page extends Collection implements CategoryMemberInterface,
     public function setTheme($pl)
     {
         $db = Database::connection();
-        $db->executeQuery('update CollectionVersions set pThemeID = ? where cID = ? and cvID = ?', [$pl->getThemeID(), $this->cID, $this->vObj->getVersionID()]);
+        $db->executeQuery('update CollectionVersions set pThemeID = ? where cID = ? and cvID = ?', [$pl ? $pl->getThemeID() : 0, $this->cID, $this->vObj->getVersionID()]);
         $this->themeObject = $pl;
     }
 

--- a/concrete/src/Page/Type/Type.php
+++ b/concrete/src/Page/Type/Type.php
@@ -330,6 +330,15 @@ class Type extends ConcreteObject implements \Concrete\Core\Permission\ObjectInt
             $template->setPermissionsToManualOverride();
         }
 
+        // either set the default page object to have the default theme of the page type, or, set the theme id to 0 to be based on active them
+        if ($this->getPageTypeDefaultThemeID() != $template->getCollectionThemeID()) {
+            if ($this->getPageTypeDefaultThemeID() > 0 && $theme = $this->getPageTypeDefaultThemeObject()) {
+                $template->setTheme($theme);
+            } else {
+                $template->setTheme(false);
+            }
+        }
+
         return $template;
     }
 

--- a/concrete/src/Updater/Migrations/Migrations/Version20210813173441.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20210813173441.php
@@ -13,7 +13,9 @@ final class Version20210813173441 extends AbstractMigration implements Repeatabl
 
     public function upgradeDatabase()
     {
-        // Nothing here. Had to move this back to Version20210216184000
+        \Concrete\Core\Database\Schema\Schema::refreshCoreXMLSchema([
+            'PageTypes',
+        ]);
     }
 
 }

--- a/concrete/src/Updater/Migrations/Migrations/Version20220507000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20220507000000.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Site\Service;
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
+
+class Version20220507000000 extends AbstractMigration implements RepeatableMigrationInterface
+{
+    /**
+     * Refresh PageTypes table
+     *
+     * @return void
+     */
+    public function upgradeDatabase()
+    {
+        \Concrete\Core\Database\Schema\Schema::refreshCoreXMLSchema([
+            'PageTypes',
+        ]);
+    }
+}


### PR DESCRIPTION
This adds a new option for configuring page types, 'Default Theme'

If set, a newly created page will automatically have the selected theme applied. If left as the default, 'Active Theme', the behaviour will be as is it currently - new pages won't be specifically assigned a theme and will adopt the active theme.

![Screen Shot 2022-05-07 at 7 56 54 pm](https://user-images.githubusercontent.com/1079600/167268146-cba40750-2e07-4eb6-a905-53574d3e9994.png)

This feature relates to my musings on the forum here: https://forums.concretecms.org/t/missing-config-option-of-default-theme-for-page-types/2992
