### PR TITLE
Prevent browser blocked reflected XSS in dashboard search pages

### DIFF
--- a/concrete/blocks/express_entry_list/view.php
+++ b/concrete/blocks/express_entry_list/view.php
@@ -8,8 +8,8 @@ if ($tableName) { ?>
 <?php } ?>
 <?php if ($tableDescription) { ?>
     <p><?=$tableDescription?></p>
-<?php } 
-	
+<?php }
+
 if (isset($entity)) { ?>
     <?php if ($enableSearch) { ?>
         <form method="get" action="<?=$c->getCollectionLink()?>">
@@ -87,7 +87,9 @@ if (isset($entity)) { ?>
             <thead>
                 <tr>
                 <?php foreach ($result->getColumns() as $column) { ?>
-                    <th class="<?=$column->getColumnStyleClass()?>"><a href="<?=$column->getColumnSortURL()?>"><?=$column->getColumnTitle()?></a></th>
+                    <th class="<?=$column->getColumnStyleClass()?>">
+                        <a href="<?=h($column->getColumnSortURL())?>"><?=$column->getColumnTitle()?></a>
+                    </th>
                 <?php } ?>
                 </tr>
             </thead>

--- a/concrete/elements/express/search/menu.php
+++ b/concrete/elements/express/search/menu.php
@@ -24,7 +24,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
                     ?>
                     <li data-items-per-page="<?= $itemsPerPageOption; ?>">
                         <a class="dropdown-item <?= ($itemsPerPageOption === $itemsPerPage) ? 'active' : ''; ?>"
-                           href="<?=$url?>"><?= $itemsPerPageOption; ?></a>
+                           href="<?= h($url) ?>"><?= $itemsPerPageOption; ?></a>
                     </li>
                 <?php } ?>
             </ul>

--- a/concrete/elements/files/search/menu.php
+++ b/concrete/elements/files/search/menu.php
@@ -38,7 +38,7 @@ use Concrete\Core\Support\Facade\Url;
                     ?>
 
                     <li data-items-per-page="<?php echo $itemsPerPageOption; ?>">
-                        <a class="dropdown-item <?php echo ($itemsPerPageOption === $itemsPerPage) ? 'active' : ''; ?>" href="<?php echo $url ?>">
+                        <a class="dropdown-item <?php echo ($itemsPerPageOption === $itemsPerPage) ? 'active' : ''; ?>" href="<?php echo h($url) ?>">
                             <?php echo $itemsPerPageOption; ?>
                         </a>
                     </li>

--- a/concrete/elements/groups/search/menu.php
+++ b/concrete/elements/groups/search/menu.php
@@ -46,7 +46,7 @@ $checker = new Permissions($currentFolder);
 
                     <li data-items-per-page="<?php echo $itemsPerPageOption; ?>">
                         <a class="dropdown-item <?php echo ($itemsPerPageOption === $itemsPerPage) ? 'active' : ''; ?>"
-                           href="<?php echo $url ?>">
+                           href="<?php echo h($url) ?>">
                             <?php echo $itemsPerPageOption; ?>
                         </a>
                     </li>

--- a/concrete/elements/pages/search/menu.php
+++ b/concrete/elements/pages/search/menu.php
@@ -36,7 +36,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 
                     <li data-items-per-page="<?php echo $itemsPerPageOption; ?>">
                         <a class="dropdown-item <?php echo ($itemsPerPageOption === $itemsPerPage) ? 'active' : ''; ?>"
-                           href="<?php echo $url ?>">
+                           href="<?php echo h($url) ?>">
                             <?php echo $itemsPerPageOption; ?>
                         </a>
                     </li>

--- a/concrete/elements/users/search/menu.php
+++ b/concrete/elements/users/search/menu.php
@@ -38,7 +38,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 
                     <li data-items-per-page="<?php echo $itemsPerPageOption; ?>">
                         <a class="dropdown-item <?php echo ($itemsPerPageOption === $itemsPerPage) ? 'active' : ''; ?>"
-                           href="<?php echo $url ?>">
+                           href="<?php echo h($url) ?>">
                             <?php echo $itemsPerPageOption; ?>
                         </a>
                     </li>

--- a/concrete/single_pages/dashboard/express/entries/entries.php
+++ b/concrete/single_pages/dashboard/express/entries/entries.php
@@ -14,7 +14,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
                 <?php foreach ($result->getColumns() as $column) { ?>
                     <th class="<?=$column->getColumnStyleClass()?>">
                         <?php if ($column->isColumnSortable()) { ?>
-                            <a href="<?=$column->getColumnSortURL()?>"><?=$column->getColumnTitle()?></a>
+                            <a href="<?= h($column->getColumnSortURL()) ?>"><?=$column->getColumnTitle()?></a>
                         <?php } else { ?>
                             <span><?=$column->getColumnTitle()?></span>
                         <?php } ?>

--- a/concrete/single_pages/dashboard/files/search.php
+++ b/concrete/single_pages/dashboard/files/search.php
@@ -68,7 +68,7 @@ if ($fp->canAddFile() || $fp->canSearchFiles()) { ?>
                         <?php
                         if ($column->isColumnSortable()) { ?>
                             <a href="<?php
-                            echo $column->getColumnSortURL() ?>">
+                            echo h($column->getColumnSortURL()) ?>">
                                 <?php
                                 echo $column->getColumnTitle() ?>
                             </a>

--- a/concrete/single_pages/dashboard/sitemap/search.php
+++ b/concrete/single_pages/dashboard/sitemap/search.php
@@ -53,7 +53,7 @@ use Concrete\Core\Page\Menu;
                 <?php /** @var Column $column */ ?>
                 <th class="<?php echo $column->getColumnStyleClass() ?>">
                     <?php if ($column->isColumnSortable()): ?>
-                        <a href="<?php echo $column->getColumnSortURL() ?>">
+                        <a href="<?php echo h($column->getColumnSortURL()) ?>">
                             <?php echo $column->getColumnTitle() ?>
                         </a>
                     <?php else: ?>

--- a/concrete/single_pages/dashboard/users/groups.php
+++ b/concrete/single_pages/dashboard/users/groups.php
@@ -53,7 +53,7 @@ use Concrete\Core\User\Group\Menu;
                 <?php /** @var Column $column */ ?>
                 <th class="<?php echo $column->getColumnStyleClass() ?>">
                     <?php if ($column->isColumnSortable()): ?>
-                        <a href="<?php echo $column->getColumnSortURL() ?>">
+                        <a href="<?php echo h($column->getColumnSortURL()) ?>">
                             <?php echo $column->getColumnTitle() ?>
                         </a>
                     <?php else: ?>

--- a/concrete/single_pages/dashboard/users/search.php
+++ b/concrete/single_pages/dashboard/users/search.php
@@ -53,7 +53,7 @@ use Concrete\Core\User\UserInfo;
                 <?php /** @var Column $column */ ?>
                 <th class="<?php echo $column->getColumnStyleClass() ?>">
                     <?php if ($column->isColumnSortable()): ?>
-                        <a href="<?php echo $column->getColumnSortURL() ?>">
+                        <a href="<?php echo h($column->getColumnSortURL()) ?>">
                             <?php echo $column->getColumnTitle() ?>
                         </a>
                     <?php else: ?>


### PR DESCRIPTION
Search pages were vulnerable to reflected XSS for users using old browsers. This change sanitizes all the URLs on output and prevents XSS.