### PR TITLE
Avoid deprecated methods when creating responses

### DIFF
--- a/concrete/controllers/backend/account.php
+++ b/concrete/controllers/backend/account.php
@@ -14,17 +14,17 @@ class Account extends AbstractController
     {
         $user = $this->app->make(LoggedUser::class);
         if (!$user->isRegistered()) {
-            return JsonResponse::create(['error' => 'User must be register.'], JsonResponse::HTTP_FORBIDDEN);
+            return new JsonResponse(['error' => 'User must be register.'], JsonResponse::HTTP_FORBIDDEN);
         }
         $token = $this->app->make('token');
         if (!$token->validate('ccm_remove_pm_new_status')) {
-            return JsonResponse::create(['error' => $token->getErrorMessage()], JsonResponse::HTTP_BAD_REQUEST);
+            return new JsonResponse(['error' => $token->getErrorMessage()], JsonResponse::HTTP_BAD_REQUEST);
         }
 
         $db = $this->app->make(Connection::class);
         $db->update('UserPrivateMessagesTo', ['msgIsNew' => 0],
             ['msgMailboxID' => Mailbox::MBTYPE_INBOX, 'uID' => $user->getUserID()]);
 
-        return JsonResponse::create(['remove_inbox_new_message_status' => ['mailbox' => Mailbox::MBTYPE_INBOX]], JsonResponse::HTTP_OK);
+        return new JsonResponse(['remove_inbox_new_message_status' => ['mailbox' => Mailbox::MBTYPE_INBOX]], JsonResponse::HTTP_OK);
     }
 }

--- a/concrete/controllers/calendar_feed.php
+++ b/concrete/controllers/calendar_feed.php
@@ -62,7 +62,7 @@ class CalendarFeed extends Controller
                     $writer->addEntry($entry);
                 }
 
-                return Response::create($writer->export('rss'), 200, array('Content-Type' => 'text/xml'));
+                return new Response($writer->export('rss'), 200, array('Content-Type' => 'text/xml'));
             }
         }
 

--- a/concrete/controllers/dialog/file/statistics.php
+++ b/concrete/controllers/dialog/file/statistics.php
@@ -94,7 +94,7 @@ class Statistics extends Controller
             ]
         );
 
-        return StreamedResponse::create(
+        return new StreamedResponse(
             function () use ($bom, $writer) {
                 echo $bom;
                 $writer->insertHeaders()->insertRecords();

--- a/concrete/controllers/single_page/dashboard/blocks/stacks.php
+++ b/concrete/controllers/single_page/dashboard/blocks/stacks.php
@@ -547,7 +547,7 @@ class Stacks extends DashboardPageController
             $moveFolder->getPage()->move($destinationPage);
         }
 
-        return JsonResponse::create(
+        return new JsonResponse(
             t2('%d item has been moved under the folder %s', '%d items have been moved under the folder %s', count($sourceIDs), count($sourceIDs), h($destinationPage->getCollectionName()))
         );
     }

--- a/concrete/controllers/single_page/dashboard/extend/install.php
+++ b/concrete/controllers/single_page/dashboard/extend/install.php
@@ -221,7 +221,7 @@ class Install extends DashboardPageController
         }
 
         if (!$this->error->has()) {
-            return RedirectResponse::create($this->action('package_deleted'));
+            return new RedirectResponse($this->action('package_deleted'));
         }
     }
 

--- a/concrete/controllers/single_page/dashboard/reports/page_changes.php
+++ b/concrete/controllers/single_page/dashboard/reports/page_changes.php
@@ -24,7 +24,7 @@ class PageChanges extends DashboardPageController
             return $this->view();
         }
 
