### PR TITLE
Improve whoops error output

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -65,47 +65,13 @@ return [
         'error_reporting' => null,
 
         /**
-         * Hide specified superglobal keys and config items from whoops error output.
-         * If you wanted to hide an environment variable named "DB_PASSWORD", you'd specify it like this:
-         * ```
-         * '_ENV' => ['DB_PASSWORD'],
-         * ```
+         * Hide specified superglobal keys and config items from whoops error output
          *
-         * The same applies for all superglobals.
+         * By default, all _SERVER, _ENV, and _COOKIE values are hidden
          *
          * @var array<string, string[]>
          */
         'hide_keys' => [
-            /** @var string[] */
-            '_ENV' => [
-                // Likely database environment variables
-                'DB_PASSWORD',
-                'DB_USERNAME',
-                'DB_HOSTNAME',
-                'DB_HOST',
-                'DB_SERVER',
-                'DATABASE_PASSWORD',
-                'DATABASE_USERNAME',
-                'DATABASE_HOSTNAME',
-                'DATABASE_HOST',
-                'DATABASE_SERVER',
-            ],
-
-            /** @var string[] */
-            '_SERVER' => [
-                // Likely database environment variables
-                'DB_PASSWORD',
-                'DB_USERNAME',
-                'DB_HOSTNAME',
-                'DB_HOST',
-                'DB_SERVER',
-                'DATABASE_PASSWORD',
-                'DATABASE_USERNAME',
-                'DATABASE_HOSTNAME',
-                'DATABASE_HOST',
-                'DATABASE_SERVER',
-            ],
-
             /** @var string[] */
             '_GET' => [],
 
@@ -114,11 +80,6 @@ return [
 
             /** @var string[] */
             '_FILES' => [],
-
-            /** @var string[] */
-            '_COOKIE' => [
-                'CONCRETE',
-            ],
 
             /** @var string[] */
             '_SESSION' => [],

--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -100,6 +100,7 @@ return [
                 'concrete.email.validate_registration.address',
                 'concrete.email.workflow_notification.address',
                 'concrete.debug.hide_keys',
+                'app.api_keys',
             ],
         ]
     ],

--- a/concrete/src/Error/Handler/ErrorHandler.php
+++ b/concrete/src/Error/Handler/ErrorHandler.php
@@ -98,11 +98,14 @@ class ErrorHandler extends PrettyPageHandler
             ]
         );
 
+        $extensions = collect(array_flip(get_loaded_extensions()))->map(function($value, string $ext) {
+            return phpversion($ext) ?: 'Unknown version';
+        });
         $this->addDataTable(
             'PHP',
             [
                 'Version' => PHP_VERSION,
-                'Extensions' => get_loaded_extensions(),
+                'Extensions' => $extensions->all(),
             ]
         );
 

--- a/concrete/src/Error/Handler/ErrorHandler.php
+++ b/concrete/src/Error/Handler/ErrorHandler.php
@@ -94,6 +94,7 @@ class ErrorHandler extends PrettyPageHandler
             [
                 'Version' => Config::get('concrete.version'),
                 'Installed Version' => Config::get('concrete.version_installed'),
+                'Database Version' => Config::get('concrete.version_db'),
             ]
         );
 
@@ -101,15 +102,36 @@ class ErrorHandler extends PrettyPageHandler
             'PHP',
             [
                 'Version' => PHP_VERSION,
+                'Extensions' => get_loaded_extensions(),
             ]
         );
-        
-        /*
-         * Config
-         */
-        $this->addDataTable('Concrete Configuration', $this->flatConfig(Config::get('concrete'), 'concrete'));
+
+        $this->addDataTable('Concrete Configuration', [
+            'concrete' => $this->cleanedConfig(Config::get('concrete'), 'concrete'),
+            'app' => $this->cleanedConfig(Config::get('app'), 'app')
+        ]);
     }
 
+    protected function cleanedConfig(array $config, $group): array
+    {
+        $clean = [];
+        foreach ($config as $key => $value) {
+            $assembled = "{$group}.{$key}";
+            if (is_array($value)) {
+                $clean[$key] = $this->cleanedConfig($value, $assembled);
+            } elseif ($this->isKeyHidden($assembled)) {
+                $clean[$key] = str_repeat('*', is_string($value) ? strlen($value) : 3);
+            } else {
+                $clean[$key] = $value;
+            }
+        }
+
+        return $clean;
+    }
+
+    /**
+     * @deprecated Will be removed
+     */
     protected function flatConfig(array $config, $group)
     {
         $flat = [];

--- a/concrete/src/Error/Provider/WhoopsServiceProvider.php
+++ b/concrete/src/Error/Provider/WhoopsServiceProvider.php
@@ -19,6 +19,16 @@ class WhoopsServiceProvider extends Provider
         $run = new Run();
 
         $handler = new ErrorHandler();
+
+        // Disallow all ENV, SERVER, and COOKIE keys
+        $disallow = $this->getDisallowedKeys();
+
+        foreach ($disallow as $global => $keys) {
+            foreach ($keys as $key) {
+                $handler->hideSuperglobalKey($global, $key);
+            }
+        }
+
         $run->pushHandler($handler);
 
         $json_handler = new JsonErrorHandler();
@@ -39,5 +49,19 @@ class WhoopsServiceProvider extends Provider
 
         $run->register();
         $this->app->instance(Run::class, $run);
+    }
+
+    /**
+     * Get the list of superglobal keys that should be masked in whoops output
+     *
+     * @return array<string, string[]> A list of disallowed superglobal keys [`_SERVER' => ['some_key']]
+     */
+    protected function getDisallowedKeys(): array
+    {
+        return [
+            '_ENV' => array_keys($_ENV),
+            '_SERVER' => array_keys($_SERVER),
+            '_COOKIE' => array_keys($_SERVER),
+        ];
     }
 }

--- a/concrete/src/Error/Provider/WhoopsServiceProvider.php
+++ b/concrete/src/Error/Provider/WhoopsServiceProvider.php
@@ -61,7 +61,7 @@ class WhoopsServiceProvider extends Provider
         return [
             '_ENV' => array_keys($_ENV),
             '_SERVER' => array_keys($_SERVER),
-            '_COOKIE' => array_keys($_SERVER),
+            '_COOKIE' => array_keys($_COOKIE),
         ];
     }
 }


### PR DESCRIPTION
This PR does the following:

- Collapses config into a single expandable item and adds `app` config. Instead of flatting our config this PR leaves it in its original hierarchical form which allows Whoops to show only the top level items with a control to expand
- Include PHP extensions name and version in the PHP output
- Hides all `_ENV` `_SERVER` and `_COOKIE` superglobal values by default. This can be overridden by extending the whoops service provider and adding your own custom `getDisallowedKeys` method.

Test this by navigating to `/dashboard/system/environment/debug/debug_example`, here's an example of the output I get with my test site: https://gist.github.com/KorvinSzanto/c2362c5f966ca9eb527a58631e2e61b3
