### PR TITLE
Allow IP changes inside specific IP ranges

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -8,7 +8,7 @@ return [
      */
     'version' => '9.2.0a3',
     'version_installed' => '9.2.0a3',
-    'version_db' => '20221219220600', // the key of the latest database migration
+    'version_db' => '20230107185800', // the key of the latest database migration
 
     /*
      * Installation status

--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -1266,6 +1266,8 @@ return [
 
             'ignored_ip_mismatches' => [],
 
+            'enable_user_specific_ignored_ip_mismatches' => false,
+
             'invalidate_inactive_users' => [
                 // Is the automatically logout inactive users setting enabled?
                 'enabled' => false,

--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -1264,6 +1264,8 @@ return [
 
             'invalidate_on_ip_mismatch' => true,
 
+            'ignored_ip_mismatches' => [],
+
             'invalidate_inactive_users' => [
                 // Is the automatically logout inactive users setting enabled?
                 'enabled' => false,

--- a/concrete/controllers/single_page/dashboard/system/registration/automated_logout.php
+++ b/concrete/controllers/single_page/dashboard/system/registration/automated_logout.php
@@ -7,24 +7,38 @@ use Concrete\Core\Config\Repository\Repository;
 use Concrete\Core\Http\ResponseFactory;
 use Concrete\Core\Page\Controller\DashboardPageController;
 use Concrete\Core\Page\Page;
+use Concrete\Core\Session\SessionValidator;
 use Concrete\Core\Url\Resolver\Manager\ResolverManager;
 use Concrete\Core\Utility\Service\Validation\Numbers;
-use IPLib\Address\AddressInterface;
 use IPLib\Factory;
+use IPLib\Address\AddressInterface;
 
 class AutomatedLogout extends DashboardPageController
 {
-    public const ITEM_IP = 'concrete.security.session.invalidate_on_ip_mismatch';
+    /**
+     * @deprecated Use \Concrete\Core\Session\SessionValidator::CONFIGKEY_IP_MISMATCH
+     */
+    public const ITEM_IP = SessionValidator::CONFIGKEY_IP_MISMATCH;
 
-    public const ITEM_IGNORED_IP = 'concrete.security.session.ignored_ip_mismatches';
+    /**
+     * @deprecated Use \Concrete\Core\Session\SessionValidator::CONFIGKEY_USERAGENT_MISMATCH
+     */
+    public const ITEM_USER_AGENT = SessionValidator::CONFIGKEY_USERAGENT_MISMATCH;
 
-    public const ITEM_USER_AGENT = 'concrete.security.session.invalidate_on_user_agent_mismatch';
+    /**
+     * @deprecated Use \Concrete\Core\Session\SessionValidator::CONFIGKEY_SESSION_INVALIDATE
+     */
+    public const ITEM_SESSION_INVALIDATE = SessionValidator::CONFIGKEY_SESSION_INVALIDATE;
 
-    public const ITEM_SESSION_INVALIDATE = 'concrete.session.valid_since';
+    /**
+     * @deprecated Use \Concrete\Core\Session\SessionValidator::CONFIGKEY_INVALIDATE_INACTIVE_USERS
+     */
+    public const ITEM_INVALIDATE_INACTIVE_USERS = SessionValidator::CONFIGKEY_INVALIDATE_INACTIVE_USERS;
 
-    public const ITEM_INVALIDATE_INACTIVE_USERS = 'concrete.security.session.invalidate_inactive_users.enabled';
-
-    public const ITEM_INVALIDATE_INACTIVE_USERS_TIME = 'concrete.security.session.invalidate_inactive_users.time';
+    /**
+     * @deprecated Use \Concrete\Core\Session\SessionValidator::CONFIGKEY_INVALIDATE_INACTIVE_USERS_TIME
+     */
+    public const ITEM_INVALIDATE_INACTIVE_USERS_TIME = SessionValidator::CONFIGKEY_INVALIDATE_INACTIVE_USERS_TIME;
 
     /**
      * The response factory we use to generate responses.
@@ -63,12 +77,12 @@ class AutomatedLogout extends DashboardPageController
     public function view()
     {
         $this->set('trustedProxyUrl', $this->urls->resolve(['/dashboard/system/permissions/trusted_proxies']));
-        $this->set('invalidateOnIPMismatch', (bool) $this->config->get(static::ITEM_IP));
-        $this->set('ignoredIPMismatches', (array) $this->config->get(static::ITEM_IGNORED_IP));
+        $this->set('invalidateOnIPMismatch', (bool) $this->config->get(SessionValidator::CONFIGKEY_IP_MISMATCH));
+        $this->set('ignoredIPMismatches', (array) $this->config->get(SessionValidator::CONFIGKEY_IP_MISMATCH_ALLOWLIST));
         $this->set('myIPAddress', $this->app->make(AddressInterface::class));
-        $this->set('invalidateOnUserAgentMismatch', (bool) $this->config->get(static::ITEM_USER_AGENT));
-        $this->set('invalidateInactiveUsers', (bool) $this->config->get(static::ITEM_INVALIDATE_INACTIVE_USERS));
-        $this->set('inactiveTime', ((int) $this->config->get(static::ITEM_INVALIDATE_INACTIVE_USERS_TIME)) ?: null);
+        $this->set('invalidateOnUserAgentMismatch', (bool) $this->config->get(SessionValidator::CONFIGKEY_USERAGENT_MISMATCH));
+        $this->set('invalidateInactiveUsers', (bool) $this->config->get(SessionValidator::CONFIGKEY_INVALIDATE_INACTIVE_USERS));
+        $this->set('inactiveTime', ((int) $this->config->get(SessionValidator::CONFIGKEY_INVALIDATE_INACTIVE_USERS_TIME)) ?: null);
         $this->set('confirmInvalidateString', $this->getConfirmInvalidateString());
     }
 
@@ -111,12 +125,12 @@ class AutomatedLogout extends DashboardPageController
         }
 
         // Save the posted settings
-        $this->config->save(static::ITEM_IP, (bool) $post->get('invalidateOnIPMismatch'));
-        $this->config->save(static::ITEM_IGNORED_IP, $ignoredIPMismatches);
-        $this->config->save(static::ITEM_USER_AGENT, (bool) $post->get('invalidateOnUserAgentMismatch'));
-        $this->config->save(static::ITEM_INVALIDATE_INACTIVE_USERS, $invalidateInactiveUsers);
+        $this->config->save(SessionValidator::CONFIGKEY_IP_MISMATCH, (bool) $post->get('invalidateOnIPMismatch'));
+        $this->config->save(SessionValidator::CONFIGKEY_IP_MISMATCH_ALLOWLIST, $ignoredIPMismatches);
+        $this->config->save(SessionValidator::CONFIGKEY_USERAGENT_MISMATCH, (bool) $post->get('invalidateOnUserAgentMismatch'));
+        $this->config->save(SessionValidator::CONFIGKEY_INVALIDATE_INACTIVE_USERS, $invalidateInactiveUsers);
         if ($invalidateInactiveUsers) {
-            $this->config->save(static::ITEM_INVALIDATE_INACTIVE_USERS_TIME, $inactiveTime);
+            $this->config->save(SessionValidator::CONFIGKEY_INVALIDATE_INACTIVE_USERS_TIME, $inactiveTime);
         }
 
         $this->flash('message', t('Successfully saved Session Security settings'));
@@ -163,7 +177,7 @@ class AutomatedLogout extends DashboardPageController
     protected function invalidateSessions()
     {
         // Save the configuration that invalidates sessions
-        $this->config->save(static::ITEM_SESSION_INVALIDATE, Carbon::now('utc')->getTimestamp());
+        $this->config->save(SessionValidator::CONFIGKEY_SESSION_INVALIDATE, Carbon::now('utc')->getTimestamp());
 
         // Invalidate the current session explicitly so that we get back to the login page with a nice error message
         $this->app->make('session')->invalidate();

--- a/concrete/controllers/single_page/dashboard/users/search.php
+++ b/concrete/controllers/single_page/dashboard/users/search.php
@@ -15,6 +15,7 @@ use Concrete\Core\Logging\Channels;
 use Concrete\Core\Logging\LoggerFactory;
 use Concrete\Core\Navigation\Breadcrumb\Dashboard\DashboardUserBreadcrumbFactory;
 use Concrete\Core\Page\Controller\DashboardPageController;
+use Concrete\Core\Page\Page;
 use Concrete\Core\Permission\Checker;
 use Concrete\Core\Url\Url;
 use Concrete\Core\User\Command\UpdateUserAvatarCommand;
@@ -42,6 +43,7 @@ use Concrete\Core\Search\Query\QueryFactory;
 use Concrete\Core\Search\Query\QueryModifier;
 use Concrete\Core\Search\Result\Result;
 use Concrete\Core\Search\Result\ResultFactory;
+use IPLib\Factory;
 use Symfony\Component\HttpFoundation\Request;
 
 class Search extends DashboardPageController
@@ -377,6 +379,21 @@ class Search extends DashboardPageController
                 $data['uPasswordConfirm'] = $passwordNew;
                 $data['uPassword'] = $passwordNew;
             }
+            if ($this->canEditIgnoredIPMismatches()) {
+                $ignoredIPMismatches = [];
+                foreach (preg_split('/\s+/', (string) $this->request->request->get('ignoredIPMismatches'), -1, PREG_SPLIT_NO_EMPTY) as $ignoredIPMismatch) {
+                    $range = Factory::parseRangeString($ignoredIPMismatch);
+                    if ($range === null) {
+                        $error->add(t('The IP address range %s is not valid.', $ignoredIPMismatch));
+                    } else {
+                        $range = (string) $range;
+                        if (!in_array($range, $ignoredIPMismatches, true)) {
+                            $ignoredIPMismatches[] = $range;
+                        }
+                    }
+                }
+                $data['ignoredIPMismatches'] = $ignoredIPMismatches;
+            }
 
             $userMessage->setError($error);
             if (!$error->has()) {
@@ -690,6 +707,18 @@ class Search extends DashboardPageController
                 || $this->canEditLanguage || $this->canEditTimezone);
             $this->set('allowedEditAttributes', $this->allowedEditAttributes);
             $this->set('canAddGroup', $this->canAddGroup);
+            $this->set('canEditIgnoredIPMismatches', $this->canEditIgnoredIPMismatches());
         }
+    }
+
+    protected function canEditIgnoredIPMismatches(): bool
+    {
+        $page = Page::getByPath('/dashboard/system/registration/automated_logout');
+        if (!$page || $page->isError()) {
+            return false;
+        }
+        $permissions = new Checker($page);
+
+        return $permissions->canViewPage() ? true : false;
     }
 }

--- a/concrete/single_pages/dashboard/system/registration/automated_logout.php
+++ b/concrete/single_pages/dashboard/system/registration/automated_logout.php
@@ -7,6 +7,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
  * @var Concrete\Controller\SinglePage\Dashboard\System\Registration\AutomatedLogout $controller
  * @var Concrete\Core\Url\UrlImmutable $trustedProxyUrl
  * @var bool $invalidateOnIPMismatch
+ * @var bool $enableUserSpecificIgnoredIPMismatches
  * @var bool $invalidateOnUserAgentMismatch
  * @var bool $invalidateInactiveUsers
  * @var int|null $inactiveTime
@@ -26,6 +27,10 @@ defined('C5_EXECUTE') or die('Access Denied.');
         <div class="form-check">
             <?= $form->checkbox('invalidateOnIPMismatch', '1', $invalidateOnIPMismatch) ?>
             <label class="form-check-label" for="invalidateOnIPMismatch"><?= t('Log users out if their IP changes') ?></label>
+        </div>
+        <div class="form-check">
+            <?= $form->checkbox('enableUserSpecificIgnoredIPMismatches', '1', $enableUserSpecificIgnoredIPMismatches) ?>
+            <label class="form-check-label" for="enableUserSpecificIgnoredIPMismatches"><?= t('Enable user-specific IP addresses to be ignored') ?></label>
         </div>
         <div class="form-check">
             <?= $form->checkbox('invalidateOnUserAgentMismatch', '1', $invalidateOnUserAgentMismatch) ?>
@@ -57,7 +62,6 @@ defined('C5_EXECUTE') or die('Access Denied.');
                 '<code>::1/8</code>'
             ) ?><br />
             <?= t('Your IP address:') ?> <code><?= h((string) $myIPAddress) ?></code>
-            <?= t('Please remark that you may also define user-specific IP ranges.') ?>
         </div>
     </div>
 
@@ -87,7 +91,13 @@ defined('C5_EXECUTE') or die('Access Denied.');
 
 <script>
 $(document).ready(function() {
-
+    $('#invalidateOnIPMismatch')
+        .on('change', function() {
+            var enabled = $('#invalidateOnIPMismatch').is(':checked');
+            $('#enableUserSpecificIgnoredIPMismatches,#ignoredIPMismatches').attr('disabled', !enabled);
+        })
+        .trigger('change')
+    ;
     $('#invalidateInactiveUsers')
         .on('change', function() {
             $('#inactiveTime').attr('disabled', $(this).is(':checked') ? null : 'disabled');

--- a/concrete/single_pages/dashboard/system/registration/automated_logout.php
+++ b/concrete/single_pages/dashboard/system/registration/automated_logout.php
@@ -10,6 +10,8 @@ defined('C5_EXECUTE') or die('Access Denied.');
  * @var bool $invalidateOnUserAgentMismatch
  * @var bool $invalidateInactiveUsers
  * @var int|null $inactiveTime
+ * @var string[] $ignoredIPMismatches
+ * @var IPLib\Address\AddressInterface $myIPAddress
  * @var string $confirmInvalidateString
  */
 ?>
@@ -39,6 +41,22 @@ defined('C5_EXECUTE') or die('Access Denied.');
 ) ?>
                 </span>
             </label>
