### PR TITLE
Add support for displaying files in browser when outside webroot

### DIFF
--- a/concrete/controllers/single_page/download_file.php
+++ b/concrete/controllers/single_page/download_file.php
@@ -248,7 +248,7 @@ class DownloadFile extends PageController
             return $this->responseFactory->redirect($fv->getURL(), Response::HTTP_TEMPORARY_REDIRECT)->send();
         } else {
             /** @noinspection PhpDeprecationInspection */
-            return $fv->forceDownload();
+            return $fv->buildNonpublicURLDownloadResponse();
         }
     }
 
@@ -268,7 +268,7 @@ class DownloadFile extends PageController
 
         if ($approvedVersion instanceof Version) {
             /** @noinspection PhpDeprecationInspection */
-            return $approvedVersion->forceDownload();
+            return $approvedVersion->buildForceDownloadResponse();
         }
     }
 }

--- a/concrete/src/Entity/File/Version.php
+++ b/concrete/src/Entity/File/Version.php
@@ -1047,9 +1047,9 @@ class Version implements ObjectInterface
         $urlResolver = $app->make(ResolverManagerInterface::class);
 
         if ($this->hasFileUUID()) {
-            return $urlResolver->resolve(['/download_file', 'force',$this->getFileUUID(), $cID]);
+            return $urlResolver->resolve(['/download_file', 'force', $this->getFileUUID(), $cID]);
         } else {
-            return $urlResolver->resolve(['/download_file', 'force',$this->getFileID(), $cID]);
+            return $urlResolver->resolve(['/download_file', 'force', $this->getFileID(), $cID]);
         }
     }
 
@@ -1060,12 +1060,35 @@ class Version implements ObjectInterface
      */
     public function buildForceDownloadResponse()
     {
+        return $this->buildDownloadResponse(ResponseHeaderBag::DISPOSITION_ATTACHMENT);
+    }
+
+    /**
+     * Get a Response instance that will allow the browser to download
+     * a file and possibly display it. This is specifically useful
+     * when the file is in a storage location outside of the webroot
+     * and therefore cannot be directly accessed.
+     *
+     * @return \Concrete\Core\Http\Response
+     */
+    public function buildNonpublicURLDownloadResponse()
+    {
+        return $this->buildDownloadResponse(ResponseHeaderBag::DISPOSITION_INLINE);
+    }
+
+    /**
+     * Get a Response instance with configurable content disposition
+     *
+     * @return \Concrete\Core\Http\Response
+     */
+    private function buildDownloadResponse($contentDisposition)
+    {
         $fre = $this->getFileResource();
 
         $fs = $this->getFile()->getFileStorageLocationObject()->getFileSystemObject();
         $response = new FlysystemFileResponse($fre->getPath(), $fs);
 
-        $response->setContentDisposition(ResponseHeaderBag::DISPOSITION_ATTACHMENT);
+        $response->setContentDisposition($contentDisposition);
 
         return $response;
     }


### PR DESCRIPTION
Fixes #11217

Rather than defaulting to forced downloads for all files that don't have a public URL, assume that the request really did want to use the `download` method rather than the `force_download` method.

