### PR TITLE
[v9][Bug] "select fileset" dialog in file manager doesn't retain file set values

### DIFF
--- a/concrete/elements/files/bulk/add_to_sets.php
+++ b/concrete/elements/files/bulk/add_to_sets.php
@@ -50,7 +50,7 @@ View::element(
             $checkbox->addClass("form-check-input");
             $checkbox->setAttribute("id", $id);
 
-            $input = new Input('hidden', 'fsID:' . $fileset->getFileSetID(), 0);
+            $input = new Input('hidden', 'fsID:' . $fileset->getFileSetID(), $fileset->getFileSetID());
             $input->setAttribute('data-set-input', $fileset->getFileSetID());
 
             $found = 0;


### PR DESCRIPTION
Issue explained in #11122 

When trying to add files to file sets from the file manager, any file sets already selected is checked in the dialog but the hidden input representing each file set gets a value of 0. So when saving, those file sets get deselected.

This fixes it