### PR TITLE
Skip translating a file name in migration 20220911000000

### DIFF
--- a/concrete/src/Updater/Migrations/Migrations/Version20220911000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20220911000000.php
@@ -21,7 +21,7 @@ final class Version20220911000000 extends AbstractMigration implements Repeatabl
     public function upgradeDatabase()
     {
         $importer = new ContentImporter();
-        $this->output(t('Importing upgrade/site_health.xml'));
+        $this->output(t(/* i18n: %s is a file name */'Importing %s', 'upgrade/site_health.xml'));
         $importer->importContentFile(DIR_BASE_CORE . '/config/install/upgrade/site_health.xml');
 
         $this->refreshEntities(


### PR DESCRIPTION
It's useless, and by using %s, the string "Importing %s" may be reused without requiring translators to translate it every time.
