### PR TITLE
Allow extending system email addresses configuration

### DIFF
--- a/concrete/single_pages/dashboard/system/mail/addresses.php
+++ b/concrete/single_pages/dashboard/system/mail/addresses.php
@@ -1,90 +1,53 @@
-<?php defined('C5_EXECUTE') or die('Access Denied.'); ?>
+<?php
+defined('C5_EXECUTE') or die('Access Denied.');
 
-<form action="<?php echo View::action('save'); ?>" method="post">
+/**
+ * @var Concrete\Core\Page\View\PageView $view
+ * @var Concrete\Core\Form\Service\Form $form
+ * @var Concrete\Core\Validation\CSRF\Token $token
+ * @var Concrete\Core\Config\Repository\Repository $config
+ * @var Concrete\Core\Mail\SenderConfiguration $senderConfiguration
+ */?>
+
+<form action="<?= h($view->action('save')) ?>" method="POST">
     <?php
-    $app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
-    $app->make('token')->output('addresses');
+    $token->output('addresses');
+    foreach ($senderConfiguration->getEntries() as $entry) {
+        $keyPrefix = $entry->getPackageHandle();
+        if ($keyPrefix !== '') {
+            $keyPrefix = "{$keyPrefix}::";
+        }
+        ?>
+        <fieldset>
+            <legend><?= h($entry->getName()) ?></legend>
+                <?php
+                if ($entry->getNameKey() !== '') {
+                    $fieldName = str_replace('.', '__', "name@{$keyPrefix}{$entry->getNameKey()}");
+                    $value = $config->get($keyPrefix . $entry->getNameKey());
+                    $attributes = ($entry->getRequired() & $entry::REQUIRED_EMAIL_AND_NAME) === $entry::REQUIRED_EMAIL_AND_NAME ? ['required' => 'required'] : [];
+                    ?>
+                    <div class="form-group">
+                        <?= $form->label($fieldName, t('Sender Name')) ?>
+                        <?= $form->text($fieldName, $value, $attributes) ?>
+                    </div>
+                    <?php
+                }
+                $fieldName = str_replace('.', '__', "address@{$keyPrefix}{$entry->getEmailKey()}");
+                $value = $config->get($keyPrefix . $entry->getEmailKey());
+                $attributes = $entry->getRequired() & $entry::REQUIRED_EMAIL === $entry::REQUIRED_EMAIL ? ['required' => 'required'] : [];
+                ?>
+                <div class="form-group">
+                    <?= $form->label($fieldName, t('Email Address')) ?>
+                    <?= $form->email($fieldName, $value, $attributes) ?>
+                </div>
+        </fieldset>
+        <?php
+    }
     ?>
-    <fieldset>
-        <legend><?php echo t('Default'); ?></legend>
-        <div class="form-group">
-            <?php echo $form->label('defaultName', t('Email From Name')); ?>
-            <?php echo $form->text('defaultName', $defaultName); ?>
-        </div>
-        <div class="form-group">
-            <?php echo $form->label('defaultAddress', t('Email Address')); ?>
-            <?php echo $form->email('defaultAddress', $defaultAddress); ?>
-        </div>
-    </fieldset>
-
-    <fieldset>
-        <legend><?php echo t('Forgot Password'); ?></legend>
-        <div class="form-group">
-            <?php echo $form->label('forgotPasswordName', t('Email From Name')); ?>
-            <?php echo $form->text('forgotPasswordName', $forgotPasswordName); ?>
-        </div>
-        <div class="form-group">
-            <?php echo $form->label('forgotPasswordAddress', t('Email Address')); ?>
-            <?php echo $form->email('forgotPasswordAddress', $forgotPasswordAddress); ?>
-        </div>
-    </fieldset>
-
-    <fieldset>
-        <legend><?php echo t('Form Block'); ?></legend>
-        <div class="form-group">
-            <?php echo $form->label('formBlockAddress', t('Email Address')); ?>
-            <?php echo $form->email('formBlockAddress', $formBlockAddress); ?>
-        </div>
-    </fieldset>
-
-    <fieldset>
-        <legend><?php echo t('Spam Notification'); ?></legend>
-        <div class="form-group">
-            <?php echo $form->label('spamNotificationAddress', t('Email Address')); ?>
-            <?php echo $form->email('spamNotificationAddress', $spamNotificationAddress); ?>
-        </div>
-    </fieldset>
-
-    <fieldset>
-        <legend><?php echo t('Website Registration Notification'); ?></legend>
-        <div class="form-group">
-            <?php echo $form->label('registerNotificationName', t('Email From Name')); ?>
-            <?php echo $form->text('registerNotificationName', $registerNotificationName); ?>
-        </div>
-        <div class="form-group">
-            <?php echo $form->label('registerNotificationAddress', t('Email Address')); ?>
-            <?php echo $form->email('registerNotificationAddress', $registerNotificationAddress); ?>
-        </div>
-    </fieldset>
-
-    <fieldset>
-        <legend><?php echo t('Validate Registration'); ?></legend>
-        <div class="form-group">
-            <?php echo $form->label('validateRegistrationName', t('Email From Name')); ?>
-            <?php echo $form->text('validateRegistrationName', $validateRegistrationName); ?>
-        </div>
-        <div class="form-group">
-            <?php echo $form->label('validateRegistrationAddress', t('Email Address')); ?>
-            <?php echo $form->email('validateRegistrationAddress', $validateRegistrationAddress); ?>
-        </div>
-    </fieldset>
-
-    <fieldset>
-        <legend><?php echo t('Workflow Notification'); ?></legend>
-        <div class="form-group">
-            <?php echo $form->label('workflowNotificationName', t('Email From Name')); ?>
-            <?php echo $form->text('workflowNotificationName', $workflowNotificationName); ?>
-        </div>
-        <div class="form-group">
-            <?php echo $form->label('workflowNotificationAddress', t('Email Address')); ?>
-            <?php echo $form->email('workflowNotificationAddress', $workflowNotificationAddress); ?>
-        </div>
-    </fieldset>
-
     <div class="ccm-dashboard-form-actions-wrapper">
         <div class="ccm-dashboard-form-actions">
             <button class="float-end btn btn-primary">
