### PR TITLE
Fix: enable to change the order of page types

### DIFF
--- a/concrete/src/Page/Type/Type.php
+++ b/concrete/src/Page/Type/Type.php
@@ -887,10 +887,10 @@ class Type extends ConcreteObject implements \Concrete\Core\Permission\ObjectInt
         $ptLaunchInComposer = $this->doesPageTypeLaunchInComposer();
         $ptDisplayOrder = $this->getPageTypeDisplayOrder();
 
-        if ($data['name']) {
+        if (isset($data['name']) && $data['name']) {
             $ptName = $data['name'];
         }
-        if ($data['handle']) {
+        if (isset($data['handle']) && $data['handle']) {
             $ptHandle = $data['handle'];
         }
         if (is_object($data['defaultTemplate'])) {
@@ -903,7 +903,7 @@ class Type extends ConcreteObject implements \Concrete\Core\Permission\ObjectInt
         } else {
             $ptDefaultThemeID = null;
         }
-        if ($data['allowedTemplates']) {
+        if (isset($data['allowedTemplates'])) {
             $ptAllowedPageTemplates = $data['allowedTemplates'];
         }
         if (isset($data['ptLaunchInComposer'])) {


### PR DESCRIPTION
I got the `Undefined array key "name"` error on changing the order of page types.
This PR fixes the the undefined array key errors.

```
/path/to/concrete/src/Page/Type/Type.php(890): Whoops\Exception\ErrorException->null
/path/to/concrete/src/Page/Type/Type.php(890): Whoops\Run->handleError
/path/to/concrete/controllers/single_page/dashboard/pages/types/organize.php(33): Concrete\Core\Page\Type\Type->update
/path/to/concrete/src/Controller/AbstractController.php(318): Concrete\Controller\SinglePage\Dashboard\Pages\Types\Organize->submit
/path/to/concrete/src/Controller/AbstractController.php(318): null->call_user_func_array
/path/to/concrete/src/Http/ResponseFactory.php(193): Concrete\Core\Controller\AbstractController->runAction
/path/to/concrete/src/Http/ResponseFactory.php(372): Concrete\Core\Http\ResponseFactory->controller
/path/to/concrete/src/Http/DefaultDispatcher.php(132): Concrete\Core\Http\ResponseFactory->collection
/path/to/concrete/src/Http/DefaultDispatcher.php(60): Concrete\Core\Http\DefaultDispatcher->handleDispatch
/path/to/concrete/src/Http/Middleware/DispatcherDelegate.php(39): Concrete\Core\Http\DefaultDispatcher->dispatch
/path/to/concrete/src/Http/Middleware/FrameOptionsMiddleware.php(39): Concrete\Core\Http\Middleware\DispatcherDelegate->next
/path/to/concrete/src/Http/Middleware/MiddlewareDelegate.php(50): Concrete\Core\Http\Middleware\FrameOptionsMiddleware->process
/path/to/concrete/src/Http/Middleware/StrictTransportSecurityMiddleware.php(36): Concrete\Core\Http\Middleware\MiddlewareDelegate->next
/path/to/concrete/src/Http/Middleware/MiddlewareDelegate.php(50): Concrete\Core\Http\Middleware\StrictTransportSecurityMiddleware->process
/path/to/concrete/src/Http/Middleware/ContentSecurityPolicyMiddleware.php(36): Concrete\Core\Http\Middleware\MiddlewareDelegate->next
/path/to/concrete/src/Http/Middleware/MiddlewareDelegate.php(50): Concrete\Core\Http\Middleware\ContentSecurityPolicyMiddleware->process
/path/to/concrete/src/Http/Middleware/CookieMiddleware.php(35): Concrete\Core\Http\Middleware\MiddlewareDelegate->next
/path/to/concrete/src/Http/Middleware/MiddlewareDelegate.php(50): Concrete\Core\Http\Middleware\CookieMiddleware->pocess
/path/to/concrete/src/Http/Middleware/ApplicationMiddleware.php(29): Concrete\Core\Http\Middleware\MiddlewareDelegate->next
/path/to/concrete/src/Http/Middleware/MiddlewareDelegate.php(50): Concrete\Core\Http\Middleware\ApplicationMiddleware->process
/path/to/concrete/src/Http/Middleware/MiddlewareStack.php(86): Concrete\Core\Http\Middleware\MiddlewareDelegate->next
/path/to/concrete/src/Http/DefaultServer.php(85): Concrete\Core\Http\Middleware\MiddlewareStack->process
/path/to/concrete/src/Foundation/Runtime/Run/DefaultRunner.php(125): Concrete\Core\Http\DefaultServer->handleRequest
/path/to/concrete/src/Foundation/Runtime/DefaultRuntime.php(102): Concrete\Core\Foundation\Runtime\Run\DefaultRunner->run
/path/to/concrete/dispatcher.php(45): Concrete\Core\Foundation\Runtime\DefaultRuntime->run
/path/to/index.php(2): null->require
```