### PR TITLE
Change cache lifetime of breadcrumb blocks to forever

### DIFF
--- a/concrete/blocks/breadcrumbs/controller.php
+++ b/concrete/blocks/breadcrumbs/controller.php
@@ -35,7 +35,7 @@ class Controller extends BlockController implements UsesFeatureInterface
     /** @var bool  */
     protected $btCacheBlockOutputForRegisteredUsers = true;
     /** @var int  */
-    protected $btCacheBlockOutputLifetime = 300;
+    protected $btCacheBlockOutputLifetime = 0;
 
     /**
      * {@inheritdoc}


### PR DESCRIPTION
When I developed the breadcrumb block type, I set the cache lifetime as the same value as autonav.
Now I think it's nonsense because the feature of breadcrumb block type is almost similar with page title. 5 minutes is too short.
Let's change the lifetime to forever (same value as page title).

Related Issues: #9600, #11240, #11245, #2786