-                <?php echo t('Save'); ?>
+                <?= t('Save') ?>
             </button>
         </div>
     </div>

--- a/concrete/src/Mail/MailServiceProvider.php
+++ b/concrete/src/Mail/MailServiceProvider.php
@@ -9,21 +9,48 @@ class MailServiceProvider extends ServiceProvider
 {
     public function register()
     {
-        $app = $this->app;
-
         $register = [
             'helper/mail' => '\Concrete\Core\Mail\Service',
             'mail' => '\Concrete\Core\Mail\Service',
         ];
-
         foreach ($register as $key => $value) {
-            $app->bind($key, $value);
+            $this->app->bind($key, $value);
         }
 
-        $this->app->bind(TransportInterface::class, function () use ($app) {
-            $factory = $app->make(TransportFactory::class);
+        $this->app->bind(TransportInterface::class, function () {
+            $factory = $this->app->make(TransportFactory::class);
 
-            return $factory->createTransportFromConfig($app->make('config'));
+            return $factory->createTransportFromConfig($this->app->make('config'));
         });
+        $this->app->extend(
+            SenderConfiguration::class,
+            static function(SenderConfiguration $configuration): SenderConfiguration {
+                return $configuration->addEntries([
+                    (new SenderConfiguration\Entry(tc('EmailAddress', 'Default'), 'concrete.email.default.address'))
+                        ->setNameKey('concrete.email.default.name')
+                        ->setPriority(100)
+                        ->setRequired(SenderConfiguration\Entry::REQUIRED_EMAIL)
+                    ,
+                    (new SenderConfiguration\Entry(t('Forgot Password'), 'concrete.email.forgot_password.address'))
+                        ->setNameKey('concrete.email.forgot_password.name')
+                    ,
+                    (new SenderConfiguration\Entry(t('Form Block'), 'concrete.email.form_block.address'))
+                        ->setNameKey('')
+                    ,
+                    (new SenderConfiguration\Entry(t('Spam Notification'), 'concrete.spam.notify_email'))
+                        ->setNameKey('')
+                    ,
+                    (new SenderConfiguration\Entry(t('Website Registration Notification'), 'concrete.email.register_notification.address'))
+                        ->setNameKey('concrete.email.register_notification.name')
+                    ,
+                    (new SenderConfiguration\Entry(t('Validate Registration'), 'concrete.email.validate_registration.address'))
+                        ->setNameKey('concrete.email.validate_registration.name')
+                    ,
+                    (new SenderConfiguration\Entry(t('Workflow Notification'), 'concrete.email.workflow_notification.address'))
+                        ->setNameKey('concrete.email.workflow_notification.name')
+                    ,
+                ]);
+            }
+        );
     }
 }

--- a/concrete/src/Mail/SenderConfiguration.php
+++ b/concrete/src/Mail/SenderConfiguration.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\Core\Mail;
+
+use RuntimeException;
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+/**
+ * This class holds the configurable addresses for outgoing emails.
+ * Packages can add their own addresses in the package controller on_start method with some code like this:
+ * <pre><code>$app->extend(
+ *     SenderConfiguration::class,
+ *     static function(SenderConfiguration $configuration): SenderConfiguration {
+ *         return $configuration->addEntry(
+ *             (new SenderConfiguration\Entry(t('Name of the option'), 'email.configuration.key'))
+ *                 ->setPackageHandle('your_package_handle')
+ *         );
+ *     }
+ * );
+ * </code></pre>.
+ */
+final class SenderConfiguration
+{
+    /**
+     * @var \Concrete\Core\Mail\SenderConfiguration\Entry[]
+     */
+    private $entries = [];
+
+    /**
+     * @var string
+     */
+    private $allConfigurationKeys = [];
+
+    /**
+     * @param \Concrete\Core\Mail\SenderConfiguration\Entry[] $entries
+     *
+     * @return $this
+     */
+    public function addEntries(iterable $entries): self
+    {
+        foreach ($entries as $entry) {
+            $this->addEntry($entry);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @throws \RuntimeException in case of duplicared configuration keys
+     *
+     * @return $this
+     */
+    public function addEntry(SenderConfiguration\Entry $entry): self
+    {
+        $prefix = $entry->getPackageHandle();
+        if ($prefix !== '') {
+            $prefix = "{$prefix}::";
+        }
+        $key = $prefix . $entry->getEmailKey();
+        if (in_array($key, $this->allConfigurationKeys, true)) {
+            throw new RuntimeException(t('The configuration key %s has been already specified.', $key));
+        }
+        $this->allConfigurationKeys[] = $key;
+        if ($entry->getNameKey() !== '') {
+            $key = $prefix . $entry->getNameKey();
+            if (in_array($key, $this->allConfigurationKeys, true)) {
+                throw new RuntimeException(t('The configuration key %s has been already specified.', $key));
+            }
+            $this->allConfigurationKeys[] = $key;
+        }
+
+        $this->entries[] = $entry;
+
+        return $this;
+    }
+
+    /**
+     * @return \Concrete\Core\Mail\SenderConfiguration\Entry[]
+     */
+    public function getEntries(): array
+    {
+        $this->sortEntries();
+
+        return $this->entries;
+    }
+
+    private function sortEntries(): void
+    {
+        usort(
+            $this->entries,
+            static function (SenderConfiguration\Entry $a, SenderConfiguration\Entry $b): int {
+                $delta = $b->getPriority() - $a->getPriority();
+                if ($delta === 0) {
+                    $delta = mb_strtolower($a->getName()) <=> mb_strtolower($b->getName());
+                }
+
+                return $delta;
+            }
+        );
+    }
+}

--- a/concrete/src/Mail/SenderConfiguration/Entry.php
+++ b/concrete/src/Mail/SenderConfiguration/Entry.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\Core\Mail\SenderConfiguration;
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+final class Entry
+{
+    /**
+     * Neither the email address nor the sender name are required.
+     *
+     * @var int
+     */
+    public const REQUIRED_NO = 0;
+
+    /**
+     * The email address is required, the sender name is optional.
+     *
+     * @var int
+     */
+    public const REQUIRED_EMAIL = 0b1;
+
+    /**
+     * Both the email address and the sender name are required.
+     *
+     * @var int
+     */
+    public const REQUIRED_EMAIL_AND_NAME = 0b10 | self::REQUIRED_EMAIL;
+
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var string
+     */
+    private $emailKey;
+
+    /**
+     * @var string
+     */
+    private $nameKey = '';
+
+    /**
+     * @var string
+     */
+    private $packageHandle = '';
+
+    /**
+     * @var int
+     */
+    private $priority = 0;
+
+    /**
+     * @var int
+     */
+    private $required = self::REQUIRED_NO;
+
+    public function __construct(string $name, string $emailKey)
+    {
+        $this->name = $name;
+        $this->emailKey = $emailKey;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setName(string $value): self
+    {
+        $this->name = $value;
+
+        return $this;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setEmailKey(string $value): self
+    {
+        $this->emailKey = $value;
+
+        return $this;
+    }
+
+    public function getEmailKey(): string
+    {
+        return $this->emailKey;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setNameKey(string $value): self
+    {
+        $this->nameKey = $value;
+
+        return $this;
+    }
+
+    public function getNameKey(): string
+    {
+        return $this->nameKey;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setPackageHandle(string $value): self
+    {
+        $this->packageHandle = $value;
+
+        return $this;
+    }
+
+    public function getPackageHandle(): string
+    {
+        return $this->packageHandle;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setPriority(int $value): self
+    {
+        $this->priority = $value;
+
+        return $this;
+    }
+
+    public function getPriority(): int
+    {
+        return $this->priority;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setRequired(int $value): self
+    {
+        $this->required = $value;
+
+        return $this;
+    }
+
+    public function getRequired(): int
+    {
+        return $this->required;
+    }
+}


### PR DESCRIPTION
We currently have 7 email addresses that can be configured in the `System & Settings` > `Email` > `System Email Addresses` dashboard page.

At the moment, they are configured in a one-by-one way.
What adding some logic to it?

Furthermore, with the approach of this PR, even 3rd party packages can add their own configurable email address, with some code like this in the `on_start()` method of the package `controller.php` file:

```php

use Concrete\Core\Mail\SenderConfiguration;

class Controller extends Package
{
    // ...
    public function on_start()
    {
        $this->app->extend(
             SenderConfiguration::class,
             static function(SenderConfiguration $configuration): SenderConfiguration {
                 return $configuration->addEntry(
                     (new SenderConfiguration\Entry(t('Name of the option'), 'email.configuration.key'))
                         ->setPackageHandle('your_package_handle')
                 );
             }
         );
    }
    // ...
}
```
