### PR TITLE
Fix sorting results of FolderItemList by file title

### DIFF
--- a/concrete/src/File/FolderItemList.php
+++ b/concrete/src/File/FolderItemList.php
@@ -391,4 +391,20 @@ class FolderItemList extends AttributedItemList implements PagerProviderInterfac
     {
         return '\\Concrete\\Core\\Attribute\\Key\\FileKey';
     }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Search\ItemList\Database\ItemList::executeSanitizedSortBy()
+     */
+    protected function executeSanitizedSortBy($column, $direction = 'asc')
+    {
+        switch ($column) {
+            case 'fv.fvTitle':
+                $column = 'if(nt.treeNodeTypeHandle=\'file\', fv.fvTitle, n.treeNodeName)';
+                break;
+        }
+
+        return parent::executeSanitizedSortBy($column, $direction);
+    }
 }


### PR DESCRIPTION
If we sort by `fv.fvTitle` we currently have this query:

```sql
SELECT distinct
    n.treeNodeID,
    if(nt.treeNodeTypeHandle='file', fv.fvTitle, n.treeNodeName) as name,
    if(nt.treeNodeTypeHandle='file', fv.fvDateAdded, n.dateModified) as dateModified,
    case when nt.treeNodeTypeHandle='file_folder' then 1 else (10 + fvType) end as type,
    fv.fvSize as size
FROM
    TreeNodes n
    INNER JOIN TreeNodeTypes nt ON nt.treeNodeTypeID = n.treeNodeTypeID
    LEFT JOIN TreeFileNodes tf ON tf.treeNodeID = n.treeNodeID
    LEFT JOIN FileVersions fv ON tf.fID = fv.fID and fv.fvIsApproved = 1
    LEFT JOIN Files f ON fv.fID = f.fID
    LEFT JOIN Users u ON f.uID = u.uID
    LEFT JOIN FileSearchIndexAttributes fsi ON f.fID = fsi.fID
WHERE
    n.treeNodeParentID = ?
ORDER BY
    fv.fvTitle desc
LIMIT 20
```

As you can see, in the `SELECT` part we have

```sql
if(nt.treeNodeTypeHandle='file', fv.fvTitle, n.treeNodeName) as name
```

whereas in the `ORDER BY` part we have

```sql
fv.fvTitle desc
```

If the result of `SELECT @@sql_mode` contains `ONLY_FULL_GROUP_BY` we have the following error:

```
SQLSTATE[HY000]: General error: 3065 Expression #1 of ORDER BY clause is not in SELECT list,
references column 'concrete5.fv.fvTitle' which is not in SELECT list;
this is incompatible with DISTINCT
```

The solution? Simply order the results by the same expression we have in the `SELECT` part (which is also more correct).
