### PR TITLE
Log the full group paths

### DIFF
--- a/concrete/src/Logging/Entry/Group/AddGroup.php
+++ b/concrete/src/Logging/Entry/Group/AddGroup.php
@@ -8,7 +8,7 @@ class AddGroup extends Group
     public function getEntryMessage()
     {
         return t('Group %1$s (ID %2$s) was created by an automated process.',
-            $this->group->getGroupName(),
+            $this->group->getGroupPath(),
             $this->group->getGroupID()
         );
     }
@@ -18,7 +18,7 @@ class AddGroup extends Group
         return t('User %1$s (ID %2$s) created group %3$s (ID %4$s).',
             $this->applier->getUserName(),
             $this->applier->getUserID(),
-            $this->group->getGroupName(),
+            $this->group->getGroupPath(),
             $this->group->getGroupID()
         );
     }

--- a/concrete/src/Logging/Entry/Group/DeleteGroup.php
+++ b/concrete/src/Logging/Entry/Group/DeleteGroup.php
@@ -8,7 +8,7 @@ class DeleteGroup extends Group
     public function getEntryMessage()
     {
         return t('Group %1$s (ID %2$s) was deleted by an automated process.',
-            $this->group->getGroupName(),
+            $this->group->getGroupPath(),
             $this->group->getGroupID()
         );
     }
@@ -18,7 +18,7 @@ class DeleteGroup extends Group
         return t('User %1$s (ID %2$s) deleted group %3$s (ID %4$s).',
             $this->applier->getUserName(),
             $this->applier->getUserID(),
-            $this->group->getGroupName(),
+            $this->group->getGroupPath(),
             $this->group->getGroupID()
         );
     }

--- a/concrete/src/Logging/Entry/Group/EnterGroup.php
+++ b/concrete/src/Logging/Entry/Group/EnterGroup.php
@@ -13,7 +13,7 @@ class EnterGroup extends UserGroup
         return t('User %1$s (ID %2$s) was added to group %3$s (ID %4$s) by an automated process.',
             $this->user->getUserName(),
             $this->user->getUserID(),
-            $this->group->getGroupName(),
+            $this->group->getGroupPath(),
             $this->group->getGroupID()
         );
     }
@@ -23,7 +23,7 @@ class EnterGroup extends UserGroup
         return t('User %1$s (ID %2$s) was added to group %3$s (ID %4$s) by %5$s (ID %6$s).',
             $this->user->getUserName(),
             $this->user->getUserID(),
-            $this->group->getGroupName(),
+            $this->group->getGroupPath(),
             $this->group->getGroupID(),
             $this->applier->getUserName(),
             $this->applier->getUserID()

--- a/concrete/src/Logging/Entry/Group/ExitGroup.php
+++ b/concrete/src/Logging/Entry/Group/ExitGroup.php
@@ -13,7 +13,7 @@ class ExitGroup extends UserGroup
         return t('User %1$s (ID %2$s) was removed from group %3$s (ID %4$s) by an automated process.',
             $this->user->getUserName(),
             $this->user->getUserID(),
-            $this->group->getGroupName(),
+            $this->group->getGroupPath(),
             $this->group->getGroupID()
         );
     }
@@ -23,7 +23,7 @@ class ExitGroup extends UserGroup
         return t('User %1$s (ID %2$s) was removed from group %3$s (ID %4$s) by %5$s (ID %6$s).',
             $this->user->getUserName(),
             $this->user->getUserID(),
-            $this->group->getGroupName(),
+            $this->group->getGroupPath(),
             $this->group->getGroupID(),
             $this->applier->getUserName(),
             $this->applier->getUserID()

--- a/concrete/src/Logging/Entry/Group/Group.php
+++ b/concrete/src/Logging/Entry/Group/Group.php
@@ -26,10 +26,11 @@ abstract class Group extends ApplierEntry
 
     public function getEntryContext()
     {
-        $context = parent::getEntryContext();
-        $context['group_id'] = $this->group->getGroupID();
-        $context['group_name'] = $this->group->getGroupName();
-        return $context;
+        return [
+            'group_id' => $this->group->getGroupID(),
+            'group_name' => $this->group->getGroupName(),
+            'group_path' => $this->group->getGroupPath(),
+        ] + parent::getEntryContext();
     }
 
 }

--- a/concrete/src/Logging/Entry/Group/UpdateGroup.php
+++ b/concrete/src/Logging/Entry/Group/UpdateGroup.php
@@ -8,7 +8,7 @@ class UpdateGroup extends Group
     public function getEntryMessage()
     {
         return t('Group %1$s (ID %2$s) was updated by an automated process.',
-            $this->group->getGroupName(),
+            $this->group->getGroupPath(),
             $this->group->getGroupID()
         );
     }
