### PR TITLE
Bugfix: Bulk update for page attributes only saves first selected page

### DIFF
--- a/concrete/src/Attribute/Key/Component/KeySelector/ControllerTrait.php
+++ b/concrete/src/Attribute/Key/Component/KeySelector/ControllerTrait.php
@@ -6,6 +6,7 @@ use Concrete\Core\Attribute\Category\CategoryInterface;
 use Concrete\Core\Attribute\Command\ClearAttributesCommand;
 use Concrete\Core\Attribute\Command\SaveAttributesCommand;
 use Concrete\Core\Attribute\ObjectInterface;
+use Concrete\Core\Error\ErrorList\ErrorList;
 use Concrete\Core\Validation\Response;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
@@ -26,7 +27,7 @@ trait ControllerTrait
 
     abstract public function canEditAttributeKey(int $akID): bool;
 
-    public function saveAttributes()
+    public function saveAttributes(): ?ErrorList
     {
         // Let's retrieve a list of attribute keys that we're trying to set.
         $selectedAttributes = (array) $this->request->request->get('selectedKeys', []);
@@ -78,8 +79,9 @@ trait ControllerTrait
 
             $this->app->executeCommand(new ClearAttributesCommand($attributesToClear, $object));
             $this->app->executeCommand(new SaveAttributesCommand($attributesToSave, $object));
-            return null;
         }
+
+        return null;
     }
 
     public function getAttribute()


### PR DESCRIPTION
Hi all,

I found a bug regarding bulk updating page attributes.
When select multiple pages only the first one is updated.

This was due to a return statement which was executed in the foreach loop.
Therefor the other objects where never updates.

I moved the return statement and added a return type for PHP 8.

Kind Regards,
Laurens van Strijland