-        return StreamedResponse::create(
+        return new StreamedResponse(
             function () {
                 $writer = $this->getWriter();
                 $writer->setUnloadDoctrineEveryTick(50);

--- a/concrete/controllers/single_page/dashboard/system/permissions/denylist/range.php
+++ b/concrete/controllers/single_page/dashboard/system/permissions/denylist/range.php
@@ -190,7 +190,7 @@ class Range extends Denylist
         $config = $this->app->make('config');
         $bom = $config->get('concrete.export.csv.include_bom') ? $config->get('concrete.charset_bom') : '';
 
-        return StreamedResponse::create(
+        return new StreamedResponse(
             function () use ($app, $type, $ranges, $bom) {
                 $writer = $app->make(IPRangesCsvWriter::class, [
                     'writer' => $app->make(WriterFactory::class)->createFromPath('php://output', 'w'),

--- a/concrete/controllers/single_page/dashboard/users/search.php
+++ b/concrete/controllers/single_page/dashboard/users/search.php
@@ -599,7 +599,7 @@ class Search extends DashboardPageController
 
         $result = $this->createSearchResult($query);
 
-        return StreamedResponse::create(
+        return new StreamedResponse(
             function () use ($app, $result, $bom) {
                 $writer = $app->make(
                     UserExporter::class,

--- a/concrete/src/Application/Service/UserInterface.php
+++ b/concrete/src/Application/Service/UserInterface.php
@@ -357,7 +357,7 @@ class UserInterface
         $ve = new ErrorView($o);
         $contents = $ve->render($o);
 
-        return Response::create($contents, Response::HTTP_INTERNAL_SERVER_ERROR);
+        return new Response($contents, Response::HTTP_INTERNAL_SERVER_ERROR);
     }
 
     /**

--- a/concrete/src/Controller/Traits/DashboardExpressEntryListTrait.php
+++ b/concrete/src/Controller/Traits/DashboardExpressEntryListTrait.php
@@ -266,7 +266,7 @@ trait DashboardExpressEntryListTrait
         $result = $this->createSearchResult($entity, $query);
         $entryList = $result->getItemListObject();
 
-        return StreamedResponse::create(function () use ($entity, $entryList, $bom, $datetime_format) {
+        return new StreamedResponse(function () use ($entity, $entryList, $bom, $datetime_format) {
             $writer = $this->app->make(CsvWriter::class, [
                 'writer' => $this->app->make(WriterFactory::class)->createFromPath('php://output', 'w'),
                 'dateFormatter' => new Date(),

--- a/concrete/src/Foundation/Runtime/Run/DefaultRunner.php
+++ b/concrete/src/Foundation/Runtime/Run/DefaultRunner.php
@@ -146,7 +146,7 @@ class DefaultRunner implements RunInterface, ApplicationAwareInterface
                 $url = rtrim((string) $resolver->resolve([]), '/');
                 define('BASE_URL', $url);
             } catch (Exception $x) {
-                return Response::create($x->getMessage(), 500);
+                return new Response($x->getMessage(), 500);
             }
         }
     }

--- a/concrete/src/Http/ResponseFactory.php
+++ b/concrete/src/Http/ResponseFactory.php
@@ -56,7 +56,7 @@ class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInter
      */
     public function create($content, $code = Response::HTTP_OK, array $headers = [])
     {
-        return Response::create($content, $code, $headers);
+        return new Response($content, $code, $headers);
     }
 
     /**
@@ -64,7 +64,7 @@ class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInter
      */
     public function json($data, $code = Response::HTTP_OK, array $headers = [])
     {
-        return JsonResponse::create($data, $code, $headers);
+        return new JsonResponse($data, $code, $headers);
     }
 
     /**
@@ -135,7 +135,7 @@ class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInter
      */
     public function redirect($to, $code = Response::HTTP_MOVED_PERMANENTLY, $headers = [])
     {
-        return RedirectResponse::create($to, $code, $headers);
+        return new RedirectResponse($to, $code, $headers);
     }
 
     /**


### PR DESCRIPTION
The `*Response::create()` methods are [deprecated since Symfony 5.1](https://github.com/symfony/http-foundation/commit/bfe9753cf60ed93b11b6bbb8f680db17d1f72878) (and Concrete [requires at least version 5.2](https://github.com/concretecms/concretecms/blob/9.0.0/concrete/composer.json#L40)).
