### PR TITLE
[v8] Avoid installing commerceguys/addressing 1.4+

### DIFF
--- a/concrete/composer.json
+++ b/concrete/composer.json
@@ -90,7 +90,7 @@
     "guzzlehttp/guzzle": "^6.3",
     "league/fractal": "^0.17.0",
     "theorchard/monolog-cascade": "0.5.*",
-    "commerceguys/addressing": "^1.0",
+    "commerceguys/addressing": "^1.0 <1.4",
     "enshrined/svg-sanitize": "^0.14.0"
   },
   "extra": {


### PR DESCRIPTION
With commerceguys/addressing 1.4+ we have this error:
```
Declaration of
Concrete\Core\Localization\Address\Formatter::buildView(...)
must be compatible with
CommerceGuys\Addressing\Formatter\DefaultFormatter::buildView(...): array
```

See https://github.com/commerceguys/addressing/pull/167#issuecomment-1326323236