+        </div>
+    </div>
+
+    <div class="form-group">
+        <?= $form->label('ignoredIPMismatches', t('Prevent logout if changed IP addresses are in the following ranges')) ?>
+        <?= $form->textarea('ignoredIPMismatches', implode("\n", $ignoredIPMismatches)) ?>
+        <div class="small text-muted">
+            <?= t('Separate IP addresses with spaces or new lines.') ?><br />
+            <?= t(
+                'Accepted values are single addresses (IPv4 like %1$s, and IPv6 like %2$s) and ranges in subnet format (IPv4 like %3$s, and IPv6 like %4$s).',
+                '<code>127.0.0.1</code>',
+                '<code>::1</code>',
+                '<code>127.0.0.1/24</code>',
+                '<code>::1/8</code>'
+            ) ?><br />
+            <?= t('Your IP address:') ?> <code><?= h((string) $myIPAddress) ?><code>
         </div>
     </div>
 

--- a/concrete/single_pages/dashboard/system/registration/automated_logout.php
+++ b/concrete/single_pages/dashboard/system/registration/automated_logout.php
@@ -56,7 +56,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
                 '<code>127.0.0.1/24</code>',
                 '<code>::1/8</code>'
             ) ?><br />
-            <?= t('Your IP address:') ?> <code><?= h((string) $myIPAddress) ?><code>
+            <?= t('Your IP address:') ?> <code><?= h((string) $myIPAddress) ?></code>
         </div>
     </div>
 

