### PR TITLE
Fix PHPDoc of getUserInfoObject() method of user entity

### DIFF
--- a/concrete/src/Entity/User/User.php
+++ b/concrete/src/Entity/User/User.php
@@ -488,7 +488,7 @@ class User implements UserEntityInterface, \JsonSerializable
     }
 
     /**
-     * @return \UserInfo|null
+     * @return \Concrete\Core\User\UserInfo|null
      */
     public function getUserInfoObject()
     {


### PR DESCRIPTION
\UserInfo is an alias of \Concrete\Core\User\UserInfoRepository whereas getUserInfoObject() actually returns a
\Concrete\Core\User\UserInfo instance
