### PR TITLE
Improvements and bug fixes to previewing pages and versions as users

### DIFF
--- a/concrete/controllers/backend/page/preview_version.php
+++ b/concrete/controllers/backend/page/preview_version.php
@@ -82,7 +82,6 @@ class PreviewVersion extends AbstractController
 
     protected function prepareRequest(Page $page): void
     {
-        $this->request->setCustomRequestUser(-1);
         $this->request->setCurrentPage($page);
     }
 
@@ -94,6 +93,7 @@ class PreviewVersion extends AbstractController
     protected function preparePage(Page $page): ?Response
     {
         $controller = $page->getPageController();
+        $controller->disableEditing();
         $response = $controller->on_start();
         if ($response instanceof Response) {
             return $response;

--- a/concrete/controllers/panel/detail/theme/preview_skin.php
+++ b/concrete/controllers/panel/detail/theme/preview_skin.php
@@ -59,6 +59,7 @@ class PreviewSkin extends BackendInterfaceController
                 $req = Request::getInstance();
                 $req->setCurrentPage($page);
                 $controller = $page->getPageController();
+                $controller->disableEditing();
                 $view = $controller->getViewObject();
                 $previewRequest = new ThemeCustomizerRequest();
 
@@ -90,7 +91,6 @@ class PreviewSkin extends BackendInterfaceController
                 $previewRequest->setCustomCss($result);
                 $view->setCustomPreviewRequest($previewRequest);
 
-                $req->setCustomRequestUser(-1);
                 $response = new Response();
                 $content = $view->render();
                 $response->setContent($content);

--- a/concrete/controllers/panel/page/design.php
+++ b/concrete/controllers/panel/page/design.php
@@ -108,6 +108,7 @@ class Design extends BackendUIPageController
         $req = Request::getInstance();
         $req->setCurrentPage($this->page);
         $controller = $this->page->getPageController();
+        $controller->disableEditing();
         $view = $controller->getViewObject();
 
         $previewRequest = new PageDesignPreviewRequest();
@@ -135,7 +136,6 @@ class Design extends BackendUIPageController
         }
 
         $view->setCustomPreviewRequest($previewRequest);
-        $req->setCustomRequestUser(-1);
         $response = new \Symfony\Component\HttpFoundation\Response();
         $content = $view->render();
         $response->setContent($content);

--- a/concrete/controllers/panel/page/devices.php
+++ b/concrete/controllers/panel/page/devices.php
@@ -43,12 +43,12 @@ class Devices extends BackendInterfacePageController
                 }
             }
 
-            $spoofed_request->setCustomRequestUser(-1);
             $spoofed_request->setCurrentPage($c);
 
             \Request::setInstance($spoofed_request);
 
             $controller = $c->getPageController();
+            $controller->disableEditing();
             $controller->runTask('view', array());
             $view = $controller->getViewObject();
             $response = new \Response();

--- a/concrete/controllers/panel/page/preview_as_user.php
+++ b/concrete/controllers/panel/page/preview_as_user.php
@@ -1,6 +1,7 @@
 <?php
 namespace Concrete\Controller\Panel\Page;
 
+use Concrete\Core\Form\Service\Widget\UserSelector;
 use Controller;
 use Page;
 use Permissions;
