### PR TITLE
change image_slider URL field to input

### DIFF
--- a/concrete/blocks/image_slider/form_setup_html.php
+++ b/concrete/blocks/image_slider/form_setup_html.php
@@ -477,7 +477,7 @@ echo $userInterface->tabs([
         </div>
         <div data-field="entry-link-url" class="form-group hide-slide-link">
             <label class="control-label form-label"><?php echo t('URL:'); ?></label>
-            <textarea class="form-control" name="<?php echo $view->field('linkURL'); ?>[]"><%=link_url%></textarea>
+            <input type="text" class="form-control" name="<?php echo $view->field('linkURL'); ?>[]" value="<%=link_url%>"></input>
         </div>
         <div data-field="entry-link-page-selector" class="form-group hide-slide-link">
             <label class="control-label form-label"><?php echo t('Choose Page:'); ?></label>


### PR DESCRIPTION
Today I had a message from a customer that he can't see the entries of his image_slider block. In the console there was a javascript error saying 
```
Uncaught SyntaxError: '' string literal contains an unescaped line break
```
So I looked in the Database and found a line break in the URL field of one entry.

I think it's not necessary to show the field as a textarea, at least it's a URL. So I changed this in the form of the block to prevent this kind of error.