### PR TITLE
Fix notifications relations

### DIFF
--- a/concrete/src/Entity/Notification/GroupCreateNotification.php
+++ b/concrete/src/Entity/Notification/GroupCreateNotification.php
@@ -1,7 +1,7 @@
 <?php
+
 namespace Concrete\Core\Entity\Notification;
 
-use Concrete\Core\Entity\User\GroupCreate;
 use Concrete\Core\Notification\View\GroupCreateListView;
 use Doctrine\ORM\Mapping as ORM;
 
@@ -13,16 +13,16 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class GroupCreateNotification extends Notification
 {
-
     /**
      * @ORM\ManyToOne(targetEntity="\Concrete\Core\Entity\User\GroupCreate", cascade={"persist", "remove"}, inversedBy="notifications"),
      * @ORM\JoinColumn(name="id", referencedColumnName="id")
+     *
+     * @var \Concrete\Core\Entity\User\GroupCreate
      */
     protected $create;
 
     /**
-     * GroupEnterNotification constructor.
-     * @param GroupCreate $create
+     * @param \Concrete\Core\Entity\User\GroupCreate $create
      */
     public function __construct($create)
     {
@@ -31,16 +31,20 @@ class GroupCreateNotification extends Notification
     }
 
     /**
-     * @return GroupCreate
+     * @return \Concrete\Core\Entity\User\GroupCreate
      */
     public function getCreate()
     {
         return $this->create;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Entity\Notification\Notification::getListView()
+     */
     public function getListView()
     {
         return new GroupCreateListView($this);
     }
-
 }

--- a/concrete/src/Entity/Notification/GroupRoleChangeNotification.php
+++ b/concrete/src/Entity/Notification/GroupRoleChangeNotification.php
@@ -1,7 +1,7 @@
 <?php
+
 namespace Concrete\Core\Entity\Notification;
 
-use Concrete\Core\Entity\User\GroupRoleChange;
 use Concrete\Core\Notification\Subject\SubjectInterface;
 use Concrete\Core\Notification\View\GroupRoleChangeListView;
 use Doctrine\ORM\Mapping as ORM;
@@ -17,13 +17,13 @@ class GroupRoleChangeNotification extends Notification
     /**
      * @ORM\ManyToOne(targetEntity="\Concrete\Core\Entity\User\GroupRoleChange", cascade={"persist", "remove"}, inversedBy="notifications"),
      * @ORM\JoinColumn(name="id", referencedColumnName="id")
+     *
+     * @var \Concrete\Core\Entity\User\GroupRoleChange
      */
     protected $groupRoleChange;
 
-
     /**
-     * GroupRoleChangeNotification constructor.
-     * @param GroupRoleChange $groupRoleChange
+     * @param \Concrete\Core\Entity\User\GroupRoleChange $groupRoleChange
      */
     public function __construct($groupRoleChange)
     {
@@ -32,16 +32,20 @@ class GroupRoleChangeNotification extends Notification
     }
 
     /**
-     * @return GroupRoleChange
+     * @return \Concrete\Core\Entity\User\GroupRoleChange
      */
     public function getGroupRoleChange(): SubjectInterface
     {
         return $this->groupRoleChange;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Entity\Notification\Notification::getListView()
+     */
     public function getListView()
     {
         return new GroupRoleChangeListView($this);
     }
-
 }

--- a/concrete/src/Entity/Notification/GroupSignupNotification.php
+++ b/concrete/src/Entity/Notification/GroupSignupNotification.php
@@ -1,8 +1,7 @@
 <?php
+
 namespace Concrete\Core\Entity\Notification;
 
-use Concrete\Core\Entity\User\GroupSignup;
-use Concrete\Core\Notification\Subject\SubjectInterface;
 use Concrete\Core\Notification\View\GroupSignupListView;
 use Doctrine\ORM\Mapping as ORM;
 
@@ -14,16 +13,16 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class GroupSignupNotification extends Notification
 {
-
     /**
      * @ORM\ManyToOne(targetEntity="\Concrete\Core\Entity\User\GroupSignup", cascade={"persist", "remove"}, inversedBy="notifications"),
      * @ORM\JoinColumn(name="id", referencedColumnName="id")
+     *
+     * @var \Concrete\Core\Entity\User\GroupSignup
      */
     protected $signup;
 
     /**
-     * GroupEnterNotification constructor.
-     * @param GroupSignup $group
+     * @param \Concrete\Core\Entity\User\GroupSignup $signup
      */
     public function __construct($signup)
     {
@@ -32,16 +31,20 @@ class GroupSignupNotification extends Notification
     }
 
     /**
-     * @return GroupSignup
+     * @return \Concrete\Core\Entity\User\GroupSignup
      */
     public function getSignup()
     {
         return $this->signup;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Entity\Notification\Notification::getListView()
+     */
     public function getListView()
     {
         return new GroupSignupListView($this);
     }
-
 }

--- a/concrete/src/Entity/Notification/GroupSignupRequestAcceptNotification.php
+++ b/concrete/src/Entity/Notification/GroupSignupRequestAcceptNotification.php
@@ -1,8 +1,7 @@
 <?php
+
 namespace Concrete\Core\Entity\Notification;
 
-use Concrete\Core\Entity\User\GroupSignupRequestAccept;
-use Concrete\Core\Notification\Subject\SubjectInterface;
 use Concrete\Core\Notification\View\GroupSignupRequestAcceptListView;
 use Doctrine\ORM\Mapping as ORM;
 
@@ -14,16 +13,16 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class GroupSignupRequestAcceptNotification extends Notification
 {
-
     /**
      * @ORM\ManyToOne(targetEntity="\Concrete\Core\Entity\User\GroupSignupRequestAccept", cascade={"persist", "remove"}, inversedBy="notifications"),
      * @ORM\JoinColumn(name="id", referencedColumnName="id")
+     *
+     * @var \Concrete\Core\Entity\User\GroupSignupRequestAccept
      */
     protected $signup;
 
     /**
-     * GroupEnterNotification constructor.
-     * @param GroupSignupRequestAccept $group
+     * @param \Concrete\Core\Entity\User\GroupSignupRequestAccept $signup
      */
     public function __construct($signup)
     {
@@ -32,16 +31,20 @@ class GroupSignupRequestAcceptNotification extends Notification
     }
 
     /**
-     * @return GroupSignupRequestAccept
+     * @return \Concrete\Core\Entity\User\GroupSignupRequestAccept
      */
     public function getSignupRequestAccept()
     {
         return $this->signup;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Entity\Notification\Notification::getListView()
+     */
     public function getListView()
     {
         return new GroupSignupRequestAcceptListView($this);
     }
-
 }

--- a/concrete/src/Entity/Notification/GroupSignupRequestDeclineNotification.php
+++ b/concrete/src/Entity/Notification/GroupSignupRequestDeclineNotification.php
@@ -1,8 +1,7 @@
 <?php
+
 namespace Concrete\Core\Entity\Notification;
 
-use Concrete\Core\Entity\User\GroupSignupRequestDecline;
-use Concrete\Core\Notification\Subject\SubjectInterface;
 use Concrete\Core\Notification\View\GroupSignupRequestDeclineListView;
 use Doctrine\ORM\Mapping as ORM;
 
@@ -14,16 +13,16 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class GroupSignupRequestDeclineNotification extends Notification
 {
-
     /**
      * @ORM\ManyToOne(targetEntity="\Concrete\Core\Entity\User\GroupSignupRequestDecline", cascade={"persist", "remove"}, inversedBy="notifications"),
      * @ORM\JoinColumn(name="id", referencedColumnName="id")
+     *
+     * @var \Concrete\Core\Entity\User\GroupSignupRequestDecline
      */
     protected $signup;
 
     /**
-     * GroupEnterNotification constructor.
-     * @param GroupSignupRequestDecline $group
+     * @param \Concrete\Core\Entity\User\GroupSignupRequestDecline $signup
      */
     public function __construct($signup)
     {
@@ -32,16 +31,20 @@ class GroupSignupRequestDeclineNotification extends Notification
     }
 
     /**
-     * @return GroupSignupRequestDecline
+     * @return \Concrete\Core\Entity\User\GroupSignupRequestDecline
      */
     public function getSignupRequestDecline()
     {
         return $this->signup;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Entity\Notification\Notification::getListView()
+     */
     public function getListView()
     {
         return new GroupSignupRequestDeclineListView($this);
     }
-
 }

--- a/concrete/src/Entity/Notification/GroupSignupRequestNotification.php
+++ b/concrete/src/Entity/Notification/GroupSignupRequestNotification.php
@@ -1,7 +1,7 @@
 <?php
+
 namespace Concrete\Core\Entity\Notification;
 
-use Concrete\Core\Entity\User\GroupSignupRequest;
 use Concrete\Core\Notification\Subject\SubjectInterface;
 use Concrete\Core\Notification\View\GroupSignupRequestListView;
 use Doctrine\ORM\Mapping as ORM;
@@ -14,16 +14,16 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class GroupSignupRequestNotification extends Notification
 {
-
     /**
      * @ORM\ManyToOne(targetEntity="\Concrete\Core\Entity\User\GroupSignupRequest", cascade={"persist", "remove"}, inversedBy="notifications"),
      * @ORM\JoinColumn(name="id", referencedColumnName="id")
+     *
+     * @var \Concrete\Core\Entity\User\GroupSignupRequest
      */
     protected $signupRequest;
 
     /**
-     * GroupSignupRequestNotification constructor.
-     * @param GroupSignupRequest $group
+     * @param \Concrete\Core\Entity\User\GroupSignupRequest $signupRequest
      */
     public function __construct(SubjectInterface $signupRequest)
     {
@@ -32,7 +32,7 @@ class GroupSignupRequestNotification extends Notification
     }
 
     /**
-     * @return GroupSignupRequest
+     * @return \Concrete\Core\Entity\User\GroupSignupRequest
      */
     public function getSignupRequest(): SubjectInterface
     {
@@ -40,18 +40,24 @@ class GroupSignupRequestNotification extends Notification
     }
 
     /**
-     * @param SubjectInterface $signupRequest
-     * @return GroupSignupRequestNotification
+     * @param \Concrete\Core\Entity\User\GroupSignupRequest $signupRequest
+     *
+     * @return $this
      */
-    public function setSignupRequest(SubjectInterface $signupRequest): GroupSignupRequestNotification
+    public function setSignupRequest(SubjectInterface $signupRequest): self
     {
         $this->signupRequest = $signupRequest;
+
         return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Entity\Notification\Notification::getListView()
+     */
     public function getListView()
     {
         return new GroupSignupRequestListView($this);
     }
-
 }

--- a/concrete/src/Entity/Notification/NewConversationMessageNotification.php
+++ b/concrete/src/Entity/Notification/NewConversationMessageNotification.php
@@ -1,10 +1,8 @@
 <?php
+
 namespace Concrete\Core\Entity\Notification;
 
-use Concrete\Core\Conversation\Message\NewMessage;
-use Concrete\Core\Entity\User\UserSignup;
 use Concrete\Core\Notification\Subject\SubjectInterface;
-use Concrete\Core\Notification\View\UserSignupListView;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -15,15 +13,15 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class NewConversationMessageNotification extends Notification
 {
-
     /**
      * @ORM\Column(type="integer", options={"unsigned":true})
+     *
+     * @var int
      */
     protected $cnvMessageID;
 
     /**
-     * UserSignupNotification constructor.
-     * @param $message NewMessage
+     * @param \Concrete\Core\Conversation\Message\NewMessage $message
      */
     public function __construct(SubjectInterface $message)
     {
@@ -31,10 +29,13 @@ class NewConversationMessageNotification extends Notification
         parent::__construct($message);
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Entity\Notification\Notification::getListView()
+     */
     public function getListView()
     {
-
+        return null;
     }
-
-
 }

--- a/concrete/src/Entity/Notification/NewFormSubmissionNotification.php
+++ b/concrete/src/Entity/Notification/NewFormSubmissionNotification.php
@@ -1,7 +1,7 @@
 <?php
+
 namespace Concrete\Core\Entity\Notification;
 
-use Concrete\Core\Entity\Express\Entry;
 use Concrete\Core\Express\Entry\Notifier\Notification\EntrySubject;
 use Concrete\Core\Notification\View\NewFormSubmissionListView;
 use Doctrine\ORM\Mapping as ORM;
@@ -14,10 +14,11 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class NewFormSubmissionNotification extends Notification
 {
-
     /**
      * @ORM\ManyToOne(targetEntity="\Concrete\Core\Entity\Express\Entry")
      * @ORM\JoinColumn(name="exEntryID", referencedColumnName="exEntryID", onDelete="CASCADE")
+     *
+     * @var \Concrete\Core\Entity\Express\Entry
      */
     protected $entry;
 
@@ -27,20 +28,21 @@ class NewFormSubmissionNotification extends Notification
         parent::__construct($subject);
     }
 
-
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Entity\Notification\Notification::getListView()
+     */
     public function getListView()
     {
         return new NewFormSubmissionListView($this);
     }
 
     /**
-     * @return Entry
+     * @return \Concrete\Core\Entity\Express\Entry
      */
     public function getEntry()
     {
         return $this->entry;
     }
-
-
-
 }

--- a/concrete/src/Entity/Notification/NewPrivateMessageNotification.php
+++ b/concrete/src/Entity/Notification/NewPrivateMessageNotification.php
@@ -1,13 +1,9 @@
 <?php
+
 namespace Concrete\Core\Entity\Notification;
 
-use Concrete\Core\Entity\User\UserSignup;
-use Concrete\Core\Notification\Subject\SubjectInterface;
 use Concrete\Core\Notification\View\NewPrivateMessageListView;
-use Concrete\Core\Notification\View\UserSignupListView;
-use Concrete\Core\Notification\View\WorkflowProgressListView;
 use Concrete\Core\User\PrivateMessage\PrivateMessage;
-use Concrete\Core\Workflow\Progress\Progress;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -18,36 +14,44 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class NewPrivateMessageNotification extends Notification
 {
-
+    /**
+     * @var \Concrete\Core\User\PrivateMessage\PrivateMessage|null
+     */
     protected $message;
 
     /**
      * @ORM\Column(type="integer", options={"unsigned":true})
+     *
+     * @var int
      */
     protected $msgID;
 
-    /**
-     * @param $message PrivateMessage
-     */
     public function __construct(PrivateMessage $message)
     {
         $this->msgID = $message->getMessageID();
+        $this->message = $message;
         parent::__construct($message);
     }
 
-
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Entity\Notification\Notification::getListView()
+     */
     public function getListView()
     {
         return new NewPrivateMessageListView($this);
     }
 
+    /**
+     * @return \Concrete\Core\User\PrivateMessage\PrivateMessage|null may be NULL if the message has been deleted
+     */
     public function getMessageObject()
     {
-        if (!isset($this->message)) {
+        if ($this->message === null) {
             $this->message = PrivateMessage::getByID($this->msgID);
         }
+
         return $this->message;
     }
-
-
 }

--- a/concrete/src/Entity/Notification/Notification.php
+++ b/concrete/src/Entity/Notification/Notification.php
@@ -1,15 +1,8 @@
 <?php
+
 namespace Concrete\Core\Entity\Notification;
 
-use Concrete\Core\Attribute\AttributeValueInterface;
-use Concrete\Core\Entity\Attribute\Key\Key;
-use Concrete\Core\Notification\Formatter\StandardFormatter;
-use Concrete\Core\Notification\Formatter\UserSignupFormatter;
 use Concrete\Core\Notification\Subject\SubjectInterface;
-use Concrete\Core\Notification\View\ListableInterface;
-use Concrete\Core\Notification\View\ListViewPopulatorInterface;
-use Concrete\Core\Notification\View\UserSignupView;
-use Concrete\Core\Notification\View\ViewInterface;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 
@@ -23,69 +16,80 @@ use Doctrine\ORM\Mapping as ORM;
  */
 abstract class Notification
 {
-
     /**
      * @ORM\Id @ORM\Column(type="integer", options={"unsigned":true})
      * @ORM\GeneratedValue(strategy="AUTO")
+     *
+     * @var int|null NULL if not yet flushed to the database
      */
     protected $nID;
 
     /**
      * @ORM\Column(type="datetime")
+     *
+     * @var \DateTime
      */
-    protected $nDate = null;
+    protected $nDate;
 
     /**
      * @ORM\OneToMany(targetEntity="Concrete\Core\Entity\Notification\NotificationAlert", cascade={"remove"}, mappedBy="notification")
      * @ORM\JoinColumn(name="nID", referencedColumnName="nID")
+     *
+     * @var \Doctrine\Common\Collections\Collection
      */
     protected $alerts;
 
-
     public function __construct(SubjectInterface $subject)
     {
+        $this->nID = null;
         $this->nDate = $subject->getNotificationDate();
+        $this->alerts = new ArrayCollection();
     }
 
+    /**
+     * @return int|null NULL if not yet flushed to the database
+     */
     public function getNotificationID()
     {
         return $this->nID;
     }
 
     /**
-     * @return mixed
+     * @return \DateTime
      */
     public function getNotificationDate()
     {
         return $this->nDate;
     }
 
+    /**
+     * @return string|null
+     */
     public function getNotificationDateTimeZone()
     {
-        $site = \Core::make('site')->getSite();
-        if ($site) {
-            return $site->getTimezone();
-        }
+        $site = app('site')->getSite();
+
+        return $site ? $site->getTimezone() : null;
     }
 
     /**
-     * @param mixed $nDate
+     * @param \DateTime $nDate
      */
     public function setNotificationDate($nDate)
     {
         $this->nDate = $nDate;
     }
 
+    /**
+     * @return \Concrete\Core\Notification\View\ListViewInterface|null
+     */
     abstract public function getListView();
 
     /**
-     * @return mixed
+     * @return \Doctrine\Common\Collections\Collection|\Concrete\Core\Entity\Notification\NotificationAlert[]
      */
     public function getAlerts()
     {
         return $this->alerts;
     }
-
-
-
 }

--- a/concrete/src/Entity/Notification/NotificationAlert.php
+++ b/concrete/src/Entity/Notification/NotificationAlert.php
@@ -1,16 +1,7 @@
 <?php
+
 namespace Concrete\Core\Entity\Notification;
 
-use Concrete\Core\Attribute\AttributeValueInterface;
-use Concrete\Core\Entity\Attribute\Key\Key;
-use Concrete\Core\Notification\Formatter\StandardFormatter;
-use Concrete\Core\Notification\Formatter\UserSignupFormatter;
-use Concrete\Core\Notification\Subject\SubjectInterface;
-use Concrete\Core\Notification\View\ListableInterface;
-use Concrete\Core\Notification\View\ListViewPopulatorInterface;
-use Concrete\Core\Notification\View\UserSignupView;
-use Concrete\Core\Notification\View\ViewInterface;
-use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -21,32 +12,39 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class NotificationAlert
 {
-
     /**
      * @ORM\Id @ORM\Column(type="integer", options={"unsigned":true})
      * @ORM\GeneratedValue(strategy="AUTO")
+     *
+     * @var int|null NULL if not yet flushed to the database
      */
     protected $naID;
 
     /**
      * @ORM\ManyToOne(targetEntity="Concrete\Core\Entity\User\User", inversedBy="alerts")
      * @ORM\JoinColumn(name="uID", referencedColumnName="uID")
+     *
+     * @var \Concrete\Core\Entity\User\User
      */
     protected $user;
 
     /**
      * @ORM\ManyToOne(targetEntity="\Concrete\Core\Entity\Notification\Notification", inversedBy="alerts")
      * @ORM\JoinColumn(name="nID", referencedColumnName="nID")
+     *
+     * @var \Concrete\Core\Entity\Notification\Notification
      */
     protected $notification;
 
     /**
      * @ORM\Column(type="boolean")
+     *
+     * @var bool
      */
     protected $naIsArchived = false;
 
     /**
-     * @return mixed
+     * @return bool
      */
     public function isNotificationArchived()
     {
@@ -54,7 +52,7 @@ class NotificationAlert
     }
 
     /**
-     * @param mixed $nIsArchived
+     * @param bool $naIsArchived
      */
     public function setNotificationIsArchived($naIsArchived)
     {
@@ -62,7 +60,7 @@ class NotificationAlert
     }
 
     /**
-     * @return mixed
+     * @return \Concrete\Core\Entity\User\User
      */
     public function getUser()
     {
@@ -70,7 +68,7 @@ class NotificationAlert
     }
 
     /**
-     * @param mixed $user
+     * @param \Concrete\Core\Entity\User\User $user
      */
     public function setUser($user)
     {
@@ -78,7 +76,7 @@ class NotificationAlert
     }
 
     /**
-     * @return mixed
+     * @return \Concrete\Core\Entity\Notification\Notification
      */
     public function getNotification()
     {
@@ -86,7 +84,7 @@ class NotificationAlert
     }
 
     /**
-     * @param mixed $notification
+     * @param \Concrete\Core\Entity\Notification\Notification $notification
      */
     public function setNotification($notification)
     {
@@ -94,12 +92,10 @@ class NotificationAlert
     }
 
     /**
-     * @return mixed
+     * @return int|null returns NULL if not yet flushed to the database
      */
     public function getNotificationAlertID()
     {
         return $this->naID;
     }
-
-
 }

--- a/concrete/src/Entity/Notification/NotificationAlertRepository.php
+++ b/concrete/src/Entity/Notification/NotificationAlertRepository.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\Entity\Notification;
 
 use Concrete\Core\User\User;
@@ -6,24 +7,27 @@ use Doctrine\ORM\EntityRepository;
 
 class NotificationAlertRepository extends EntityRepository
 {
-
+    /**
+     * @return \Concrete\Core\Entity\Notification\NotificationAlert[]
+     */
     public function findMyAlerts(User $user)
     {
         $entity = $user->getUserInfoObject()->getEntityObject();
         $query = $this->getEntityManager()->createQuery('select na, n from Concrete\Core\Entity\Notification\NotificationAlert na join na.notification n where na.naIsArchived = false and na.user = :user order by n.nDate desc');
         $query->setParameter('user', $entity);
-        $result = $query->getResult();
-        return $result;
+
+        return $query->getResult();
     }
 
+    /**
+     * @param int $id
+     *
+     * @return \Concrete\Core\Entity\Notification\NotificationAlert|null
+     */
     public function findOneById($id)
     {
         return $this->findOneBy(
-            array('naID' => $id)
+            ['naID' => $id]
         );
     }
-
-
 }
-
-

--- a/concrete/src/Entity/Notification/UserDeactivatedNotification.php
+++ b/concrete/src/Entity/Notification/UserDeactivatedNotification.php
@@ -14,38 +14,39 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class UserDeactivatedNotification extends Notification
 {
-
     /**
-     * The user that is being deactivated
+     * The user that is being deactivated.
      *
      * @ORM\Column(type="integer", options={"unsigned": true})
+     *
+     * @var int
      */
     protected $userID;
 
     /**
-     * The user doing the deactivating
+     * The user doing the deactivating.
      *
      * @ORM\Column(type="integer", nullable=true, options={"unsigned": true})
-     */
-    protected $actorID = null;
-
-    /**
-     * UserSignupNotification constructor.
      *
-     * @param \Concrete\Core\User\Event\DeactivateUser $event
+     * @var int|null
      */
+    protected $actorID;
+
     public function __construct(DeactivateUser $event)
     {
         $this->userID = $event->getUserEntity()->getUserID();
-
         $actor = $event->getActorEntity();
         if ($actor) {
             $this->actorID = $event->getActorEntity()->getUserID();
         }
-
         parent::__construct($event);
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Entity\Notification\Notification::getListView()
+     */
     public function getListView()
     {
         /** @todo Replace this with something that enables autowiring */
@@ -53,7 +54,7 @@ class UserDeactivatedNotification extends Notification
     }
 
     /**
-     * Get the deactivated user id
+     * Get the deactivated user id.
      *
      * @return int
      */
@@ -63,9 +64,9 @@ class UserDeactivatedNotification extends Notification
     }
 
     /**
-     * Get the user id of the user that triggered deactivation
+     * Get the user id of the user that triggered deactivation, if available.
      *
-     * @return int
+     * @return int|null
      */
     public function getActorID()
     {

--- a/concrete/src/Entity/Notification/UserSignupNotification.php
+++ b/concrete/src/Entity/Notification/UserSignupNotification.php
@@ -1,7 +1,7 @@
 <?php
+
 namespace Concrete\Core\Entity\Notification;
 
-use Concrete\Core\Entity\User\UserSignup;
 use Concrete\Core\Notification\Subject\SubjectInterface;
 use Concrete\Core\Notification\View\UserSignupListView;
 use Doctrine\ORM\Mapping as ORM;
@@ -14,16 +14,16 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class UserSignupNotification extends Notification
 {
-
     /**
      * @ORM\ManyToOne(targetEntity="\Concrete\Core\Entity\User\UserSignup", cascade={"persist", "remove"}, inversedBy="notifications"),
      * @ORM\JoinColumn(name="usID", referencedColumnName="usID")
+     *
+     * @var \Concrete\Core\Entity\User\UserSignup
      */
     protected $signup;
 
     /**
-     * UserSignupNotification constructor.
-     * @param $signup UserSignup
+     * @param \Concrete\Core\Entity\User\UserSignup $signup
      */
     public function __construct(SubjectInterface $signup)
     {
@@ -32,14 +32,18 @@ class UserSignupNotification extends Notification
     }
 
     /**
-     * @return mixed
+     * @return \Concrete\Core\Entity\User\UserSignup
      */
     public function getSignupRequest()
     {
         return $this->signup;
     }
 
-
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Entity\Notification\Notification::getListView()
+     */
     public function getListView()
     {
         return new UserSignupListView($this);

--- a/concrete/src/Entity/Notification/WorkflowProgressNotification.php
+++ b/concrete/src/Entity/Notification/WorkflowProgressNotification.php
@@ -1,9 +1,7 @@
 <?php
+
 namespace Concrete\Core\Entity\Notification;
 
-use Concrete\Core\Entity\User\UserSignup;
-use Concrete\Core\Notification\Subject\SubjectInterface;
-use Concrete\Core\Notification\View\UserSignupListView;
 use Concrete\Core\Notification\View\WorkflowProgressListView;
 use Concrete\Core\Workflow\Progress\Progress;
 use Concrete\Core\Workflow\Progress\SiteProgressInterface;
@@ -17,29 +15,40 @@ use Doctrine\ORM\Mapping as ORM;
  */
 class WorkflowProgressNotification extends Notification
 {
-
-    protected $progressObject;
-
     /**
      * @ORM\Column(type="integer", options={"unsigned":true})
+     *
+     * @var int
      */
     protected $wpID;
 
     /**
-     * @param $signup Progress
+     * @var \Concrete\Core\Workflow\Progress\Progress|null
      */
+    protected $progressObject;
+
     public function __construct(Progress $progress)
     {
         $this->wpID = $progress->getWorkflowProgressID();
+        $this->progressObject = $progress;
         parent::__construct($progress);
     }
 
-
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Entity\Notification\Notification::getListView()
+     */
     public function getListView()
     {
         return new WorkflowProgressListView($this);
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Entity\Notification\Notification::getNotificationDateTimeZone()
+     */
     public function getNotificationDateTimeZone()
     {
         $progress = $this->getWorkflowProgressObject();
@@ -49,15 +58,19 @@ class WorkflowProgressNotification extends Notification
                 return $site->getTimezone();
             }
         }
+
+        return null;
     }
 
+    /**
+     * @return \Concrete\Core\Workflow\Progress\Progress|null may be NULL if the progress object has been deleted
+     */
     public function getWorkflowProgressObject()
     {
-        if (!isset($this->progressObject)) {
-            $this->progressObject = Progress::getByID($this->wpID);
+        if ($this->progressObject === null) {
+            $this->progressObject = Progress::getByID($this->wpID) ?: null;
         }
+
         return $this->progressObject;
     }
-
-
 }

--- a/concrete/src/Entity/User/GroupCreate.php
+++ b/concrete/src/Entity/User/GroupCreate.php
@@ -5,6 +5,9 @@ namespace Concrete\Core\Entity\User;
 use Concrete\Core\Notification\Subject\SubjectInterface;
 use Concrete\Core\User\Group\Group;
 use Concrete\Core\User\UserInfo;
+use DateTime;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -16,124 +19,117 @@ use Doctrine\ORM\Mapping as ORM;
 class GroupCreate implements SubjectInterface
 {
     /**
-     * @var int
      * @ORM\Id
      * @ORM\Column(type="integer", options={"unsigned":true})
      * @ORM\GeneratedValue(strategy="AUTO")
+     *
+     * @var int|null NULL if not yet flushed to the database
      */
     protected $id;
 
     /**
-     * @var int
      * @ORM\OneToMany(targetEntity="\Concrete\Core\Entity\Notification\GroupCreateNotification", mappedBy="create", cascade={"remove"}),
+     *
+     * @var \Doctrine\Common\Collections\Collection
      */
     protected $notifications;
 
     /**
-     * @var int
      * @ORM\Column(type="integer", options={"unsigned":true})
+     *
+     * @var int
      */
     protected $gID;
 
     /**
-     * @var User
      * @ORM\ManyToOne(targetEntity="\Concrete\Core\Entity\User\User")
      * @ORM\JoinColumn(name="uID", referencedColumnName="uID", onDelete="SET NULL")
+     *
+     * @var \Concrete\Core\Entity\User\User|null
      */
     protected $user;
 
     /**
-     * @var \DateTime
      * @ORM\Column(type="datetime")
+     *
+     * @var \DateTime
      */
-    protected $requested = null;
+    protected $requested;
 
     /**
-     * GroupCreateRequest constructor.
-     * @param Group $group
-     * @param \Concrete\Core\User\User $user
-     * @throws \Exception
+     * @param \Concrete\Core\User\Group\Group|null $group
+     * @param \Concrete\Core\User\User|null $user
      */
     public function __construct($group = null, $user = null)
     {
+        $this->notifications = new ArrayCollection();
         if ($group instanceof Group) {
             $this->gID = $group->getGroupID();
         }
-
         if ($user instanceof \Concrete\Core\User\User) {
-            if ($user->getUserInfoObject() instanceof UserInfo) {
-                $this->user = $user->getUserInfoObject()->getEntityObject();
+            $userInfo = $user->getUserInfoObject();
+            if ($userInfo instanceof UserInfo) {
+                $this->user = $userInfo->getEntityObject();
             }
         }
-
-        $this->requested = new \DateTime();
+        $this->requested = new DateTime();
     }
 
     /**
-     * @return Group
+     * @return \Concrete\Core\User\Group\Group|null
      */
     public function getGroup()
     {
         return Group::getByID($this->getGID());
     }
 
-    /**
-     * @return int
-     */
     public function getGID(): int
     {
         return $this->gID;
     }
 
     /**
-     * @param int $gID
-     * @return GroupCreate
+     * @return $this
      */
-    public function setGID(int $gID): GroupCreate
+    public function setGID(int $gID): self
     {
         $this->gID = $gID;
+
         return $this;
     }
 
-    /**
-     * @return User
-     */
-    public function getUser(): User
+    public function getUser(): ?User
     {
         return $this->user;
     }
 
     /**
-     * @param User $user
-     * @return GroupCreate
+     * @return $this
      */
-    public function setUser(User $user): GroupCreate
+    public function setUser(User $user): self
     {
         $this->user = $user;
+
         return $this;
     }
 
-    /**
-     * @return \DateTime
-     */
-    public function getRequested(): \DateTime
+    public function getRequested(): DateTime
     {
         return $this->requested;
     }
 
     /**
-     * @param \DateTime $requested
-     * @return GroupCreate
+     * @return $this
      */
-    public function setRequested(\DateTime $requested): GroupCreate
+    public function setRequested(\DateTime $requested): self
     {
         $this->requested = $requested;
+
         return $this;
     }
 
-
     /**
-     * Get the date of this notification
+     * Get the date of this notification.
      *
      * @return \DateTime
      */
@@ -145,5 +141,13 @@ class GroupCreate implements SubjectInterface
     public function getUsersToExcludeFromNotification()
     {
         return [];
+    }
+
+    /**
+     * @return \Concrete\Core\Entity\Notification\GroupCreateNotification[]
+     */
+    public function getNotifications(): Collection
+    {
+        return $this->notifications;
     }
 }

--- a/concrete/src/Entity/User/GroupRoleChange.php
+++ b/concrete/src/Entity/User/GroupRoleChange.php
@@ -1,10 +1,14 @@
 <?php
+
 namespace Concrete\Core\Entity\User;
 
 use Concrete\Core\Notification\Subject\SubjectInterface;
 use Concrete\Core\User\Group\Group;
 use Concrete\Core\User\Group\GroupRole;
 use Concrete\Core\User\UserInfo;
+use DateTime;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -16,157 +20,151 @@ use Doctrine\ORM\Mapping as ORM;
 class GroupRoleChange implements SubjectInterface
 {
     /**
-     * @var int
      * @ORM\Id
      * @ORM\Column(type="integer", options={"unsigned":true})
      * @ORM\GeneratedValue(strategy="AUTO")
+     *
+     * @var int|null NULL if not yet flushed to the database
      */
     protected $id;
 
     /**
-     * @var int
      * @ORM\OneToMany(targetEntity="\Concrete\Core\Entity\Notification\GroupRoleChangeNotification", mappedBy="signup", cascade={"remove"}),
+     *
+     * @var \Doctrine\Common\Collections\Collection
      */
     protected $notifications;
 
     /**
-     * @var int
      * @ORM\Column(type="integer", options={"unsigned":true})
+     *
+     * @var int
      */
     protected $gID;
 
     /**
-     * @var int
      * @ORM\Column(type="integer", options={"unsigned":true})
+     *
+     * @var int
      */
     protected $grID;
 
     /**
-     * @var User
      * @ORM\ManyToOne(targetEntity="\Concrete\Core\Entity\User\User")
      * @ORM\JoinColumn(name="uID", referencedColumnName="uID", onDelete="SET NULL")
+     *
+     * @var \Concrete\Core\Entity\User\User|null
      */
     protected $user;
 
     /**
-     * @var \DateTime
      * @ORM\Column(type="datetime")
+     *
+     * @var \DateTime
      */
-    protected $requested = null;
+    protected $requested;
 
     /**
-     * GroupSignupRequest constructor.
-     * @param Group $group
-     * @param \Concrete\Core\User\User $user
-     * @param GroupRole $role
-     * @throws \Exception
+     * @param \Concrete\Core\User\Group\Group|null $group
+     * @param \Concrete\Core\User\User|null $user
+     * @param \Concrete\Core\User\Group\GroupRole|null $role
      */
     public function __construct($group = null, $user = null, $role = null)
     {
+        $this->notifications = new ArrayCollection();
         if ($group instanceof Group) {
             $this->gID = $group->getGroupID();
         }
-
         if ($user instanceof \Concrete\Core\User\User) {
-            if ($user->getUserInfoObject() instanceof UserInfo) {
-                $this->user = $user->getUserInfoObject()->getEntityObject();
+            $userInfo = $user->getUserInfoObject();
+            if ($userInfo instanceof UserInfo) {
+                $this->user = $userInfo->getEntityObject();
             }
         }
-
         if ($role instanceof GroupRole) {
             $this->grID = $role->getId();
         }
-
-        $this->requested = new \DateTime();
+        $this->requested = new DateTime();
     }
 
     /**
-     * @return Group
+     * @return \Concrete\Core\User\Group\Group|null
      */
     public function getGroup()
     {
         return Group::getByID($this->getGID());
     }
 
-    public function getRole() {
+    /**
+     * @return \Concrete\Core\User\Group\GroupRole|false
+     */
+    public function getRole()
+    {
         return GroupRole::getByID($this->getGrID());
     }
 
-    /**
-     * @return int
-     */
     public function getGID(): int
     {
         return $this->gID;
     }
 
     /**
-     * @param int $gID
-     * @return GroupSignup
+     * @return $this
      */
-    public function setGID(int $gID): GroupSignup
+    public function setGID(int $gID): self
     {
         $this->gID = $gID;
+
         return $this;
     }
 
-    /**
-     * @return int
-     */
     public function getGrID(): int
     {
         return $this->grID;
     }
 
     /**
-     * @param int $grID
-     * @return GroupRoleChange
+     * @return $this
      */
-    public function setGrID(int $grID): GroupRoleChange
+    public function setGrID(int $grID): self
     {
         $this->grID = $grID;
+
         return $this;
     }
 
-    /**
-     * @return User
-     */
-    public function getUser(): User
+    public function getUser(): ?User
     {
         return $this->user;
     }
 
     /**
-     * @param User $user
-     * @return GroupSignup
+     * @return $this
      */
-    public function setUser(User $user): GroupSignup
+    public function setUser(User $user): self
     {
         $this->user = $user;
+
         return $this;
     }
 
-    /**
-     * @return \DateTime
-     */
-    public function getRequested(): \DateTime
+    public function getRequested(): DateTime
     {
         return $this->requested;
     }
 
     /**
-     * @param \DateTime $requested
-     * @return GroupSignup
+     * @return $this
      */
-    public function setRequested(\DateTime $requested): GroupSignup
+    public function setRequested(DateTime $requested): self
     {
         $this->requested = $requested;
+
         return $this;
     }
 
-
     /**
-     * Get the date of this notification
+     * Get the date of this notification.
      *
      * @return \DateTime
      */
@@ -178,5 +176,13 @@ class GroupRoleChange implements SubjectInterface
     public function getUsersToExcludeFromNotification()
     {
         return [];
+    }
+
+    /**
+     * @return \Concrete\Core\Entity\Notification\GroupRoleChangeNotification[]
+     */
+    public function getNotifications(): Collection
+    {
+        return $this->notifications;
     }
 }

--- a/concrete/src/Entity/User/GroupSignup.php
+++ b/concrete/src/Entity/User/GroupSignup.php
@@ -5,6 +5,9 @@ namespace Concrete\Core\Entity\User;
 use Concrete\Core\Notification\Subject\SubjectInterface;
 use Concrete\Core\User\Group\Group;
 use Concrete\Core\User\UserInfo;
+use DateTime;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -16,124 +19,116 @@ use Doctrine\ORM\Mapping as ORM;
 class GroupSignup implements SubjectInterface
 {
     /**
-     * @var int
      * @ORM\Id
      * @ORM\Column(type="integer", options={"unsigned":true})
      * @ORM\GeneratedValue(strategy="AUTO")
+     *
+     * @var int|null NULL if not yet flushed to the database
      */
     protected $id;
 
     /**
-     * @var int
      * @ORM\OneToMany(targetEntity="\Concrete\Core\Entity\Notification\GroupSignupNotification", mappedBy="signup", cascade={"remove"}),
+     *
+     * @var \Doctrine\Common\Collections\Collection
      */
     protected $notifications;
 
     /**
-     * @var int
      * @ORM\Column(type="integer", options={"unsigned":true})
+     *
+     * @var int
      */
     protected $gID;
 
     /**
-     * @var User
      * @ORM\ManyToOne(targetEntity="\Concrete\Core\Entity\User\User")
      * @ORM\JoinColumn(name="uID", referencedColumnName="uID", onDelete="SET NULL")
+     *
+     * @var \Concrete\Core\Entity\User\User|null
      */
     protected $user;
 
     /**
-     * @var \DateTime
      * @ORM\Column(type="datetime")
+     *
+     * @var \DateTime
      */
-    protected $requested = null;
+    protected $requested;
 
     /**
-     * GroupSignupRequest constructor.
-     * @param Group $group
-     * @param \Concrete\Core\User\User $user
-     * @throws \Exception
+     * @param \Concrete\Core\User\Group\Group|null $group
+     * @param \Concrete\Core\User\User|null $user
      */
     public function __construct($group = null, $user = null)
     {
+        $this->notifications = new ArrayCollection();
         if ($group instanceof Group) {
             $this->gID = $group->getGroupID();
         }
-
         if ($user instanceof \Concrete\Core\User\User) {
             if ($user->getUserInfoObject() instanceof UserInfo) {
                 $this->user = $user->getUserInfoObject()->getEntityObject();
             }
         }
-
-        $this->requested = new \DateTime();
+        $this->requested = new DateTime();
     }
 
     /**
-     * @return Group
+     * @return \Concrete\Core\User\Group\Group|null
      */
     public function getGroup()
     {
         return Group::getByID($this->getGID());
     }
 
-    /**
-     * @return int
-     */
     public function getGID(): int
     {
         return $this->gID;
     }
 
     /**
-     * @param int $gID
-     * @return GroupSignup
+     * @return $this
      */
-    public function setGID(int $gID): GroupSignup
+    public function setGID(int $gID): self
     {
         $this->gID = $gID;
+
         return $this;
     }
 
-    /**
-     * @return User
-     */
-    public function getUser(): User
+    public function getUser(): ?User
     {
         return $this->user;
     }
 
     /**
-     * @param User $user
-     * @return GroupSignup
+     * @return $this
      */
-    public function setUser(User $user): GroupSignup
+    public function setUser(User $user): self
     {
         $this->user = $user;
+
         return $this;
     }
 
-    /**
-     * @return \DateTime
-     */
-    public function getRequested(): \DateTime
+    public function getRequested(): DateTime
     {
         return $this->requested;
     }
 
     /**
-     * @param \DateTime $requested
-     * @return GroupSignup
+     * @return $this
      */
-    public function setRequested(\DateTime $requested): GroupSignup
+    public function setRequested(\DateTime $requested): self
     {
         $this->requested = $requested;
+
         return $this;
     }
 
-
     /**
-     * Get the date of this notification
+     * Get the date of this notification.
      *
      * @return \DateTime
      */
@@ -145,5 +140,13 @@ class GroupSignup implements SubjectInterface
     public function getUsersToExcludeFromNotification()
     {
         return [];
+    }
+
+    /**
+     * @return \Concrete\Core\Entity\Notification\GroupSignupNotification[]
+     */
+    public function getNotifications(): Collection
+    {
+        return $this->notifications;
     }
 }

--- a/concrete/src/Entity/User/GroupSignupRequest.php
+++ b/concrete/src/Entity/User/GroupSignupRequest.php
@@ -1,74 +1,81 @@
 <?php
+
 namespace Concrete\Core\Entity\User;
 
 use Concrete\Core\Notification\Subject\SubjectInterface;
 use Concrete\Core\User\Group\Group;
 use Concrete\Core\User\UserInfo;
+use DateTime;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
-* @ORM\Entity
-* @ORM\Table(
-*     name="GroupSignupRequests"
-* )
-*/
+ * @ORM\Entity
+ * @ORM\Table(
+ *     name="GroupSignupRequests"
+ * )
+ */
 class GroupSignupRequest implements SubjectInterface
 {
     /**
-     * @var int
      * @ORM\Id
      * @ORM\Column(type="integer", options={"unsigned":true})
      * @ORM\GeneratedValue(strategy="AUTO")
+     *
+     * @var int|null NULL if not yet flushed to the database
      */
     protected $id;
 
     /**
      * @ORM\OneToMany(targetEntity="\Concrete\Core\Entity\Notification\GroupSignupRequestNotification", mappedBy="signup", cascade={"remove"}),
+     *
+     * @var \Doctrine\Common\Collections\Collection
      */
     protected $notifications;
 
     /**
-     * @var int
      * @ORM\Column(type="integer", options={"unsigned":true})
+     *
+     * @var int
      */
     protected $gID;
 
     /**
-     * @var User
      * @ORM\ManyToOne(targetEntity="\Concrete\Core\Entity\User\User")
      * @ORM\JoinColumn(name="uID", referencedColumnName="uID", onDelete="SET NULL")
+     *
+     * @var \Concrete\Core\Entity\User\User|null
      */
     protected $user;
 
     /**
-     * @var \DateTime
      * @ORM\Column(type="datetime")
+     *
+     * @var \DateTime
      */
-    protected $requested = null;
+    protected $requested;
 
     /**
-     * GroupSignupRequest constructor.
-     * @param Group $group
+     * @param \Concrete\Core\User\Group\Group|null $group
      * @param \Concrete\Core\User\User $user
-     * @throws \Exception
      */
     public function __construct($group = null, $user = null)
     {
+        $this->notifications = new ArrayCollection();
         if ($group instanceof Group) {
             $this->gID = $group->getGroupID();
         }
-
         if ($user instanceof \Concrete\Core\User\User) {
             if ($user->getUserInfoObject() instanceof UserInfo) {
                 $this->user = $user->getUserInfoObject()->getEntityObject();
             }
         }
-
-        $this->requested = new \DateTime();
+        $this->requested = new DateTime();
     }
 
     /**
-     * @return Group
+     * @return \Concrete\Core\User\Group\Group|null
      */
     public function getGroup()
     {
@@ -76,20 +83,20 @@ class GroupSignupRequest implements SubjectInterface
     }
 
     /**
-     * @return int
+     * @return int|null return NULL if not yet flushed to the database
      */
-    public function getId(): int
+    public function getId(): ?int
     {
         return $this->id;
     }
 
     /**
-     * @param int $id
-     * @return GroupSignupRequest
+     * @return $this
      */
-    public function setId(int $id): GroupSignupRequest
+    public function setId(?int $id): self
     {
         $this->id = $id;
+
         return $this;
     }
 
@@ -102,53 +109,47 @@ class GroupSignupRequest implements SubjectInterface
     }
 
     /**
-     * @param int $gID
-     * @return GroupSignupRequest
+     * @return $this
      */
-    public function setGID(int $gID): GroupSignupRequest
+    public function setGID(int $gID): self
     {
         $this->gID = $gID;
+
         return $this;
     }
 
-    /**
-     * @return User
-     */
-    public function getUser(): User
+    public function getUser(): ?User
     {
         return $this->user;
     }
 
     /**
-     * @param User $user
-     * @return GroupSignupRequest
+     * @return $this
      */
-    public function setUser(User $user): GroupSignupRequest
+    public function setUser(User $user): self
     {
         $this->user = $user;
+
         return $this;
     }
 
-    /**
-     * @return \DateTime
-     */
-    public function getRequested(): \DateTime
+    public function getRequested(): DateTime
     {
         return $this->requested;
     }
 
     /**
-     * @param \DateTime $requested
-     * @return GroupSignupRequest
+     * @return $this
      */
-    public function setRequested(\DateTime $requested): GroupSignupRequest
+    public function setRequested(DateTime $requested): self
     {
         $this->requested = $requested;
+
         return $this;
     }
 
     /**
-     * Get the date of this notification
+     * Get the date of this notification.
      *
      * @return \DateTime
      */
@@ -160,5 +161,13 @@ class GroupSignupRequest implements SubjectInterface
     public function getUsersToExcludeFromNotification()
     {
         return [];
+    }
+
+    /**
+     * @return \Concrete\Core\Entity\Notification\GroupSignupRequestNotification[]
+     */
+    public function getNotifications(): Collection
+    {
+        return $this->notifications;
     }
 }

--- a/concrete/src/Entity/User/GroupSignupRequestAccept.php
+++ b/concrete/src/Entity/User/GroupSignupRequestAccept.php
@@ -1,9 +1,13 @@
 <?php
+
 namespace Concrete\Core\Entity\User;
 
 use Concrete\Core\Notification\Subject\SubjectInterface;
 use Concrete\Core\User\Group\Group;
 use Concrete\Core\User\UserInfo;
+use DateTime;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -15,90 +19,94 @@ use Doctrine\ORM\Mapping as ORM;
 class GroupSignupRequestAccept implements SubjectInterface
 {
     /**
-     * @var int
      * @ORM\Id
      * @ORM\Column(type="integer", options={"unsigned":true})
      * @ORM\GeneratedValue(strategy="AUTO")
+     *
+     * @var int|null NULL if not yet flushed to the database
      */
     protected $id;
 
     /**
      * @ORM\OneToMany(targetEntity="\Concrete\Core\Entity\Notification\GroupSignupRequestAcceptNotification", mappedBy="signup", cascade={"remove"}),
+     *
+     * @var \Doctrine\Common\Collections\Collection
      */
     protected $notifications;
 
     /**
-     * @var int
      * @ORM\Column(type="integer", options={"unsigned":true})
+     *
+     * @var int
      */
     protected $gID;
 
     /**
-     * @var User
      * @ORM\ManyToOne(targetEntity="\Concrete\Core\Entity\User\User")
      * @ORM\JoinColumn(name="uID", referencedColumnName="uID", onDelete="SET NULL")
+     *
+     * @var \Concrete\Core\Entity\User\User|null
      */
     protected $user;
 
     /**
-     * @var User
      * @ORM\ManyToOne(targetEntity="\Concrete\Core\Entity\User\User")
      * @ORM\JoinColumn(name="managerUID", referencedColumnName="uID", onDelete="SET NULL")
+     *
+     * @var \Concrete\Core\Entity\User\User|null
      */
     protected $manager;
 
     /**
-     * @var \DateTime
      * @ORM\Column(type="datetime")
+     *
+     * @var \DateTime
      */
-    protected $RequestAccepted = null;
+    protected $RequestAccepted;
 
     /**
-     * GroupSignupRequestAccept constructor.
-     * @param Group $group
-     * @param \Concrete\Core\User\User $user
-     * @param \Concrete\Core\User\User $manager
-     * @throws \Exception
+     * @param \Concrete\Core\User\Group\Group|null $group
+     * @param \Concrete\Core\User\User|null $user
+     * @param \Concrete\Core\User\User|null $manager
      */
     public function __construct($group = null, $user = null, $manager = null)
     {
+        $this->notifications = new ArrayCollection();
         if ($group instanceof Group) {
             $this->gID = $group->getGroupID();
         }
-
         if ($user instanceof \Concrete\Core\User\User) {
-            if ($user->getUserInfoObject() instanceof UserInfo) {
-                $this->user = $user->getUserInfoObject()->getEntityObject();
+            $userInfo = $user->getUserInfoObject();
+            if ($userInfo instanceof UserInfo) {
+                $this->user = $userInfo->getEntityObject();
             }
         }
-
         if ($manager instanceof \Concrete\Core\User\User) {
-            $this->manager = $user->getUserInfoObject()->getEntityObject();
+            $userInfo = $manager->getUserInfoObject();
+            if ($userInfo instanceof UserInfo) {
+                $this->manager = $userInfo->getEntityObject();
+            }
         }
-
-        $this->RequestAccepted = new \DateTime();
+        $this->RequestAccepted = new DateTime();
     }
 
-    /**
-     * @return User
-     */
-    public function getManager(): User
+    public function getManager(): ?User
     {
         return $this->manager;
     }
 
     /**
-     * @param User $manager
-     * @return GroupSignupRequestAccept
+     * @return $this
      */
-    public function setManager(User $manager): GroupSignupRequestAccept
+    public function setManager(User $manager): self
     {
         $this->manager = $manager;
+
         return $this;
     }
 
     /**
-     * @return Group
+     * @return \Concrete\Core\User\Group\Group|null
      */
     public function getGroup()
     {
@@ -106,79 +114,70 @@ class GroupSignupRequestAccept implements SubjectInterface
     }
 
     /**
-     * @return int
+     * @return int|null return NULL if not yet flushed to the database
      */
-    public function getId(): int
+    public function getId(): ?int
     {
         return $this->id;
     }
 
     /**
-     * @param int $id
-     * @return GroupSignupRequestAccept
+     * @return $this
      */
-    public function setId(int $id): GroupSignupRequestAccept
+    public function setId(?int $id): self
     {
         $this->id = $id;
+
         return $this;
     }
 
-    /**
-     * @return int
-     */
     public function getGID(): int
     {
         return $this->gID;
     }
 
     /**
-     * @param int $gID
-     * @return GroupSignupRequestAccept
+     * @return $this
      */
-    public function setGID(int $gID): GroupSignupRequestAccept
+    public function setGID(int $gID): self
     {
         $this->gID = $gID;
+
         return $this;
     }
 
-    /**
-     * @return User
-     */
-    public function getUser(): User
+    public function getUser(): ?User
     {
         return $this->user;
     }
 
     /**
-     * @param User $user
-     * @return GroupSignupRequestAccept
+     * @return $this
      */
-    public function setUser(User $user): GroupSignupRequestAccept
+    public function setUser(User $user): self
     {
         $this->user = $user;
+
         return $this;
     }
 
-    /**
-     * @return \DateTime
-     */
-    public function getRequestAccepted(): \DateTime
+    public function getRequestAccepted(): DateTime
     {
         return $this->RequestAccepted;
     }
 
     /**
-     * @param \DateTime $RequestAccepted
-     * @return GroupSignupRequestAccept
+     * @return $this
      */
-    public function setRequestAccepted(\DateTime $RequestAccepted): GroupSignupRequestAccept
+    public function setRequestAccepted(DateTime $RequestAccepted): self
     {
         $this->RequestAccepted = $RequestAccepted;
+
         return $this;
     }
 
     /**
-     * Get the date of this notification
+     * Get the date of this notification.
      *
      * @return \DateTime
      */
@@ -190,5 +189,13 @@ class GroupSignupRequestAccept implements SubjectInterface
     public function getUsersToExcludeFromNotification()
     {
         return [];
+    }
+
+    /**
+     * @return \Concrete\Core\Entity\Notification\GroupSignupRequestAcceptNotification[]
+     */
+    public function getNotifications(): Collection
+    {
+        return $this->notifications;
     }
 }

--- a/concrete/src/Entity/User/GroupSignupRequestDecline.php
+++ b/concrete/src/Entity/User/GroupSignupRequestDecline.php
@@ -1,9 +1,13 @@
 <?php
+
 namespace Concrete\Core\Entity\User;
 
 use Concrete\Core\Notification\Subject\SubjectInterface;
 use Concrete\Core\User\Group\Group;
 use Concrete\Core\User\UserInfo;
+use DateTime;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -15,90 +19,94 @@ use Doctrine\ORM\Mapping as ORM;
 class GroupSignupRequestDecline implements SubjectInterface
 {
     /**
-     * @var int
      * @ORM\Id
      * @ORM\Column(type="integer", options={"unsigned":true})
      * @ORM\GeneratedValue(strategy="AUTO")
+     *
+     * @var int|null NULL if not yet flushed to the database
      */
     protected $id;
 
     /**
      * @ORM\OneToMany(targetEntity="\Concrete\Core\Entity\Notification\GroupSignupRequestDeclineNotification", mappedBy="signup", cascade={"remove"}),
+     *
+     * @var \Doctrine\Common\Collections\Collection
      */
     protected $notifications;
 
     /**
-     * @var int
      * @ORM\Column(type="integer", options={"unsigned":true})
+     *
+     * @var int
      */
     protected $gID;
 
     /**
-     * @var User
      * @ORM\ManyToOne(targetEntity="\Concrete\Core\Entity\User\User")
      * @ORM\JoinColumn(name="uID", referencedColumnName="uID", onDelete="SET NULL")
+     *
+     * @var \Concrete\Core\Entity\User\User|null
      */
     protected $user;
 
     /**
-     * @var User
      * @ORM\ManyToOne(targetEntity="\Concrete\Core\Entity\User\User")
      * @ORM\JoinColumn(name="managerUID", referencedColumnName="uID", onDelete="SET NULL")
+     *
+     * @var \Concrete\Core\Entity\User\User|null
      */
     protected $manager;
 
     /**
-     * @var \DateTime
      * @ORM\Column(type="datetime")
+     *
+     * @var \DateTime
      */
-    protected $RequestDeclineed = null;
+    protected $RequestDeclineed;
 
     /**
-     * GroupSignupRequestDecline constructor.
-     * @param Group $group
-     * @param \Concrete\Core\User\User $user
-     * @param \Concrete\Core\User\User $manager
-     * @throws \Exception
+     * @param \Concrete\Core\User\Group\Group|null $group
+     * @param \Concrete\Core\User\User|null $user
+     * @param \Concrete\Core\User\User|null $manager
      */
     public function __construct($group = null, $user = null, $manager = null)
     {
+        $this->notifications = new ArrayCollection();
         if ($group instanceof Group) {
             $this->gID = $group->getGroupID();
         }
-
         if ($user instanceof \Concrete\Core\User\User) {
-            if ($user->getUserInfoObject() instanceof UserInfo) {
-                $this->user = $user->getUserInfoObject()->getEntityObject();
+            $userInfo = $user->getUserInfoObject();
+            if ($userInfo instanceof UserInfo) {
+                $this->user = $userInfo->getEntityObject();
             }
         }
-
         if ($manager instanceof \Concrete\Core\User\User) {
-            $this->manager = $user->getUserInfoObject()->getEntityObject();
+            $userInfo = $manager->getUserInfoObject();
+            if ($userInfo instanceof UserInfo) {
+                $this->manager = $userInfo->getEntityObject();
+            }
         }
-
-        $this->RequestDeclineed = new \DateTime();
+        $this->RequestDeclineed = new DateTime();
     }
 
-    /**
-     * @return User
-     */
-    public function getManager(): User
+    public function getManager(): ?User
     {
         return $this->manager;
     }
 
     /**
-     * @param User $manager
-     * @return GroupSignupRequestDecline
+     * @return $this
      */
-    public function setManager(User $manager): GroupSignupRequestDecline
+    public function setManager(User $manager): self
     {
         $this->manager = $manager;
+
         return $this;
     }
 
     /**
-     * @return Group
+     * @return \Concrete\Core\User\Group\Group|null
      */
     public function getGroup()
     {
@@ -106,79 +114,70 @@ class GroupSignupRequestDecline implements SubjectInterface
     }
 
     /**
-     * @return int
+     * @return int|null return NULL if not yet flushed to the database
      */
-    public function getId(): int
+    public function getId(): ?int
     {
         return $this->id;
     }
 
     /**
-     * @param int $id
-     * @return GroupSignupRequestDecline
+     * @return $this
      */
-    public function setId(int $id): GroupSignupRequestDecline
+    public function setId(?int $id): self
     {
         $this->id = $id;
+
         return $this;
     }
 
-    /**
-     * @return int
-     */
     public function getGID(): int
     {
         return $this->gID;
     }
 
     /**
-     * @param int $gID
-     * @return GroupSignupRequestDecline
+     * @return $this
      */
-    public function setGID(int $gID): GroupSignupRequestDecline
+    public function setGID(int $gID): self
     {
         $this->gID = $gID;
+
         return $this;
     }
 
-    /**
-     * @return User
-     */
-    public function getUser(): User
+    public function getUser(): ?User
     {
         return $this->user;
     }
 
     /**
-     * @param User $user
-     * @return GroupSignupRequestDecline
+     * @return $this
      */
-    public function setUser(User $user): GroupSignupRequestDecline
+    public function setUser(User $user): self
     {
         $this->user = $user;
+
         return $this;
     }
 
-    /**
-     * @return \DateTime
-     */
-    public function getRequestDeclineed(): \DateTime
+    public function getRequestDeclineed(): DateTime
     {
         return $this->RequestDeclineed;
     }
 
     /**
-     * @param \DateTime $RequestDeclineed
-     * @return GroupSignupRequestDecline
+     * @return $this
      */
-    public function setRequestDeclineed(\DateTime $RequestDeclineed): GroupSignupRequestDecline
+    public function setRequestDeclineed(DateTime $RequestDeclineed): self
     {
         $this->RequestDeclineed = $RequestDeclineed;
+
         return $this;
     }
 
     /**
-     * Get the date of this notification
+     * Get the date of this notification.
      *
      * @return \DateTime
      */
@@ -190,5 +189,13 @@ class GroupSignupRequestDecline implements SubjectInterface
     public function getUsersToExcludeFromNotification()
     {
         return [];
+    }
+
+    /**
+     * @return \Concrete\Core\Entity\Notification\GroupSignupRequestDeclineNotification[]
+     */
+    public function getNotifications(): Collection
+    {
+        return $this->notifications;
     }
 }

--- a/concrete/src/Entity/User/User.php
+++ b/concrete/src/Entity/User/User.php
@@ -1,6 +1,8 @@
 <?php
 namespace Concrete\Core\Entity\User;
 
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use League\OAuth2\Server\Entities\UserEntityInterface;
 
@@ -24,6 +26,8 @@ class User implements UserEntityInterface, \JsonSerializable
     /**
      * @ORM\OneToMany(targetEntity="\Concrete\Core\Entity\Notification\NotificationAlert", cascade={"remove"}, mappedBy="user")
      * @ORM\JoinColumn(name="uID", referencedColumnName="uID")
+     *
+     * @var \Doctrine\Common\Collections\Collection
      */
     protected $alerts;
 
@@ -142,6 +146,7 @@ class User implements UserEntityInterface, \JsonSerializable
 
     public function __construct()
     {
+        $this->alerts = new ArrayCollection();
         $this->uLastPasswordChange = new \DateTime();
         $this->uDateLastUpdated = new \DateTime();
         $this->uDateAdded = new \DateTime();
@@ -524,5 +529,13 @@ class User implements UserEntityInterface, \JsonSerializable
             'name' => $this->getUserName(),
             'email' => $this->getUserEmail(),
         ];
+    }
+
+    /**
+     * @return \Concrete\Core\Entity\Notification\NotificationAlert[]
+     */
+    public function getAlerts(): Collection
+    {
+        return $this->alerts;
     }
 }

--- a/concrete/src/Entity/User/UserSignup.php
+++ b/concrete/src/Entity/User/UserSignup.php
@@ -1,7 +1,10 @@
 <?php
+
 namespace Concrete\Core\Entity\User;
 
 use Concrete\Core\Notification\Subject\SubjectInterface;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -13,36 +16,46 @@ use Doctrine\ORM\Mapping as ORM;
 class UserSignup implements SubjectInterface
 {
     /**
-     * @ORM\Id @ORM\Column(type="integer", options={"unsigned":true})
+     * @ORM\Id
+     * @ORM\Column(type="integer", options={"unsigned":true})
      * @ORM\GeneratedValue(strategy="AUTO")
+     *
+     * @var int|null NULL if not yet flushed to the database
      */
     protected $usID;
 
     /**
      * @ORM\OneToOne(targetEntity="\Concrete\Core\Entity\User\User", inversedBy="signup"),
      * @ORM\JoinColumn(name="uID", referencedColumnName="uID")
+     *
+     * @var \Concrete\Core\Entity\User\User
      */
     protected $user;
 
     /**
      * @ORM\OneToMany(targetEntity="\Concrete\Core\Entity\Notification\UserSignupNotification", mappedBy="signup", cascade={"remove"}),
+     *
+     * @var \Doctrine\Common\Collections\Collection
      */
     protected $notifications;
 
     /**
      * @ORM\ManyToOne(targetEntity="\Concrete\Core\Entity\User\User"),
      * @ORM\JoinColumn(name="createdBy", referencedColumnName="uID")
+     *
+     * @var \Concrete\Core\Entity\User\User|null
      */
     protected $createdBy;
 
-    public function __construct(User $user, User $createdBy = null)
+    public function __construct(User $user, ?User $createdBy = null)
     {
         $this->user = $user;
         $this->createdBy = $createdBy;
+        $this->notifications = new ArrayCollection();
     }
 
     /**
-     * @return User
+     * @return \Concrete\Core\Entity\User\User
      */
     public function getUser()
     {
@@ -58,25 +71,33 @@ class UserSignup implements SubjectInterface
     }
 
     /**
-     * @return User|null
+     * @return \Concrete\Core\Entity\User\User|null
      */
     public function getCreatedBy()
     {
         return $this->createdBy;
     }
 
-    /**
-     * @param User $user
-     */
-    public function setCreatedBy(User $user) {
+    public function setCreatedBy(User $user)
+    {
         $this->createdBy = $user;
     }
 
     /**
-     * @return array|User[]
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Notification\Subject\SubjectInterface::getUsersToExcludeFromNotification()
      */
     public function getUsersToExcludeFromNotification()
     {
         return is_object($this->createdBy) ? [$this->createdBy] : [];
+    }
+
+    /**
+     * @return \Concrete\Core\Entity\Notification\UserSignupNotification[]
+     */
+    public function getNotifications(): Collection
+    {
+        return $this->notifications;
     }
 }

--- a/concrete/src/Notification/Notifier/StandardNotifier.php
+++ b/concrete/src/Notification/Notifier/StandardNotifier.php
@@ -93,6 +93,7 @@ class StandardNotifier implements NotifierInterface
             $alert = new NotificationAlert();
             $alert->setUser($user->getEntityObject());
             $alert->setNotification($notification);
+            $notification->getAlerts()->add($alert);
             $this->entityManager->persist($alert);
         }
 

--- a/concrete/src/User/Group/Command/AddGroupCommandHandler.php
+++ b/concrete/src/User/Group/Command/AddGroupCommandHandler.php
@@ -94,6 +94,7 @@ class AddGroupCommandHandler
                 $subscription = $type->getSubscription($subject);
                 $users = $notifier->getUsersToNotify($subscription, $subject);
                 $notification = new GroupCreateNotification($subject);
+                $subject->getNotifications()->add($notification);
                 $notifier->notify($users, $notification);
             }
         }

--- a/concrete/src/User/Group/Group.php
+++ b/concrete/src/User/Group/Group.php
@@ -261,6 +261,7 @@ class Group extends ConcreteObject implements \Concrete\Core\Permission\ObjectIn
                 $subscription = $type->getSubscription($subject);
                 $users = $notifier->getUsersToNotify($subscription, $subject);
                 $notification = new GroupSignupRequestNotification($subject);
+                $subject->getNotifications()->add($notification);
                 $notifier->notify($users, $notification);
             }
 

--- a/concrete/src/User/Group/Group.php
+++ b/concrete/src/User/Group/Group.php
@@ -220,6 +220,7 @@ class Group extends ConcreteObject implements \Concrete\Core\Permission\ObjectIn
                     $subscription = $type->getSubscription($subject);
                     $users = $notifier->getUsersToNotify($subscription, $subject);
                     $notification = new GroupRoleChangeNotification($subject);
+                    $subject->getNotifications()->add($notification);
                     $notifier->notify($users, $notification);
                 }
 

--- a/concrete/src/User/Group/GroupJoinRequest.php
+++ b/concrete/src/User/Group/GroupJoinRequest.php
@@ -68,6 +68,7 @@ class GroupJoinRequest extends ConcreteObject implements SubjectInterface
                 $subscription = $type->getSubscription($subject);
                 $users = $notifier->getUsersToNotify($subscription, $subject);
                 $notification = new GroupSignupRequestAcceptNotification($subject);
+                $subject->getNotifications()->add($notification);
                 $notifier->notify($users, $notification);
             }
 

--- a/concrete/src/User/Group/GroupJoinRequest.php
+++ b/concrete/src/User/Group/GroupJoinRequest.php
@@ -97,6 +97,7 @@ class GroupJoinRequest extends ConcreteObject implements SubjectInterface
                 $subscription = $type->getSubscription($subject);
                 $users = $notifier->getUsersToNotify($subscription, $subject);
                 $notification = new GroupSignupRequestDeclineNotification($subject);
+                $subject->getNotifications()->add($notification);
                 $notifier->notify($users, $notification);
             }
 

--- a/concrete/src/User/RegistrationService.php
+++ b/concrete/src/User/RegistrationService.php
@@ -149,6 +149,7 @@ class RegistrationService implements RegistrationServiceInterface
             $subscription = $type->getSubscription($signup);
             $notified = $notifier->getUsersToNotify($subscription, $signup);
             $notification = $type->createNotification($signup);
+            $signup->getNotifications()->add($notification);
             $notifier->notify($notified, $notification);
         }
 

--- a/concrete/src/User/User.php
+++ b/concrete/src/User/User.php
@@ -793,6 +793,7 @@ class User extends ConcreteObject
                     $subscription = $type->getSubscription($subject);
                     $users = $notifier->getUsersToNotify($subscription, $subject);
                     $notification = new GroupSignupNotification($subject);
+                    $subject->getNotifications()->add($notification);
                     $notifier->notify($users, $notification);
                 }
             }


### PR DESCRIPTION
Consider this code:

```php
$app = app();
$command = (new Concrete\Core\User\Group\Command\AddGroupCommand())->setName('Test');
$group = $app->executeCommand($command);
echo "Group: {$group->getGroupPath()} (ID={$group->getGroupID()})\n";

$user = Concrete\Core\User\User::getByUserID(USER_SUPER_ID);
$user->enterGroup($group);
echo $user->inGroup($group) ? "User correctly entered group.\n" : "User didn't enter the group!\n";

$command = new Concrete\Core\User\Group\Command\DeleteGroupCommand($group->getGroupID());
$deleted = $app->executeCommand($command);
echo $deleted === false ? "Not deleted.\n" : "Deleted\n";
```

At the moment it fails with the following output:

```sh
Group: /Test (ID=4)
User correctly entered group.

In HandleMessageMiddleware.php line 128:

  Handling "Concrete\Core\User\Group\Command\DeleteGroupCommand" failed: An exception occurred while executing 'DELETE FROM GroupSignups WHERE id = ?' with params [1]:

  SQLSTATE[23000]: Integrity constraint violation: 1451 Cannot delete or update a parent row: a foreign key constraint fails (`c5`.`GroupSignupNotifications`, CONSTRAINT `FK_77F3EABF396750` FOREIGN KEY (`id
  `) REFERENCES `GroupSignups` (`id`))
```

The reason?
Concrete creates a new GroupSignup instance without initializing its notifications property.
So, when we delete the group, Doctrine would like to remove the GroupSignup instance and its child notifications.
But since the notifications property isn't initialized, the GroupSignupNotifications records aren't deleted by Doctrine (and MySQL complains about orphaned records).
This issue doesn't occur when we load GroupSignup instances from the DB, since Doctrine correctly initialize the notifications field.

The solution?
When we create GroupSignup instances on our own, we need to correctly configure its notifications.

PS: this also occurs in some other places. I *think* in this PR I fixed all of them.