### PR TITLE
Order query parameters are ignored by the express_entry_list block

### DIFF
--- a/concrete/blocks/express_entry_list/controller.php
+++ b/concrete/blocks/express_entry_list/controller.php
@@ -306,9 +306,9 @@ class Controller extends BlockController implements UsesFeatureInterface
                 $columnSet = new DefaultSet($category);
             }
 
-            $query = $queryModifier->process($query);
             $query->setColumns($columnSet);
-
+            $query = $queryModifier->process($query);
+            
             $result = $resultFactory->createFromQuery($searchProvider, $query);
             $list = $result->getItemListObject();
             if (!isset($itemsPerPageSpecified)) {


### PR DESCRIPTION
Issue posted here: #10980 
The query modifiers were running first and then setColumns(). 

setColumns() was overriding what the query modifiers had done.

As a result, parameters like ccm_order_by and ccm_order_by_direction had no effect on the block.

I checked that this modification doesn't affect pagination.
