### PR TITLE
Fix: Enable to edit a Group on PHP8

### DIFF
--- a/concrete/controllers/single_page/dashboard/users/groups.php
+++ b/concrete/controllers/single_page/dashboard/users/groups.php
@@ -320,12 +320,6 @@ class Groups extends DashboardPageController
             $this->error->add($valt->getErrorMessage());
         }
 
-        if ($_POST['gIsBadge']) {
-            if (!$this->post('gBadgeDescription')) {
-                $this->error->add(t('You must specify a description for this badge. It will be displayed publicly.'));
-            }
-        }
-
         foreach($cnta->validateRoles()->getList() as $error) {
             $this->error->add($error);
         }


### PR DESCRIPTION
```
Whoops\Exception\ErrorException thrown with message "Undefined array key "gIsBadge""

Stacktrace:
#27 Whoops\Exception\ErrorException in /path/to/concrete/controllers/single_page/dashboard/users/groups.php:323
```

Badge is now deprecated, so we can remove these lines.