### PR TITLE
Fix content of swap file initially empty

### DIFF
--- a/concrete/views/dialogs/file/import.php
+++ b/concrete/views/dialogs/file/import.php
@@ -46,7 +46,7 @@ $dropZoneId = "ccm-drop-zone-" . $idHelper->getString();
     ?>
 
     <div class="tab-content">
-        <div class="tab-pane fade active" id="local" role="tabpanel" aria-labelledby="local-tab">
+        <div class="tab-pane active" id="local" role="tabpanel" aria-labelledby="local-tab">
 
             <concrete-file-uploader <?php if (isset($replacingFile) && $replacingFile) { ?>replace-file-id="<?=$replacingFile->getFileID()?>"<?php } ?> :max-files="1"></concrete-file-uploader>
 


### PR DESCRIPTION
When swapping a file, the tab pane inside the "Swap File" dialog is empty: see

![swap-file-hidden](https://user-images.githubusercontent.com/928116/188290771-1030fe06-447b-458a-9aab-a01fe7d038f8.gif)

Let's fix it.

Fix https://github.com/concretecms/concretecms/issues/10729