### PR TITLE
Add state parameter to external concrete authentication service

### DIFF
--- a/concrete/src/Authentication/Type/ExternalConcrete/ExternalConcreteService.php
+++ b/concrete/src/Authentication/Type/ExternalConcrete/ExternalConcreteService.php
@@ -106,4 +106,12 @@ class ExternalConcreteService extends AbstractService
     {
         return self::AUTHORIZATION_METHOD_HEADER_BEARER;
     }
+
+    /**
+     * Always send through and verify "state" parameter
+     */
+    public function needsStateParameterInAuthUrl(): bool
+    {
+        return true;
+    }
 }


### PR DESCRIPTION
This pull request also makes it easier to enable state in custom services as well, before you needed to override the `handle_authentication_callback()` which I did like this in the past:
```php
public function handle_attach_callback()
{
    $this->getService()->assertStateValid($this->app->make(Request::class)->get('state'));
    return parent::handle_authentication_callback();
}
```
and a method on my service:
```php
/**
 * Validate the given state
 * @throws \OAuth\OAuth2\Service\Exception\InvalidAuthorizationStateException
 */
public function assertStateValid(string $state): void
{
    $this->validateAuthorizationState($state);
}
```

Now all you need to do to support this in custom oauth2 services is override the `needsStateParameterInAuthUrl` and return true like the `ExternalConcreteService` does.