### PR TITLE
Handle null results node ID in csv writer

### DIFF
--- a/concrete/src/Express/Export/EntryList/CsvWriter.php
+++ b/concrete/src/Express/Export/EntryList/CsvWriter.php
@@ -122,7 +122,8 @@ class CsvWriter
         yield 'publicIdentifier' => $entry->getPublicIdentifier();
 
         // Resolve the site
-        $site = $this->getSiteService()->getSiteByExpressResultsNodeID($entry->getResultsNodeID());
+        $resultsNodeId = $entry->getResultsNodeID();
+        $site = $resultsNodeId ? $this->getSiteService()->getSiteByExpressResultsNodeID($resultsNodeId) : null;
         yield 'site' => $site instanceof Site ? $site->getSiteHandle() : null;
 
         $author = $entry->getAuthor();


### PR DESCRIPTION
A null results node id will cause `->getSiteByExpressResultsNodeID(...)` to throw an exception causing csv export to fail. Instead we should treat a null result node id as if the site is null and continue as usual.
