### PR TITLE
Create a Text instance just once when calling h()

### DIFF
--- a/concrete/bootstrap/helpers.php
+++ b/concrete/bootstrap/helpers.php
@@ -79,7 +79,8 @@ function tc($context, $text, ...$args)
  */
 function h($input)
 {
-    return (new Text())->specialchars($input);
+    static $text;
+    return ($text ?? $text = new Text())->specialchars($input);
 }
 
 /**


### PR DESCRIPTION
Every time we call the `h()` global function, a new instance of the `Concrete\Core\Utility\Service\Text` class is created and then destroyed.

Let's avoid that: it's useless.