### PR TITLE
Support doctrine/orm 2.14+

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1526,51 +1526,52 @@
         },
         {
             "name": "doctrine/orm",
-            "version": "2.13.5",
+            "version": "2.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/orm.git",
-                "reference": "099e51d8990c586778c564a9ed1eaa6401f2bc83"
+                "reference": "de7eee5ed7b1b35c99b118f26f210a8281e6db8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/orm/zipball/099e51d8990c586778c564a9ed1eaa6401f2bc83",
-                "reference": "099e51d8990c586778c564a9ed1eaa6401f2bc83",
+                "url": "https://api.github.com/repos/doctrine/orm/zipball/de7eee5ed7b1b35c99b118f26f210a8281e6db8e",
+                "reference": "de7eee5ed7b1b35c99b118f26f210a8281e6db8e",
                 "shasum": ""
             },
             "require": {
                 "composer-runtime-api": "^2",
                 "doctrine/cache": "^1.12.1 || ^2.1.1",
-                "doctrine/collections": "^1.5",
+                "doctrine/collections": "^1.5 || ^2.0",
                 "doctrine/common": "^3.0.3",
                 "doctrine/dbal": "^2.13.1 || ^3.2",
                 "doctrine/deprecations": "^0.5.3 || ^1",
-                "doctrine/event-manager": "^1.1",
+                "doctrine/event-manager": "^1.2 || ^2",
                 "doctrine/inflector": "^1.4 || ^2.0",
                 "doctrine/instantiator": "^1.3",
-                "doctrine/lexer": "^1.2.3",
+                "doctrine/lexer": "^1.2.3 || ^2",
                 "doctrine/persistence": "^2.4 || ^3",
                 "ext-ctype": "*",
                 "php": "^7.1 || ^8.0",
                 "psr/cache": "^1 || ^2 || ^3",
-                "symfony/console": "^3.0 || ^4.0 || ^5.0 || ^6.0",
+                "symfony/console": "^4.2 || ^5.0 || ^6.0",
                 "symfony/polyfill-php72": "^1.23",
                 "symfony/polyfill-php80": "^1.16"
             },
             "conflict": {
-                "doctrine/annotations": "<1.13 || >= 2.0"
+                "doctrine/annotations": "<1.13 || >= 3.0"
             },
             "require-dev": {
-                "doctrine/annotations": "^1.13",
+                "doctrine/annotations": "^1.13 || ^2",
                 "doctrine/coding-standard": "^9.0.2 || ^11.0",
                 "phpbench/phpbench": "^0.16.10 || ^1.0",
-                "phpstan/phpstan": "~1.4.10 || 1.9.4",
+                "phpstan/phpstan": "~1.4.10 || 1.9.8",
                 "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
                 "psr/log": "^1 || ^2 || ^3",
                 "squizlabs/php_codesniffer": "3.7.1",
                 "symfony/cache": "^4.4 || ^5.4 || ^6.0",
+                "symfony/var-exporter": "^4.4 || ^5.4 || ^6.2",
                 "symfony/yaml": "^3.4 || ^4.0 || ^5.0 || ^6.0",
-                "vimeo/psalm": "4.30.0 || 5.3.0"
+                "vimeo/psalm": "4.30.0 || 5.4.0"
             },
             "suggest": {
                 "ext-dom": "Provides support for XSD validation for XML mapping files",
@@ -1620,9 +1621,9 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/orm/issues",
-                "source": "https://github.com/doctrine/orm/tree/2.13.5"
+                "source": "https://github.com/doctrine/orm/tree/2.14.1"
             },
-            "time": "2022-12-19T14:04:28+00:00"
+            "time": "2023-01-16T18:36:59+00:00"
         },
         {
             "name": "doctrine/persistence",

--- a/concrete/composer.json
+++ b/concrete/composer.json
@@ -50,7 +50,7 @@
     "scssphp/scssphp": "^1.4",
     "doctrine/annotations": "^1.13.2",
     "doctrine/dbal": "^2.13.2",
-    "doctrine/orm": "^2.13 <2.14",
+    "doctrine/orm": "^2.13",
     "doctrine/lexer": "^1.2.3",
     "doctrine/common": "^3.1.2",
     "doctrine/persistence": "^2.5.1",

--- a/concrete/src/Database/EntityManagerConfigFactory.php
+++ b/concrete/src/Database/EntityManagerConfigFactory.php
@@ -84,6 +84,9 @@ class EntityManagerConfigFactory implements ApplicationAwareInterface, EntityMan
      */
     public function getMetadataDriverImpl()
     {
+        // Register the doctrine Annotations
+        \Doctrine\Common\Annotations\AnnotationRegistry::registerUniqueLoader('class_exists');
+
         $legacyNamespace = $this->getConfigRepository()->get('app.enable_legacy_src_namespace');
         if ($legacyNamespace) {
             \Doctrine\Common\Annotations\AnnotationRegistry::registerAutoloadNamespace('Application\Src',

--- a/concrete/src/Database/EntityManagerConfigFactory.php
+++ b/concrete/src/Database/EntityManagerConfigFactory.php
@@ -84,9 +84,6 @@ class EntityManagerConfigFactory implements ApplicationAwareInterface, EntityMan
      */
     public function getMetadataDriverImpl()
     {
-        // Register the doctrine Annotations
-        \Doctrine\Common\Annotations\AnnotationRegistry::registerFile('doctrine/orm/lib/Doctrine/ORM/Mapping/Driver/DoctrineAnnotations.php');
-
         $legacyNamespace = $this->getConfigRepository()->get('app.enable_legacy_src_namespace');
         if ($legacyNamespace) {
             \Doctrine\Common\Annotations\AnnotationRegistry::registerAutoloadNamespace('Application\Src',


### PR DESCRIPTION
Doctrine 2.14.1 comes with [this breaking change](https://github.com/doctrine/orm/pull/10321).

This causes Concrete to break with an `E_COMPILE_ERROR` error:

```
Doctrine\Common\Annotations\AnnotationRegistry::registerFile():
Failed opening required 'doctrine/orm/lib/Doctrine/ORM/Mapping/Driver/DoctrineAnnotations.php'
```

If this was the reason of 18b82169a87cd6821d19402e0cca48cf84a27aa5 (its description isn't descriptive that much :wink:), we can fix the issue by simply avoiding the `registerFile()` call (it's useless since `doctrine/annotations` 1.10, and we require `^1.13.2`).