### PR TITLE
Optimize configuration of system email addresses

### DIFF
--- a/concrete/src/Mail/MailServiceProvider.php
+++ b/concrete/src/Mail/MailServiceProvider.php
@@ -24,33 +24,38 @@ class MailServiceProvider extends ServiceProvider
         });
         $this->app->extend(
             SenderConfiguration::class,
-            static function(SenderConfiguration $configuration): SenderConfiguration {
-                return $configuration->addEntries([
-                    (new SenderConfiguration\Entry(tc('EmailAddress', 'Default'), 'concrete.email.default.address'))
-                        ->setNameKey('concrete.email.default.name')
-                        ->setPriority(100)
-                        ->setRequired(SenderConfiguration\Entry::REQUIRED_EMAIL)
-                    ,
-                    (new SenderConfiguration\Entry(t('Forgot Password'), 'concrete.email.forgot_password.address'))
-                        ->setNameKey('concrete.email.forgot_password.name')
-                    ,
-                    (new SenderConfiguration\Entry(t('Form Block'), 'concrete.email.form_block.address'))
-                        ->setNameKey('')
-                    ,
-                    (new SenderConfiguration\Entry(t('Spam Notification'), 'concrete.spam.notify_email'))
-                        ->setNameKey('')
-                    ,
-                    (new SenderConfiguration\Entry(t('Website Registration Notification'), 'concrete.email.register_notification.address'))
-                        ->setNameKey('concrete.email.register_notification.name')
-                    ,
-                    (new SenderConfiguration\Entry(t('Validate Registration'), 'concrete.email.validate_registration.address'))
-                        ->setNameKey('concrete.email.validate_registration.name')
-                    ,
-                    (new SenderConfiguration\Entry(t('Workflow Notification'), 'concrete.email.workflow_notification.address'))
-                        ->setNameKey('concrete.email.workflow_notification.name')
-                    ,
-                ]);
+            function (SenderConfiguration $configuration): SenderConfiguration {
+                return $this->configureSenders($configuration);
             }
         );
+    }
+
+    private function configureSenders(SenderConfiguration $configuration): SenderConfiguration
+    {
+        return $configuration->addEntries([
+            (new SenderConfiguration\Entry(tc('EmailAddress', 'Default'), 'concrete.email.default.address'))
+                ->setNameKey('concrete.email.default.name')
+                ->setPriority(100)
+                ->setRequired(SenderConfiguration\Entry::REQUIRED_EMAIL)
+            ,
+            (new SenderConfiguration\Entry(t('Forgot Password'), 'concrete.email.forgot_password.address'))
+                ->setNameKey('concrete.email.forgot_password.name')
+            ,
+            (new SenderConfiguration\Entry(t('Form Block'), 'concrete.email.form_block.address'))
+                ->setNameKey('')
+            ,
+            (new SenderConfiguration\Entry(t('Spam Notification'), 'concrete.spam.notify_email'))
+                ->setNameKey('')
+            ,
+            (new SenderConfiguration\Entry(t('Website Registration Notification'), 'concrete.email.register_notification.address'))
+                ->setNameKey('concrete.email.register_notification.name')
+            ,
+            (new SenderConfiguration\Entry(t('Validate Registration'), 'concrete.email.validate_registration.address'))
+                ->setNameKey('concrete.email.validate_registration.name')
+            ,
+            (new SenderConfiguration\Entry(t('Workflow Notification'), 'concrete.email.workflow_notification.address'))
+                ->setNameKey('concrete.email.workflow_notification.name')
+            ,
+        ]);
     }
 }


### PR DESCRIPTION
Binding a big closure requires that PHP keeps it in memory.

The alternative approach of this PR saves 752 bytes of memory (320 instead of 1072).