### PR TITLE
Clear tree/node request cache when deleting a group

### DIFF
--- a/concrete/src/User/Group/Command/DeleteGroupCommandHandler.php
+++ b/concrete/src/User/Group/Command/DeleteGroupCommandHandler.php
@@ -2,6 +2,7 @@
 
 namespace Concrete\Core\User\Group\Command;
 
+use Concrete\Core\Cache\Level\RequestCache;
 use Concrete\Core\Database\Connection\Connection;
 use Concrete\Core\Entity\User\GroupCreate;
 use Concrete\Core\Entity\User\GroupSignup;
@@ -36,17 +37,24 @@ class DeleteGroupCommandHandler
      */
     protected $entityManager;
 
+    /**
+     * @var \Concrete\Core\Cache\Level\RequestCache
+     */
+    protected $requestCache;
+
     public function __construct(
         GroupRepository $groupRepository,
         Connection $connection,
         EventDispatcher $dispatcher,
-        EntityManager  $entityManager
+        EntityManager  $entityManager,
+        RequestCache $requestCache
     )
     {
         $this->groupRepository = $groupRepository;
         $this->connection = $connection;
         $this->dispatcher = $dispatcher;
         $this->entityManager = $entityManager;
+        $this->requestCache = $requestCache;
     }
 
     public function __invoke(DeleteGroupCommand $command)
@@ -108,6 +116,7 @@ class DeleteGroupCommandHandler
         $this->connection->query('DELETE FROM UserGroups WHERE gID = ?', [intval($groupID)]);
         $this->connection->query('DELETE FROM ' . $table . ' WHERE gID = ?', [(int) $groupID]);
         $this->connection->query('delete from GroupSelectedRoles where gID = ?', [(int) $groupID]);
+        $this->requestCache->delete('tree/node');
     }
 
 


### PR DESCRIPTION
Consider the case that, in the same request, we have some code that:

1. delete the group X
2. delete the group Y which is the parent of X

In this case, when we delete Y, in the request cache we have that it still has the child group X.
So, we may have problems like the one I reported at #10948.

By clearing the request cache related to tree nodes the problem is solved.