### PR TITLE
Warn admins when they are potentially giving more access than they expect

### DIFF
--- a/concrete/controllers/single_page/dashboard/system/permissions/users.php
+++ b/concrete/controllers/single_page/dashboard/system/permissions/users.php
@@ -14,6 +14,19 @@ class Users extends DashboardPageController
 
     public function view()
     {
+        // Get the pkID of permission keys we want to warn about
+        $sudo = PermissionKey::getByHandle('sudo');
+        $groupEdit = PermissionKey::getByHandle('edit_group_folder');
+
+        $this->set('permissionWarnings', [
+            $sudo->getPermissionKeyID() => t(
+                'Users with this permission can manage aspects of all users including elevating their own permissions.'
+            ),
+            $groupEdit->getPermissionKeyID() => t(
+                'Users who can edit groups can elevate their own permissions by moving groups.'
+            ),
+        ]);
+
         $tree = GroupTree::get();
         $root = $tree->getRootTreeNodeObject();
         $this->set('root', $root);

--- a/concrete/single_pages/dashboard/system/permissions/users.php
+++ b/concrete/single_pages/dashboard/system/permissions/users.php
@@ -1,4 +1,4 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); 
+<?php defined('C5_EXECUTE') or die("Access Denied.");
 $app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
 ?>
 
@@ -40,3 +40,76 @@ $app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
 	    </div>
 	</div>
 </form>
+
+<script type="text/template" id="access-warning-template">
+    <div>
+        <% for (const {message, id, name} of warnings) { %>
+            <h6 class="col-4"><%= name %></h6>
+            <div>
+                <p class="alert alert-warning"><%= message %></p>
+            </div>
+        <% } %>
+        <div class="dialog-buttons">
+            <button class="btn btn-secondary float-start" onclick="jQuery.fn.dialog.closeTop()"><?=t('Cancel')?></button>
+            <button class="btn btn-danger float-end accept"><?= t('I understand') ?></button>
+        </div>
+    </div>
+</script>
+
+<script>
+    (function() {
+        const warnings = JSON.parse(<?= json_encode(json_encode($permissionWarnings ?? [])) ?>)
+        let skipWarnings = false
+        function populateCache() {
+            const cache = {}
+            for (const keyId in warnings) {
+                cache[keyId] = $('[name="pkID[' + keyId + ']"]').val()
+            }
+            return cache
+        }
+
+        const cache = populateCache()
+        const form = $('table.ccm-permission-grid').closest('form')
+
+        form.on('submit', function() {
+            if (skipWarnings) {
+                return true
+            }
+
+            const changes = populateCache();
+            const warn = Object.keys(changes)
+                .map(k => changes[k] !== cache[k] ? k : null)
+                .filter(k => k !== null)
+                .map(k => ({
+                   message: warnings[k],
+                   id: k,
+                   name: $('a[data-pkid="' + k + '"]').attr('dialog-title'),
+                }))
+
+            if (warn.length) {
+                const warningHtml = _.template($('#access-warning-template').text())({
+                    warnings: warn
+                })
+
+                const dialog = $(warningHtml)
+                dialog.find('button.accept').click(function() {
+                    skipWarnings = true
+                    form.trigger('submit')
+                })
+
+                jQuery.fn.dialog.open({
+                    title: "<?= t('Access Warnings') ?>",
+                    element: dialog,
+                    modal: true,
+                    width: 500,
+                    height: 380
+                })
+
+                return false
+            }
+
+            return true
+        })
+
+    }())
+</script>


### PR DESCRIPTION
This pull request modifies the user permissions dashboard single page to include some JS that alerts the administrator to the risk  of assigning either the `sudo` or the `edit_group_folder` permission. 

![image](https://user-images.githubusercontent.com/1007419/194117494-78a8247d-0b5e-49b9-9d4e-0616c573ef8a.png)

This dialog will only show if either the `sudo` or the `edit_group_folder` permissions are modified.