### PR TITLE
Fix PageItem class urls

### DIFF
--- a/concrete/src/Navigation/Item/PageItem.php
+++ b/concrete/src/Navigation/Item/PageItem.php
@@ -57,8 +57,11 @@ class PageItem extends Item
     public function getURL(): string
     {
         $p = Page::getByID($this->pageID);
-        if ($p->isExternalLink()) { $url = $p->getCollectionPointerExternalLink(); } else { $url = $p->getCollectionLink(); }
-        
+        if ($p->isExternalLink()) {
+            $url = $p->getCollectionPointerExternalLink();
+        } else {
+            $url = $p->getCollectionLink();
+        }
         return $url;
     }
     

--- a/concrete/src/Navigation/Item/PageItem.php
+++ b/concrete/src/Navigation/Item/PageItem.php
@@ -28,7 +28,7 @@ class PageItem extends Item
         if ($page) {
             $this->pageID = $page->getCollectionID();
             $this->keywords = (string)$page->getAttribute("meta_keywords");
-            parent::__construct($page->getCollectionLink(), $page->getCollectionName(), $isActive);
+            parent::__construct($this->getURL(), $page->getCollectionName(), $isActive);
         }
         if ($this->keywords === null) {
             $this->keywords = '';
@@ -51,6 +51,17 @@ class PageItem extends Item
         $this->pageID = $pageID;
     }
 
+    /**
+     * @return string
+     */
+    public function getURL(): string
+    {
+        $p = Page::getByID($this->pageID);
+        if ($p->isExternalLink()) { $url = $p->getCollectionPointerExternalLink(); } else { $url = $p->getCollectionLink(); }
+        
+        return $url;
+    }
+    
     /**
      * @return string
      */
@@ -86,6 +97,7 @@ class PageItem extends Item
             // We need to use the parent's getName method (it's in English)
             'name' => parent::getName(),
             'pageID' => $this->getPageID(),
+            'url' => $this->getURL(),
             'keywords' => $this->getKeywords(),
         ] + parent::jsonSerialize();
     }


### PR DESCRIPTION
Fix PageItem class external link targets.  This allows for anchor links as nav targets in the top navigation bar block, that properly render, similar to autonav block.