### PR TITLE
Migrate session when logging in with OAuth

### DIFF
--- a/concrete/src/Authentication/Type/OAuth/GenericOauthTypeController.php
+++ b/concrete/src/Authentication/Type/OAuth/GenericOauthTypeController.php
@@ -195,6 +195,7 @@ abstract class GenericOauthTypeController extends AuthenticationTypeController
         if ($user_id && $user_id > 0) {
             $user = User::loginByUserID($user_id);
             if ($user && !$user->isError()) {
+                $this->app->make('session')->migrate();
                 return $user;
             }
         }


### PR DESCRIPTION
This PR "migrate"s the session when a user logs in using an authentication type that relies on this generic oauth controller. The value of migrating the session is we end up with a new session ID which can make it more difficult for someone to guess or steal a session ID.