### PR TITLE
using new PasswordInput component

### DIFF
--- a/concrete/single_pages/dashboard/users/add.php
+++ b/concrete/single_pages/dashboard/users/add.php
@@ -39,7 +39,8 @@ $fileFolderSelector = $app->make(FileFolderSelector::class);
                 <?php echo t('Required') ?>
             </span>
             </div>
-            <?= $form->password('uPassword', ['autocomplete' => 'off']); ?>
+            <?= ''//$form->password('uPassword', ['autocomplete' => 'off']); ?>
+            <password-input name="uPassword"/>
 		</div>
 
 		<div class="form-group">
@@ -117,3 +118,14 @@ $fileFolderSelector = $app->make(FileFolderSelector::class);
 		</div>
 	</div>
 </form>
+
+<script type="text/javascript">
+    $(function() {
+        Concrete.Vue.activateContext('cms', function(Vue, config) {
+            new Vue({
+                el: '#ccm-dashboard-content-regular',
+                components: config.components
+            })
+        })
+    });
+</script>

--- a/concrete/single_pages/dashboard/users/search/edit.php
+++ b/concrete/single_pages/dashboard/users/search/edit.php
@@ -229,17 +229,17 @@ if (count($languages) > 0) {
 
                                     <div class="form-group">
                                         <?php echo $form->label('uPasswordMine', t('Your Current Password')); ?>
-                                        <?php echo $form->password('uPasswordMine', ['autocomplete' => 'off']); ?>
+                                        <password-input name="uPasswordMine"/>
                                     </div>
 
                                     <div class="form-group">
                                         <?php echo $form->label('uPasswordNew', t('New Password')); ?>
-                                        <?php echo $form->password('uPasswordNew', ['autocomplete' => 'off']); ?>
+                                        <password-input name="uPasswordNew"/>
                                     </div>
 
                                     <div class="form-group">
                                         <?php echo $form->label('uPasswordNewConfirm', t('Confirm New Password')); ?>
-                                        <?php echo $form->password('uPasswordNewConfirm', ['autocomplete' => 'off']); ?>
+                                        <password-input name="uPasswordNewConfirm"/>
                                     </div>
                                     <div class="help-block"><?php echo h(t('Leave blank to leave the password unchanged.')); ?></div>
                                 </fieldset>


### PR DESCRIPTION
Using the new `PasswordInput` Vue component for password visibility toggle.
companion pull request in the bedrock: https://github.com/concretecms/bedrock/pull/236

![2022-06-22_14-50-24](https://user-images.githubusercontent.com/7886999/177320300-0fb66894-b91f-4dae-b0e6-914639b1c520.gif)

