### PR TITLE
Add the setupSiteInterfaceLocalization in the controller method in ResponseFactory.php

### DIFF
--- a/concrete/src/Http/ResponseFactory.php
+++ b/concrete/src/Http/ResponseFactory.php
@@ -158,6 +158,12 @@ class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInter
      */
     public function controller(Controller $controller, $code = Response::HTTP_OK, $headers = [])
     {
+        $dl = $this->app->make('multilingual/detector');
+        $c = Page::getCurrentPage();
+        // if the page exists and is not in error
+        if ($c && !$c->isError()) {
+            $dl->setupSiteInterfaceLocalization($c);
+        }
         $this->localization->pushActiveContext(Localization::CONTEXT_SITE);
         try {
             $request = $this->request;


### PR DESCRIPTION
I don't know if it's a bug, but it's pretty weird.
We have a controller to display news fetched from algolia.
Our controller is a PageTypeController and have a public method to fetch data in json with a JsonResponse.
The method is named getEvents and does the exact same thing as the view method (return list of news by params).

News have a date and we use the helper/date to format the date to 'd M'.

When we use the view method our date display in french (the local we use), but if we use the getEvents method it display in english (seems to be the fallback locale).

After investigation i discovered that the ResponseFactory doesn't call the Detector to setup the local on controller call.

In the pr i added some line of code, it instanciate the multilingual detector, get the current page, and if the page exists and is not in error it try to setup the locale with the multilingual detector.