### PR TITLE
Let's be sure we create the core groups with correct IDs

### DIFF
--- a/concrete/src/Package/StartingPointPackage.php
+++ b/concrete/src/Package/StartingPointPackage.php
@@ -10,6 +10,7 @@ use Concrete\Core\Database\DatabaseStructureManager;
 use Concrete\Core\Entity\OAuth\Scope;
 use Concrete\Core\File\Filesystem;
 use Concrete\Core\File\Service\File;
+use Concrete\Core\User\Group\Command\AddGroupCommand;
 use Concrete\Core\Localization\Localization;
 use Concrete\Core\Mail\Importer\MailImporter;
 use Concrete\Core\Package\Routine\AttachModeInstallRoutine;
@@ -495,19 +496,22 @@ class StartingPointPackage extends Package
         // insert the default groups
         // create the groups our site users
         // specify the ID's since auto increment may not always be +1
-        $g1 = Group::add(
-            tc('GroupName', 'Guest'),
-            tc('GroupDescription', 'The guest group represents unregistered visitors to your site.'),
-            false,
-            false,
-            GUEST_GROUP_ID);
-        $g2 = Group::add(
-            tc('GroupName', 'Registered Users'),
-            tc('GroupDescription', 'The registered users group represents all user accounts.'),
-            false,
-            false,
-            REGISTERED_GROUP_ID);
-        $g3 = Group::add(tc('GroupName', 'Administrators'), '', false, false, ADMIN_GROUP_ID);
+        $command = new AddGroupCommand();
+        $this->app->executeCommand($command
+            ->setName(tc('GroupName', 'Guest'))
+            ->setDescription(tc('GroupDescription', 'The guest group represents unregistered visitors to your site.'))
+            ->setForcedNewGroupID(GUEST_GROUP_ID)
+        );
+        $this->app->executeCommand($command
+            ->setName(tc('GroupName', 'Registered Users'))
+            ->setDescription(tc('GroupDescription', 'The registered users group represents all user accounts.'))
+            ->setForcedNewGroupID(REGISTERED_GROUP_ID)
+        );
+        $this->app->executeCommand($command
+            ->setName(tc('GroupName', 'Administrators'))
+            ->setDescription('')
+            ->setForcedNewGroupID(ADMIN_GROUP_ID)
+        );
 
         $superuser = UserInfo::addSuperUser($this->installerOptions->getUserPasswordHash(), $this->installerOptions->getUserEmail());
         $u = User::getByUserID(USER_SUPER_ID, true, false);

--- a/concrete/src/User/Group/Command/AddGroupCommand.php
+++ b/concrete/src/User/Group/Command/AddGroupCommand.php
@@ -14,6 +14,11 @@ class AddGroupCommand extends Command
      */
     protected $pkgID;
 
+    /**
+     * @var int|null
+     */
+    protected $forcedNewGroupID;
+
     public function getPackageID(): ?int
     {
         return $this->pkgID;
@@ -25,6 +30,21 @@ class AddGroupCommand extends Command
     public function setPackageID(?int $pkgID): object
     {
         $this->pkgID = $pkgID;
+
+        return $this;
+    }
+
+    public function getForcedNewGroupID(): ?int
+    {
+        return $this->forcedNewGroupID;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setForcedNewGroupID(?int $value): self
+    {
+        $this->forcedNewGroupID = $value;
 
         return $this;
     }

--- a/concrete/src/User/Group/Command/AddGroupCommandHandler.php
+++ b/concrete/src/User/Group/Command/AddGroupCommandHandler.php
@@ -6,9 +6,7 @@ use Concrete\Core\Database\Connection\Connection;
 use Concrete\Core\Entity\Notification\GroupCreateNotification;
 use Concrete\Core\Entity\User\GroupCreate;
 use Concrete\Core\Notification\Type\GroupCreateType;
-use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\Tree\Node\Node as TreeNode;
-use Concrete\Core\User\Group\Command\Traits\ParentNodeRetrieverTrait;
 use Concrete\Core\User\Group\Event;
 use Concrete\Core\User\Group\GroupRepository;
 use Concrete\Core\User\User;
@@ -48,7 +46,8 @@ class AddGroupCommandHandler
 
     public function __invoke(AddGroupCommand $command)
     {
-        $user = new User();
+        $app = app();
+        $user = $app->make(User::class);
 
         $data = [
             'gName' => $command->getName(),
@@ -56,12 +55,21 @@ class AddGroupCommandHandler
             'pkgID' => (int) $command->getPackageID(),
             'gAuthorID' => (int) $user->getUserID()
         ];
+        $newGroupID = $command->getForcedNewGroupID();
+        if ($newGroupID !== null && $newGroupID > 0) {
+            $data['gID'] = $newGroupID;
+        } else {
+            $newGroupID = null;
+        }
         $this->connection->insert(
             $this->connection->getDatabasePlatform()->quoteSingleIdentifier('Groups'),
             $data
         );
 
-        $ng = $this->groupRepository->getGroupById($this->connection->lastInsertId());
+        if ($newGroupID === null) {
+            $newGroupID = (int) $this->connection->lastInsertId();
+        }
+        $ng = $this->groupRepository->getGroupById($newGroupID);
         $node = null;
         if ($command->getParentGroupID()) {
             $node = GroupNode::getTreeNodeByGroupID($command->getParentGroupID());
@@ -81,8 +89,6 @@ class AddGroupCommandHandler
 
         $ge = new Event($ng);
         $this->dispatcher->dispatch('on_group_add', $ge);
-
-        $app = Application::getFacadeApplication();
 
         if ($user->isRegistered()) {
             /** @noinspection PhpUnhandledExceptionInspection */


### PR DESCRIPTION
Since 310117283d0a142d1b0e33ab546e7bf1f83dbcba we've lost support for creating the core groups with the required IDs.
That means that, depending on server setup, the IDs of the admin/guest/registered users groups may not be the one that Concrete requires.

Let's restore it.