@@ -18,7 +18,7 @@ class UpdateGroup extends Group
         return t('User %1$s (ID %2$s) updated group %3$s (ID %4$s).',
             $this->applier->getUserName(),
             $this->applier->getUserID(),
-            $this->group->getGroupName(),
+            $this->group->getGroupPath(),
             $this->group->getGroupID()
         );
     }

--- a/concrete/src/User/Group/Command/AddGroupCommandHandler.php
+++ b/concrete/src/User/Group/Command/AddGroupCommandHandler.php
@@ -78,6 +78,7 @@ class AddGroupCommandHandler
         if (is_object($node)) {
             GroupNode::add($ng, $node);
         }
+        $ng->rescanGroupPath();
 
         $ge = new Event($ng);
         $this->dispatcher->dispatch('on_group_add', $ge);
@@ -97,8 +98,6 @@ class AddGroupCommandHandler
                 $notifier->notify($users, $notification);
             }
         }
-
-        $ng->rescanGroupPath();
 
         return $ng;
     }

--- a/tests/tests/User/GroupLoggingTest.php
+++ b/tests/tests/User/GroupLoggingTest.php
@@ -25,15 +25,17 @@ class GroupLoggingTest extends TestCase
         $user->shouldReceive('getUserID')->andReturn(33);
         $group->shouldReceive('getGroupID')->andReturn(5);
         $group->shouldReceive('getGroupName')->andReturn('Editors');
+        $group->shouldReceive('getGroupPath')->andReturn('/Editors');
 
         $entry = new EnterGroup($user, $group);
