### PR TITLE
Let translators swap file extension and file type

### DIFF
--- a/concrete/src/Entity/File/Version.php
+++ b/concrete/src/Entity/File/Version.php
@@ -846,8 +846,9 @@ class Version implements ObjectInterface
             $extension = $this->getExtension();
             if ($extension) {
                 return tc(
+                    /* i18n: %1$s is a file extension (eg 'JPG'), %2$s is a file type (eg 'Image') */
                     'FileExtensionAndType',
-                    '%s %s',
+                    '%1$s %2$s',
                     strtoupper($extension),
                     $to->getGenericDisplayType()
                 );


### PR DESCRIPTION
In English we say "JPG Image", but for example in Italian we say "Immagine JPG".

So, how about letting translators to swap the order of the file extension and the file type?