### PR TITLE
Add the FlushableInterface import in the ClearCacheCommandHandler.php

### DIFF
--- a/concrete/src/Cache/Command/ClearCacheCommandHandler.php
+++ b/concrete/src/Cache/Command/ClearCacheCommandHandler.php
@@ -5,6 +5,7 @@ namespace Concrete\Core\Cache\Command;
 use Concrete\Core\Application\Application;
 use Concrete\Core\Area\GlobalArea;
 use Concrete\Core\Block\BlockType\BlockType;
+use Concrete\Core\Cache\FlushableInterface;
 use Concrete\Core\Config\Repository\Repository;
 use Concrete\Core\Database\DatabaseManager;
 use Concrete\Core\Foundation\Environment;


### PR DESCRIPTION
Hi, we discovered a "bug" in the clear-cache task.

To optimize our website we added the redis cache to the fullpagecache with the concrete.cache.page config. But when we tried to clear the cache it didn't seemed to clear correctly.

When checking the code we saw that the FlushableInterface was missing in the ClearCacheCommandHandler. 
When added the use it works all fine.

Currently we fixed it with a psr4 namespace in composer

```json
"autoload": {
    "psr-4": {
      "Concrete\\Core\\Cache\\Command\\": "./public/application/src/Concrete/Cache/Command"
    },
  },
```

Our config to reproduce :
```php
<?php

// a custom class store our credentials (for compatibility between dev and prod)
$config = new Config();
$redisConfig = $config->credentials('redis');

return [
    'updates' => [
        // Skip the automatic check of new concrete5 versions availability
        'skip_core' => true,
    ],
    'debug' => [
        'hide_keys' => [
            // Hide database password and hostname in whoops output if supported
            '_ENV' => ['DB_PASSWORD', 'DB_HOSTNAME'],
            '_SERVER' => ['DB_PASSWORD', 'DB_HOSTNAME'],
        ]
    ],
    'sitemap_xml' => [
        'file' => 'sitemaps/sitemap.xml',
        'frequency' => 'weekly',
        'priority' => 0.5,
    ],
    'session' => [
        'handler' => 'redis',
        'redis' => [
            'servers' => [
                [
                    'server' => $redisConfig['host'],
                    'port' => $redisConfig['port'],
                    'password' => null,
                    'ttl' => 30
                ],
            ],
            'database' => 1,
        ],
    ],
    'cache' => [
        'page' => [
            'adapter' => 'redis',
            'redis' => [
                'servers' => [
                    [
                        'server' => $redisConfig['host'],
                        'port' => $redisConfig['port'],
                        'password' => null,
                    ],
                ],
                'database' => 2,
            ],
        ],
        'levels' => [
            'overrides' => [
                'preferred_driver' => 'core_filesystem',
                'drivers' => [
                    'redis' => [
                        'options' => [
                            'servers' => [
                                [
                                    'server' => $redisConfig['host'],
                                    'port' => $redisConfig['port'],
                                    'password' => null,
                                ],
                            ],
                            'prefix' => 'concrete_overrides',
                            'database' => 3,
                        ],
                    ],
                ],
            ],
            'expensive' => [
                'preferred_driver' => 'core_filesystem',
                'drivers' => [
                    'redis' => [
                        'options' => [
                            'servers' => [
                                [
                                    'server' => $redisConfig['host'],
                                    'port' => $redisConfig['port'],
                                    'password' => null,
                                ],
                            ],
                            'prefix' => 'concrete_expensive',
                            'database' => 4,
                        ],
                    ],
                ]
            ]
        ]
    ]
];

```

