### PR TITLE
[v9] Avoid Undefined property: concrete/src/Block/BlockController.php::$requestArray

### DIFF
--- a/concrete/src/Block/BlockController.php
+++ b/concrete/src/Block/BlockController.php
@@ -59,6 +59,8 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
     /** @var null|string  */
     protected $btTable = null;
     protected $btID;
+    /** @var array */
+    protected $requestArray;
 
     /**
      * @internal


### PR DESCRIPTION
This PR fixes the following exception with PHP8.

```
Avoid Undefined property: concrete/src/Block/BlockController.php::$requestArray
```

