### PR TITLE
Add notification message for closed page.

### DIFF
--- a/concrete/elements/page_controls_footer.php
+++ b/concrete/elements/page_controls_footer.php
@@ -344,6 +344,18 @@ if (isset($cp) && $cp->canViewToolbar() && (!$dh->inDashboard()) && !$view->isEd
                                 'buttons' => $buttons,
                             ]);
                         }
+                        $publishEndDate = $vo->getPublishEndDate();
+                        if ($publishEndDate && $dateHelper->toDateTime() > $dateHelper->toDateTime($publishEndDate)) {
+                            $date = $dateHelper->formatDate($publishEndDate);
+                            $time = $dateHelper->formatTime($publishEndDate);
+                            $message = t(/*i18n: %1$s is a date, %2$s is a time */'This version of the page was closed on %1$s at %2$s', $date, $time);
+                            echo $cih->notify([
+                                'title' => t('Closed Page.'),
+                                'text' => $message,
+                                'type' => 'info',
+                                'icon' => 'fas fa-cog',
+                            ]);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
This is a feature request from my client. There's no notification message when you visit the page that was already closed. Let's add it like publigh pending message.

![Screenshot 2023-03-11 at 11 12 30](https://user-images.githubusercontent.com/514294/224459762-92faca24-e8fc-4d10-93ac-200fe12fe936.png)
