### PR TITLE
Fix PHP 8+ on null variables

### DIFF
--- a/concrete/blocks/top_navigation_bar/edit.php
+++ b/concrete/blocks/top_navigation_bar/edit.php
@@ -62,18 +62,18 @@ if ($includeBrandText && $includeBrandLogo) {
         </div>
         <div class="mb-3" v-if="brandingMode == 'logoText' || brandingMode == 'logo'">
             <label class="form-label" for="brandingLogo"><?=t('Logo')?></label>
-            <concrete-file-input choose-text="<?=t('Choose Logo')?>" input-name="brandingLogo" file-id="<?=$brandingLogo?>"></concrete-file-input>
+            <concrete-file-input choose-text="<?=t('Choose Logo')?>" input-name="brandingLogo" file-id="<?=$brandingLogo??null?>"></concrete-file-input>
         </div>
         <div class="mb-3" v-if="includeTransparency && (brandingMode == 'logoText' || brandingMode == 'logo')">
             <label class="form-label" for="brandingTransparentLogo"><?=t('Transparent Logo')?></label>
-            <concrete-file-input choose-text="<?=t('Choose Logo')?>" input-name="brandingTransparentLogo" file-id="<?=$brandingTransparentLogo?>"></concrete-file-input>
+            <concrete-file-input choose-text="<?=t('Choose Logo')?>" input-name="brandingTransparentLogo" file-id="<?=$brandingTransparentLogo??null?>"></concrete-file-input>
         </div>
     </fieldset>
     <fieldset v-if="includeSearchInput" class="border-top pt-3">
         <legend><?=t('Search')?></legend>
         <div class="mb-3">
             <label class="form-label" for="searchInputFormActionPageID"><?=t('Search Results Page')?></label>
-            <concrete-page-input choose-text="<?=t('Choose Page')?>" page-id="<?=$searchInputFormActionPageID?>" input-name="searchInputFormActionPageID"></concrete-page-input>
+            <concrete-page-input choose-text="<?=t('Choose Page')?>" page-id="<?=$searchInputFormActionPageID??null?>" input-name="searchInputFormActionPageID"></concrete-page-input>
         </div>
     </fieldset>
 </div>
@@ -91,9 +91,9 @@ if ($includeBrandText && $includeBrandLogo) {
                 includeNavigationDropdowns: <?=$includeNavigationDropdowns ? 'true' : 'false'?>,
                 includeStickyNav: <?=$includeStickyNav ? 'true' : 'false'?>,
                 includeSearchInput: <?=$includeSearchInput ? 'true' : 'false'?>,
-                brandingLogo: <?=(int) $brandingLogo?>,
-                brandingTransparentLogo: <?=(int) $brandingTransparentLogo?>,
-                searchInputFormActionPageID: <?=(int) $searchInputFormActionPageID?>,
+                brandingLogo: <?=(int) ($brandingLogo??null)?>,
+                brandingTransparentLogo: <?=(int) ($brandingTransparentLogo??null)?>,
+                searchInputFormActionPageID: <?=(int) ($searchInputFormActionPageID??null)?>,
                 brandingMode: '<?=$brandingMode?>',
             }
         })


### PR DESCRIPTION
PHP 8+ no longer treats undefined variables as null and instead throws an exception. This fixes such a set of exceptions if logos are not set and you later attempt to edit the nav bar.