### PR TITLE
[v9][Bug][Perf. Improv.] All global areas' blocks loaded on every page load

### DIFF
--- a/concrete/src/Page/Collection/Collection.php
+++ b/concrete/src/Page/Collection/Collection.php
@@ -32,7 +32,7 @@ use Loader;
 use Page;
 use PageCache;
 use Permissions;
-use Stack;
+use Concrete\Core\Page\Stack\Stack;
 
 class Collection extends ConcreteObject implements TrackableInterface
 {
@@ -916,7 +916,7 @@ class Collection extends ConcreteObject implements TrackableInterface
     /**
      * Get the IDs for blocks contained in all the global areas in this collection.
      *
-     * @return \Concrete\Core\Block\Block[]
+     * @return array Return a list of arrays, each one is a dictionary like ['bID' => <block ID>, 'arHandle' => <area handle>]
      */
     public function getGlobalBlockIDs()
     {
@@ -934,7 +934,7 @@ class Collection extends ConcreteObject implements TrackableInterface
     /**
      * Get all the global stacks loaded in this collection.
      *
-     * @return \Concrete\Core\Block\Block[]
+     * @return \Concrete\Core\Page\Stack\Stack[]
      */
     protected function getGlobalStacksForCollection()
     {

--- a/concrete/src/Page/Collection/Collection.php
+++ b/concrete/src/Page/Collection/Collection.php
@@ -896,22 +896,64 @@ class Collection extends ConcreteObject implements TrackableInterface
     }
 
     /**
-     * Get the blocks contained in the all the global areas.
+     * Get the blocks contained in all the global areas in this collection.
      *
      * @return \Concrete\Core\Block\Block[]
      */
     public function getGlobalBlocks()
+    {
+        $stacks = $this->getGlobalStacksForCollection();
+        $blocks = [];
+
+        foreach($stacks as $s) {
+            $blocksTmp = $s->getBlocks(STACKS_AREA_NAME);
+            $blocks = array_merge($blocks, $blocksTmp);
+        }
+
+        return $blocks;
+    }
+
+    /**
+     * Get the IDs for blocks contained in all the global areas in this collection.
+     *
+     * @return \Concrete\Core\Block\Block[]
+     */
+    public function getGlobalBlockIDs()
+    {
+        $stacks = $this->getGlobalStacksForCollection();
+        $blockIDs = [];
+
+        foreach ($stacks as $s) {
+            $blockIDsTmp = $s->getBlockIDs(STACKS_AREA_NAME);
+            $blockIDs = array_merge($blockIDs, $blockIDsTmp);
+        }
+
+        return $blockIDs;
+    }
+
+    /**
+     * Get all the global stacks loaded in this collection.
+     *
+     * @return \Concrete\Core\Block\Block[]
+     */
+    protected function getGlobalStacksForCollection()
     {
         $app = Application::getFacadeApplication();
         /** @var Connection $db */
         $db = $app->make(Connection::class);
         $qb = $db->createQueryBuilder();
         $rs = $qb->select('stName')
-            ->from('Stacks')
-            ->where('stType = :stType')
+            ->from('Stacks', 's')
+            ->innerJoin('s', 'Areas', 'a', 'a.arHandle = s.stName')
+            ->andWhere('a.arIsGlobal = 1')
+            ->andWhere('a.cID = :cID')
+            ->andWhere('s.stType = :stType')
+            ->setParameter('cID', $this->getCollectionID())
             ->setParameter('stType', Stack::ST_TYPE_GLOBAL_AREA)
             ->execute()->fetchAll(FetchMode::COLUMN);
-        $blocks = [];
+
+        $stacks = [];
+
         if (count($rs) > 0) {
             $pcp = new Permissions($this);
             foreach ($rs as $garHandle) {
@@ -921,13 +963,12 @@ class Collection extends ConcreteObject implements TrackableInterface
                     $s = Stack::getByName($garHandle, 'ACTIVE');
                 }
                 if (is_object($s)) {
-                    $blocksTmp = $s->getBlocks(STACKS_AREA_NAME);
-                    $blocks = array_merge($blocks, $blocksTmp);
+                    $stacks[] = $s;
                 }
             }
         }
 
-        return $blocks;
+        return $stacks;
     }
 
     /**


### PR DESCRIPTION
As explained in issue #11035 Any time a page loads, it loads blocks from all Global Areas in the site regardless of whether the area belongs to the current page or not. As a result, it also triggers the on_block_load event for blocks that are not on the page which leads to issues if listening to that event.

This PR does 3 things:

1. It fixes the method getGlobalBlocks() to only fetch global blocks for the current page
2. It adds a public getGlobalBlockIDs() method to mirror the get BlockIDs() method
3. It adds a protected getGlobalStacksForCollection() method used by the 2 other methods

Modifying getGlobalBlocks() to return only the blocks on the current page instead of all the blocks from all the global areas is possible because this method is only used twice in the core and both time in situations where only blocks on the page are needed.