### PR TITLE
Fix entity mappings

### DIFF
--- a/concrete/src/Entity/Health/Report/Finding.php
+++ b/concrete/src/Entity/Health/Report/Finding.php
@@ -26,7 +26,7 @@ abstract class Finding
     protected $id;
 
     /**
-     * @ORM\ManyToOne(targetEntity="Result")
+     * @ORM\ManyToOne(targetEntity="Result", inversedBy="findings")
      */
     protected $result;
 

--- a/concrete/src/Entity/User/GroupRoleChange.php
+++ b/concrete/src/Entity/User/GroupRoleChange.php
@@ -29,7 +29,7 @@ class GroupRoleChange implements SubjectInterface
     protected $id;
 
     /**
-     * @ORM\OneToMany(targetEntity="\Concrete\Core\Entity\Notification\GroupRoleChangeNotification", mappedBy="signup", cascade={"remove"}),
+     * @ORM\OneToMany(targetEntity="\Concrete\Core\Entity\Notification\GroupRoleChangeNotification", mappedBy="groupRoleChange", cascade={"remove"}),
      *
      * @var \Doctrine\Common\Collections\Collection
      */

--- a/concrete/src/Entity/User/GroupSignupRequest.php
+++ b/concrete/src/Entity/User/GroupSignupRequest.php
@@ -28,7 +28,7 @@ class GroupSignupRequest implements SubjectInterface
     protected $id;
 
     /**
-     * @ORM\OneToMany(targetEntity="\Concrete\Core\Entity\Notification\GroupSignupRequestNotification", mappedBy="signup", cascade={"remove"}),
+     * @ORM\OneToMany(targetEntity="\Concrete\Core\Entity\Notification\GroupSignupRequestNotification", mappedBy="signupRequest", cascade={"remove"}),
      *
      * @var \Doctrine\Common\Collections\Collection
      */


### PR DESCRIPTION
### Before

```
biplob@Biplobs-MacBook-Pro concretecms % c5 orm:validate-schema

Mapping
-------

 [FAIL] The entity-class Concrete\Core\Entity\Notification\GroupSignupRequestNotification mapping is invalid:
 * The mappings Concrete\Core\Entity\Notification\GroupSignupRequestNotification#signupRequest and Concrete\Core\Entity\User\GroupSignupRequest#notifications are inconsistent with each other.


 [FAIL] The entity-class Concrete\Core\Entity\Notification\GroupRoleChangeNotification mapping is invalid:
 * The mappings Concrete\Core\Entity\Notification\GroupRoleChangeNotification#groupRoleChange and Concrete\Core\Entity\User\GroupRoleChange#notifications are inconsistent with each other.


 [FAIL] The entity-class Concrete\Core\Entity\Health\Report\SearchResult mapping is invalid:
 * The field Concrete\Core\Entity\Health\Report\SearchResult#findings is on the inverse side of a bi-directional relationship, but the specified mappedBy association on the target-entity Concrete\Core\Entity\Health\Report\Finding#result does not contain the required 'inversedBy="findings"' attribute.


 [FAIL] The entity-class Concrete\Core\Entity\Health\Report\Result mapping is invalid:
 * The field Concrete\Core\Entity\Health\Report\Result#findings is on the inverse side of a bi-directional relationship, but the specified mappedBy association on the target-entity Concrete\Core\Entity\Health\Report\Finding#result does not contain the required 'inversedBy="findings"' attribute.


 [FAIL] The entity-class Concrete\Core\Entity\User\GroupRoleChange mapping is invalid:
 * The association Concrete\Core\Entity\User\GroupRoleChange#notifications refers to the owning side field Concrete\Core\Entity\Notification\GroupRoleChangeNotification#signup which does not exist.


 [FAIL] The entity-class Concrete\Core\Entity\User\GroupSignupRequest mapping is invalid:
 * The association Concrete\Core\Entity\User\GroupSignupRequest#notifications refers to the owning side field Concrete\Core\Entity\Notification\GroupSignupRequestNotification#signup which does not exist.
```

### After

```
biplob@Biplobs-MacBook-Pro concretecms % c5 orm:validate-schema

Mapping
-------

                                                                                                                        
 [OK] The mapping files are correct.                                                                                    
                                                                                                                        
```

