### PR TITLE
Avoid type error on breadcrumbs navigation

### DIFF
--- a/concrete/src/Navigation/Breadcrumb/PageBreadcrumbFactory.php
+++ b/concrete/src/Navigation/Breadcrumb/PageBreadcrumbFactory.php
@@ -103,7 +103,7 @@ class PageBreadcrumbFactory
         /** @var Page $_page */
         foreach ($pages as $_page) {
             if (!$this->shouldExcludeFromNav($_page) && $this->canViewPage($_page)) {
-                $breadcrumb->add(new Item($_page->getCollectionLink(), $_page->getCollectionName()));
+                $breadcrumb->add(new Item($_page->getCollectionLink(), (string) $_page->getCollectionName()));
             }
             if ($this->shouldExcludeSubpagesFromNav($_page)) {
                 $this->setIncludeCurrent(false);


### PR DESCRIPTION
You'll get `Argument 2 passed to Concrete\Core\Navigation\Item\Item::__construct() must be of the type string, null given` error when you unapproved all versions of a parent page. Let's avoid this error