### PR TITLE
Allow for saving Hero Image Blocks without Image while avoiding the current datatype Exception

### DIFF
--- a/concrete/blocks/hero_image/controller.php
+++ b/concrete/blocks/hero_image/controller.php
@@ -171,8 +171,6 @@ class Controller extends BlockController implements FileTrackableInterface, Uses
                 if (!$checker->canViewFileInFileManager()) {
                     $e->add(t('Access Denied. You do not have access to that file.'));
                 }
-            } else {
-                $e->add(t('You must provide a valid file object.'));
             }
         }
 
@@ -183,6 +181,7 @@ class Controller extends BlockController implements FileTrackableInterface, Uses
     {
         list($imageLinkType, $imageLinkValue) = $this->app->make(DestinationPicker::class)->decode('imageLink', $this->getImageLinkPickers(), null, null, $args);
 
+        $args['image'] = is_numeric($args['image']) ? $args['image'] : 0;
         $args['buttonInternalLinkCID'] = $imageLinkType === 'page' ? $imageLinkValue : 0;
         $args['buttonFileLinkID'] = $imageLinkType === 'file' ? $imageLinkValue : 0;
         $args['buttonExternalLink'] = $imageLinkType === 'external_url' ? $imageLinkValue : '';


### PR DESCRIPTION
Currently you can add a Hero Image Block without a Image since the Validation Code in place doesn't seem to be working as expected.
However: removing a Image from a existing Block [produces a Exception](https://github.com/concretecms/concretecms/issues/10744).

This PR makes it so the Hero Block can be saved without Issues whether or not a Image is selected.
The default Block template already makes sure the Block only is rendered when a Image is given. - But this gives the freedom to theme/ template developers to create templates that render nicely with or without images. (for example by using CSS implemented flat colors, gradients etc. to fill the space instead)