### PR TITLE
Commit in case of splitter failure

### DIFF
--- a/concrete/dispatcher.php
+++ b/concrete/dispatcher.php
@@ -7,7 +7,7 @@ if (!defined('PHP_VERSION_ID') || PHP_VERSION_ID < 70209) {
 /*
  * ----------------------------------------------------------------------------
  * Set required constants, including directory names, attempt to include site configuration file with database
- * information, attempt to determine if we ought to skip to an updated core, etc...
+ * information, attempt to determine if we ought to skip to an updated core, etc.
  * ----------------------------------------------------------------------------
  */
 require __DIR__ . '/bootstrap/configure.php';


### PR DESCRIPTION
This is a pr that touches concrete that makes a trivial change to a comment in order to fix the core splitter.  Otherwise you have to manually rebuild if you merge a change that doesn't touch concrete until we fix the splitter.