### PR TITLE
Add more info in user details dashboard page

### DIFF
--- a/concrete/single_pages/dashboard/users/search/edit.php
+++ b/concrete/single_pages/dashboard/users/search/edit.php
@@ -102,6 +102,18 @@ if (count($languages) > 0) {
         <dd>
             <div><?= $user->getLastIPAddress() ? $user->getLastIPAddress() : t('None') ?></div>
         </dd>
+        <dt><?= t('Last Password Change') ?></dt>
+        <dd>
+            <div><?= $user->getUserLastPasswordChange() === null ? t('Never') : $dh->formatDateTime($user->getUserLastPasswordChange()) ?></div>
+        </dd>
+        <dt><?= t('Last Seen Online') ?></dt>
+        <dd>
+            <div><?= $user->getLastOnline() ? $dh->formatDateTime($user->getLastOnline()) : t('Never') ?></div>
+        </dd>
+        <dt><?= t('# Logins') ?></dt>
+        <dd>
+            <div><?= $user->getNumLogins() ?></div>
+        </dd>
         <?php
         if (Config::get('concrete.misc.user_timezones')) {
             $uTimezone = $user->getUserTimezone();

--- a/concrete/src/User/UserInfo.php
+++ b/concrete/src/User/UserInfo.php
@@ -875,6 +875,14 @@ class UserInfo extends ConcreteObject implements AttributeObjectInterface, Permi
     }
 
     /**
+     * @see \Concrete\Core\Entity\User\User::getUserLastPasswordChange()
+     */
+    public function getUserLastPasswordChange(): ?\DateTimeInterface
+    {
+        return $this->entity->getUserLastPasswordChange();
+    }
+
+    /**
      * @see \Concrete\Core\Entity\User\User::isUserActive()
      */
     public function isActive()


### PR DESCRIPTION
| Before | After |
|---|---|
| ![Before](https://user-images.githubusercontent.com/928116/198406341-290d66fb-f2db-4ce5-add8-cdb56bbb7f46.png) | ![After](https://user-images.githubusercontent.com/928116/198406385-292068f3-2bf8-4bbc-b9ae-178bad9d6d4c.png) |

New details added:
- Last Password Change
- Last Seen Online
- \# Logins (this is already displayed in the users list page: any reason to not display it in the user details page?)