### PR TITLE
Fix undefined array key

### DIFF
--- a/concrete/src/Express/Export/EntryList/CsvWriter.php
+++ b/concrete/src/Express/Export/EntryList/CsvWriter.php
@@ -100,7 +100,7 @@ class CsvWriter
         $result = [];
 
         foreach ($headerKeys as $key) {
-            $result[$key] = $entry[$key];
+            $result[$key] = $entry[$key] ?? null;
         }
 
         return $result;


### PR DESCRIPTION
Fix undefined array key when exporting Express entries on PHP 8

