### PR TITLE
fix incorrect typehint in queueable job class

### DIFF
--- a/concrete/src/Job/QueueableJob.php
+++ b/concrete/src/Job/QueueableJob.php
@@ -33,7 +33,7 @@ abstract class QueueableJob extends AbstractJob
     /**
      * Process a QueueMessage
      *
-     * @param \ZendQueue\Message $msg
+     * @param JobQueueMessage $msg
      * @return void
      */
     abstract public function processQueueItem(JobQueueMessage $msg);


### PR DESCRIPTION
Minor fix to an incorrect annotation param typehint in `concrete/src/Job/QueueableJob.php`