### PR TITLE
Fix: limit fields to specific types

### DIFF
--- a/concrete/single_pages/dashboard/system/environment/proxy.php
+++ b/concrete/single_pages/dashboard/system/environment/proxy.php
@@ -19,12 +19,12 @@
     <fieldset>
         <div class="form-group">
             <?= $form->label('http_proxy_host', t('Proxy Host')); ?>
-            <?= $form->text('http_proxy_host', $http_proxy_host); ?>
+            <?= $form->url('http_proxy_host', $http_proxy_host); ?>
         </div>
 
         <div class="form-group">
             <?= $form->label('http_proxy_port', t('Proxy Port')); ?>
-            <?= $form->text('http_proxy_port', $http_proxy_port); ?>
+            <?= $form->number('http_proxy_port', $http_proxy_port); ?>
         </div>
 
         <div class="form-group">

--- a/concrete/single_pages/dashboard/system/multisite/sites/form.php
+++ b/concrete/single_pages/dashboard/system/multisite/sites/form.php
@@ -25,7 +25,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
         </div>
         <div class="form-group">
             <?= $form->label('canonical_url', t('Canonical URL'), ['class' => 'launch-tooltip form-label', 'title' => t('The full URL at which this site will live. e.g. http://www.my-website.com')]) ?>
-            <?= $form->text('canonical_url', '') ?>
+            <?= $form->url('canonical_url', '') ?>
         </div>
         <div class="form-group">
             <?= $form->label('timezone', t('Default Timezone'), ['class' => 'launch-tooltip form-label', 'data-bs-placement' => 'right', 'title' => t('This will control the default timezone that will be used to display date/times.')]) ?>

--- a/concrete/src/Mail/SenderConfiguration.php
+++ b/concrete/src/Mail/SenderConfiguration.php
@@ -49,7 +49,7 @@ final class SenderConfiguration
     }
 
     /**
-     * @throws \RuntimeException in case of duplicared configuration keys
+     * @throws \RuntimeException in case of duplicated configuration keys
      *
      * @return $this
      */


### PR DESCRIPTION
Domains for multisite hosting and proxies accept anything. We should accept just URLs (addresses #11106). Same for proxy port.

And fixed a typo.
