### PR TITLE
Use bordoni fork of hautelook/phpass

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1581,17 +1581,17 @@
             "time": "2019-07-01T23:21:34+00:00"
         },
         {
-            "name": "hautelook/phpass",
+            "name": "bordoni/phpass",
             "version": "0.3.5",
             "source": {
                 "type": "git",
-                "url": "https://github.com/hautelook/phpass.git",
-                "reference": "b4cbd9b67ed3ef5672ec79d8e0c46d24bd844abd"
+                "url": "https://github.com/bordoni/phpass.git",
+                "reference": "fd57c109213e95150b7de1dc8908c55605cd8e55"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/hautelook/phpass/zipball/b4cbd9b67ed3ef5672ec79d8e0c46d24bd844abd",
-                "reference": "b4cbd9b67ed3ef5672ec79d8e0c46d24bd844abd",
+                "url": "https://api.github.com/repos/bordoni/phpass/zipball/fd57c109213e95150b7de1dc8908c55605cd8e55",
+                "reference": "fd57c109213e95150b7de1dc8908c55605cd8e55",
                 "shasum": ""
             },
             "require": {
@@ -1612,6 +1612,11 @@
                     "name": "Solar Designer",
                     "email": "solar@openwall.com",
                     "homepage": "http://openwall.com/phpass/"
+                },
+                {
+                    "name": "Gustavo Bordoni",
+                    "email": "gustavo@bordoni.me",
+                    "homepage": "https://bordoni.me"
                 }
             ],
             "description": "Portable PHP password hashing framework",

--- a/concrete/composer.json
+++ b/concrete/composer.json
@@ -56,7 +56,7 @@
     "mobiledetect/mobiledetectlib": "2.*",
     "monolog/monolog": "^1.5.0",
     "sunra/php-simple-html-dom-parser": "1.*",
-    "hautelook/phpass": "0.3.*",
+    "bordoni/phpass": "0.3.*",
     "voku/urlify": "~1.0.1",
     "dapphp/securimage": "3.*",
     "anahkiasen/html-object": "~1.4",


### PR DESCRIPTION
This PR replaces the deleted `hautelook/phpass` dependency with `bordoni/phpass` which is effectively the same.