### PR TITLE
Antispam getByHandle broken with PHP 8

### DIFF
--- a/concrete/src/Antispam/Library.php
+++ b/concrete/src/Antispam/Library.php
@@ -96,7 +96,7 @@ class Library extends ConcreteObject
     {
         $db = Loader::db();
         $r = $db->GetRow('select saslHandle, saslIsActive, pkgID, saslName from SystemAntispamLibraries where saslHandle = ?', array($saslHandle));
-        if (is_array($r) && $r['saslHandle']) {
+        if (is_array($r) && isset($r['saslHandle']) && $r['saslHandle']) {
             $sc = new static();
             $sc->setPropertiesFromArray($r);
 


### PR DESCRIPTION
A fix for PHP 8: checking an array key exists before using it. Nothing to it. Explained in #11080 