### PR TITLE
Add group selector

### DIFF
--- a/concrete/controllers/frontend/assets_localization.php
+++ b/concrete/controllers/frontend/assets_localization.php
@@ -43,6 +43,7 @@ var ccmi18n = ' . json_encode([
     'changeBlockCSS' => t('Design'),
     'changeBlockTemplate' => t('Block Template'),
     'chooseFont' => t('Choose Font'),
+    'chooseGroup' => t('Choose a Group'),
     'chooseUser' => t('Choose a User'),
     'clear' => t('Clear'),
     'closeWindow' => t('Close'),


### PR DESCRIPTION
The current Group selector is rather basic, and it's quite hard to use it when we have many groups.
In addition, it displays the breadcrumb HTML code.

What about refactoring it?

Current group selector (as of `develop` branch):

https://user-images.githubusercontent.com/928116/192971916-d36108c2-7637-422b-bc5b-6a297527dbb1.mp4

Group selector with this PR:

https://user-images.githubusercontent.com/928116/192972084-471b4142-7453-41a9-a2b7-bd2114181579.mp4

PS: this PR requires:
- #10963
- #10964
- https://github.com/concretecms/bedrock/pull/255
