### PR TITLE
[v9][Bug] Fix legacy alpha channel in upgradeColorValue function

### DIFF
--- a/concrete/src/Updater/Migrations/Migrations/Version20211023155414.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20211023155414.php
@@ -71,7 +71,7 @@ final class Version20211023155414 extends AbstractMigration implements Repeatabl
         $value->setRed($legacyValueValueData['r']);
         $value->setGreen($legacyValueValueData['g']);
         $value->setBlue($legacyValueValueData['b']);
-        if ($legacyValueValueData['a']) {
+        if (isset($legacyValueValueData['a'])) {
             $value->setAlpha($legacyValueValueData['a']);
         } else {
             $value->setAlpha(1);

--- a/concrete/src/Updater/Migrations/Migrations/Version20211023155414.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20211023155414.php
@@ -72,7 +72,7 @@ final class Version20211023155414 extends AbstractMigration implements Repeatabl
         $value->setGreen($legacyValueValueData['g']);
         $value->setBlue($legacyValueValueData['b']);
         if (isset($legacyValueValueData['a'])) {
-            $value->setAlpha($legacyValueValueData['a']);
+            $value->setAlpha((float) $legacyValueValueData['a']);
         } else {
             $value->setAlpha(1);
         }

--- a/concrete/src/Updater/Migrations/Migrations/Version20211023155414.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20211023155414.php
@@ -71,13 +71,12 @@ final class Version20211023155414 extends AbstractMigration implements Repeatabl
         $value->setRed($legacyValueValueData['r']);
         $value->setGreen($legacyValueValueData['g']);
         $value->setBlue($legacyValueValueData['b']);
-        if (isset($legacyValueValueData['a'])) {
-            if (is_bool($legacyValueValueData['a'])) {
-                $legacyValueValueData['a'] = (int) $legacyValueValueData['a'];
-            }
+        if ($legacyValueValueData['a']) {
             $value->setAlpha($legacyValueValueData['a']);
-        } else {
+        } elseif (is_bool($legacyValueValueData['a'])) {
             $value->setAlpha(1);
+        } else {
+            $value->setAlpha(0);
         }
         return $value;
     }

--- a/concrete/src/Updater/Migrations/Migrations/Version20211023155414.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20211023155414.php
@@ -72,7 +72,10 @@ final class Version20211023155414 extends AbstractMigration implements Repeatabl
         $value->setGreen($legacyValueValueData['g']);
         $value->setBlue($legacyValueValueData['b']);
         if (isset($legacyValueValueData['a'])) {
-            $value->setAlpha((float) $legacyValueValueData['a']);
+            if (is_bool($legacyValueValueData['a'])) {
+                $legacyValueValueData['a'] = (int) $legacyValueValueData['a'];
+            }
+            $value->setAlpha($legacyValueValueData['a']);
         } else {
             $value->setAlpha(1);
         }


### PR DESCRIPTION
Fix upgradeColorValue function : legacy value for alpha channel can now be equal to 0. It was changed to 1 if it was equal to 0.