### PR TITLE
Add min to Page List num input

### DIFF
--- a/concrete/blocks/page_list/page_list_form.php
+++ b/concrete/blocks/page_list/page_list_form.php
@@ -123,7 +123,7 @@ echo $userInterface->tabs([
         <fieldset>
             <div class="form-group">
                 <?php echo $form->label('num', t('Number of Pages to Display')); ?>
-                <?php echo $form->number("num", $num); ?>
+                <?php echo $form->number("num", $num, ['min' => 0]); ?>
             </div>
 
             <div class="form-group">


### PR DESCRIPTION
The Page List Block currently allows for saving negative numbers that always revert to zero.  This is senseless and solved by adding min to the input
