### PR TITLE
Update name and link of Concrete website in elemental theme footer

### DIFF
--- a/concrete/themes/elemental/elements/footer.php
+++ b/concrete/themes/elemental/elements/footer.php
@@ -65,7 +65,7 @@ $displayFirstSection = $footerSiteTitleBlocks > 0 || $footerSocialBlocks > 0 || 
     <div class="container">
         <div class="row">
             <div class="col-sm-12">
-                <span><?php echo t('Built with <a href="http://www.concrete5.org" class="concrete5" rel="nofollow">concrete5</a> CMS.') ?></span>
+                <span><?php echo t('Built with <a href="https://www.concretecms.org" class="concrete5" rel="nofollow">Concrete CMS</a>.') ?></span>
                 <span class="pull-right">
                     <?php echo Core::make('helper/navigation')->getLogInOutLink() ?>
                 </span>


### PR DESCRIPTION
When installing Concrete with the elemental_blank starting point package, we have a footer referring to the good old concrete5.

Let's update it.