### PR TITLE
[v8] Require Concrete dependency patches in the core

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,7 @@
     ]
   },
   "require": {
-    "wikimedia/composer-merge-plugin": "~1.3",
-    "concrete5/dependency-patches": "^1.5.0"
+    "wikimedia/composer-merge-plugin": "~1.3"
   },
   "require-dev": {
     "friendsofphp/php-cs-fixer": "^2.2",
@@ -44,7 +43,7 @@
       "merge-extra": false
     },
     "allow-subpatches": [
-      "concrete5/dependency-patches"
+      "concretecms/dependency-patches"
     ]
   },
   "autoload-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a75f2b80311eccccb34c437db223e2b9",
+    "content-hash": "1cb4cc71ed8d56882a96d33d6de7e87d",
     "packages": [
         {
             "name": "anahkiasen/html-object",
@@ -106,76 +106,6 @@
                 "postal"
             ],
             "time": "2019-10-21T14:31:17+00:00"
-        },
-        {
-            "name": "concrete5/dependency-patches",
-            "version": "1.5.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/concretecms/dependency-patches.git",
-                "reference": "ab8d9078c862d0decf90dbca90de411fbb987fa7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/concretecms/dependency-patches/zipball/ab8d9078c862d0decf90dbca90de411fbb987fa7",
-                "reference": "ab8d9078c862d0decf90dbca90de411fbb987fa7",
-                "shasum": ""
-            },
-            "require": {
-                "mlocati/composer-patcher": "^1.0.0"
-            },
-            "type": "library",
-            "extra": {
-                "patches": {
-                    "doctrine/annotations:1.2.7": {
-                        "Fix access array offset on value of type null": "doctrine/annotations/access-array-offset-on-null.patch"
-                    },
-                    "doctrine/orm:2.5.14": {
-                        "Fix UnitOfWork::createEntity()": "doctrine/orm/UnitOfWork-createEntity-continue.patch"
-                    },
-                    "zendframework/zend-stdlib:2.7.7": {
-                        "Fix ArrayObject::unserialize()": "zendframework/zend-stdlib/ArrayObject-unserialize-continue.patch"
-                    },
-                    "sunra/php-simple-html-dom-parser:1.5.2": {
-                        "Fix minus in regular expressions": "sunra/php-simple-html-dom-parser/minus-in-regular-expressions.patch"
-                    },
-                    "phpunit/phpunit:4.8.36": {
-                        "Avoid each() in Getopt": "phpunit/phpunit/Getopt-each.patch"
-                    },
-                    "tedivm/jshrink:1.1.0": {
-                        "Fix continue switch in Minifier": "tedivm/jshrink/fix-minifier-loop.patch",
-                        "Update to upstream version 1.3.2": "tedivm/jshrink/update-upstream-1.3.2.patch"
-                    },
-                    "zendframework/zend-code:2.6.3": {
-                        "Fix continue switch in FileGenerator and MethodReflection": "zendframework/zend-code/switch-continue.patch"
-                    },
-                    "zendframework/zend-http:2.6.0": {
-                        "Remove support for the X-Original-Url and X-Rewrite-Url headers": "zendframework/zend-http/no-x-original-url-x-rewrite.patch"
-                    },
-                    "zendframework/zend-mail:2.7.3": {
-                        "Fix idn_to_ascii deprecation warning": "zendframework/zend-mail/fix-idn_to_ascii-deprecation-warning.patch"
-                    },
-                    "zendframework/zend-validator:2.8.2": {
-                        "Fix idn_to_ascii/idn_to_utf8 deprecation warning": "zendframework/zend-validator/fix-idn_to_-deprecation-warning.patch"
-                    }
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Michele Locati",
-                    "email": "michele@locati.it",
-                    "homepage": "https://mlocati.github.io",
-                    "role": "author"
-                }
-            ],
-            "description": "Patches required for concrete5 dependencies",
-            "homepage": "https://github.com/concrete5/dependency-patches",
-            "abandoned": "concretecms/dependency-patches",
-            "time": "2019-07-29T08:25:31+00:00"
         },
         {
             "name": "concrete5/doctrine-xml",
@@ -320,6 +250,95 @@
             ],
             "abandoned": "concretecms/zend-queue",
             "time": "2016-09-01T14:16:11+00:00"
