### PR TITLE
Add environment name

### DIFF
--- a/concrete/controllers/single_page/dashboard/system/environment/info.php
+++ b/concrete/controllers/single_page/dashboard/system/environment/info.php
@@ -12,6 +12,9 @@ class Info extends DashboardPageController
     {
         $info = $this->app->make(SystemInfo::class);
 
+        $hostname = $info->getHostName();
+        $environment = $info->getEnvironment();
+
         $dbInfos = '';
         if ($info->isInstalled()) {
             $dbInfos = "\n# Database Information\nVersion: {$info->getDBMSVersion()}\nSQL Mode: {$info->getDBMSSqlMode()}\n";
@@ -22,6 +25,12 @@ class Info extends DashboardPageController
         $phpExtensions = ($info->getPhpExtensions() === false) ? 'Unable to determine' : $info->getPhpExtensions();
 
         $content = <<<EOL
+# Hostname
+{$hostname}
+
+# Environment
+{$environment}
+
 # Concrete Version
 {$info->getCoreVersions()}
 {$dbInfos}

--- a/concrete/src/Console/Command/InfoCommand.php
+++ b/concrete/src/Console/Command/InfoCommand.php
@@ -33,6 +33,12 @@ EOT
         $info = Facade::getFacadeApplication()->make(Info::class);
         /* @var Info $info */
 
+        $output->writeln('<info># Hostname</info>');
+        $output->writeln($info->getHostname());
+        $output->writeln('');
+        $output->writeln('<info># Environment</info>');
+        $output->writeln($info->getEnvironment());
+        $output->writeln('');
         $output->writeln('<info># Version</info>');
         $output->writeln('Installed - ' . ($info->isInstalled() ? 'Yes' : 'No'));
         $output->writeln($info->getCoreVersions());

--- a/concrete/src/System/Info.php
+++ b/concrete/src/System/Info.php
@@ -472,4 +472,14 @@ class Info
 
         return $this->dbmsSqlMode;
     }
+
+    public function getHostname()
+    {
+        return gethostname();
+    }
+
+    public function getEnvironment()
+    {
+        return $this->app->environment();
+    }
 }


### PR DESCRIPTION
This adds the Hostname and detected Environment to the start of the environment text, as well as to the output of the info command.

I was recently referring to https://documentation.concretecms.org/tutorials/loading-configuration-based-host-and-environment, to set up an environment based config file, and realised that there wasn't an easy way to work out what Concrete was actually detecting. 

In my case, I run valet locally, and didn't realise that the Concrete driver sets the environment for you (https://github.com/laravel/valet/blob/master/cli/drivers/Concrete5ValetDriver.php#L27)
![Screen Shot 2022-08-07 at 10 20 27 pm](https://user-images.githubusercontent.com/1079600/183311756-8665d731-d5ff-4b37-9986-8816da8249eb.png)
It was a bit confusing why my environment detection wasn't working, I had to add code to output the detected environment name. 

So this code simply makes it easier to view what is actually being set.