--- a/concrete/single_pages/dashboard/system/registration/automated_logout.php
+++ b/concrete/single_pages/dashboard/system/registration/automated_logout.php
@@ -57,6 +57,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
                 '<code>::1/8</code>'
             ) ?><br />
             <?= t('Your IP address:') ?> <code><?= h((string) $myIPAddress) ?></code>
+            <?= t('Please remark that you may also define user-specific IP ranges.') ?>
         </div>
     </div>
 

--- a/concrete/single_pages/dashboard/users/search/edit.php
+++ b/concrete/single_pages/dashboard/users/search/edit.php
@@ -6,29 +6,47 @@ use Concrete\Core\Form\Service\Widget\FileFolderSelector;
 use Concrete\Core\Localization\Localization;
 use Concrete\Core\Support\Facade\Application;
 
-/**
- * @var Concrete\Core\User\UserInfo $user
- */
 
+/**
+ * @var Concrete\Core\Page\View\PageView $view
+ * @var Concrete\Core\Form\Service\Form $form
+ * @var Concrete\Core\Validation\CSRF\Token $token
+ * @var Concrete\Core\User\UserInfo $user
+ * @var string[] $folderList
+ * @var bool $canEditAvatar
+ * @var bool $canEditUserName
+ * @var bool $canEditEmail
+ * @var bool $canEditPassword
+ * @var bool $canEditHomeFileManagerFolderID
+ * @var bool $canEditTimezone
+ * @var bool $canEditLanguage
+ * @var bool $canViewAccountModal
+ * @var string[] $allowedEditAttributes
+ * @var bool $canAddGroup
+ * @var string $groupsJSON
+ * @var Doctrine\ORM\PersistentCollection $attributeSets
+ * @var Concrete\Core\Entity\Attribute\Key\UserKey[] $unassigned
+ * @var Concrete\Core\Url\UrlImmutable $saveAvatarUrl
+ */
 $app = Application::getFacadeApplication();
