### PR TITLE
Add the missing user param on page_version_approve event

### DIFF
--- a/concrete/src/Page/Collection/Version/Version.php
+++ b/concrete/src/Page/Collection/Version/Version.php
@@ -710,7 +710,7 @@ class Version extends ConcreteObject implements PermissionObjectInterface, Attri
         $db = $app->make(Connection::class);
         /** @var Date $dh */
         $dh = $app->make('helper/date');
-        $u = $app->make(\Concrete\Core\User\User::class);
+        $u = $app->make(User::class);
         $uID = $u->getUserID();
         $cvID = $this->getVersionID();
         $cID = $this->getCollectionID();
@@ -943,7 +943,7 @@ class Version extends ConcreteObject implements PermissionObjectInterface, Attri
         $cvID = $this->cvID;
         $c = Page::getByID($this->cID, $cvID);
         $cID = $c->getCollectionID();
-        $u = $app->make(\Concrete\Core\User\User::class);
+        $u = $app->make(User::class);
 
         $q = "select bID, arHandle from CollectionVersionBlocks where cID = ? and cvID = ?";
         $r = $db->executeQuery($q, array(

--- a/concrete/src/Page/Collection/Version/Version.php
+++ b/concrete/src/Page/Collection/Version/Version.php
@@ -943,6 +943,7 @@ class Version extends ConcreteObject implements PermissionObjectInterface, Attri
         $cvID = $this->cvID;
         $c = Page::getByID($this->cID, $cvID);
         $cID = $c->getCollectionID();
+        $u = $app->make(\Concrete\Core\User\User::class);
 
         $q = "select bID, arHandle from CollectionVersionBlocks where cID = ? and cvID = ?";
         $r = $db->executeQuery($q, array(
@@ -992,6 +993,7 @@ class Version extends ConcreteObject implements PermissionObjectInterface, Attri
         $this->refreshCache();
 
         $ev = new Event($c);
+        $ev->setUser($u);
         $ev->setCollectionVersionObject($this);
         $app->make('director')->dispatch('on_page_version_delete', $ev);
     }

--- a/concrete/src/Page/Collection/Version/Version.php
+++ b/concrete/src/Page/Collection/Version/Version.php
@@ -810,6 +810,7 @@ class Version extends ConcreteObject implements PermissionObjectInterface, Attri
             );
         }
         $ev = new Event($c);
+        $ev->setUser($u);
         $ev->setCollectionVersionObject($this);
         $app->make('director')->dispatch('on_page_version_approve', $ev);
 


### PR DESCRIPTION
The user params was missing and we were only able to get the user with :
```php
use Concrete\Core\User\User;
use Symfony\Component\HttpFoundation\Session\Session;
/** @var Session $session */
$session = $this->app->make('session');
dd(User::getByUserID($session->get('uID')));
```