### PR TITLE
Add support for commerceguys/addressing v1.4+

### DIFF
--- a/concrete/src/Localization/Address/Formatter.php
+++ b/concrete/src/Localization/Address/Formatter.php
@@ -49,7 +49,7 @@ class Formatter extends DefaultFormatter
         AddressInterface $address,
         AddressFormat $addressFormat,
         array $options
-    ) {
+    ): array {
         $view = parent::buildView($address, $addressFormat, $options);
 
         if ($options['subdivision_names'] === true) {


### PR DESCRIPTION
In commerceguys/addressing 1.4.0 they [introduced a breaking change](https://github.com/commerceguys/addressing/pull/167).

For ConcreteCMS v9 we can be adopt the fix of this PR (since inherited methods can have a return type that's stricter than the overriden methods).
For concrete5 v8 I don't see any other solution than the one I suggested in #11087