-/** @var FileFolderSelector $fileFolderSelector */
+
 $fileFolderSelector = $app->make(FileFolderSelector::class);
+/** @var Concrete\Core\Form\Service\Widget\FileFolderSelector $fileFolderSelector */
 
 $dh = $app->make('helper/date');
-// @var $dh \Concrete\Core\Localization\Service\Date
+/** @var $dh Concrete\Core\Localization\Service\Date */
+
 $languages = Localization::getAvailableInterfaceLanguages();
 $locales = [];
-if (count($languages) > 0) {
+if ($languages !== []) {
     array_unshift($languages, Localization::BASE_LOCALE);
-}
-if (count($languages) > 0) {
     foreach ($languages as $lang) {
         $locales[$lang] = \Punic\Language::getName($lang, $lang);
     }
     asort($locales);
     $locales = array_merge(['' => tc('Default locale', '** Default')], $locales);
 }
-
+$userEntity = $user->getEntityObject();
 ?>
 
 <section data-section="basics" class="mb-3 row">
@@ -46,8 +64,8 @@ if (count($languages) > 0) {
                 <?php } ?>
             </div>
             <div class="ccm-user-detail-basics-name">
-                <h5 class="mb-2"><?= $user->getUserName() ?></h5>
-                <div class="mb-2"><a href="mailto:<?= $user->getUserEmail() ?>"><?= $user->getUserEmail() ?></a></div>
+                <h5 class="mb-2"><?= $userEntity->getUserName() ?></h5>
+                <div class="mb-2"><a href="mailto:<?= $userEntity->getUserEmail() ?>"><?= $userEntity->getUserEmail() ?></a></div>
                 <?php
                 $privateMessagesEnabled = $user->getAttribute('profile_private_messages_enabled');
                 $profileURL = $user->getUserPublicProfileURL();
@@ -58,8 +76,8 @@ if (count($languages) > 0) {
                         <?php
                         if ($privateMessagesEnabled) {
                             $u = Core::make(Concrete\Core\User\User::class);
-                            if ($u->getUserID() != $user->getUserID()) { ?>
-                                <a href="<?php echo View::url('/account/messages', 'write', $user->getUserID())?>" class="btn btn-secondary"><?php echo t("Send Private Message")?></a>
+                            if ($u->getUserID() != $userEntity->getUserID()) { ?>
+                                <a href="<?php echo View::url('/account/messages', 'write', $userEntity->getUserID())?>" class="btn btn-secondary"><?php echo t("Send Private Message")?></a>
                             <?php } ?>
                         <?php } ?>
 
@@ -82,7 +100,7 @@ if (count($languages) > 0) {
 
 <?php if ($canViewAccountModal) { ?>
 <div id="folderSelectorSourceContainer" class="d-none">
-    <?php echo $fileFolderSelector->selectFileFolder('uHomeFileManagerFolderID', $user->getUserHomeFolderId()); ?>
+    <?php echo $fileFolderSelector->selectFileFolder('uHomeFileManagerFolderID', $userEntity->getHomeFileManagerFolderID()); ?>
 </div>
 <?php } ?>
 
@@ -96,27 +114,27 @@ if (count($languages) > 0) {
     <dl class="ccm-user-detail-account">
         <dt><?= t('Date Created') ?></dt>
         <dd>
-            <div><?= $dh->formatDateTime($user->getUserDateAdded()) ?></div>
+            <div><?= $dh->formatDateTime($userEntity->getUserDateAdded()) ?></div>
         </dd>
         <dt><?= t('Last IP Address') ?></dt>
         <dd>
-            <div><?= $user->getLastIPAddress() ? $user->getLastIPAddress() : t('None') ?></div>
+            <div><?= $user->getLastIPAddress() ?? t('None') ?></div>
         </dd>
         <dt><?= t('Last Password Change') ?></dt>
         <dd>
-            <div><?= $user->getUserLastPasswordChange() === null ? t('Never') : $dh->formatDateTime($user->getUserLastPasswordChange()) ?></div>
+            <div><?= $userEntity->getUserLastPasswordChange() === null ? t('Never') : $dh->formatDateTime($userEntity->getUserLastPasswordChange()) ?></div>
         </dd>
         <dt><?= t('Last Seen Online') ?></dt>
         <dd>
-            <div><?= $user->getLastOnline() ? $dh->formatDateTime($user->getLastOnline()) : t('Never') ?></div>
+            <div><?= $userEntity->getUserLastOnline() ? $dh->formatDateTime($userEntity->getUserLastOnline()) : t('Never') ?></div>
         </dd>
         <dt><?= t('# Logins') ?></dt>
         <dd>
-            <div><?= $user->getNumLogins() ?></div>
+            <div><?= $userEntity->getUserTotalLogins() ?></div>
         </dd>
         <?php
         if (Config::get('concrete.misc.user_timezones')) {
-            $uTimezone = $user->getUserTimezone();
+            $uTimezone = $userEntity->getUserTimezone();
             if (empty($uTimezone)) {
                 $uTimezone = date_default_timezone_get();
             }
@@ -133,9 +151,9 @@ if (count($languages) > 0) {
         if (count($languages) > 0) {
             ?>
             <dt><?= t('Language') ?></dt>
-            <?php if ($user->getUserDefaultLanguage()) { ?>
+            <?php if ($userEntity->getUserDefaultLanguage()) { ?>
                 <dd>
-                    <div><?= h(Punic\Language::getName($user->getUserDefaultLanguage())) ?></div>
+                    <div><?= h(Punic\Language::getName($userEntity->getUserDefaultLanguage())) ?></div>
                 </dd>
             <?php } else { ?>
                 <dd>
@@ -150,7 +168,7 @@ if (count($languages) > 0) {
         </dt>
         <dd>
             <div>
-                <?php echo isset($folderList[$user->getUserHomeFolderId()]) && $user->getUserHomeFolderId() !== null ? $folderList[$user->getUserHomeFolderId()] : t('None') ?>
+                <?php echo $userEntity->getHomeFileManagerFolderID() !== null && isset($folderList[$userEntity->getHomeFileManagerFolderID()]) ? $folderList[$userEntity->getHomeFileManagerFolderID()] : t('None') ?>
             </div>
         </dd>
 
@@ -159,13 +177,13 @@ if (count($languages) > 0) {
             ?>
             <dt><?= t('Full Registration Record') ?></dt>
             <dd>
-                <div><?= ($user->isFullRecord()) ? t('Yes') : t('No') ?></div>
+                <div><?= ($userEntity->isUserFullRecord()) ? t('Yes') : t('No') ?></div>
             </dd>
             <dt><?= t('Email Validated') ?></dt>
             <dd>
                 <div>
                     <?php
-                    switch ($user->isValidated()) {
+                    switch ($userEntity->isUserValidated()) {
                         case '-1':
                             print t('Unknown');
                             break;
@@ -201,20 +219,20 @@ if (count($languages) > 0) {
                                 <?php if ($canEditUserName) { ?>
                                     <div class="form-group">
                                         <?= $form->label('uName', t('Username')); ?>
-                                        <?= $form->text('uName', $user->getUserName()); ?>
+                                        <?= $form->text('uName', $userEntity->getUserName()); ?>
                                     </div>
                                 <?php } ?>
                                 <?php if ($canEditEmail) { ?>
                                     <div class="form-group">
                                         <?= $form->label('uEmail', t('Email')); ?>
-                                        <?= $form->text('uEmail', $user->getUserEmail()); ?>
+                                        <?= $form->text('uEmail', $userEntity->getUserEmail()); ?>
                                     </div>
                                 <?php } ?>
                                 <?php if ($canEditTimezone) { ?>
                                     <?php if (Config::get('concrete.misc.user_timezones')) { ?>
                                         <div class="form-group">
                                             <?= $form->label('uTimezone', t('Time Zone')); ?>
-                                            <?= $form->select('uTimezone', $dh->getTimezones(), ($user->getUserTimezone() ? $user->getUserTimezone() : date_default_timezone_get())); ?>
+                                            <?= $form->select('uTimezone', $dh->getTimezones(), $userEntity->getUserTimezone() ?? date_default_timezone_get()); ?>
                                         </div>
                                     <?php } ?>
                                 <?php } ?>
@@ -329,7 +347,7 @@ if (count($languages) > 0) {
     if (count($allowedEditAttributes)) {
         ?>
         <a class="dialog-launch btn-section btn btn-secondary"
-           href="<?=URL::to('/ccm/system/dialogs/user/attributes', $user->getUserID())?>"
+           href="<?=URL::to('/ccm/system/dialogs/user/attributes', $userEntity->getUserID())?>"
            dialog-width="800" dialog-height="640" dialog-title="<?=t('Edit Attributes')?>">
         <?= t('Edit') ?></a>
     <?php } ?>
@@ -401,7 +419,7 @@ if (count($languages) > 0) {
                         data.push({'name': 'ccm_token', 'value': '<?=$token->generate('save_account')?>'})
 
                         $.concreteAjax({
-                            url: "<?=$view->action('save_account', $user->getUserID())?>",
+                            url: "<?=$view->action('save_account', $userEntity->getUserID())?>",
                             data: data,
                             success: function (r) {
                                 window.location.reload()
@@ -427,7 +445,7 @@ if (count($languages) > 0) {
                             url: "<?=URL::to('/ccm/system/user/add_group')?>",
                             data: {
                                 gID: group.gID,
-                                uID: '<?=$user->getUserID()?>',
+                                uID: '<?=$userEntity->getUserID()?>',
                                 ccm_token: '<?= $token->generate('add_group') ?>'
                             },
                             success: function (r) {
@@ -443,7 +461,7 @@ if (count($languages) > 0) {
                             url: "<?=URL::to('/ccm/system/user/remove_group')?>",
                             data: {
                                 gID: gID,
-                                uID: '<?=$user->getUserID()?>',
+                                uID: '<?=$userEntity->getUserID()?>',
                                 ccm_token: '<?= $token->generate('remove_group') ?>'
                             },
                             success: function (r) {

--- a/concrete/single_pages/dashboard/users/search/edit.php
+++ b/concrete/single_pages/dashboard/users/search/edit.php
@@ -23,6 +23,7 @@ use Concrete\Core\Support\Facade\Application;
  * @var bool $canViewAccountModal
  * @var string[] $allowedEditAttributes
  * @var bool $canAddGroup
+ * @var bool $canEditIgnoredIPMismatches
  * @var string $groupsJSON
  * @var Doctrine\ORM\PersistentCollection $attributeSets
  * @var Concrete\Core\Entity\Attribute\Key\UserKey[] $unassigned
@@ -171,6 +172,20 @@ $userEntity = $user->getEntityObject();
                 <?php echo $userEntity->getHomeFileManagerFolderID() !== null && isset($folderList[$userEntity->getHomeFileManagerFolderID()]) ? $folderList[$userEntity->getHomeFileManagerFolderID()] : t('None') ?>
             </div>
         </dd>
+        <dt>
+            <?= t('Ignored IP changes for') ?>
+        </dt>
+        <dd>
+            <div>
+                <?php
+                if ($userEntity->getIgnoredIPMismatches() === []) {
+                    echo t('None');
+                } else {
+                    echo nl2br(htmlspecialchars(implode("\n", $userEntity->getIgnoredIPMismatches())));
+                }
+                ?>
+            </div>
+        </dd>
 
         <?php
         if (Config::get('concrete.user.registration.validate_email')) {
@@ -216,40 +231,71 @@ $userEntity = $user->getEntityObject();
                         <div class="modal-body">
                             <fieldset>
                                 <legend><?= t('Basic Information'); ?></legend>
-                                <?php if ($canEditUserName) { ?>
+                                <?php
+                                if ($canEditUserName) {
+                                    ?>
                                     <div class="form-group">
                                         <?= $form->label('uName', t('Username')); ?>
                                         <?= $form->text('uName', $userEntity->getUserName()); ?>
                                     </div>
-                                <?php } ?>
-                                <?php if ($canEditEmail) { ?>
+                                    <?php
+                                }
+                                if ($canEditEmail) {
+                                    ?>
                                     <div class="form-group">
                                         <?= $form->label('uEmail', t('Email')); ?>
                                         <?= $form->text('uEmail', $userEntity->getUserEmail()); ?>
                                     </div>
-                                <?php } ?>
-                                <?php if ($canEditTimezone) { ?>
-                                    <?php if (Config::get('concrete.misc.user_timezones')) { ?>
+                                    <?php
+                                }
+                                if ($canEditTimezone) {
+                                    if (Config::get('concrete.misc.user_timezones')) {
+                                        ?>
                                         <div class="form-group">
                                             <?= $form->label('uTimezone', t('Time Zone')); ?>
                                             <?= $form->select('uTimezone', $dh->getTimezones(), $userEntity->getUserTimezone() ?? date_default_timezone_get()); ?>
                                         </div>
-                                    <?php } ?>
-                                <?php } ?>
-                                <?php if ($canEditLanguage) { ?>
-                                    <?php if (is_array($locales) && count($locales)) { ?>
+                                        <?php
+                                    }
+                                }
+                                if ($canEditLanguage) {
+                                    if (is_array($locales) && count($locales)) {
+                                        ?>
                                         <div class="form-group">
                                             <?= $form->label('uDefaultLanguage', t('Language')); ?>
                                             <?= $form->select('uDefaultLanguage', $locales, Localization::activeLocale()); ?>
                                         </div>
-                                    <?php } ?>
-                                <?php } ?>
-                                <?php if ($canEditHomeFileManagerFolderID) { ?>
+                                        <?php
+                                    }
+                                }
+                                if ($canEditHomeFileManagerFolderID) {
+                                    ?>
                                     <div class="form-group">
                                         <?php echo $form->label('uHomeFileManagerFolderID', t('Home Folder')); ?>
                                         <div id="folderSelectorDestinationContainer"></div>
                                     </div>
-                                <?php } ?>
+                                    <?php
+                                }
+                                if ($canEditIgnoredIPMismatches) {
+                                    ?>
+                                    <div class="form-group">
+                                        <?= $form->label('ignoredIPMismatches', t('Ignored IP changes for')) ?>
+                                        <?= $form->textarea('ignoredIPMismatches', implode("\n", $userEntity->getIgnoredIPMismatches())) ?>
+                                        <div class="small text-muted">
+                                            <?= t('Separate IP addresses with spaces or new lines.') ?><br />
+                                            <?= t(
+                                                'Accepted values are single addresses (IPv4 like %1$s, and IPv6 like %2$s) and ranges in subnet format (IPv4 like %3$s, and IPv6 like %4$s).',
+                                                '<code>127.0.0.1</code>',
+                                                '<code>::1</code>',
+                                                '<code>127.0.0.1/24</code>',
+                                                '<code>::1/8</code>'
+                                            ) ?><br />
+                                            <?= t('Please remark that you may also define global IP ranges.') ?>
+                                        </div>
+                                    </div>
+                                    <?php
+                                }
+                                ?>
                             </fieldset>
                             <?php if ($canEditPassword) { ?>
                                 <fieldset>

--- a/concrete/single_pages/dashboard/users/search/edit.php
+++ b/concrete/single_pages/dashboard/users/search/edit.php
@@ -23,6 +23,7 @@ use Concrete\Core\Support\Facade\Application;
  * @var bool $canViewAccountModal
  * @var string[] $allowedEditAttributes
  * @var bool $canAddGroup
+ * @var bool $shouldViewIgnoredIPMismatches
  * @var bool $canEditIgnoredIPMismatches
  * @var string $groupsJSON
  * @var Doctrine\ORM\PersistentCollection $attributeSets
@@ -172,22 +173,25 @@ $userEntity = $user->getEntityObject();
                 <?php echo $userEntity->getHomeFileManagerFolderID() !== null && isset($folderList[$userEntity->getHomeFileManagerFolderID()]) ? $folderList[$userEntity->getHomeFileManagerFolderID()] : t('None') ?>
             </div>
         </dd>
-        <dt>
-            <?= t('Ignored IP changes for') ?>
-        </dt>
-        <dd>
-            <div>
-                <?php
-                if ($userEntity->getIgnoredIPMismatches() === []) {
-                    echo t('None');
-                } else {
-                    echo nl2br(htmlspecialchars(implode("\n", $userEntity->getIgnoredIPMismatches())));
-                }
-                ?>
-            </div>
-        </dd>
-
         <?php
+        if ($shouldViewIgnoredIPMismatches) {
+            ?>
+            <dt>
+                <?= t('Ignored IP changes for') ?>
+            </dt>
+            <dd>
+                <div>
+                    <?php
+                    if ($userEntity->getIgnoredIPMismatches() === []) {
+                        echo t('None');
+                    } else {
+                        echo nl2br(htmlspecialchars(implode("\n", $userEntity->getIgnoredIPMismatches())));
+                    }
+                    ?>
+                </div>
+            </dd>
+            <?php
+        }
         if (Config::get('concrete.user.registration.validate_email')) {
             ?>
             <dt><?= t('Full Registration Record') ?></dt>
@@ -276,7 +280,7 @@ $userEntity = $user->getEntityObject();
                                     </div>
                                     <?php
                                 }
-                                if ($canEditIgnoredIPMismatches) {
+                                if ($shouldViewIgnoredIPMismatches && $canEditIgnoredIPMismatches) {
                                     ?>
                                     <div class="form-group">
                                         <?= $form->label('ignoredIPMismatches', t('Ignored IP changes for')) ?>

--- a/concrete/src/Entity/User/User.php
+++ b/concrete/src/Entity/User/User.php
@@ -144,12 +144,19 @@ class User implements UserEntityInterface, \JsonSerializable
      */
     protected $uHomeFileManagerFolderID = null;
 
+    /**
+     * @var string[]|null
+     * @ORM\Column(type="simple_array", nullable=true)
+     */
+    protected $ignoredIPMismatches;
+
     public function __construct()
     {
         $this->alerts = new ArrayCollection();
         $this->uLastPasswordChange = new \DateTime();
         $this->uDateLastUpdated = new \DateTime();
         $this->uDateAdded = new \DateTime();
+        $this->ignoredIPMismatches = [];
     }
 
     /**
@@ -490,6 +497,26 @@ class User implements UserEntityInterface, \JsonSerializable
     public function setHomeFileManagerFolderID($uHomeFileManagerFolderID)
     {
         $this->uHomeFileManagerFolderID = $uHomeFileManagerFolderID;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getIgnoredIPMismatches(): array
+    {
+        return $this->ignoredIPMismatches;
+    }
+
+    /**
+     * @param string[] $value
+     *
+     * @return $this
+     */
+    public function setIgnoredIPMismatches(array $value): self
+    {
+        $this->ignoredIPMismatches = $value;
+
+        return $this;
     }
 
     /**

--- a/concrete/src/Updater/Migrations/Migrations/Version20230107185800.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20230107185800.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Entity\User\User;
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
+
+final class Version20230107185800 extends AbstractMigration implements RepeatableMigrationInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Updater\Migrations\AbstractMigration::upgradeDatabase()
+     */
+    public function upgradeDatabase()
+    {
+        $this->refreshEntities([
+            User::class,
+        ]);
+    }
+}

--- a/concrete/src/User/UserInfo.php
+++ b/concrete/src/User/UserInfo.php
@@ -46,6 +46,7 @@ use Concrete\Core\Utility\Service\Identifier;
 use Concrete\Core\Workflow\Request\ActivateUserRequest as ActivateUserWorkflowRequest;
 use Concrete\Core\Workflow\Request\DeleteUserRequest as DeleteUserWorkflowRequest;
 use Core;
+use Doctrine\DBAL\Types\SimpleArrayType;
 use Doctrine\ORM\EntityManagerInterface;
 use Group;
 use Imagine\Image\ImageInterface;
@@ -543,9 +544,13 @@ class UserInfo extends ConcreteObject implements AttributeObjectInterface, Permi
                     $result = null;
                 }
             }
+            if (is_array($data['ignoredIPMismatches'] ?? null)) {
+                $fields[] = 'ignoredIPMismatches = ?';
+                $values[] = (new SimpleArrayType())->convertToDatabaseValue($data['ignoredIPMismatches'], $this->connection->getDatabasePlatform());
+            }
             if ($result === true && !empty($fields)) {
                 $this->connection->executeQuery(
-                    'update Users set  ' . implode(', ', $fields) . 'where uID = ? limit 1',
+                    'update Users set  ' . implode(', ', $fields) . ' where uID = ? limit 1',
                     array_merge($values, [$uID])
                 );
                 if (!empty($nullFields)) {

--- a/tests/tests/Session/SessionValidatorTest.php
+++ b/tests/tests/Session/SessionValidatorTest.php
@@ -40,14 +40,10 @@ class SessionValidatorTest extends TestCase
         $this->app['config'] = clone $this->app['config'];
 
         $this->request = Request::create('http://url.com/');
-        $em = $this->getMockBuilder(EntityManagerInterface::class)
-            ->getMock()
-        ;
         $this->validator = new SessionValidator(
             $this->app,
             $this->app['config'],
-            $this->request,
-            $em
+            $this->request
         );
 
         $store = [];

--- a/tests/tests/Session/SessionValidatorTest.php
+++ b/tests/tests/Session/SessionValidatorTest.php
@@ -41,7 +41,12 @@ class SessionValidatorTest extends TestCase
 
         $this->request = Request::create('http://url.com/');
         $config = $this->app->make('config');
-        $this->validator = new SessionValidator($this->app, $this->app['config'], $this->request, $this->app->make(IPService::class, ['config' => $config, 'request' => $this->request]));
+        $this->validator = new SessionValidator(
+            $this->app,
+            $this->app['config'],
+            $this->request,
+            $this->app->make(IPService::class, ['config' => $config, 'request' => $this->request])
+        );
 
         $store = [];
         $mock = $this->getMockBuilder('Symfony\Component\HttpFoundation\Session\Session')

--- a/tests/tests/Session/SessionValidatorTest.php
+++ b/tests/tests/Session/SessionValidatorTest.php
@@ -3,10 +3,10 @@
 namespace Concrete\Tests\Session;
 
 use Concrete\Core\Http\Request;
-use Concrete\Core\Permission\IPService;
 use Concrete\Core\Session\SessionValidator;
 use Concrete\Core\Support\Facade\Application;
 use Concrete\Tests\TestCase;
+use Doctrine\ORM\EntityManagerInterface;
 use IPLib\Address\AddressInterface;
 use IPLib\Factory;
 use IPLib\ParseStringFlag;
@@ -40,12 +40,14 @@ class SessionValidatorTest extends TestCase
         $this->app['config'] = clone $this->app['config'];
 
         $this->request = Request::create('http://url.com/');
-        $config = $this->app->make('config');
+        $em = $this->getMockBuilder(EntityManagerInterface::class)
+            ->getMock()
+        ;
         $this->validator = new SessionValidator(
             $this->app,
             $this->app['config'],
             $this->request,
-            $this->app->make(IPService::class, ['config' => $config, 'request' => $this->request])
+            $em
         );
 
         $store = [];


### PR DESCRIPTION
Close #10656

Here's the UI changes:

| Before | After |
|---|---|
| ![immagine](https://user-images.githubusercontent.com/928116/211175332-84d45788-6033-4e07-a53c-af0f1dfa64c5.png) | ![immagine](https://user-images.githubusercontent.com/928116/211175338-1057a29b-d096-428e-a76e-b369e7c43271.png) |
| ![immagine](https://user-images.githubusercontent.com/928116/211175501-65f2f572-da35-4dfc-8768-2913c6dd8ba9.png) | ![immagine](https://user-images.githubusercontent.com/928116/211175505-7dd63508-8218-4eca-84b6-aa031a8d98e7.png) |
| ![immagine](https://user-images.githubusercontent.com/928116/211175541-759a9d58-b6a7-4055-9e17-ec9738ebbd0d.png) | ![immagine](https://user-images.githubusercontent.com/928116/211175547-4021bd40-df30-4b19-aa38-b68ae3a53270.png) |

I think that this feature is rather specific, and not many people would use it (at least for the user-specific IP ranges).

So, what about adding the following new option in the `System & Settings` > `Login & Registration` > `Automated Logout`:

```
[ ] Enable user-specific IP ranges
```

By default this option should be turned off, and in this case in the user details page we won't see this new *Ignored IP changes for* stuff.

If that's ok, I can implement this change.