### PR TITLE
Make Top Nav Bar Block Respect nav_target Page Attribute & External Link Targets

### DIFF
--- a/concrete/blocks/top_navigation_bar/controller.php
+++ b/concrete/blocks/top_navigation_bar/controller.php
@@ -292,19 +292,19 @@ class Controller extends BlockController implements UsesFeatureInterface, FileTr
     
     public function getPageItemNavTarget($pageItem) // Respect nav_target Page Attribute & External Link targets
     {
-		if (!is_object($pageItem) || !$pageItem instanceof \Concrete\Core\Navigation\Item\PageItem) {
-			return '';
-		}
-		$page = Page::getByID($pageItem->getPageID());
-		
-		if ($page->getCollectionPointerExternalLink() != '' && $page->openCollectionPointerExternalLinkInNewWindow()) {
-			$target = '_blank';
-		} else {
-			$target = $page->getAttribute('nav_target');
-		}
-		$target = empty($target) ? '_self' : $target;
-		
-		return $target;
+	if (!is_object($pageItem) || !$pageItem instanceof \Concrete\Core\Navigation\Item\PageItem) {
+		return '';
+	}
+	$page = Page::getByID($pageItem->getPageID());
+	
+	if ($page->getCollectionPointerExternalLink() != '' && $page->openCollectionPointerExternalLinkInNewWindow()) {
+		$target = '_blank';
+	} else {
+		$target = $page->getAttribute('nav_target');
+	}
+	$target = empty($target) ? '_self' : $target;
+	
+	return $target;
     }
 
 }

--- a/concrete/blocks/top_navigation_bar/controller.php
+++ b/concrete/blocks/top_navigation_bar/controller.php
@@ -289,5 +289,22 @@ class Controller extends BlockController implements UsesFeatureInterface, FileTr
         }
         return $files;
     }
+    
+    public function getPageItemNavTarget($pageItem) // Respect nav_target Page Attribute & External Link targets
+    {
+		if (!is_object($pageItem) || !$pageItem instanceof \Concrete\Core\Navigation\Item\PageItem) {
+			return '';
+		}
+		$page = Page::getByID($pageItem->getPageID());
+		
+		if ($page->getCollectionPointerExternalLink() != '' && $page->openCollectionPointerExternalLinkInNewWindow()) {
+			$target = '_blank';
+		} else {
+			$target = $page->getAttribute('nav_target');
+		}
+		$target = empty($target) ? '_self' : $target;
+		
+		return $target;
+    }
 
 }

--- a/concrete/blocks/top_navigation_bar/controller.php
+++ b/concrete/blocks/top_navigation_bar/controller.php
@@ -293,14 +293,14 @@ class Controller extends BlockController implements UsesFeatureInterface, FileTr
     public function getPageItemNavTarget($pageItem) // Respect nav_target Page Attribute & External Link targets
     {
 	if (!is_object($pageItem) || !$pageItem instanceof \Concrete\Core\Navigation\Item\PageItem) {
-		return '';
+	    return '';
 	}
 	$page = Page::getByID($pageItem->getPageID());
 	
 	if ($page->getCollectionPointerExternalLink() != '' && $page->openCollectionPointerExternalLinkInNewWindow()) {
-		$target = '_blank';
+	    $target = '_blank';
 	} else {
-		$target = $page->getAttribute('nav_target');
+	    $target = $page->getAttribute('nav_target');
 	}
 	$target = empty($target) ? '_self' : $target;
 	

--- a/concrete/blocks/top_navigation_bar/view.php
+++ b/concrete/blocks/top_navigation_bar/view.php
@@ -60,17 +60,17 @@ $c = Page::getCurrentPage();
                              */
                             if (count($item->getChildren()) > 0) { ?>
                                 <li class="nav-item dropdown">
-                                    <a class="nav-link dropdown-toggle<?= $item->isActive() ? " active" : ""; ?>" data-concrete-toggle="dropdown" href="<?= $item->getUrl() ?>">
+                                    <a class="nav-link dropdown-toggle<?= $item->isActive() ? " active" : ""; ?>" data-concrete-toggle="dropdown" target="<?=$controller->getPageItemNavTarget($item)?>" href="<?= $item->getUrl() ?>">
                                         <?=$item->getName()?>
                                     </a>
                                     <ul class="dropdown-menu">
                                         <?php foreach ($item->getChildren() as $dropdownChild) { ?>
-                                            <li><a class="dropdown-item<?= $dropdownChild->isActive() ? " active" : ""; ?>" href="<?=$dropdownChild->getUrl()?>"><?=$dropdownChild->getName()?></a></li>
+                                            <li><a class="dropdown-item<?= $dropdownChild->isActive() ? " active" : ""; ?>" target="<?=$controller->getPageItemNavTarget($dropdownChild)?>" href="<?=$dropdownChild->getUrl()?>"><?=$dropdownChild->getName()?></a></li>
                                         <?php } ?>
                                     </ul>
                                 </li>
                             <?php } else { ?>
-                                <li class="nav-item"><a class="nav-link<?= $item->isActive() ? " active" : ""; ?>" href="<?=$item->getUrl()?>"><?=$item->getName()?></a></li>
+                                <li class="nav-item"><a class="nav-link<?= $item->isActive() ? " active" : ""; ?>" target="<?=$controller->getPageItemNavTarget($item)?>" href="<?=$item->getUrl()?>"><?=$item->getName()?></a></li>
                             <?php } ?>
                         <?php } ?>
                     </ul>


### PR DESCRIPTION
I recently released a nav_target page attribute package to the marketplace.  In review @JohntheFish pointed out the top nav bar wasn't respecting the nav_target attribute and could use fixing.  I later found it wasn't respecting the external link target either.  This should be problem solved...