-        $this->assertEquals('User andrew (ID 33) was added to group Editors (ID 5) by an automated process.',
+        $this->assertEquals('User andrew (ID 33) was added to group /Editors (ID 5) by an automated process.',
             $entry->getMessage());
         $this->assertEquals([
             'user_id' => 33,
             'user_name' => 'andrew',
             'group_id' => 5,
             'group_name' => 'Editors',
+            'group_path' => '/Editors',
             'operation' => 'enter_group'
         ], $entry->getContext());
 
@@ -42,13 +44,14 @@ class GroupLoggingTest extends TestCase
         $applier->shouldReceive('isRegistered')->andReturn(true);
 
         $entry = new EnterGroup($user, $group, $applier);
-        $this->assertEquals('User andrew (ID 33) was added to group Editors (ID 5) by admin (ID 1).',
+        $this->assertEquals('User andrew (ID 33) was added to group /Editors (ID 5) by admin (ID 1).',
             $entry->getMessage());
         $this->assertEquals([
             'user_id' => 33,
             'user_name' => 'andrew',
             'group_id' => 5,
             'group_name' => 'Editors',
+            'group_path' => '/Editors',
             'applier_id' => 1,
             'applier_name' => 'admin',
             'operation' => 'enter_group'
@@ -65,15 +68,17 @@ class GroupLoggingTest extends TestCase
         $user->shouldReceive('getUserID')->andReturn(33);
         $group->shouldReceive('getGroupID')->andReturn(5);
         $group->shouldReceive('getGroupName')->andReturn('Editors');
+        $group->shouldReceive('getGroupPath')->andReturn('/Editors');
 
         $entry = new ExitGroup($user, $group);
-        $this->assertEquals('User andrew (ID 33) was removed from group Editors (ID 5) by an automated process.',
+        $this->assertEquals('User andrew (ID 33) was removed from group /Editors (ID 5) by an automated process.',
             $entry->getMessage());
         $this->assertEquals([
             'user_id' => 33,
             'user_name' => 'andrew',
             'group_id' => 5,
             'group_name' => 'Editors',
+            'group_path' => '/Editors',
             'operation' => 'exit_group'
         ], $entry->getContext());
 
@@ -82,13 +87,14 @@ class GroupLoggingTest extends TestCase
         $applier->shouldReceive('isRegistered')->andReturn(true);
 
         $entry = new ExitGroup($user, $group, $applier);
-        $this->assertEquals('User andrew (ID 33) was removed from group Editors (ID 5) by admin (ID 1).',
+        $this->assertEquals('User andrew (ID 33) was removed from group /Editors (ID 5) by admin (ID 1).',
             $entry->getMessage());
         $this->assertEquals([
             'user_id' => 33,
             'user_name' => 'andrew',
             'group_id' => 5,
             'group_name' => 'Editors',
+            'group_path' => '/Editors',
             'applier_id' => 1,
             'applier_name' => 'admin',
             'operation' => 'exit_group'
@@ -102,13 +108,15 @@ class GroupLoggingTest extends TestCase
 
         $group->shouldReceive('getGroupID')->andReturn(5);
         $group->shouldReceive('getGroupName')->andReturn('Editors');
+        $group->shouldReceive('getGroupPath')->andReturn('/Editors');
 
         $entry = new AddGroup($group);
-        $this->assertEquals('Group Editors (ID 5) was created by an automated process.',
+        $this->assertEquals('Group /Editors (ID 5) was created by an automated process.',
             $entry->getMessage());
         $this->assertEquals([
             'group_id' => 5,
             'group_name' => 'Editors',
+            'group_path' => '/Editors',
             'operation' => 'add_group'
         ], $entry->getContext());
 
@@ -117,11 +125,12 @@ class GroupLoggingTest extends TestCase
         $applier->shouldReceive('isRegistered')->andReturn(true);
 
         $entry = new AddGroup($group, $applier);
-        $this->assertEquals('User admin (ID 1) created group Editors (ID 5).',
+        $this->assertEquals('User admin (ID 1) created group /Editors (ID 5).',
             $entry->getMessage());
         $this->assertEquals([
             'group_id' => 5,
             'group_name' => 'Editors',
+            'group_path' => '/Editors',
             'applier_id' => 1,
             'applier_name' => 'admin',
             'operation' => 'add_group'
@@ -135,13 +144,15 @@ class GroupLoggingTest extends TestCase
 
         $group->shouldReceive('getGroupID')->andReturn(5);
         $group->shouldReceive('getGroupName')->andReturn('Editors');
+        $group->shouldReceive('getGroupPath')->andReturn('/Editors');
 
         $entry = new UpdateGroup($group);
-        $this->assertEquals('Group Editors (ID 5) was updated by an automated process.',
+        $this->assertEquals('Group /Editors (ID 5) was updated by an automated process.',
             $entry->getMessage());
         $this->assertEquals([
             'group_id' => 5,
             'group_name' => 'Editors',
+            'group_path' => '/Editors',
             'operation' => 'update_group'
         ], $entry->getContext());
 
@@ -150,11 +161,12 @@ class GroupLoggingTest extends TestCase
         $applier->shouldReceive('isRegistered')->andReturn(true);
 
         $entry = new UpdateGroup($group, $applier);
-        $this->assertEquals('User admin (ID 1) updated group Editors (ID 5).',
+        $this->assertEquals('User admin (ID 1) updated group /Editors (ID 5).',
             $entry->getMessage());
         $this->assertEquals([
             'group_id' => 5,
             'group_name' => 'Editors',
+            'group_path' => '/Editors',
             'applier_id' => 1,
             'applier_name' => 'admin',
             'operation' => 'update_group'
@@ -168,13 +180,15 @@ class GroupLoggingTest extends TestCase
 
         $group->shouldReceive('getGroupID')->andReturn(5);
         $group->shouldReceive('getGroupName')->andReturn('Editors');
+        $group->shouldReceive('getGroupPath')->andReturn('/Editors');
 
         $entry = new DeleteGroup($group);
-        $this->assertEquals('Group Editors (ID 5) was deleted by an automated process.',
+        $this->assertEquals('Group /Editors (ID 5) was deleted by an automated process.',
             $entry->getMessage());
         $this->assertEquals([
             'group_id' => 5,
             'group_name' => 'Editors',
+            'group_path' => '/Editors',
             'operation' => 'delete_group'
         ], $entry->getContext());
 
@@ -183,11 +197,12 @@ class GroupLoggingTest extends TestCase
         $applier->shouldReceive('isRegistered')->andReturn(true);
 
         $entry = new DeleteGroup($group, $applier);
-        $this->assertEquals('User admin (ID 1) deleted group Editors (ID 5).',
+        $this->assertEquals('User admin (ID 1) deleted group /Editors (ID 5).',
             $entry->getMessage());
         $this->assertEquals([
             'group_id' => 5,
             'group_name' => 'Editors',
+            'group_path' => '/Editors',
             'applier_id' => 1,
             'applier_name' => 'admin',
             'operation' => 'delete_group'


### PR DESCRIPTION
We may have user groups with the same name, but available at different paths.

For example, if we have this structure

```
/
├── Project1
│   |
│   └── Admins
|
└── Project2
    |
    └── Admins
```

In the logs we have entries like these:

![immagine](https://user-images.githubusercontent.com/928116/190966565-3f6048c4-b50d-47cd-86d5-4f9d03900072.png)

What about logging the full path of the groups instead?
We'd have something like this:

![immagine](https://user-images.githubusercontent.com/928116/190966636-90e1360b-d034-4b91-ad3a-f0926309b3ff.png)