@@ -14,6 +15,7 @@ class PreviewAsUser extends Controller
 {
     public function view()
     {
+        $this->set('userSelector', $this->app->make(UserSelector::class));
         $this->setViewObject(new View('/panels/page/preview_as/form'));
     }
 
@@ -38,14 +40,23 @@ class PreviewAsUser extends Controller
             $request->setCurrentPage($page);
 
             if ($request->request('customUser')) {
-                $user_info = UserInfo::getByUserName($request->request('customUser'));
+                $user_info = UserInfo::getByID($request->request('customUser'));
                 if ($user_info && is_object($user_info) && !$user_info->isError()) {
                     $request->setCustomRequestUser($user_info);
                 }
             }
-            $request->setCustomRequestDateTime(Core::make('helper/form/date_time')->translate('preview_as_user_datetime', $request->request()));
+            $customRequestDateTime = null;
+            if ($request->query->has('customDate')) {
+                $customRequestDateTime = $request->query->get('customDate');
+                if ($request->query->has('customTime')) {
+                    $customRequestDateTime .= ' ' . $request->query->get('customTime');
+                }
+                $dateTime = new \DateTime($customRequestDateTime);
+                $request->setCustomRequestDateTime($dateTime->format("Y-m-d H:i:s"));
+            }
 
             $controller = $page->getPageController();
+            $controller->disableEditing();
             $view = $controller->getViewObject();
 
             $response = new \Response();

--- a/concrete/elements/header_required.php
+++ b/concrete/elements/header_required.php
@@ -193,7 +193,9 @@ if (!empty($alternateHreflangTags)) {
 <?php
 $v = View::getRequestInstance();
 if ($cp) {
-    View::element('page_controls_header', ['cp' => $cp, 'c' => $c]);
+    if (!$v->isEditingDisabled()) {
+        View::element('page_controls_header', ['cp' => $cp, 'c' => $c]);
+    }
     if ($isEditMode) {
         $cookie = $app->make('cookie');
         if ($cookie->get('ccmLoadAddBlockWindow')) {

--- a/concrete/elements/page_controls_footer.php
+++ b/concrete/elements/page_controls_footer.php
@@ -10,7 +10,7 @@ $app = Concrete\Core\Support\Facade\Facade::getFacadeApplication();
 $dh = $app->make('helper/concrete/dashboard');
 $sh = $app->make('helper/concrete/dashboard/sitemap');
 
-if (isset($cp) && $cp->canViewToolbar() && (!$dh->inDashboard())) {
+if (isset($cp) && $cp->canViewToolbar() && (!$dh->inDashboard()) && !$view->isEditingDisabled()) {
     $cih = $app->make('helper/concrete/ui');
     $ihm = $app->make('helper/concrete/ui/menu');
     $valt = $app->make('helper/validation/token');

--- a/concrete/src/Area/Area.php
+++ b/concrete/src/Area/Area.php
@@ -1,6 +1,7 @@
 <?php
 namespace Concrete\Core\Area;
 
+use Concrete\Core\Page\View\PageView;
 use Concrete\Core\Support\Facade\Application;
 use Core;
 use Database;
@@ -209,6 +210,10 @@ class Area extends ConcreteObject implements \Concrete\Core\Permission\ObjectInt
     public function __construct($arHandle)
     {
         $this->arHandle = $arHandle;
+        $v = View::getRequestInstance();
+        if ($v instanceof PageView && $v->isEditingDisabled()) {
+            $this->disableControls();
+        }
     }
 
     /**
@@ -815,7 +820,6 @@ class Area extends ConcreteObject implements \Concrete\Core\Permission\ObjectInt
         if (!$c) {
             $c = Page::getCurrentPage();
         }
-        $v = View::getRequestInstance();
 
         if (!is_object($c) || $c->isError()) {
             return false;

--- a/concrete/src/Form/Service/Widget/UserSelector.php
+++ b/concrete/src/Form/Service/Widget/UserSelector.php
@@ -170,6 +170,8 @@ EOL;
 
         $identifier = $idHelper->getString(32);
 
+        $miscFields['classes'] = '';
+
         /** @noinspection PhpComposerExtensionStubsInspection */
         /** @noinspection BadExpressionStatementJS */
         return sprintf(

--- a/concrete/src/Page/Controller/PageController.php
+++ b/concrete/src/Page/Controller/PageController.php
@@ -26,6 +26,7 @@ class PageController extends Controller
     protected $requestValidated;
     /** @var BlockController[] */
     protected $blocks = [];
+    protected $editingDisabled = false;
 
     /** @var bool A flag to track whether we've loaded sets from the session flash bags */
     private $hasCheckedSessionMessages = false;
@@ -206,6 +207,25 @@ class PageController extends Controller
     public function getRequestActionParameters()
     {
         return $this->parameters;
+    }
+
+    /**
+     * Disables the display of an editing toolbar on the page. This does not impact permissions – it's an additional
+     * check that is used when pages are previewed (e.g. when we want to show a page but not the toolbar, even if the
+     * user is logged in.) This has to be a separate check because sometimes pages are protected but we still
+     * want to act like the user can't edit the page. We can't just use setCustomRequestUser and set it to -1.
+     */
+    public function disableEditing()
+    {
+        $this->editingDisabled = true;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEditingDisabled()
+    {
+        return $this->editingDisabled;
     }
 
     public function getControllerActionPath()

--- a/concrete/src/Page/View/PageView.php
+++ b/concrete/src/Page/View/PageView.php
@@ -1,6 +1,7 @@
 <?php
 namespace Concrete\Core\Page\View;
 
+use Concrete\Core\Page\Controller\PageController;
 use Concrete\Core\Page\Template as PageTemplate;
 use Concrete\Core\Page\View\Preview\PageDesignPreviewRequest;
 use Concrete\Core\Page\View\Preview\PreviewRequestInterface;
@@ -40,6 +41,18 @@ class PageView extends View
     public function getPageTemplate()
     {
         return PageTemplate::getByID($this->pTemplateID);
+    }
+
+    /**
+     * Checks to see if page editing has been manually disabled through code. This does things like hide the toolbar
+     * etc...
+     */
+    public function isEditingDisabled(): bool
+    {
+        if ($this->controller instanceof PageController) {
+            return $this->controller->isEditingDisabled();
+        }
+        return false;
     }
 
     public function renderSinglePageByFilename($cFilename, $pkgHandle = null)

--- a/concrete/views/panels/page/preview_as/form.php
+++ b/concrete/views/panels/page/preview_as/form.php
@@ -14,18 +14,29 @@ $currentTime = $dh->formatCustom('Y-m-d H:i:s');
     </header>
     <form class="preview-panel-form">
         <div class="ccm-panel-content-inner" id="ccm-menu-page-attributes-list">
-            <label class="col-form-label"><?php echo t('Date / Time'); ?></label>
-            <div id="ccm-view-as-user-wrapper">
-                <?php echo $fdh->datetime('preview_as_user_datetime', $currentTime, false, true, 'dark-panel-calendar'); ?>
+            <div class="mb-3">
+                <label class="form-label" for="date"><?php echo t('Date'); ?></label>
+                <input type="date" id="preview-page-as-user-date" value="" class="form-control">
             </div>
-            <label class="col-form-label"><?php echo t('View As'); ?></label>
-            <div class="btn-group d-flex">
-                <button class="guest-button btn btn-secondary active"><?php echo t('Guest'); ?></button>
-                <button class="user-button btn btn-secondary"><?php echo t('Site User'); ?></button>
+            <div class="mb-3">
+                <label class="form-label" for="time"><?php echo t('Time'); ?></label>
+                <input type="time" id="preview-page-as-user-time"  value="" class="form-control">
             </div>
-            <div class="site-user" style="display:none">
+            <div class="mb-3">
+                <label class="form-label"><?php echo t('View As'); ?></label>
+                <div>
+                    <div class="btn-group btn-group-sm">
+                        <button class="guest-button btn btn-secondary active"><?php echo t('Guest'); ?></button>
+                        <button class="user-button btn btn-secondary"><?php echo t('Site User'); ?></button>
+                    </div>
+                </div>
+            </div>
+            <div class="mb-3 site-user" style="display:none">
                 <label class="col-form-label"><?php echo t('User'); ?></label>
-                <input class="form-control custom-user" name="user" />
+                <?=$userSelector->quickSelect('custom-user')?>
+            </div>
+            <div class="mt-5 d-grid">
+                <button type="button" class="btn btn-primary" data-button="preview-page-as-user"><?=t('Preview')?></button>
             </div>
         </div>
     </form>

--- a/concrete/views/panels/page/preview_as/frame.php
+++ b/concrete/views/panels/page/preview_as/frame.php
@@ -20,15 +20,9 @@
 
             var bind = _.once(function() {
                 form = $('form.preview-panel-form');
-                form.change(function() {
-                    handleChange();
-                });
-                form.find('button').click(function() {
-                    handleChange();
-                });
-                form.find('input').keydown(_.debounce(function() {
-                    handleChange();
-                }, 1000));
+                form.find('button[data-button=preview-page-as-user]').click(function() {
+                    handleChange()
+                })
             });
 
             frame.on('load', function() {
@@ -46,18 +40,16 @@
 
         function handleChange() {
             var guest_button = form.find('button.guest-button'),
-                user_input = form.find('input.custom-user'),
-                query = {
-                    cID: CCM_CID,
-                    customUser: guest_button.hasClass('active') ? 0 : user_input.val()
-                };
+                user_input = form.find('select#custom-user'),
+                customDate = form.find('#preview-page-as-user-date').val(),
+                customTime = form.find('#preview-page-as-user-time').val()
 
-            form.find('input[name],select[name]').each(function() {
-                var $me = $(this), name = $me.attr('name');
-                if(name && (name.indexOf('preview_as_user_datetime_') === 0)) {
-                    query[name] = $me.val();
-                }
-            });
+            var query = {
+                    cID: CCM_CID,
+                    customUser: guest_button.hasClass('active') ? 0 : user_input.val(),
+                    customDate: customDate,
+                    customTime: customTime
+                };
 
             var src = frame.data('src') + "?" + $.param(query);
 


### PR DESCRIPTION
* Fix #10702 
* Fix #6502
* Fix #6428

Additionally, improves the display, functionality and resilience in the View as User panel by using native browser controls and fixing some display bugs.

<img width="310" alt="Screen Shot 2022-06-21 at 10 38 49 AM" src="https://user-images.githubusercontent.com/527809/174865368-55ec2931-b7fa-460d-ade6-03268569e088.png">

