### PR TITLE
Fix $fileset->update() php8 undefined error

### DIFF
--- a/concrete/controllers/single_page/dashboard/files/sets.php
+++ b/concrete/controllers/single_page/dashboard/files/sets.php
@@ -87,7 +87,7 @@ class Sets extends DashboardPageController
             $file_set = FileSet::getByID($this->post('fsID'));
 
 
-            $file_set->update($setName, $fsOverrideGlobalPermissions);
+            $file_set->update($setName);
             $file_set->updateFileSetDisplayOrder($this->post('fsDisplayOrder'));
 
             $this->redirect("/dashboard/files/sets", 'view_detail', $this->post('fsID'), 'file_set_updated');


### PR DESCRIPTION
Removing unused parameter $fsOverrideGlobalPermissions.
update() method requires $setName only.
