### PR TITLE
Fix handling of page removal when deleting a calendar event

### DIFF
--- a/concrete/src/Calendar/Event/EventService.php
+++ b/concrete/src/Calendar/Event/EventService.php
@@ -222,9 +222,10 @@ class EventService implements ApplicationAwareInterface
 
     public function delete(CalendarEvent $event)
     {
-        if ($event->getPageID() && $event->getRelatedPageRelationType() == 'C') {
-            $calendarPage = Page::getByID($this->cID);
-            if ($calendarPage && !$calendarPage->isError()) {
+        $version = $event->getSelectedVersion() ?: $event->getApprovedVersion();
+        if ($version && $version->getRelatedPageRelationType() === 'C') {
+            $calendarPage = $version->getPageObject();
+            if ($calendarPage) {
                 if ($this->config->get('concrete.misc.enable_trash_can')) {
                     $calendarPage->moveToTrash();
                 } else {


### PR DESCRIPTION
As [reported in the forums](https://forums.concretecms.org/t/error-deleting-calendar-event/4105), there's an issue when deleting a calendar event in PHP 8.

That's not about simply referring to an undefined object property: that `E_WARNING` highlights that the code is buggy.

Indeed the `CalendarEvent` event doesn't have a `cID` property, and we'd like to use the `cID` property of the event version (but `CalendarEvent` doesn't implement the `__get` magic method, only `__call`).
