### PR TITLE
Make changes to config files atomic

### DIFF
--- a/concrete/src/Config/FileSaver.php
+++ b/concrete/src/Config/FileSaver.php
@@ -95,7 +95,7 @@ class FileSaver implements SaverInterface
         );
 
         $rendered = $renderer->render(PHP_EOL, '    ', implode(PHP_EOL, $header));
-        $result = $this->files->put($file, $rendered) !== false;
+        $result = $this->files->replace($file, $rendered) !== false;
         if ($result) {
             OpCache::clear($file);
         }

--- a/concrete/src/Config/FileSaver.php
+++ b/concrete/src/Config/FileSaver.php
@@ -3,6 +3,7 @@ namespace Concrete\Core\Config;
 
 use Illuminate\Filesystem\Filesystem;
 use Concrete\Core\Cache\OpCache;
+use Concrete\Core\Support\Facade\Config;
 
 class FileSaver implements SaverInterface
 {
@@ -60,7 +61,7 @@ class FileSaver implements SaverInterface
 
         $current = array();
         if ($this->files->exists($file)) {
-            if (\Config::get('concrete.config.temp_save', true)) {
+            if (Config::get('concrete.config.temp_save', true)) {
                 // Make sure that we miss cache.
                 $temp_file = tempnam($path, $group . '_');
                 $contents = $this->files->get($file);
@@ -97,6 +98,7 @@ class FileSaver implements SaverInterface
         $rendered = $renderer->render(PHP_EOL, '    ', implode(PHP_EOL, $header));
         $result = $this->files->replace($file, $rendered) !== false;
         if ($result) {
+            @chmod($file, Config::get('concrete.filesystem.permissions.file'));
             OpCache::clear($file);
         }
 


### PR DESCRIPTION
Make changes to config files atomic, as discussed by https://github.com/concretecms/concretecms/issues/11170. A put() to file has been replaced with a replace(). See concrete/vendor/illuminate/filesystem/Filesystem.php 

https://github.com/illuminate/filesystem/blob/6ca65f4f24d3277e22b8e8e7c62557c118209d0f/Filesystem.php#L188 https://github.com/illuminate/filesystem/blob/6ca65f4f24d3277e22b8e8e7c62557c118209d0f/Filesystem.php#L200

The illuminate replace() method does not have an actual return flag as the put() method does, however, the !==false test will return true and allow the following OpCache::clear() to be called.
