### PR TITLE
Fixes double slash issue in Calendar Block modal href

### DIFF
--- a/concrete/blocks/calendar/view.php
+++ b/concrete/blocks/calendar/view.php
@@ -50,7 +50,7 @@ if ($c->isEditMode()) {
 
                 eventRender: function(event, element) {
                     <?php if ($controller->supportsLightbox()) { ?>
-                        element.attr('href', '<?=rtrim(URL::route(array('/view_event', 'calendar'), $bID))?>/' + event.id).magnificPopup({
+                        element.attr('href', '<?=rtrim(URL::route(array('/view_event', 'calendar'), $bID), " \n\r\t\v\x00\/")?>/' + event.id).magnificPopup({
                             type: 'ajax',
                             callbacks: {
                                 beforeOpen: function () {


### PR DESCRIPTION
Fixes issue where the `href` values generated in the Calendar Block `view.php` are malformed when trailing slashes are enabled in config:

```
# before
https://example.com/ccm/calendar/view_event/1529//9

# after
https://example.com/ccm/calendar/view_event/1529/9
```