+        },
+        {
+            "name": "concretecms/dependency-patches",
+            "version": "1.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/concretecms/dependency-patches.git",
+                "reference": "ec219a55e89c2552efb7368175c65e68cd2a3de0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/concretecms/dependency-patches/zipball/ec219a55e89c2552efb7368175c65e68cd2a3de0",
+                "reference": "ec219a55e89c2552efb7368175c65e68cd2a3de0",
+                "shasum": ""
+            },
+            "require": {
+                "mlocati/composer-patcher": "^1.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "patches": {
+                    "doctrine/annotations:1.2.7": {
+                        "Fix access array offset on value of type null": "doctrine/annotations/access-array-offset-on-null.patch"
+                    },
+                    "doctrine/orm:2.5.14": {
+                        "Fix UnitOfWork::createEntity()": "doctrine/orm/UnitOfWork-createEntity-continue.patch",
+                        "Fix access array offset on value of type null": "doctrine/orm/access-array-offset-on-null.patch"
+                    },
+                    "egulias/email-validator:1.2.15": {
+                        "Fix access array offset on value of type null": "egulias/email-validator/access-array-offset-on-null.patch"
+                    },
+                    "zendframework/zend-stdlib:2.7.7": {
+                        "Fix ArrayObject::unserialize()": "zendframework/zend-stdlib/ArrayObject-unserialize-continue.patch"
+                    },
+                    "sunra/php-simple-html-dom-parser:1.5.2": {
+                        "Fix minus in regular expressions": "sunra/php-simple-html-dom-parser/minus-in-regular-expressions.patch",
+                        "Add PHP 8.1 compatibility": "sunra/php-simple-html-dom-parser/php8.1-compatibility.patch"
+                    },
+                    "phpunit/phpunit:4.8.36": {
+                        "Avoid each() in Getopt": "phpunit/phpunit/Getopt-each.patch"
+                    },
+                    "tedivm/jshrink:1.1.0": {
+                        "Fix continue switch in Minifier": "tedivm/jshrink/fix-minifier-loop.patch",
+                        "Update to upstream version 1.3.2": "tedivm/jshrink/update-upstream-1.3.2.patch"
+                    },
+                    "zendframework/zend-code:2.6.3": {
+                        "Fix continue switch in FileGenerator and MethodReflection": "zendframework/zend-code/switch-continue.patch"
+                    },
+                    "zendframework/zend-http:2.6.0": {
+                        "Remove support for the X-Original-Url and X-Rewrite-Url headers": "zendframework/zend-http/no-x-original-url-x-rewrite.patch"
+                    },
+                    "zendframework/zend-mail:2.7.3": {
+                        "Fix idn_to_ascii deprecation warning": "zendframework/zend-mail/fix-idn_to_ascii-deprecation-warning.patch"
+                    },
+                    "zendframework/zend-validator:2.8.2": {
+                        "Fix idn_to_ascii/idn_to_utf8 deprecation warning": "zendframework/zend-validator/fix-idn_to_-deprecation-warning.patch"
+                    },
+                    "lcobucci/jwt:3.4.5": {
+                        "Add PHP 8 compatibility": "lcobucci/jwt/php8-compatibility.patch"
+                    },
+                    "lcobucci/jwt:3.4.6": {
+                        "Add PHP 8 compatibility": "lcobucci/jwt/php8-compatibility.patch"
+                    },
+                    "league/url:3.3.5": {
+                        "Add PHP 8.1 compatibility": "league/url/php8.1-compatibility.patch"
+                    },
+                    "laminas/laminas-code:3.4.1": {
+                        "Add PHP 8.1 compatibility": "laminas/laminas-code/php8.1-compatibility.patch"
+                    },
+                    "anahkiasen/html-object:1.4.4": {
+                        "Add PHP 8.1 compatibility": "anahkiasen/html-object/php8.1-compatibility.patch"
+                    }
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Michele Locati",
+                    "email": "michele@locati.it",
+                    "homepage": "https://mlocati.github.io",
+                    "role": "author"
+                }
+            ],
+            "description": "Patches required for concrete5 dependencies",
+            "homepage": "https://github.com/concrete5/dependency-patches",
+            "time": "2022-03-31T17:52:31+00:00"
         },
         {
             "name": "container-interop/container-interop",
@@ -492,16 +511,6 @@
             "extra": {
                 "branch-alias": {
                     "dev-master": "1.3.x-dev"
-                },
-                "patches_applied": {
-                    "hash": "82e8d7bd5d0530366e7da28f81a2cef0f28bab55",
-                    "list": [
-                        {
-                            "from-package": "concrete5/dependency-patches 1.5.0",
-                            "path": "doctrine/annotations/access-array-offset-on-null.patch",
-                            "description": "Fix access array offset on value of type null"
-                        }
-                    ]
                 }
             },
             "autoload": {
@@ -1118,16 +1127,6 @@
             "extra": {
                 "branch-alias": {
                     "dev-master": "2.6.x-dev"
-                },
-                "patches_applied": {
-                    "hash": "f03553f596500df8083abdd1cd87cd1916d1a3f4",
-                    "list": [
-                        {
-                            "from-package": "concrete5/dependency-patches 1.5.0",
-                            "path": "doctrine/orm/UnitOfWork-createEntity-continue.patch",
-                            "description": "Fix UnitOfWork::createEntity()"
-                        }
-                    ]
                 }
             },
             "autoload": {
@@ -2750,16 +2749,16 @@
         },
         {
             "name": "mlocati/composer-patcher",
-            "version": "1.2.2",
+            "version": "1.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mlocati/composer-patcher.git",
-                "reference": "38db5a938b33dfba6ccba5f0eb11a2fba8205b52"
+                "reference": "c97e540390f6d1658348e864752c9e5c9b640629"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mlocati/composer-patcher/zipball/38db5a938b33dfba6ccba5f0eb11a2fba8205b52",
-                "reference": "38db5a938b33dfba6ccba5f0eb11a2fba8205b52",
+                "url": "https://api.github.com/repos/mlocati/composer-patcher/zipball/c97e540390f6d1658348e864752c9e5c9b640629",
+                "reference": "c97e540390f6d1658348e864752c9e5c9b640629",
                 "shasum": ""
             },
             "require": {
@@ -2813,7 +2812,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2020-10-30T11:26:06+00:00"
+            "time": "2022-06-10T16:28:20+00:00"
         },
         {
             "name": "mlocati/concrete5-translation-library",
@@ -3928,18 +3927,6 @@
                 "php": ">=5.3.2"
             },
             "type": "library",
-            "extra": {
-                "patches_applied": {
-                    "hash": "43699395013691839330f8406ee49fa752c163fb",
-                    "list": [
-                        {
-                            "from-package": "concrete5/dependency-patches 1.5.0",
-                            "path": "sunra/php-simple-html-dom-parser/minus-in-regular-expressions.patch",
-                            "description": "Fix minus in regular expressions"
-                        }
-                    ]
-                }
-            },
             "autoload": {
                 "psr-0": {
                     "Sunra\\PhpSimple\\HtmlDomParser": "Src/"
@@ -4032,6 +4019,7 @@
                     "type": "tidelift"
                 }
             ],
+            "abandoned": true,
             "time": "2020-10-24T10:57:07+00:00"
         },
         {
@@ -5666,23 +5654,6 @@
                 "satooshi/php-coveralls": "dev-master"
             },
             "type": "library",
-            "extra": {
-                "patches_applied": {
-                    "hash": "c8ec7f9d85bbbe7d89dd1fe73ea17f64a508e3f9",
-                    "list": [
-                        {
-                            "from-package": "concrete5/dependency-patches 1.5.0",
-                            "path": "tedivm/jshrink/fix-minifier-loop.patch",
-                            "description": "Fix continue switch in Minifier"
-                        },
-                        {
-                            "from-package": "concrete5/dependency-patches 1.5.0",
-                            "path": "tedivm/jshrink/update-upstream-1.3.2.patch",
-                            "description": "Update to upstream version 1.3.2"
-                        }
-                    ]
-                }
-            },
             "autoload": {
                 "psr-0": {
                     "JShrink": "src/"
@@ -6218,16 +6189,6 @@
                 "branch-alias": {
                     "dev-master": "2.6-dev",
                     "dev-develop": "2.7-dev"
-                },
-                "patches_applied": {
-                    "hash": "43aec57a6422c48c002031806c8a8ca01b6208cf",
-                    "list": [
-                        {
-                            "from-package": "concrete5/dependency-patches 1.5.0",
-                            "path": "zendframework/zend-code/switch-continue.patch",
-                            "description": "Fix continue switch in FileGenerator and MethodReflection"
-                        }
-                    ]
                 }
             },
             "autoload": {
@@ -6441,16 +6402,6 @@
                 "branch-alias": {
                     "dev-master": "2.6-dev",
                     "dev-develop": "2.7-dev"
-                },
-                "patches_applied": {
-                    "hash": "b1172d4359d8b116dcf51b148427b53e41d1ae2a",
-                    "list": [
-                        {
-                            "from-package": "concrete5/dependency-patches 1.5.0",
-                            "path": "zendframework/zend-http/no-x-original-url-x-rewrite.patch",
-                            "description": "Remove support for the X-Original-Url and X-Rewrite-Url headers"
-                        }
-                    ]
                 }
             },
             "autoload": {
@@ -6684,16 +6635,6 @@
                 "zf": {
                     "component": "Zend\\Mail",
                     "config-provider": "Zend\\Mail\\ConfigProvider"
-                },
-                "patches_applied": {
-                    "hash": "2eef0fc6a76db7a14e55b9d0717ffd9092bce7ce",
-                    "list": [
-                        {
-                            "from-package": "concrete5/dependency-patches 1.5.0",
-                            "path": "zendframework/zend-mail/fix-idn_to_ascii-deprecation-warning.patch",
-                            "description": "Fix idn_to_ascii deprecation warning"
-                        }
-                    ]
                 }
             },
             "autoload": {
@@ -6861,16 +6802,6 @@
                     "dev-release-2.7": "2.7-dev",
                     "dev-master": "3.0-dev",
                     "dev-develop": "3.1-dev"
-                },
-                "patches_applied": {
-                    "hash": "f247c9d47f2ba4ae8d9dfe6d1a25c8627e377753",
-                    "list": [
-                        {
-                            "from-package": "concrete5/dependency-patches 1.5.0",
-                            "path": "zendframework/zend-stdlib/ArrayObject-unserialize-continue.patch",
-                            "description": "Fix ArrayObject::unserialize()"
-                        }
-                    ]
                 }
             },
             "autoload": {
@@ -6990,16 +6921,6 @@
                 "zf": {
                     "component": "Zend\\Validator",
                     "config-provider": "Zend\\Validator\\ConfigProvider"
-                },
-                "patches_applied": {
-                    "hash": "37d53a3bf7979793505330148334c2e97b2f7a0a",
-                    "list": [
-                        {
-                            "from-package": "concrete5/dependency-patches 1.5.0",
-                            "path": "zendframework/zend-validator/fix-idn_to_-deprecation-warning.patch",
-                            "description": "Fix idn_to_ascii/idn_to_utf8 deprecation warning"
-                        }
-                    ]
                 }
             },
             "autoload": {
@@ -8006,16 +7927,6 @@
             "extra": {
                 "branch-alias": {
                     "dev-master": "4.8.x-dev"
-                },
-                "patches_applied": {
-                    "hash": "b230cedd50b7175de81a87b2ec86ad380ee748f9",
-                    "list": [
-                        {
-                            "from-package": "concrete5/dependency-patches 1.5.0",
-                            "path": "phpunit/phpunit/Getopt-each.patch",
-                            "description": "Avoid each() in Getopt"
-                        }
-                    ]
                 }
             },
             "autoload": {

--- a/concrete/composer.json
+++ b/concrete/composer.json
@@ -91,7 +91,8 @@
     "league/fractal": "^0.17.0",
     "theorchard/monolog-cascade": "0.5.*",
     "commerceguys/addressing": "^1.0 <1.4",
-    "enshrined/svg-sanitize": "^0.14.0"
+    "enshrined/svg-sanitize": "^0.14.0",
+    "concretecms/dependency-patches": "^1.7.2"
   },
   "extra": {
     "branch-alias": {


### PR DESCRIPTION
What about adding the `dependency-patches` composer package to the core?
Also, let's rename it from `concrete5/dependency-patches` to `concretecms/dependency-patches`, accordingly to https://github.com/concretecms/dependency-patches/commit/850c21a1ab5925900bc4be9b764600967a41380b