### PR TITLE
Fix Forms miscFields in __call()

### DIFF
--- a/concrete/src/Form/Service/Form.php
+++ b/concrete/src/Form/Service/Form.php
@@ -435,7 +435,7 @@ class Form
      */
     public function __call($name, $args)
     {
-        if(is_array($args[2])){
+        if(!empty($args[2]) && is_array($args[2])){
             return $this->inputType( $args[0], $name, $args[1], $args[2]);
         }else{
             return $this->inputType( $args[0], $name, $args[1],[]);

--- a/concrete/src/Form/Service/Form.php
+++ b/concrete/src/Form/Service/Form.php
@@ -435,10 +435,11 @@ class Form
      */
     public function __call($name, $args)
     {
-        $key = $args[0];
-        $valueOrMiscFields = $args[1];
-        $miscFields = array_slice($args,2);
-        return $this->inputType($key, $name, $valueOrMiscFields, $miscFields);
+        if(is_array($args[2])){
+            return $this->inputType( $args[0], $name, $args[1], $args[2]);
+        }else{
+            return $this->inputType( $args[0], $name, $args[1],[]);
+        }
     }
     
     


### PR DESCRIPTION
$miscFields was incorrectly created by slicing the tail of the $args array. This left it as an array[0][miscFields] rather than array[miscFields]

Take 2 on this. Better tested than my now deleted https://github.com/concretecms/concretecms/pull/10759