### PR TITLE
Add missing for attribute to checkbox label of option list attribute

### DIFF
--- a/concrete/attributes/select/form.php
+++ b/concrete/attributes/select/form.php
@@ -17,7 +17,7 @@ if ($akSelectAllowMultipleValues && !$akSelectAllowOtherValues) {
         <div class="form-check">
             <?=$form->checkbox($view->field('atSelectOptionValue') . '[]', $opt->getSelectAttributeOptionID(), in_array($opt->getSelectAttributeOptionID(), $selectedOptionIDs));
         ?>
-            <label class="form-check-label">
+            <label class="form-check-label" for="<?= $view->field('atSelectOptionValue') . '_' . $opt->getSelectAttributeOptionID(); ?>">
                 <?=$opt->getSelectAttributeOptionDisplayValue()?>
             </label>
         </div>


### PR DESCRIPTION
This simply adds a 'for' attribute to each label alongside a checkbox, in an option list attribute.
![Screen Shot 2022-10-20 at 2 31 31 pm](https://user-images.githubusercontent.com/1079600/196967209-53b3b905-066b-4faf-bf61-89ce24878f1b.png)

- It means you can click the label to select the checkbox, instead of having to click the checkbox control itself. (and it now matches the behaviour of the individual checkbox attribute)
- Better accessibility.

