### PR TITLE
Add warning interstitial when moving groups

### DIFF
--- a/concrete/single_pages/dashboard/users/groups/tree.php
+++ b/concrete/single_pages/dashboard/users/groups/tree.php
@@ -6,10 +6,39 @@ defined('C5_EXECUTE') or die('Access Denied.');
 
 <div class="group-tree"></div>
 
+<script type="text/template" id="access-warning-template">
+    <div>
+        <p>
+            <?= t("Moving a group underneath another group will cause all users in the moved group to gain the permissions of the parent group."); ?>
+        </p>
+        <div class="dialog-buttons">
+            <button class="btn btn-secondary float-start" onclick="jQuery.fn.dialog.closeTop()"><?=t('Cancel')?></button>
+            <button class="btn btn-danger float-end accept"><?= t('I understand') ?></button>
+        </div>
+    </div>
+</script>
 <script type="text/javascript">
 $(function() {
-    $('.group-tree').concreteTree({
-        'treeID': '<?php echo $tree->getTreeID()?>'
-    });
+    const parentDragRequest = ConcreteTree.prototype.dragRequest
+    ConcreteTree.prototype.dragRequest = function() {
+        const me = this
+        const params = arguments
+        const dialog = $($('#access-warning-template').text())
+        jQuery.fn.dialog.open({
+            title: "<?= t('Access Warning') ?>",
+            element: dialog,
+            modal: true,
+            width: 500,
+            height: 180
+        })
+        dialog.find('button.accept').click(function() {
+            parentDragRequest.apply(me, params)
+            jQuery.fn.dialog.closeTop()
+        })
+    }
+
+    new ConcreteTree($('.group-tree'), {
+        treeID: <?= json_encode($tree->getTreeID()) ?>,
+    })
 })
 </script>


### PR DESCRIPTION
This PR adds a warning interstitial when moving groups. Instead of updating bedrock to handle this in the `ConcreteTree` class I've opted to overriding the `dragRequest` method in order to make this change easy to backport.

![image](https://user-images.githubusercontent.com/1007419/195454789-4ae0f8b2-1d80-4f5a-9786-9a17d0ca36d5.png)
