### PR TITLE
Fix: HTML block breaks composer interface on PHP 8.1

### DIFF
--- a/concrete/blocks/html/composer.php
+++ b/concrete/blocks/html/composer.php
@@ -1,5 +1,11 @@
 <?php
 defined('C5_EXECUTE') or die('Access Denied.');
+/** @var \Concrete\Core\Form\Service\Form $form */
+/** @var \Concrete\Core\View\View $view */
+$label = $label ?? '';
+$description = $description ?? '';
+$content = $content ?? '';
+$class = $class ?? '';
 ?>
 
 <div class="form-group">


### PR DESCRIPTION
Fixes #11160

Maybe we can remove `$description` and `$class`.
There's no way to set them from editor interface.