### PR TITLE
Fix XSS on API Integrations H1 1753684

### DIFF
--- a/concrete/single_pages/dashboard/system/api/integrations.php
+++ b/concrete/single_pages/dashboard/system/api/integrations.php
@@ -16,7 +16,7 @@ if ($pagination->getTotalResults() > 0) { ?>
         <?php foreach ($pagination->getCurrentPageResults() as $client) { ?>
         <tr data-details-url="<?=$view->action('view_client', $client->getIdentifier())?>">
             <td class="text-nowrap"><?=$client->getIdentifier()?></td>
-            <td class="ccm-search-results-name w-100"><?=$client->getName()?></td>
+            <td class="ccm-search-results-name w-100"><?=h($client->getName())?></td>
         </tr>
         <?php } ?>
         </tbody>

--- a/concrete/single_pages/dashboard/system/api/integrations/view_client.php
+++ b/concrete/single_pages/dashboard/system/api/integrations/view_client.php
@@ -29,7 +29,7 @@ $consentType = $client->getConsentType();
 
     <div class="mb-3">
         <label class="form-label"><?=t('Name')?></label>
-        <div><?=$client->getName()?></div>
+        <div><?=h($client->getName())?></div>
     </div>
 
     <div class="mb-3">


### PR DESCRIPTION
This fixes XSS which was due to getName() function lacked sanitization on two places. This commit fixes this issue.