### PR TITLE
Deprecate Ajax::isAjaxRequest()

### DIFF
--- a/concrete/src/Http/ResponseFactory.php
+++ b/concrete/src/Http/ResponseFactory.php
@@ -7,7 +7,6 @@ use Concrete\Core\Application\ApplicationAwareTrait;
 use Concrete\Core\Command\Process\Menu\Item\RunningProcessesItem;
 use Concrete\Core\Config\Repository\Repository;
 use Concrete\Core\Controller\Controller;
-use Concrete\Core\Http\Service\Ajax;
 use Concrete\Core\Localization\Localization;
 use Concrete\Core\Page\Collection\Collection;
 use Concrete\Core\Page\Controller\PageController;
@@ -72,7 +71,7 @@ class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInter
      */
     public function notFound($content, $code = Response::HTTP_NOT_FOUND, $headers = [])
     {
-        if ($this->app->make(Ajax::class)->isAjaxRequest($this->request)) {
+        if ($this->request->isXmlHttpRequest()) {
             $this->localization->pushActiveContext(Localization::CONTEXT_SITE);
             $responseData = [
                 'error' => t('Page not found'),

--- a/concrete/src/Http/Service/Ajax.php
+++ b/concrete/src/Http/Service/Ajax.php
@@ -12,16 +12,12 @@ class Ajax
      * @param Request $request
      *
      * @return bool
+     *
+     * @deprecated use the isXmlHttpRequest() method of the request object
      */
     public function isAjaxRequest(Request $request)
     {
-        $result = false;
-        $requestedWith = $request->server->get('HTTP_X_REQUESTED_WITH');
-        if (is_string($requestedWith) && strcasecmp($requestedWith, 'XMLHttpRequest') === 0) {
-            $result = true;
-        }
-
-        return $result;
+        return $request->isXmlHttpRequest();
     }
 
     /**

--- a/concrete/src/Validation/CSRF/Token.php
+++ b/concrete/src/Validation/CSRF/Token.php
@@ -5,7 +5,6 @@ use Concrete\Core\Logging\Channels;
 use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\User\User;
 use Concrete\Core\Http\Request;
-use Concrete\Core\Http\Service\Ajax;
 
 class Token
 {
@@ -32,8 +31,7 @@ class Token
     {
         $app = Application::getFacadeApplication();
         $request = $app->make(Request::class);
-        $ajax = $app->make(Ajax::class);
-        if ($ajax->isAjaxRequest($request)) {
+        if ($request->isXmlHttpRequest()) {
             return t("Invalid token. Please reload the page and retry.");
         } else {
             return t("Invalid form token. Please reload this form and submit again.");


### PR DESCRIPTION
The Symfony Request class already offers this feature.