### PR TITLE
Fix miscFields in __call()

### DIFF
--- a/concrete/src/Form/Service/Form.php
+++ b/concrete/src/Form/Service/Form.php
@@ -437,7 +437,7 @@ class Form
     {
         $key = $args[0];
         $valueOrMiscFields = $args[1];
-        $miscFields = array_slice($args,2);
+        $miscFields =  $args[2]; 
         return $this->inputType($key, $name, $valueOrMiscFields, $miscFields);
     }
     


### PR DESCRIPTION
$miscFields was incorrectly created by slicing the tail of the $args array. This left it as an array[0][miscFields] rather than array[miscFields]
