### PR TITLE
Adds ability to configure Composer form sets to be collapsable

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -8,7 +8,7 @@ return [
      */
     'version' => '9.2.0a2',
     'version_installed' => '9.2.0a2',
-    'version_db' => '20220911000000', // the key of the latest database migration
+    'version_db' => '20220919000000', // the key of the latest database migration
 
     /*
      * Installation status

--- a/concrete/config/db.xml
+++ b/concrete/config/db.xml
@@ -177,6 +177,7 @@
     </field>
     <field name="ptComposerFormLayoutSetName" type="string" size="255"/>
     <field name="ptComposerFormLayoutSetDescription" type="text" size="65535"/>
+    <field name="ptComposerFormLayoutSetCollapseType" type="string" size="12"/>
     <field name="ptComposerFormLayoutSetDisplayOrder" type="integer" size="10">
       <unsigned/>
       <default value="0"/>

--- a/concrete/controllers/single_page/dashboard/pages/types/form.php
+++ b/concrete/controllers/single_page/dashboard/pages/types/form.php
@@ -63,6 +63,7 @@ class Form extends DashboardPageController
         $sec = Loader::helper('security');
         $name = $sec->sanitizeString($this->post('ptComposerFormLayoutSetName'));
         $description = $sec->sanitizeString($this->post('ptComposerFormLayoutSetDescription'));
+        $collapseType = $sec->sanitizeString($this->post('ptComposerFormLayoutSetCollapseType'));
         if (!$this->token->validate('update_set')) {
             $this->error->add(t($this->token->getErrorMessage()));
         }
@@ -70,6 +71,7 @@ class Form extends DashboardPageController
         if (!$this->error->has()) {
             $set->updateFormLayoutSetName($name);
             $set->updateFormLayoutSetDescription($description);
+            $set->updateFormLayoutSetCollapseType($collapseType);
             $this->redirect('/dashboard/pages/types/form', $set->getPageTypeID(), 'layout_set_updated');
         }
     }
@@ -94,8 +96,9 @@ class Form extends DashboardPageController
         $sec = Loader::helper('security');
         $name = $sec->sanitizeString($this->post('ptComposerFormLayoutSetName'));
         $description = $sec->sanitizeString($this->post('ptComposerFormLayoutSetDescription'));
+        $collapseType = $sec->sanitizeString($this->post('ptComposerFormLayoutSetCollapseType'));
         if ($this->token->validate('add_set')) {
-            $set = $this->pagetype->addPageTypeComposerFormLayoutSet($name, $description);
+            $set = $this->pagetype->addPageTypeComposerFormLayoutSet($name, $description, $collapseType);
             $this->redirect('/dashboard/pages/types/form', $this->pagetype->getPageTypeID(), 'layout_set_added');
         }
     }

--- a/concrete/elements/page_types/composer/form/output/form.php
+++ b/concrete/elements/page_types/composer/form/output/form.php
@@ -1,5 +1,6 @@
 <?php
 defined('C5_EXECUTE') or die("Access Denied.");
+
 use \Concrete\Core\Page\Type\Composer\FormLayoutSet as PageTypeComposerFormLayoutSet;
 use \Concrete\Core\Page\Type\Composer\FormLayoutSetControl as PageTypeComposerFormLayoutSetControl;
 
@@ -17,42 +18,63 @@ if (is_object($targetPage)) {
 
 <div class="ccm-ui">
 
-<div class="alert alert-info" style="display: none" id="ccm-page-type-composer-form-save-status"></div>
+    <div class="alert alert-info" style="display: none" id="ccm-page-type-composer-form-save-status"></div>
 
-    <input type="hidden" name="ptID" value="<?=$pagetype->getPageTypeID()?>" />
+    <input type="hidden" name="ptID" value="<?= $pagetype->getPageTypeID() ?>"/>
 
-<?php foreach ($fieldsets as $cfl) {
-    ?>
-	<fieldset>
-		<?php if ($cfl->getPageTypeComposerFormLayoutSetDisplayName()) {
-    ?>
-			<legend><?=$cfl->getPageTypeComposerFormLayoutSetDisplayName()?></legend>
-		<?php 
-}
-    ?>
-		<?php if ($cfl->getPageTypeComposerFormLayoutSetDisplayDescription()) {
-    ?>
-			<span class="form-text"><?=$cfl->getPageTypeComposerFormLayoutSetDisplayDescription()?></span>
-		<?php 
-}
-    ?>
-		<?php $controls = PageTypeComposerFormLayoutSetControl::getList($cfl);
-
-    foreach ($controls as $con) {
-        if (is_object($page)) { // we are loading content in
-                $con->setPageObject($page);
-        }
-        $con->setTargetParentPageID($targetParentPageID);
+    <?php foreach ($fieldsets as $cfl) {
+        $collapseType = $cfl->getPageTypeComposerFormLayoutSetCollapseType();
         ?>
-			<?php $con->render();
-        ?>
-		<?php 
-    }
-    ?>
+        <fieldset class="pt-3 pb-3">
+            <?php if ($cfl->getPageTypeComposerFormLayoutSetDisplayName()) {
+                ?>
+                <legend class="mb-3">
+                    <?php if ($collapseType != 'never') { ?>
+                    <a href="#composerset<?= $cfl->getPageTypeComposerFormLayoutSetID(); ?>" class="d-block composersettoggle <?= ($collapseType == 'collapsed' ? 'collapsed' : '') ?>" data-bs-toggle="collapse" role="button" aria-expanded="<?= ($collapseType == 'collapsed' ? 'false' : 'true') ?>" aria-controls="composerset<?= $cfl->getPageTypeComposerFormLayoutSetID(); ?>">
+                        <?php } ?>
+                        <?= $cfl->getPageTypeComposerFormLayoutSetDisplayName() ?>
+                        <?php if ($collapseType != 'never') { ?>
+                        <span class="fas fa-angle-right float-end setcollapsed"></span><span class="fas fa-angle-down float-end setexpanded"></span></a>
+                <?php } ?>
+                </legend>
+                <?php
+            }
+            ?>
+            <?php if ($cfl->getPageTypeComposerFormLayoutSetDisplayDescription()) {
+                ?>
+                <div class="form-text mb-4"><?= $cfl->getPageTypeComposerFormLayoutSetDisplayDescription() ?></div>
+                <?php
+            }
+            ?>
+            <?php $controls = PageTypeComposerFormLayoutSetControl::getList($cfl);
+            ?>
+            <div id="composerset<?= $cfl->getPageTypeComposerFormLayoutSetID(); ?>" class="<?= ($collapseType == 'collapsed' ? 'collapse' : 'show') ?>">
+                <?php
+                foreach ($controls as $con) {
+                    if (is_object($page)) { // we are loading content in
+                        $con->setPageObject($page);
+                    }
+                    $con->setTargetParentPageID($targetParentPageID);
+                    ?>
+                    <?php $con->render();
+                    ?>
+                    <?php
+                }
+                ?>
+            </div>
+        </fieldset>
 
-	</fieldset>
-
-<?php
-} ?>
+        <?php
+    } ?>
 
 </div>
+
+<style>
+    .ccm-ui .composersettoggle .setcollapsed, .ccm-ui .composersettoggle.collapsed .setexpanded {
+        display: none;
+    }
+
+    .ccm-ui .composersettoggle.collapsed .setcollapsed, .ccm-ui .composersettoggle .setexpanded {
+        display: inline-block;
+    }
+</style>

--- a/concrete/single_pages/dashboard/pages/types/form.php
+++ b/concrete/single_pages/dashboard/pages/types/form.php
@@ -4,6 +4,7 @@ use Concrete\Core\Page\Type\Composer\FormLayoutSetControl as PageTypeComposerFor
 use Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface;
 
 $resolverManager = app(ResolverManagerInterface::class);
+$showHideOptions = [''=>t('Set displayed by default'), 'collapsed'=>t('Set hidden by default'), 'never'=>t('Not collapsable')];
 ?>
 
 <div style="display: none">
@@ -18,6 +19,10 @@ $resolverManager = app(ResolverManagerInterface::class);
 				<?= $form->label('ptComposerFormLayoutSetDescription', tc('Description of a set', 'Set Description')) ?>
 				<?= $form->textarea('ptComposerFormLayoutSetDescription') ?>
 			</div>
+            <div class="form-group">
+                <?= $form->label('ptComposerFormLayoutSetCollapseType', t('Show/Hide Controls')) ?>
+                <?= $form->select('ptComposerFormLayoutSetCollapseType', $showHideOptions) ?>
+            </div>
 		</form>
 		<div class="dialog-buttons">
 			<button class="btn btn-secondary float-start" onclick="jQuery.fn.dialog.closeTop()"><?= t('Cancel') ?></button>
@@ -77,6 +82,10 @@ $resolverManager = app(ResolverManagerInterface::class);
                         <div class="form-group">
                             <?= $form->label('ptComposerFormLayoutSetDescription', tc('Description of a set', 'Set Description')) ?>
                             <?= $form->textarea('ptComposerFormLayoutSetDescription', $set->getPageTypeComposerFormLayoutSetDescription()) ?>
+                        </div>
+                        <div class="form-group">
+                            <?= $form->label('ptComposerFormLayoutSetCollapseType', t('Show/Hide Controls')) ?>
+                            <?= $form->select('ptComposerFormLayoutSetCollapseType', $showHideOptions, $set->getPageTypeComposerFormLayoutSetCollapseType()) ?>
                         </div>
                         <div class="dialog-buttons">
                             <button class="btn btn-secondary float-start" onclick="jQuery.fn.dialog.closeTop();"><?= t('Cancel') ?></button>

--- a/concrete/src/Page/Type/Composer/FormLayoutSet.php
+++ b/concrete/src/Page/Type/Composer/FormLayoutSet.php
@@ -20,6 +20,10 @@ class FormLayoutSet extends ConcreteObject
     {
         return $this->ptComposerFormLayoutSetDescription;
     }
+    public function getPageTypeComposerFormLayoutSetCollapseType()
+    {
+        return $this->ptComposerFormLayoutSetCollapseType;
+    }
     public function getPageTypeComposerFormLayoutSetDisplayOrder()
     {
         return $this->ptComposerFormLayoutSetDisplayOrder;
@@ -95,6 +99,7 @@ class FormLayoutSet extends ConcreteObject
         $node = $fxml->addChild('set');
         $node->addAttribute('name', $this->getPageTypeComposerFormLayoutSetName());
         $node->addAttribute('description', $this->getPageTypeComposerFormLayoutSetDescription());
+        $node->addAttribute('collapseType', $this->getPageTypeComposerFormLayoutSetCollapseType());
         $controls = FormLayoutSetControl::getList($this);
         foreach ($controls as $con) {
             $con->export($node);
@@ -117,6 +122,15 @@ class FormLayoutSet extends ConcreteObject
             $ptComposerFormLayoutSetDescription, $this->ptComposerFormLayoutSetID,
         ));
         $this->ptComposerFormLayoutSetDescription = $ptComposerFormLayoutSetDescription;
+    }
+
+    public function updateFormLayoutSetCollapseType($ptComposerFormLayoutSetCollapseType)
+    {
+        $db = Loader::db();
+        $db->Execute('update PageTypeComposerFormLayoutSets set ptComposerFormLayoutSetCollapseType = ? where ptComposerFormLayoutSetID = ?', array(
+            $ptComposerFormLayoutSetCollapseType, $this->ptComposerFormLayoutSetID,
+        ));
+        $this->ptComposerFormLayoutSetCollapseType = $ptComposerFormLayoutSetCollapseType;
     }
 
     public function updateFormLayoutSetDisplayOrder($displayOrder)

--- a/concrete/src/Page/Type/Type.php
+++ b/concrete/src/Page/Type/Type.php
@@ -781,7 +781,7 @@ class Type extends ConcreteObject implements \Concrete\Core\Permission\ObjectInt
         if (is_object($data['defaultTheme'])) {
             $ptDefaultThemeID = $data['defaultTheme']->getThemeID();
         }
-        
+
         $ptAllowedPageTemplates = 'A';
         if ($data['allowedTemplates']) {
             $ptAllowedPageTemplates = $data['allowedTemplates'];
@@ -1152,7 +1152,7 @@ class Type extends ConcreteObject implements \Concrete\Core\Permission\ObjectInt
         }
     }
 
-    public function addPageTypeComposerFormLayoutSet($ptComposerFormLayoutSetName, $ptComposerFormLayoutSetDescription)
+    public function addPageTypeComposerFormLayoutSet($ptComposerFormLayoutSetName, $ptComposerFormLayoutSetDescription, $collapseType = '')
     {
         $db = Loader::db();
         $displayOrder = $db->GetOne(
@@ -1163,10 +1163,11 @@ class Type extends ConcreteObject implements \Concrete\Core\Permission\ObjectInt
             $displayOrder = 0;
         }
         $db->Execute(
-            'insert into PageTypeComposerFormLayoutSets (ptComposerFormLayoutSetName, ptComposerFormLayoutSetDescription, ptID, ptComposerFormLayoutSetDisplayOrder) values (?, ?, ?, ?)',
+            'insert into PageTypeComposerFormLayoutSets (ptComposerFormLayoutSetName, ptComposerFormLayoutSetDescription, ptComposerFormLayoutSetCollapseType, ptID, ptComposerFormLayoutSetDisplayOrder) values (?, ?, ?, ?, ?)',
             array(
                 $ptComposerFormLayoutSetName,
                 $ptComposerFormLayoutSetDescription,
+                $collapseType,
                 $this->ptID,
                 $displayOrder,
             )

--- a/concrete/src/Updater/Migrations/Migrations/Version20220919000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20220919000000.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
+
+final class Version20220919000000 extends AbstractMigration implements RepeatableMigrationInterface
+{
+    public function upgradeDatabase()
+    {
+        $this->output(t('Updating tables found in doctrine xml...'));
+        \Concrete\Core\Database\Schema\Schema::refreshCoreXMLSchema([
+            'PageTypeComposerFormLayoutSets',
+        ]);
+    }
+}


### PR DESCRIPTION
This feature is in response to the discussion at:
https://forums.concretecms.org/t/a-quick-way-to-make-composer-forms-more-condensed/3813/4

This makes the composer form set legend text triggers for showing and collapsing the set of attributes below it.
<img width="982" alt="Screen Shot 2022-09-19 at 4 21 39 pm" src="https://user-images.githubusercontent.com/1079600/191053692-f029504d-e80a-45d9-888f-7007cbd69dc7.png">
And when clicked:
<img width="1047" alt="Screen Shot 2022-09-19 at 4 21 34 pm" src="https://user-images.githubusercontent.com/1079600/191053715-4d4e3ecd-6e19-475d-8ad8-40f27dbc3473.png">

When configuring a set of composer fields, there is an option to either set the set to be open by default, collapsed by default, or not able to be collapsed. 
<img width="412" alt="Screen Shot 2022-09-19 at 4 22 06 pm" src="https://user-images.githubusercontent.com/1079600/191053620-b50387bd-26da-42e6-8fb2-6f7cbd0376b8.png">

This can help to make a long composer form with many attributes more manageable, by hiding lesser used set of attributes by default. 

The default behaviour is to add showing/collapsing to sets, but to remain visible, meaning already existing composer forms aren't changed in terms of field visibility.

A few minor spacing adjustments have also been made to the composer page, to balance out the headings and descriptions.