### PR TITLE
Fix member profile url

### DIFF
--- a/concrete/authentication/community/controller.php
+++ b/concrete/authentication/community/controller.php
@@ -111,7 +111,7 @@ class Controller extends GenericOauth2TypeController
         if ($binding !== null) {
             $concreteUserID = (int) $binding;
             if ($concreteUserID !== 0) {
-                $result = "https://community.concretecms.com/profile/-/view/{$concreteUserID}/";
+                $result = "https://community.concretecms.com/members/profile/{$concreteUserID}";
             }
         }
 


### PR DESCRIPTION
The URL of the Concrete community memers changed from
`https://community.concretecms.com/profile/-/view/<UserID>/`
to
`https://community.concretecms.com/profile/<UserID>`

For example, [this doesn't work](https://community.concretecms.com/profile/-/view/35655/), but [this does](https://community.concretecms.com/members/profile/35655).