### PR TITLE
SMTP config page: don't send the SMTP password to the clients

### DIFF
--- a/concrete/controllers/single_page/dashboard/system/mail/method.php
+++ b/concrete/controllers/single_page/dashboard/system/mail/method.php
@@ -19,7 +19,9 @@ class Method extends DashboardPageController
             if ($this->post('MAIL_SEND_METHOD') == 'SMTP') {
                 $config->save('concrete.mail.methods.smtp.server', $this->post('MAIL_SEND_METHOD_SMTP_SERVER'));
                 $config->save('concrete.mail.methods.smtp.username', $this->post('MAIL_SEND_METHOD_SMTP_USERNAME'));
-                $config->save('concrete.mail.methods.smtp.password', $this->post('MAIL_SEND_METHOD_SMTP_PASSWORD'));
+                if ($this->post('MAIL_SEND_METHOD_SMTP_PASSWORD_CHANGE')) {
+                    $config->save('concrete.mail.methods.smtp.password', $this->post('MAIL_SEND_METHOD_SMTP_PASSWORD'));
+                }
                 $config->save('concrete.mail.methods.smtp.port', $this->post('MAIL_SEND_METHOD_SMTP_PORT'));
                 $config->save('concrete.mail.methods.smtp.encryption', $this->post('MAIL_SEND_METHOD_SMTP_ENCRYPTION'));
                 $messages_per_connection = (int) $this->post('MAIL_SEND_METHOD_SMTP_MESSAGES_PER_CONNECTION');
@@ -33,7 +35,7 @@ class Method extends DashboardPageController
                 $config->clear('concrete.mail.methods.smtp.encryption');
             }
             $this->flash('success', t('Global mail settings saved.'));
-            $this->redirect($this->action(''));
+            return $this->buildRedirect($this->action(''));
         } else {
             $this->error->add($this->token->getErrorMessage());
         }

--- a/concrete/single_pages/dashboard/system/mail/method.php
+++ b/concrete/single_pages/dashboard/system/mail/method.php
@@ -1,11 +1,14 @@
 <?php
 defined('C5_EXECUTE') or die('Access Denied.');
 
-// Arguments
-/* @var Concrete\Core\Config\Repository\Repository $config */
-/* @var \Concrete\Core\Form\Service\Form $form */
+/**
+ * @var Concrete\Core\Config\Repository\Repository $config
+ * @var Concrete\Core\Form\Service\Form $form
+ * @var Concrete\Core\Page\View\PageView $view
+ * @var Concrete\Core\Application\Service\UserInterface $interface
+ * @var Concrete\Core\Validation\CSRF\Token $token
+ */
 
-$enabledVals = ['0' => t('No'), '1' => t('Yes')];
 $secureVals = ['' => t('None'), 'SSL' => tc('Encryption', 'SSL'), 'TLS' => tc('Encryption', 'TLS')];
 ?>
 
@@ -56,7 +59,15 @@ $secureVals = ['' => t('None'), 'SSL' => tc('Encryption', 'SSL'), 'TLS' => tc('E
 
         <div class="form-group">
             <?= $form->label('MAIL_SEND_METHOD_SMTP_PASSWORD', t('Password')) ?>
-            <?= $form->password('MAIL_SEND_METHOD_SMTP_PASSWORD', $config->get('concrete.mail.methods.smtp.password'), ['autocomplete' => 'off']) ?>
+            <div class="input-group">
+                <div class="input-group-text">
+                    <label>
+                        <?= $form->checkbox('MAIL_SEND_METHOD_SMTP_PASSWORD_CHANGE', 1) ?>
+                        <?= t('Change') ?>
+                    </label>
+                </div>
+                <?= $form->password('MAIL_SEND_METHOD_SMTP_PASSWORD', '', ['autocomplete' => 'off', 'disabled' => 'disabled']) ?>
+            </div>
         </div>
 
         <div class="form-group">
@@ -83,19 +94,29 @@ $secureVals = ['' => t('None'), 'SSL' => tc('Encryption', 'SSL'), 'TLS' => tc('E
 
     <div class="ccm-dashboard-form-actions-wrapper">
         <div class="ccm-dashboard-form-actions">
-            <a href="<?= $this->action('test') ?>" class="btn btn-secondary float-start"><?= t('Test Settings') ?></a>
+            <a href="<?= $view->action('test') ?>" class="btn btn-secondary float-start"><?= t('Test Settings') ?></a>
             <?= $interface->submit(t('Save'), 'mail-settings-form', 'right', 'btn-primary') ?>
         </div>
     </div>
 </form>
 
-<script type="text/javascript">
-$('input[name=MAIL_SEND_METHOD]')
-    .change(function() {
-        if ($('input[name="MAIL_SEND_METHOD"]:checked').val() === 'SMTP') {
-            $('#ccm-settings-mail-smtp').show();
-        } else {
-            $('#ccm-settings-mail-smtp').hide();
-        }
-    });
+<script>
+$(document).ready(function() {
+    $('input[name=MAIL_SEND_METHOD]')
+        .on('change', function() {
+            if ($('input[name="MAIL_SEND_METHOD"]:checked').val() === 'SMTP') {
+                $('#ccm-settings-mail-smtp').show();
+            } else {
+                $('#ccm-settings-mail-smtp').hide();
+            }
+        })
+        .trigger('change')
+    ;
+    $('#MAIL_SEND_METHOD_SMTP_PASSWORD_CHANGE')
+        .on('change', function() {
+            $('#MAIL_SEND_METHOD_SMTP_PASSWORD').prop('disabled', !$('#MAIL_SEND_METHOD_SMTP_PASSWORD_CHANGE').is(':checked'));
+        })
+        .trigger('change')
+    ;
+});
 </script>


### PR DESCRIPTION
In the `System & Settings` > `Email` > `SMTP Method` dashboard page we have this section:

![immagine](https://user-images.githubusercontent.com/928116/198038472-66ecb420-bf98-4309-84f6-16eb319b888e.png)

The password is sent to the client, and it's rather easy to get it.

Since it's not necessary, what about this approach instead?

1. When users load the page, they see the following:
   
   ![immagine](https://user-images.githubusercontent.com/928116/198038513-d7b8a2d0-8168-4ad6-be8b-3a1e23594600.png)
3. If they want to set a new password, they simply have to check the "Change" checkbox:
   
   ![immagine](https://user-images.githubusercontent.com/928116/198038654-131926c8-f898-43ea-8883-b24b8757290a.png)

It's not possible to adopt a "leave blank to keep the current password" approach, since the SMTP password may be empty.