### PR TITLE
Declare ::$page class property that's in use

### DIFF
--- a/concrete/src/Page/Type/Composer/Control/Control.php
+++ b/concrete/src/Page/Type/Composer/Control/Control.php
@@ -14,6 +14,7 @@ use HtmlObject\Element;
 
 abstract class Control extends ConcreteObject
 {
+    protected $page;
     protected $ptComposerControlIdentifier;
     protected $ptComposerControlName;
     protected $ptComposerControlIconSRC;


### PR DESCRIPTION
I get errors in PHP 8.2 due to this property not being declared.