### PR TITLE
Improve block cache support

### DIFF
--- a/concrete/blocks/gallery/controller.php
+++ b/concrete/blocks/gallery/controller.php
@@ -27,6 +27,9 @@ class Controller extends BlockController implements FileTrackableInterface, Uses
     protected $btExportTables = ['btGallery', 'btGalleryEntries', 'btGalleryEntryDisplayChoices'];
     protected $btExportFileColumns = ['fID'];
     protected $btCacheBlockRecord = false;
+    protected $btCacheBlockOutput = true;
+    protected $btCacheBlockOutputForRegisteredUsers = true;
+    protected $btCacheBlockOutputOnPost = true;
     /** @var int */
     protected $includeDownloadLink;
     /** @var Connection|null */

--- a/concrete/blocks/gallery/controller.php
+++ b/concrete/blocks/gallery/controller.php
@@ -28,7 +28,7 @@ class Controller extends BlockController implements FileTrackableInterface, Uses
     protected $btExportFileColumns = ['fID'];
     protected $btCacheBlockRecord = false;
     protected $btCacheBlockOutput = true;
-    protected $btCacheBlockOutputForRegisteredUsers = true;
+    protected $btCacheBlockOutputForRegisteredUsers = false;
     protected $btCacheBlockOutputOnPost = true;
     /** @var int */
     protected $includeDownloadLink;

--- a/concrete/blocks/next_previous/controller.php
+++ b/concrete/blocks/next_previous/controller.php
@@ -19,6 +19,14 @@ class Controller extends BlockController implements UsesFeatureInterface
 
     protected $btCacheBlockRecord = true;
 
+    protected $btCacheBlockOutput = true;
+
+    protected $btCacheBlockOutputForRegisteredUsers = true;
+
+    protected $btCacheBlockOutputOnPost = true;
+
+    protected $btCacheBlockOutputLifetime = 300;
+
     protected $btWrapperClass = 'ccm-ui';
 
     /**

--- a/concrete/blocks/switch_language/controller.php
+++ b/concrete/blocks/switch_language/controller.php
@@ -20,6 +20,9 @@ class Controller extends BlockController implements UsesFeatureInterface
     protected $btInterfaceWidth = 500;
     protected $btInterfaceHeight = 150;
     protected $btTable = 'btSwitchLanguage';
+    protected $btCacheBlockOutput = true;
+    protected $btCacheBlockOutputForRegisteredUsers = true;
+    protected $btCacheBlockOutputLifetime = 300;
 
     public $helpers = ['form'];
 

--- a/concrete/blocks/topic_list/controller.php
+++ b/concrete/blocks/topic_list/controller.php
@@ -53,6 +53,11 @@ class Controller extends BlockController implements UsesFeatureInterface
     protected $btExportPageColumns = ['cParentID'];
 
     /**
+     * @var bool
+     */
+    protected $btCacheSettingsInitialized = false;
+
+    /**
      * {@inheritdoc}
      *
      * @return string
@@ -276,5 +281,63 @@ class Controller extends BlockController implements UsesFeatureInterface
         }
 
         parent::save($data);
+    }
+
+    /**
+     * @return bool
+     */
+    public function cacheBlockOutput()
+    {
+        $this->setupCacheSettings();
+
+        return $this->btCacheBlockOutput;
+    }
+
+    /**
+     * @return bool
+     */
+    public function cacheBlockOutputOnPost()
+    {
+        $this->setupCacheSettings();
+
+        return $this->btCacheBlockOutputOnPost;
+    }
+
+    /**
+     * @return bool
+     */
+    public function cacheBlockOutputForRegisteredUsers()
+    {
+        $this->setupCacheSettings();
+
+        return $this->btCacheBlockOutputForRegisteredUsers;
+    }
+
+    /**
+     * @return void
+     */
+    protected function setupCacheSettings(): void
+    {
+        $page = $this->getCollectionObject();
+        if ($this->btCacheSettingsInitialized || !is_object($page) || $page->isEditMode()) {
+            return;
+        }
+
+        $this->btCacheSettingsInitialized = true;
+
+        $btCacheBlockOutput = false;
+        $btCacheBlockOutputOnPost = false;
+        $btCacheBlockOutputForRegisteredUsers = false;
+
+        // If post result page is another page, we don't need to care about "active" topic
+        if ($this->cParentID && $this->cParentID !== $page->getCollectionID()) {
+            $btCacheBlockOutput = true;
+            $btCacheBlockOutputOnPost = true;
+            $btCacheBlockOutputForRegisteredUsers = true;
+        }
+
+        $this->btCacheBlockOutput = $btCacheBlockOutput;
+        $this->btCacheBlockOutputOnPost = $btCacheBlockOutputOnPost;
+        $this->btCacheBlockOutputForRegisteredUsers = $btCacheBlockOutputForRegisteredUsers;
     }
 }


### PR DESCRIPTION
Some block types are disabled output cache, but I think there's no reason to keep them off.

## Gallery

I think we can enable block cache for gallery block because image or image_slider block supports output cache.
Also, I wonder why `$btCacheBlockRecord` is `false` .

## Next Previous & Switch Language

I think we can enable block cache for next previous and switch language because autonav supports output cache. 
Lifetime 300 is same as autonav block.

## Topic List

I guess we can enable block cache for topic list when it just show the list of topics and doesn't update the view.
It means we should disable block cache for search result pages.

## Related Issue

#2786, #11238