### PR TITLE
Sanitize pagination direction parameter value

### DIFF
--- a/concrete/src/Search/ItemList/Database/ItemList.php
+++ b/concrete/src/Search/ItemList/Database/ItemList.php
@@ -88,7 +88,7 @@ abstract class ItemList extends AbstractItemList
     protected function executeSanitizedSortBy($column, $direction = 'asc')
     {
         if (preg_match('/[^0-9a-zA-Z\$\.\_\x{0080}-\x{ffff}]+/u', $column) === 0) {
-            $this->executeSortBy($column, $direction);
+            $this->executeSortBy($column, (string) $direction);
         }
     }
 


### PR DESCRIPTION
Steps to reproduce the error:

1. Go to `/dashboard/reports/logs` page and click the pagination link
2. Change the URL parameter `ccm_order_by_direction=desc` to `ccm_order_by_direction[]=desc`
3. You'll got `strtolower() expects parameter 1 to be string, array given` error

You'll get the same error if you develop an item list class that extends `\Concrete\Core\Search\ItemList\Database\ItemList` abstract class.