### PR TITLE
Cache lifetime should respect lifetime of each block on the pages

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -269,6 +269,13 @@ return [
          */
         'full_page_lifetime' => 'default',
 
+        /**
+         * Respect lifetime of each block on the page
+         *
+         * @var bool
+         */
+        'full_page_lifetime_block' => false,
+
         /*
          * Custom lifetime value, only used if concrete.cache.full_page_lifetime is 'custom'
          *

--- a/concrete/controllers/single_page/dashboard/system/optimization/cache.php
+++ b/concrete/controllers/single_page/dashboard/system/optimization/cache.php
@@ -18,6 +18,7 @@ class Cache extends DashboardPageController
         $this->set('enableOverrideCache', (bool) $config->get('concrete.cache.overrides'));
         $this->set('fullPageCacheGlobal', (string) $config->get('concrete.cache.pages'));
         $this->set('fullPageCacheLifetime', (string) $config->get('concrete.cache.full_page_lifetime'));
+        $this->set('fullPageCacheLifetimeBlock', (bool) $config->get('concrete.cache.full_page_lifetime_block'));
         $this->set('defaultCacheLifetime', (int) $config->get('concrete.cache.lifetime'));
         $this->set('fullPageCacheCustomLifetime', (int) $config->get('concrete.cache.full_page_lifetime_value') ?: null);
     }
@@ -46,6 +47,7 @@ class Cache extends DashboardPageController
         $config->save('concrete.cache.overrides', (bool) $post->get('ENABLE_OVERRIDE_CACHE'));
         $config->save('concrete.cache.pages', (string) $this->post('FULL_PAGE_CACHE_GLOBAL'));
         $config->save('concrete.cache.full_page_lifetime', (string) $post->get('FULL_PAGE_CACHE_LIFETIME'));
+        $config->save('concrete.cache.full_page_lifetime_block', (bool) $post->get('FULL_PAGE_CACHE_BLOCK_LIFETIME'));
         if (isset($customFullPageLifetimeValue)) {
             $config->save('concrete.cache.full_page_lifetime_value', $customFullPageLifetimeValue);
         }

--- a/concrete/single_pages/dashboard/system/optimization/cache.php
+++ b/concrete/single_pages/dashboard/system/optimization/cache.php
@@ -15,6 +15,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
  * @var bool $enableOverrideCache
  * @var string $fullPageCacheGlobal
  * @var string $fullPageCacheLifetime
+ * @var bool $fullPageCacheLifetimeBlock
  * @var int $defaultCacheLifetime
  * @var int|null $fullPageCacheCustomLifetime
  */
@@ -91,6 +92,17 @@ defined('C5_EXECUTE') or die('Access Denied.');
                         <div class="form-check">
                             <?= $form->radio('FULL_PAGE_CACHE_LIFETIME', 'custom', $fullPageCacheLifetime, ['id' => 'FULL_PAGE_CACHE_LIFETIME-custom']) ?>
                             <label class="form-check-label" for="FULL_PAGE_CACHE_LIFETIME-custom"><?= t('Every %s minutes', $form->number('FULL_PAGE_CACHE_LIFETIME_CUSTOM', $fullPageCacheCustomLifetime, ['min' => 1, 'class' => 'd-inline form-control-sm', 'style' => 'width: 5rem'])) ?></label>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label class="control-label form-label"><?= t('Respect Block Cache Lifetime') ?></label>
+                        <div class="form-check">
+                            <?= $form->radio('FULL_PAGE_CACHE_BLOCK_LIFETIME', 0, $fullPageCacheLifetimeBlock ? 1 : 0, ['id' => 'FULL_PAGE_CACHE_LIFETIME_BLOCK-0']) ?>
+                            <label class="form-check-label" for="FULL_PAGE_CACHE_LIFETIME_BLOCK-0"><?= t('Off - Use same lifetime for all pages.') ?></label>
+                        </div>
+                        <div class="form-check">
+                            <?= $form->radio('FULL_PAGE_CACHE_BLOCK_LIFETIME', 1, $fullPageCacheLifetimeBlock ? 1 : 0, ['id' => 'FULL_PAGE_CACHE_LIFETIME_BLOCK-1']) ?>
+                            <label class="form-check-label" for="FULL_PAGE_CACHE_LIFETIME_BLOCK-1"><?= t('On - If some blocks on a page have a shorter cache lifetime, use that value instead of the global lifetime value.') ?></label>
                         </div>
                     </div>
                 </fieldset>

--- a/concrete/single_pages/dashboard/system/optimization/cache.php
+++ b/concrete/single_pages/dashboard/system/optimization/cache.php
@@ -102,8 +102,9 @@ defined('C5_EXECUTE') or die('Access Denied.');
                         </div>
                         <div class="form-check">
                             <?= $form->radio('FULL_PAGE_CACHE_BLOCK_LIFETIME', 1, $fullPageCacheLifetimeBlock ? 1 : 0, ['id' => 'FULL_PAGE_CACHE_LIFETIME_BLOCK-1']) ?>
-                            <label class="form-check-label" for="FULL_PAGE_CACHE_LIFETIME_BLOCK-1"><?= t('On - If some blocks on a page have a shorter cache lifetime, use that value instead of the global lifetime value.') ?></label>
+                            <label class="form-check-label" for="FULL_PAGE_CACHE_LIFETIME_BLOCK-1"><?= t('On - Change the lifetime for each page based on the block cache lifetime.') ?></label>
                         </div>
+                        <div class="help-block"><?= t('If you select "On," some pages may have a shorter cache lifetime if some blocks on a page allow a shorter cache lifetime than the global lifetime value.') ?></div>
                     </div>
                 </fieldset>
             </div>

--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -3789,6 +3789,21 @@ EOT
             }
         }
 
+        // Let's check block output lifetime
+        if ($app['config']->get('concrete.cache.full_page_lifetime_block')) {
+            $blocks = $this->getBlocks();
+            $blocks = array_merge($this->getGlobalBlocks(), $blocks);
+            foreach ($blocks as $b) {
+                if ($b->cacheBlockOutput()) {
+                    $blockLifetime = $b->getBlockOutputCacheLifetime();
+                    // We should ignore 0 because it means forever
+                    if ($blockLifetime > 0 && $lifetime > $blockLifetime) {
+                        $lifetime = $blockLifetime;
+                    }
+                }
+            }
+        }
+
         return $lifetime;
     }
 


### PR DESCRIPTION
fixes #11244

This is a test page that contains a page list block.

![Screenshot 2023-03-01 at 5 22 06](https://user-images.githubusercontent.com/514294/221977634-e43fd1e6-aa7e-401b-bb5b-25451791464d.png)

before: max-age is 6 hours (global settings)

![Screenshot 2023-03-01 at 5 22 19](https://user-images.githubusercontent.com/514294/221977816-d4c01246-a0fb-46bc-819d-f175ed0e2224.png)

after: max-age is 5 minutes (comes from page list block controller)

![Screenshot 2023-03-01 at 5 41 57](https://user-images.githubusercontent.com/514294/221977897-44da406a-3400-49d8-912d-3a5e634d6901.png)

