### PR TITLE
Fix Call to a member function populateDirectChildrenOnly() on null

### DIFF
--- a/concrete/src/User/Group/Group.php
+++ b/concrete/src/User/Group/Group.php
@@ -137,6 +137,9 @@ class Group extends ConcreteObject implements \Concrete\Core\Permission\ObjectIn
         $this->rescanGroupPath();
 
         $node = GroupTreeNode::getTreeNodeByGroupID($this->gID);
+        if (!$node) {
+            return;
+        }
         $node->populateDirectChildrenOnly();
         foreach ($node->getChildNodes() as $child) {
             if ($child instanceof \Concrete\Core\Tree\Node\Type\Group) {


### PR DESCRIPTION
I have some custom code that deletes group and child groups.

I'm not sure when and how this occurs, but I have this error:

```
Error: Call to a member function populateDirectChildrenOnly() on null
in concrete/src/User/Group/Group.php:142
Stack trace:
#0 concrete/src/Tree/Node/Type/Group.php(104): Concrete\Core\User\Group\Group->rescanGroupPathRecursive()
#1 concrete/src/User/Group/Command/DeleteGroupCommandHandler.php(84): Concrete\Core\Tree\Node\Type\Group->move(Object(Concrete\Core\Tree\Node\Type\GroupFolder))
```
