### PR TITLE
[v9] Make the select attribute controller properties private to protected

### DIFF
--- a/concrete/attributes/select/controller.php
+++ b/concrete/attributes/select/controller.php
@@ -24,15 +24,15 @@ class Controller extends AttributeTypeController implements SimpleTextExportable
         'options' => ['default' => null, 'notnull' => false],
     ];
 
-    private $akSelectAllowMultipleValues;
+    protected $akSelectAllowMultipleValues;
 
-    private $akSelectAllowOtherValues;
+    protected $akSelectAllowOtherValues;
 
-    private $akHideNoneOption;
+    protected $akHideNoneOption;
 
-    private $akSelectOptionDisplayOrder;
+    protected $akSelectOptionDisplayOrder;
 
-    private $akDisplayMultipleValuesOnSelect;
+    protected $akDisplayMultipleValuesOnSelect;
 
     public function getIconFormatter()
     {


### PR DESCRIPTION
Recently, I was developing a package that extends the select attribute controller. I had to override some of the methods as the properties are private and there are not enough getters and setters.
Let's change the visibility to `protected` from `private`.