### PR TITLE
Top Nav Bar > Get External Link URL Text Like Autonav

### DIFF
--- a/concrete/blocks/top_navigation_bar/controller.php
+++ b/concrete/blocks/top_navigation_bar/controller.php
@@ -306,5 +306,19 @@ class Controller extends BlockController implements UsesFeatureInterface, FileTr
 	
 	return $target;
     }
+    
+    public function getPageItemURL($pageItem) 
+    {
+	if (!is_object($pageItem) || !$pageItem instanceof \Concrete\Core\Navigation\Item\PageItem) {
+	    return '';
+	}
+	$page = Page::getByID($pageItem->getPageID());
+	$url = $pageItem->getUrl();
+	if ($page->getCollectionPointerExternalLink() != '') {
+		$url = $page->getCollectionPointerExternalLink();
+	}
+	
+	return $url;
+    }
 
 }

--- a/concrete/blocks/top_navigation_bar/view.php
+++ b/concrete/blocks/top_navigation_bar/view.php
@@ -65,12 +65,12 @@ $c = Page::getCurrentPage();
                                     </a>
                                     <ul class="dropdown-menu">
                                         <?php foreach ($item->getChildren() as $dropdownChild) { ?>
-                                            <li><a class="dropdown-item<?= $dropdownChild->isActive() ? " active" : ""; ?>" target="<?=$controller->getPageItemNavTarget($dropdownChild)?>" href="<?=$dropdownChild->getUrl()?>"><?=$dropdownChild->getName()?></a></li>
+                                            <li><a class="dropdown-item<?= $dropdownChild->isActive() ? " active" : ""; ?>" target="<?=$controller->getPageItemNavTarget($dropdownChild)?>" href="<?=$controller->getPageItemURL($dropdownChild)?>"><?=$dropdownChild->getName()?></a></li>
                                         <?php } ?>
                                     </ul>
                                 </li>
                             <?php } else { ?>
-                                <li class="nav-item"><a class="nav-link<?= $item->isActive() ? " active" : ""; ?>" target="<?=$controller->getPageItemNavTarget($item)?>" href="<?=$item->getUrl()?>"><?=$item->getName()?></a></li>
+                                <li class="nav-item"><a class="nav-link<?= $item->isActive() ? " active" : ""; ?>" target="<?=$controller->getPageItemNavTarget($item)?>" href="<?=$controller->getPageItemURL($item)?>"><?=$item->getName()?></a></li>
                             <?php } ?>
                         <?php } ?>
                     </ul>


### PR DESCRIPTION
This PR implements a new Top Nav Bar block controller method to get us clean external link url text from external link pages that appear in the nav, similar to how the core autonav block renders external links.

This should solve the issues at https://forums.concretecms.org/t/url-in-top-navigation-bar-block-including-full-site-path/3361 where additional description of the issues can be found...