### PR TITLE
[v9] Fix/error in reindex contents task with Page Objects

### DIFF
--- a/concrete/src/Page/Stack/UsageTracker.php
+++ b/concrete/src/Page/Stack/UsageTracker.php
@@ -114,7 +114,8 @@ class UsageTracker implements TrackerInterface
         $buffer = 0;
 
         foreach ($blocks as $block) {
-            $controller = null; // Reset conntroller
+            // Reset controller and php8+ warning fix
+            $controller = null;
             if ($block instanceof Controller) {
                 $controller = $block;
                 $block = $controller->getBlockObject();

--- a/concrete/src/Page/Stack/UsageTracker.php
+++ b/concrete/src/Page/Stack/UsageTracker.php
@@ -114,7 +114,7 @@ class UsageTracker implements TrackerInterface
         $buffer = 0;
 
         foreach ($blocks as $block) {
-
+            $controller = null; // Reset conntroller
             if ($block instanceof Controller) {
                 $controller = $block;
                 $block = $controller->getBlockObject();

--- a/concrete/src/Summary/Data/Field/DatetimeDataFieldData.php
+++ b/concrete/src/Summary/Data/Field/DatetimeDataFieldData.php
@@ -9,7 +9,7 @@ class DatetimeDataFieldData implements DataFieldDataInterface
 {
 
     /**
-     * @var DateTime
+     * @var DateTime | null
      */
     protected $dateTime;
     
@@ -22,11 +22,11 @@ class DatetimeDataFieldData implements DataFieldDataInterface
 
     public function __toString()
     {
-        return (string) $this->dateTime->getTimestamp();
+        return ($this->dateTime !== null) ? (string) $this->dateTime->getTimestamp() : '';
     }
 
     /**
-     * @return DateTime
+     * @return DateTime|null
      */
     public function getDateTime()
     {
@@ -36,10 +36,19 @@ class DatetimeDataFieldData implements DataFieldDataInterface
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
+
+        if ($this->dateTime !== null) {
+            return [
+                'class' => self::class,
+                'timestamp' => (string) $this->dateTime->getTimestamp(),
+                'timezone' => (string) $this->dateTime->getTimezone()->getName()
+            ];
+        }
+
         return [
             'class' => self::class,
-            'timestamp' => (string) $this->dateTime->getTimestamp(),
-            'timezone' => (string) $this->dateTime->getTimezone()->getName()
+            'timestamp' => '',
+            'timezone' => ''
         ];
     }
     


### PR DESCRIPTION
If you have a page/page object without a public date, i.e. in the trash or waiting to be published. The re-index job will fail due to trying to call ->getTimeStamp() on null.

Since we allow for the DateTime to be null, we should check for that. While investigating this I also found on php8 there is an error on the $controller check (we should also reset the controller, just incase)