### PR TITLE
Make it so heartbeat updates uLastOnline

### DIFF
--- a/concrete/bootstrap/configure.php
+++ b/concrete/bootstrap/configure.php
@@ -325,6 +325,9 @@ const DEFAULT_GROUP_ROLE_ID = '1';
  */
 const USER_FOREVER_COOKIE_LIFETIME = 1209600; // 14 days
 const USER_CHANGE_PASSWORD_URL_LIFETIME = 7200;
+/**
+ * @deprecated use app(\Concrete\Core\Session\SessionValidator::class)->getUserActivityThreshold()
+ */
 const ONLINE_NOW_TIMEOUT = 300;
 const UVTYPE_REGISTER = 0;
 const UVTYPE_CHANGE_PASSWORD = 1;

--- a/concrete/controllers/frontend/heartbeat.php
+++ b/concrete/controllers/frontend/heartbeat.php
@@ -5,6 +5,7 @@ namespace Concrete\Controller\Frontend;
 use Concrete\Core\Controller\Controller;
 use Concrete\Core\Http\ResponseFactoryInterface;
 use Concrete\Core\Session\SessionValidator;
+use Concrete\Core\User\User;
 
 class Heartbeat extends Controller
 {
@@ -12,8 +13,11 @@ class Heartbeat extends Controller
     {
         $sessionValidator = $this->app->make(SessionValidator::class);
         if ($sessionValidator->hasActiveSession()) {
-            // "Touch" the session so that it remains open
-            $this->app->make('session');
+            // This also "touches" the session so that it remains open
+            $user = $this->app->make(User::class);
+            if ($user->isRegistered()) {
+                $user->updateOnlineCheck();
+            }
         }
 
         return $this->app->make(ResponseFactoryInterface::class)->json(true);

--- a/concrete/src/Application/Service/User.php
+++ b/concrete/src/Application/Service/User.php
@@ -1,13 +1,14 @@
 <?php
 namespace Concrete\Core\Application\Service;
 
+use Concrete\Core\Session\SessionValidator;
 use Loader;
 use TaskPermission;
 
 class User
 {
     /**
-     * @param $uo \User
+     * @param $uo \Concrete\Core\User\User|int
      * @param bool $showSpacer
      *
      * @return mixed
@@ -22,8 +23,8 @@ class User
             $db = Loader::db();
             $ul = $db->getOne("select uLastOnline from Users where uID = {$uo}");
         }
-
-        $online = (time() - $ul) <= ONLINE_NOW_TIMEOUT;
+        $onlineTimeout = app(SessionValidator::class)->getUserActivityThreshold();
+        $online = (time() - $ul) <= $onlineTimeout;
 
         if ($online) {
             return ONLINE_NOW_SRC_ON;

--- a/concrete/src/User/User.php
+++ b/concrete/src/User/User.php
@@ -137,14 +137,7 @@ class User extends ConcreteObject
                     return false;
                 }
 
-                $session->set('uOnlineCheck', time());
-                if (($session->get('uOnlineCheck') - $session->get('uLastOnline') > (ONLINE_NOW_TIMEOUT / 2))) {
-                    // This code throttles the writing of uLastOnline to the database, so that we're not constantly
-                    // updating the Users table. If you need to have the exact up to date metric on when a session
-                    // last looked at a page, use uOnlineCheck.
-                    $db->query('update Users set uLastOnline = ? where uID = ?', [$session->get('uOnlineCheck'), $this->uID]);
-                    $session->set('uLastOnline', $session->get('uOnlineCheck'));
-                }
+                $this->updateOnlineCheck();
 
                 return true;
             } else {
@@ -153,6 +146,23 @@ class User extends ConcreteObject
         }
 
         return false;
+    }
+
+    /**
+     * This code throttles the writing of uLastOnline to the database, so that we're not constantly
+     * updating the Users table. If you need to have the exact up to date metric on when a session
+     * last looked at a page, use the uOnlineCheck session key.
+     */
+    public function updateOnlineCheck(): void
+    {
+        $now = time();
+        $session = app('session');
+        $session->set('uOnlineCheck', $now);
+        if (($now - $session->get('uLastOnline')) > (ONLINE_NOW_TIMEOUT / 2)) {
+            $db = app(Connection::class);
+            $db->update('Users', ['uLastOnline' => $now], ['uID' => $this->getUserID()]);
+            $session->set('uLastOnline', $now);
+        }
     }
 
     /**

--- a/concrete/src/User/User.php
+++ b/concrete/src/User/User.php
@@ -158,7 +158,10 @@ class User extends ConcreteObject
         $now = time();
         $session = app('session');
         $session->set('uOnlineCheck', $now);
-        if (($now - $session->get('uLastOnline')) > (ONLINE_NOW_TIMEOUT / 2)) {
+        $activityThreshold = app(SessionValidator::class)->getUserActivityThreshold();
+        $saveThreshold = $activityThreshold / 2;
+        $elapsedTime = $now - $session->get('uLastOnline');
+        if ($elapsedTime > $saveThreshold) {
             $db = app(Connection::class);
             $db->update('Users', ['uLastOnline' => $now], ['uID' => $this->getUserID()]);
             $session->set('uLastOnline', $now);


### PR DESCRIPTION
The route `/ccm/system/heartbeat` is [called every 30 seconds](https://github.com/concretecms/bedrock/blob/e9042c2e279e58c4ae58efe8799145589ad2d3bf/assets/cms/js/edit-mode/heartbeat.js#L6) when there's [some user activity](https://github.com/concretecms/bedrock/blob/e9042c2e279e58c4ae58efe8799145589ad2d3bf/assets/cms/js/edit-mode/heartbeat.js#L8) on the client side.

What about updating the value of the `uLastOnline` user field and the `uOnlineCheck` session key accordingly?

That way, the session validator won't think that users have been away too much whereas they are actually working on the client side (and so avoiding session invalidation if `concrete.security.session.invalidate_inactive_users.enabled` is set to `true`).

Also, we have the `ONLINE_NOW_TIMEOUT` global constant, which has the same meaning as the `concrete.security.session.invalidate_inactive_users.time` configuration key: what about deprecating that constant?