### PR TITLE
Fix PHP 8.2 issues

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         php-version:
           - "7.4"
-          - "8.1"
+          - "8.2"
         starting-point:
           - atomik_full
     steps:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -45,6 +45,9 @@ jobs:
           - php-version: 8.1
             operating-system: "ubuntu-latest"
             dependencies: "locked"
+          - php-version: 8.2
+            operating-system: "ubuntu-latest"
+            dependencies: "locked"
 
     steps:
       - name: Enable code coverage

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -16,7 +16,7 @@ jobs:
           - 9.0.1
         php-version:
           - "7.4"
-          - "8.1"
+          - "8.2"
     steps:
       -
         name: Configure environment

--- a/composer.lock
+++ b/composer.lock
@@ -323,16 +323,16 @@
         },
         {
             "name": "concretecms/dependency-patches",
-            "version": "1.7.2",
+            "version": "1.7.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/concretecms/dependency-patches.git",
-                "reference": "ec219a55e89c2552efb7368175c65e68cd2a3de0"
+                "reference": "8dbbdcbfe0ed7aae3dcfb0883ea00e1a0554cb7a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/concretecms/dependency-patches/zipball/ec219a55e89c2552efb7368175c65e68cd2a3de0",
-                "reference": "ec219a55e89c2552efb7368175c65e68cd2a3de0",
+                "url": "https://api.github.com/repos/concretecms/dependency-patches/zipball/8dbbdcbfe0ed7aae3dcfb0883ea00e1a0554cb7a",
+                "reference": "8dbbdcbfe0ed7aae3dcfb0883ea00e1a0554cb7a",
                 "shasum": ""
             },
             "require": {
@@ -391,6 +391,9 @@
                     },
                     "anahkiasen/html-object:1.4.4": {
                         "Add PHP 8.1 compatibility": "anahkiasen/html-object/php8.1-compatibility.patch"
+                    },
+                    "wikimedia/less.php:1.8.2": {
+                        "Add PHP 8.2 compatibility": "wikimedia/less.php/fix-php-8.2-compatibility.patch"
                     }
                 }
             },
@@ -406,13 +409,13 @@
                     "role": "author"
                 }
             ],
-            "description": "Patches required for concrete5 dependencies",
-            "homepage": "https://github.com/concrete5/dependency-patches",
+            "description": "Patches required for concrete5 and Concrete CMS dependencies",
+            "homepage": "https://github.com/concretecms/dependency-patches",
             "support": {
                 "issues": "https://github.com/concretecms/dependency-patches/issues",
-                "source": "https://github.com/concretecms/dependency-patches/tree/1.7.2"
+                "source": "https://github.com/concretecms/dependency-patches/tree/1.7.4"
             },
-            "time": "2022-03-31T17:52:31+00:00"
+            "time": "2023-03-14T20:25:27+00:00"
         },
         {
             "name": "concretecms/doctrine-xml",

--- a/concrete/blocks/accordion/controller.php
+++ b/concrete/blocks/accordion/controller.php
@@ -103,6 +103,26 @@ class AccordionEntry implements \JsonSerializable
 class Controller extends BlockController implements UsesFeatureInterface
 {
     /**
+     * @var string|null
+     */
+    public $initialState;
+
+    /**
+     * @var string|null
+     */
+    public $itemHeadingFormat;
+
+    /**
+     * @var int|string|null
+     */
+    public $alwaysOpen;
+
+    /**
+     * @var int|string|null
+     */
+    public $flush;
+
+    /**
      * @var int
      */
     protected $btInterfaceWidth = 720;

--- a/concrete/blocks/calendar_event/controller.php
+++ b/concrete/blocks/calendar_event/controller.php
@@ -21,6 +21,56 @@ defined('C5_EXECUTE') or die('Access Denied.');
 class Controller extends BlockController implements UsesFeatureInterface
 {
     /**
+     * @var string|null
+     */
+    protected $mode = 'S';
+
+    /**
+     * @var string|null
+     */
+    protected $calendarEventAttributeKeyHandle;
+
+    /**
+     * @var int|string|null
+     */
+    public $calendarID;
+
+    /**
+     * @var int|string|null
+     */
+    protected $eventID;
+
+    /**
+     * @var string|null
+     */
+    public $displayEventAttributes;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $allowExport;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $enableLinkToPage;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $displayEventName;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $displayEventDate;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $displayEventDescription;
+
+    /**
      * @var int
      */
     protected $btInterfaceWidth = 550;
@@ -34,21 +84,6 @@ class Controller extends BlockController implements UsesFeatureInterface
      * @var string
      */
     protected $btTable = 'btCalendarEvent';
-
-    /**
-     * @var string
-     */
-    protected $mode = 'S';
-
-    /**
-     * @var string
-     */
-    protected $calendarEventAttributeKeyHandle;
-
-    /**
-     * @var int|null
-     */
-    protected $eventID;
 
     /**
      * {@inheritdoc}

--- a/concrete/blocks/core_area_layout/controller.php
+++ b/concrete/blocks/core_area_layout/controller.php
@@ -26,6 +26,11 @@ use Concrete\Core\Support\Facade\Url;
 class Controller extends BlockController implements UsesFeatureInterface
 {
     /**
+     * @var int|string|null
+     */
+    public $arLayoutID;
+
+    /**
      * @var \Concrete\Core\Area\Layout\CustomLayout|\Concrete\Core\Area\Layout\PresetLayout|\Concrete\Core\Area\Layout\ThemeGridLayout|null
      */
     public $arLayout;
@@ -59,11 +64,6 @@ class Controller extends BlockController implements UsesFeatureInterface
      * @var string[]
      */
     protected $requiredFeatures = [];
-
-    /**
-     * @var Area|null
-     */
-    protected $area;
 
     /**
      * @return bool

--- a/concrete/blocks/core_conversation/controller.php
+++ b/concrete/blocks/core_conversation/controller.php
@@ -18,14 +18,79 @@ use Concrete\Core\User\UserInfo;
 class Controller extends BlockController implements UsesFeatureInterface
 {
     /**
-     * @var int|null
+     * @var int|string|null
      */
-    public $enableTopCommentReviews;
-
+    public $cnvID;
+    
+    /**
+     * @var int|string|null
+     */
+    public $enablePosting;
+    
+    /**
+     * @var bool|int|string|null
+     */
+    public $paginate;
+    
+    /**
+     * @var int|string|null
+     */
+    public $itemsPerPage;
+    
     /**
      * @var string|null
      */
+    public $displayMode;
+    
+    /**
+     * @var string|null
+     */
+    public $orderBy;
+    
+    /**
+     * @var bool|int|string|null
+     */
+    public $enableOrdering;
+    
+    /**
+     * @var bool|int|string|null
+     */
+    public $enableCommentRating;
+    
+    /**
+     * @var bool|int|string|null
+     */
+    public $enableTopCommentReviews;
+    
+    /**
+     * @var bool|int|string|null
+     */
+    public $displaySocialLinks;
+    
+    /**
+     * @var int|string|null
+     */
     public $reviewAggregateAttributeKey;
+    
+    /**
+     * @var string|null
+     */
+    public $displayPostingForm;
+    
+    /**
+     * @var string|null
+     */
+    public $addMessageLabel;
+    
+    /**
+     * @var string|null
+     */
+    public $dateFormat;
+    
+    /**
+     * @var string|null
+     */
+    public $customDateFormat;
 
     /**
      * @var int|null
@@ -36,11 +101,6 @@ class Controller extends BlockController implements UsesFeatureInterface
      * @var int|null
      */
     public $maxFilesGuest;
-
-    /**
-     * @var bool|int
-     */
-    public $enablePosting;
 
     /**
      * @var int

--- a/concrete/blocks/date_navigation/controller.php
+++ b/concrete/blocks/date_navigation/controller.php
@@ -14,6 +14,41 @@ use Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface;
 class Controller extends BlockController implements UsesFeatureInterface
 {
     /**
+     * @var string|null
+     */
+    public $title;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $filterByParent;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $redirectToResults;
+
+    /**
+     * @var int|string|null
+     */
+    protected $cParentID;
+
+    /**
+     * @var int|string|null
+     */
+    protected $cTargetID;
+
+    /**
+     * @var int|string|null
+     */
+    protected $ptID;
+
+    /**
+     * @var string|null
+     */
+    public $titleFormat;
+
+    /**
      * @var int
      */
     protected $btInterfaceWidth = 400;
@@ -39,16 +74,6 @@ class Controller extends BlockController implements UsesFeatureInterface
     protected $btTable = 'btDateNavigation';
 
     /**
-     * @var int|null
-     */
-    protected $cTargetID;
-
-    /**
-     * @var int|null
-     */
-    protected $ptID;
-
-    /**
      * @var string|int|null
      */
     protected $selectedYear;
@@ -57,11 +82,6 @@ class Controller extends BlockController implements UsesFeatureInterface
      * @var string|int|null
      */
     protected $selectedMonth;
-
-    /**
-     * @var int|null
-     */
-    protected $cParentID;
 
     /**
      * @return string[]

--- a/concrete/blocks/desktop_draft_list/controller.php
+++ b/concrete/blocks/desktop_draft_list/controller.php
@@ -16,6 +16,11 @@ defined('C5_EXECUTE') or die('Access Denied.');
 class Controller extends BlockController implements UsesFeatureInterface
 {
     /**
+     * @var int|string|null
+     */
+    public $draftsPerPage;
+
+    /**
      * @var string
      */
     protected $btTable = 'btDesktopDraftList';

--- a/concrete/blocks/document_library/controller.php
+++ b/concrete/blocks/document_library/controller.php
@@ -30,6 +30,146 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
 
 class Controller extends BlockController implements UsesFeatureInterface
 {
+    /**
+     * @var string|null
+     */
+    public $setIds;
+
+    /**
+     * @var int|string|null
+     */
+    protected $folderID = 0;
+
+    /**
+     * @var string|null
+     */
+    public $setMode;
+
+    /**
+     * @var int|string|null
+     */
+    public $onlyCurrentUser;
+
+    /**
+     * @var string|null
+     */
+    public $tags;
+
+    /**
+     * @var string|null
+     */
+    public $viewProperties;
+
+    /**
+     * @var string|null
+     */
+    public $expandableProperties;
+
+    /**
+     * @var string|null
+     */
+    public $searchProperties;
+
+    /**
+     * @var string|null
+     */
+    public $orderBy;
+
+    /**
+     * @var int|string|null
+     */
+    public $displayLimit;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $displayOrderDesc;
+
+    /**
+     * @var int|string|null
+     */
+    public $addFilesToSetID;
+
+    /**
+     * @var int|string|null
+     */
+    public $maxThumbWidth;
+
+    /**
+     * @var int|string|null
+     */
+    public $maxThumbHeight;
+
+    /**
+     * @var int|string|null
+     */
+    public $enableSearch;
+
+    /**
+     * @var string|null
+     */
+    public $heightMode;
+
+    /**
+     * @var string|null
+     */
+    public $downloadFileMethod;
+
+    /**
+     * @var int|string|null
+     */
+    public $fixedHeightSize;
+
+    /**
+     * @var string|null
+     */
+    public $headerBackgroundColor;
+
+    /**
+     * @var string|null
+     */
+    public $headerBackgroundColorActiveSort;
+
+    /**
+     * @var string|null
+     */
+    public $headerTextColor;
+
+    /**
+     * @var int|string|null
+     */
+    public $allowFileUploading;
+
+    /**
+     * @var int|string|null
+     */
+    public $allowInPageFileManagement;
+
+    /**
+     * @var string|null
+     */
+    public $tableName;
+
+    /**
+     * @var string|null
+     */
+    public $tableDescription;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $tableStriped;
+
+    /**
+     * @var string|null
+     */
+    public $rowBackgroundColorAlternate;
+
+    /**
+     * @var int|string|null
+     */
+    public $hideFolders;
+
     protected $btInterfaceWidth = '640';
     protected $btInterfaceHeight = '400';
     protected $btTable = 'btDocumentLibrary';
@@ -38,9 +178,6 @@ class Controller extends BlockController implements UsesFeatureInterface
 
     /** @var FileFolder|null */
     protected $rootNode = null;
-
-    /** @var int */
-    protected $folderID = 0;
 
     public function getBlockTypeDescription()
     {
@@ -286,7 +423,7 @@ class Controller extends BlockController implements UsesFeatureInterface
                     $subselect
                         ->select('count(distinct fsf.fsID) as sets')
                         ->addSelect('fsf.fID')
-                        // fsID and fsDisplayOrder are only needed if ordering by fileset. 
+                        // fsID and fsDisplayOrder are only needed if ordering by fileset.
                         // Although when including files that are in all filesets
                         // ordering by fileset doesn't always make sense let's do it anyway!
                         ->addSelect('fsf.fsID')
@@ -315,7 +452,7 @@ class Controller extends BlockController implements UsesFeatureInterface
                     $query->andWhere($expr);
                     break;
             }
-            
+
             if ($this->orderBy == 'set') {
                 $order = $this->displayOrderDesc ? 'desc' : 'asc';
                 $query->orderBy('fsf.fsID', 'asc')->addOrderBy('fsf.fsDisplayOrder', $order);
@@ -645,7 +782,7 @@ class Controller extends BlockController implements UsesFeatureInterface
 
     /**
      * @param int |false $bID BlockID
-     * @return Symfony\Component\HttpFoundation\Response | void
+     * @return \Symfony\Component\HttpFoundation\Response | void
      * @throws UserMessageException
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
@@ -743,7 +880,7 @@ class Controller extends BlockController implements UsesFeatureInterface
         $list = $this->setupFolderFileSetFilter($list);
         $list = $this->setupFolderFileFolderFilter($list);
         $list->ignorePermissions();
-        
+
         // Ordering by FileSet Order is dealt with in setupFolderFileSetFilter()
         // No need to run this code here then
         if ($this->orderBy != 'set') {

--- a/concrete/blocks/event_list/controller.php
+++ b/concrete/blocks/event_list/controller.php
@@ -17,6 +17,71 @@ defined('C5_EXECUTE') or die("Access Denied.");
 
 class Controller extends BlockController implements UsesFeatureInterface
 {
+    /**
+     * @var string|null
+     */
+    public $caID;
+
+    /**
+     * @var string|null
+     */
+    public $calendarAttributeKeyHandle;
+
+    /**
+     * @var int|string|null
+     */
+    public $totalToRetrieve;
+
+    /**
+     * @var int|string|null
+     */
+    public $totalPerPage;
+
+    /**
+     * @var int|string|null
+     */
+    public $filterByTopicAttributeKeyID;
+
+    /**
+     * @var int|string|null
+     */
+    public $filterByTopicID;
+
+    /**
+     * @var string|null
+     */
+    public $filterByPageTopicAttributeKeyHandle;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $filterByFeatured;
+
+    /**
+     * @var string|null
+     */
+    public $eventListTitle;
+
+    /**
+     * @var int|string|null
+     */
+    public $linkToPage;
+
+    /**
+     * @var string|null
+     */
+    public $titleFormat;
+
+    /**
+     * @var string|null
+     */
+    public $eventPeriod;
+
+    /**
+     * @var string|null
+     */
+    public $eventOrder;
+
     public $helpers = array('form');
 
     protected $btInterfaceWidth = 500;

--- a/concrete/blocks/express_entry_list/controller.php
+++ b/concrete/blocks/express_entry_list/controller.php
@@ -34,18 +34,110 @@ use Symfony\Component\HttpFoundation\Request;
 
 class Controller extends BlockController implements UsesFeatureInterface
 {
+    /**
+     * @var string|null
+     */
+    public $exEntityID;
+
+    /**
+     * @var int|string|null
+     */
+    public $detailPage;
+
+    /**
+     * @var string|null
+     */
+    public $linkedProperties;
+
+    /**
+     * @var string|null
+     */
+    public $searchProperties = false;
+
+    /**
+     * @var string|null
+     */
+    public $searchAssociations;
+
+    /**
+     * @var string|null
+     */
+    public $columns;
+
+    /**
+     * @var string|null
+     */
+    public $filterFields;
+
+    /**
+     * @var int|string|null
+     */
+    public $displayLimit;
+
+    /**
+     * @var int|string|null
+     */
+    public $enableItemsPerPageSelection = false;
+
+    /**
+     * @var int|string|null
+     */
+    public $enablePagination;
+
+    /**
+     * @var int|string|null
+     */
+    public $enableSearch;
+
+    /**
+     * @var int|string|null
+     */
+    public $enableKeywordSearch;
+
+    /**
+     * @var string|null
+     */
+    public $headerBackgroundColor;
+
+    /**
+     * @var string|null
+     */
+    public $headerBackgroundColorActiveSort;
+
+    /**
+     * @var string|null
+     */
+    public $headerTextColor;
+
+    /**
+     * @var string|null
+     */
+    public $tableName;
+
+    /**
+     * @var string|null
+     */
+    public $tableDescription;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $tableStriped;
+
+    /**
+     * @var string|null
+     */
+    public $rowBackgroundColorAlternate;
+
+    /**
+     * @var string|null
+     */
+    public $titleFormat;
+
     protected $btInterfaceWidth = "640";
     protected $btInterfaceHeight = "400";
     protected $btTable = 'btExpressEntryList';
     protected $entityAttributes = [];
-
-    public $enableItemsPerPageSelection = false;
-
-    public $searchProperties = false;
-
-    public $searchAssociations;
-
-    public $columns;
 
     public function on_start()
     {
@@ -75,7 +167,7 @@ class Controller extends BlockController implements UsesFeatureInterface
             Features::EXPRESS
         ];
     }
-    
+
     public function add()
     {
         $this->loadData();
@@ -168,7 +260,7 @@ class Controller extends BlockController implements UsesFeatureInterface
 
                 $fieldManager = $this->getSearchFieldManager($entity);
                 $fieldSelectorElement = new SearchFieldSelector($fieldManager, $this->getActionURL('add_search_field'));
-                
+
                 $query = new Query();
                 if ($this->filterFields) {
                     $filterFields = unserialize($this->filterFields);
@@ -307,7 +399,7 @@ class Controller extends BlockController implements UsesFeatureInterface
 
             $query->setColumns($columnSet);
             $query = $queryModifier->process($query);
-            
+
             $result = $resultFactory->createFromQuery($searchProvider, $query);
             $list = $result->getItemListObject();
             if (!isset($itemsPerPageSpecified)) {

--- a/concrete/blocks/express_form/controller.php
+++ b/concrete/blocks/express_form/controller.php
@@ -47,19 +47,67 @@ use Concrete\Core\Permission\Checker;
 
 class Controller extends BlockController implements NotificationProviderInterface, UsesFeatureInterface
 {
+    /**
+     * @var string|null
+     */
+    public $exFormID;
+
+    /**
+     * @var string|null
+     */
+    public $submitLabel;
+
+    /**
+     * @var string|null
+     */
+    public $thankyouMsg;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $notifyMeOnSubmission;
+
+    /**
+     * @var string|null
+     */
+    public $recipientEmail;
+
+    /**
+     * @var int|string|null
+     */
+    public $displayCaptcha;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $storeFormSubmission = 1;
+
+    /**
+     * @var int|string|null
+     */
+    public $redirectCID;
+
+    /**
+     * @var string|null
+     */
+    public $replyToEmailControlID;
+
+    /**
+     * @var int|string|null
+     */
+    public $addFilesToSet;
+
+    /**
+     * @var int|string|null
+     */
+    public $addFilesToFolder;
+
     protected $btInterfaceWidth = 640;
     protected $btInterfaceHeight = 700;
     protected $btCacheBlockOutput = false;
     protected $btTable = 'btExpressForm';
     protected $btExportPageColumns = ['redirectCID'];
     protected $btCopyWhenPropagate = true;
-
-    public $notifyMeOnSubmission;
-    public $recipientEmail;
-    public $replyToEmailControlID;
-    public $storeFormSubmission = 1;
-    public $exFormID;
-    public $addFilesToFolder;
 
     const FORM_RESULTS_CATEGORY_NAME = 'Forms';
 
@@ -251,9 +299,9 @@ class Controller extends BlockController implements NotificationProviderInterfac
                         $key = $this->saveAttributeKeySettings($controller, $key, $post);
                         $entityManager->persist($key);
                         $entityManager->flush();
-                        
+
                         $this->runAttributeIndexer($entity, $key);
-                        
+
                         $control->setAttributeKey($key);
                     }
                     break;
@@ -696,7 +744,7 @@ class Controller extends BlockController implements NotificationProviderInterfac
         $entityManager->persist($settings);
         return $key;
     }
-    
+
     /**
      * @param \Concrete\Core\Entity\Express\Entity $entity
      * @param ExpressKey $key
@@ -707,7 +755,7 @@ class Controller extends BlockController implements NotificationProviderInterfac
     protected function runAttributeIndexer(Entity $entity, ExpressKey $key, $update = false)
     {
         $category = $entity->getAttributeKeyCategory();
-        
+
         if (is_object($category)) {
             $indexer = $category->getSearchIndexer();
 
@@ -721,7 +769,7 @@ class Controller extends BlockController implements NotificationProviderInterfac
             }
         }
     }
-    
+
     public function edit()
     {
         $this->set('formSubmissionConfig', $this->getFormSubmissionConfigValue());

--- a/concrete/blocks/external_form/controller.php
+++ b/concrete/blocks/external_form/controller.php
@@ -5,6 +5,11 @@ use Concrete\Core\Block\BlockController;
 
 class Controller extends BlockController
 {
+    /**
+     * @var string|null
+     */
+    public $filename;
+
     public $helpers = ['file', 'form'];
     protected $btTable = 'btExternalForm';
     protected $btInterfaceWidth = 420;

--- a/concrete/blocks/faq/controller.php
+++ b/concrete/blocks/faq/controller.php
@@ -9,6 +9,11 @@ use Concrete\Core\Feature\UsesFeatureInterface;
 
 class Controller extends BlockController implements UsesFeatureInterface
 {
+    /**
+     * @var string|null
+     */
+    public $blockTitle;
+
     protected $btInterfaceWidth = 600;
     protected $btInterfaceHeight = 465;
     protected $btTable = 'btFaq';

--- a/concrete/blocks/feature/controller.php
+++ b/concrete/blocks/feature/controller.php
@@ -12,6 +12,36 @@ use Core;
 
 class Controller extends BlockController implements UsesFeatureInterface
 {
+    /**
+     * @var string|null
+     */
+    protected $icon;
+
+    /**
+     * @var string|null
+     */
+    public $title;
+
+    /**
+     * @var string|null
+     */
+    public $paragraph;
+
+    /**
+     * @var string|null
+     */
+    public $externalLink;
+
+    /**
+     * @var int|string|null
+     */
+    public $internalLinkCID;
+
+    /**
+     * @var string|null
+     */
+    public $titleFormat;
+
     public $helpers = array('form');
 
     protected $btInterfaceWidth = 400;
@@ -21,10 +51,6 @@ class Controller extends BlockController implements UsesFeatureInterface
     protected $btExportPageColumns = array('internalLinkCID');
     protected $btInterfaceHeight = 520;
     protected $btTable = 'btFeature';
-
-    protected $icon;
-
-    public $paragraph;
 
     public function getBlockTypeDescription()
     {

--- a/concrete/blocks/feature_link/controller.php
+++ b/concrete/blocks/feature_link/controller.php
@@ -19,15 +19,63 @@ defined('C5_EXECUTE') or die('Access Denied.');
 
 class Controller extends BlockController implements UsesFeatureInterface
 {
+    /**
+     * @var string|null
+     */
+    public $title;
+
+    /**
+     * @var string|null
+     */
+    public $body;
+
+    /**
+     * @var string|null
+     */
+    public $buttonText;
+
+    /**
+     * @var string|null
+     */
+    public $buttonExternalLink;
+
+    /**
+     * @var int|string|null
+     */
+    public $buttonInternalLinkCID;
+
+    /**
+     * @var int|string|null
+     */
+    public $buttonFileLinkID;
+
+    /**
+     * @var string|null
+     */
+    public $buttonColor;
+
+    /**
+     * @var string|null
+     */
+    public $buttonStyle;
+
+    /**
+     * @var string|null
+     */
+    public $buttonSize;
+
+    /**
+     * @var string|null
+     */
+    public $titleFormat;
+
+    /**
+     * @var string|null
+     */
+    protected $icon;
+
     public $helpers = ['form'];
 
-    public $buttonInternalLinkCID;
-    public $buttonExternalLink;
-    public $buttonFileLinkID;
-    public $buttonText;
-    public $buttonSize;
-    public $buttonStyle;
-    public $buttonColor;
     public $buttonIcon;
 
     protected $btDefaultSet = 'basic';
@@ -39,8 +87,6 @@ class Controller extends BlockController implements UsesFeatureInterface
     protected $btCacheBlockOutputOnPost = true;
     protected $btCacheBlockOutputForRegisteredUsers = true;
     protected $btCacheBlockOutputLifetime = 300;
-
-    protected $icon;
 
     /**
      * {@inheritdoc}
@@ -156,9 +202,6 @@ class Controller extends BlockController implements UsesFeatureInterface
       }
     }
 
-
-
-
     public function save($args)
     {
         list($imageLinkType, $imageLinkValue) = $this->app->make(DestinationPicker::class)->decode('imageLink', $this->getImageLinkPickers(), null, null, $args);
@@ -166,12 +209,9 @@ class Controller extends BlockController implements UsesFeatureInterface
         $args['buttonInternalLinkCID'] = $imageLinkType === 'page' ? $imageLinkValue : 0;
         $args['buttonFileLinkID'] = $imageLinkType === 'file' ? $imageLinkValue : 0;
         $args['buttonExternalLink'] = $imageLinkType === 'external_url' ? $imageLinkValue : '';
-        /** @var SanitizeService $security */
         $security = $this->app->make('helper/security');
         $args['icon'] = $security->sanitizeString($args['icon'] ?? '');
 
         parent::save($args);
     }
-    
-
 }

--- a/concrete/blocks/form/controller.php
+++ b/concrete/blocks/form/controller.php
@@ -20,6 +20,51 @@ use FileImporter;
 
 class Controller extends BlockController
 {
+    /**
+     * @var int|string|null
+     */
+    public $questionSetId;
+    
+    /**
+     * @var string|null
+     */
+    public $surveyName;
+    
+    /**
+     * @var string|null
+     */
+    public $submitText = '';
+    
+    /**
+     * @var string|null
+     */
+    public $thankyouMsg = '';
+    
+    /**
+     * @var bool|int|string|null
+     */
+    public $notifyMeOnSubmission;
+    
+    /**
+     * @var string|null
+     */
+    public $recipientEmail;
+    
+    /**
+     * @var int|string|null
+     */
+    public $displayCaptcha;
+    
+    /**
+     * @var int|string|null
+     */
+    public $redirectCID;
+    
+    /**
+     * @var int|string|null
+     */
+    public $addFilesToSet;
+
     public $btTable = 'btForm';
 
     public $btQuestionsTablename = 'btFormQuestions';
@@ -31,10 +76,6 @@ class Controller extends BlockController
     public $btInterfaceWidth = '525';
 
     public $btInterfaceHeight = '550';
-
-    public $thankyouMsg = '';
-
-    public $submitText = '';
 
     public $noSubmitFormRedirect = 0;
 

--- a/concrete/blocks/google_map/controller.php
+++ b/concrete/blocks/google_map/controller.php
@@ -10,6 +10,51 @@ use Config;
 
 class Controller extends BlockController implements UsesFeatureInterface
 {
+    /**
+     * @var string|null
+     */
+    public $title;
+
+    /**
+     * @var string|null
+     */
+    public $location;
+
+    /**
+     * @var float|string|null
+     */
+    public $latitude;
+
+    /**
+     * @var float|string|null
+     */
+    public $longitude;
+
+    /**
+     * @var int|string|null
+     */
+    public $zoom;
+
+    /**
+     * @var string|null
+     */
+    public $width;
+
+    /**
+     * @var string|null
+     */
+    public $height;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $scrollwheel;
+
+    /**
+     * @var string|null
+     */
+    public $titleFormat;
+
     protected $btTable = 'btGoogleMap';
 
     protected $btInterfaceWidth = 525;

--- a/concrete/blocks/hero_image/controller.php
+++ b/concrete/blocks/hero_image/controller.php
@@ -19,17 +19,74 @@ defined('C5_EXECUTE') or die('Access Denied.');
 
 class Controller extends BlockController implements FileTrackableInterface, UsesFeatureInterface
 {
+    /**
+     * @var int|string|null
+     */
+    public $image;
+
+    /**
+     * @var string|null
+     */
+    public $title;
+
+    /**
+     * @var string|null
+     */
+    public $body;
+
+    /**
+     * @var string|null
+     */
+    public $buttonText;
+
+    /**
+     * @var string|null
+     */
+    public $buttonExternalLink;
+
+    /**
+     * @var int|string|null
+     */
+    public $buttonInternalLinkCID;
+
+    /**
+     * @var int|string|null
+     */
+    public $buttonFileLinkID;
+
+    /**
+     * @var string|null
+     */
+    public $height;
+
+    /**
+     * @var string|null
+     */
+    public $buttonColor;
+
+    /**
+     * @var string|null
+     */
+    public $buttonStyle;
+
+    /**
+     * @var string|null
+     */
+    public $buttonSize;
+
+    /**
+     * @var string|null
+     */
+    public $titleFormat;
+
+    /**
+     * @var string|null
+     */
+    protected $icon;
+
     public $helpers = ['form'];
 
-    public $buttonInternalLinkCID;
-    public $buttonExternalLink;
-    public $buttonFileLinkID;
-    public $buttonText;
-    public $buttonSize;
-    public $buttonStyle;
-    public $buttonColor;
     public $buttonIcon;
-    public $titleFormat;
 
     protected $btInterfaceWidth = 640;
     protected $btInterfaceHeight = 500;
@@ -42,7 +99,6 @@ class Controller extends BlockController implements FileTrackableInterface, Uses
     protected $btCacheBlockOutputLifetime = 300;
     protected $btIgnorePageThemeGridFrameworkContainer = true;
     protected $btExportFileColumns = ['image'];
-    protected $icon;
 
     /**
      * {@inheritdoc}
@@ -186,7 +242,6 @@ class Controller extends BlockController implements FileTrackableInterface, Uses
         $args['buttonFileLinkID'] = $imageLinkType === 'file' ? $imageLinkValue : 0;
         $args['buttonExternalLink'] = $imageLinkType === 'external_url' ? $imageLinkValue : '';
 
-        /** @var SanitizeService $security */
         $security = $this->app->make('helper/security');
         $args['icon'] = $security->sanitizeString($args['icon'] ?? '');
 

--- a/concrete/blocks/image/controller.php
+++ b/concrete/blocks/image/controller.php
@@ -17,6 +17,66 @@ use Concrete\Core\View\View;
 
 class Controller extends BlockController implements FileTrackableInterface, UsesFeatureInterface
 {
+    /**
+     * @var int|string|null
+     */
+    public $fID;
+
+    /**
+     * @var int|string|null
+     */
+    public $fOnstateID;
+
+    /**
+     * @var int|string|null
+     */
+    public $cropImage;
+
+    /**
+     * @var int|string|null
+     */
+    public $maxWidth;
+
+    /**
+     * @var int|string|null
+     */
+    public $maxHeight;
+
+    /**
+     * @var string|null
+     */
+    public $externalLink;
+
+    /**
+     * @var int|string|null
+     */
+    public $internalLinkCID;
+
+    /**
+     * @var int|string|null
+     */
+    public $fileLinkID;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $openLinkInNewWindow;
+
+    /**
+     * @var string|null
+     */
+    public $altText;
+
+    /**
+     * @var string|null
+     */
+    public $title;
+
+    /**
+     * @var string|null
+     */
+    public $sizingOption;
+
     protected $btInterfaceWidth = 400;
     protected $btInterfaceHeight = 550;
     protected $btTable = 'btContentImage';
@@ -445,7 +505,7 @@ class Controller extends BlockController implements FileTrackableInterface, Uses
         if ($svg && isset($args['cropImage'])) {
             $e->add(t('SVG images cannot be cropped.'));
         }
-        
+
         $this->app->make(DestinationPicker::class)->decode('imageLink', $this->getImageLinkPickers(), $e, t('Image Link'), $args);
 
         return $e;

--- a/concrete/blocks/image_slider/controller.php
+++ b/concrete/blocks/image_slider/controller.php
@@ -15,6 +15,36 @@ use Page;
 
 class Controller extends BlockController implements FileTrackableInterface, UsesFeatureInterface
 {
+    /**
+     * @var int|string|null
+     */
+    public $navigationType;
+
+    /**
+     * @var int|string|null
+     */
+    public $timeout;
+
+    /**
+     * @var int|string|null
+     */
+    public $speed;
+
+    /**
+     * @var int|string|null
+     */
+    public $noAnimate;
+
+    /**
+     * @var int|string|null
+     */
+    public $pause;
+
+    /**
+     * @var int|string|null
+     */
+    public $maxWidth;
+
     protected $btTable = 'btImageSlider';
     protected $btExportTables = ['btImageSlider', 'btImageSliderEntries'];
     protected $btInterfaceWidth = 600;
@@ -43,7 +73,7 @@ class Controller extends BlockController implements FileTrackableInterface, Uses
         parent::__construct($obj);
         $this->tracker = $tracker;
     }
-    
+
     public function getRequiredFeatures(): array
     {
         return [
@@ -99,7 +129,7 @@ class Controller extends BlockController implements FileTrackableInterface, Uses
     {
         $this->edit();
     }
-    
+
     public function getEntries()
     {
         $db = Database::get();

--- a/concrete/blocks/page_attribute_display/controller.php
+++ b/concrete/blocks/page_attribute_display/controller.php
@@ -17,33 +17,54 @@ defined('C5_EXECUTE') or die('Access Denied.');
  */
 class Controller extends BlockController implements UsesFeatureInterface
 {
+    /**
+     * @var string|null
+     */
+    public $attributeHandle;
+
+    /**
+     * @var string|null
+     */
+    public $attributeTitleText;
+
+    /**
+     * @var string|null
+     */
+    public $displayTag;
+
+    /**
+     * @var string|null
+     */
+    public $dateFormat;
+
+    /**
+     * Thumbnail height.
+     *
+     * @var int|string|null
+     */
+    public $thumbnailHeight = 250;
+
+    /**
+     * Thumbnail width.
+     *
+     * @var int|string|null
+     */
+    public $thumbnailWidth = 250;
+
+    /**
+     * @var string|null
+     */
+    public $delimiter;
+
     protected $btTable = 'btPageAttributeDisplay';
     protected $btInterfaceWidth = "500";
     protected $btInterfaceHeight = "365";
-    /** @var string|null */
-    public $dateFormat;
     /** @var bool */
     protected $btCacheBlockOutput = true;
     /** @var bool */
     protected $btCacheBlockOutputOnPost = true;
     /** @var bool */
     protected $btCacheBlockOutputForRegisteredUsers = false;
-
-    /**
-     * @var int thumbnail height
-     */
-    public $thumbnailHeight = 250;
-
-    /**
-     * @var int thumbnail width
-     */
-    public $thumbnailWidth = 250;
-    /** @var string|null */
-    public $attributeHandle;
-    /** @var string|null */
-    public $attributeTitleText;
-    /** @var string|null */
-    public $displayTag;
 
     public function getBlockTypeDescription()
     {
@@ -85,7 +106,7 @@ class Controller extends BlockController implements UsesFeatureInterface
         if (!is_numeric($args['thumbnailHeight'])) {
             $error->add(t('Thumbnail Height must be a number.'));
         }
-        
+
         if (!is_numeric($args['thumbnailWidth'])) {
             $error->add(t('Thumbnail Width must be a number.'));
         }
@@ -320,8 +341,8 @@ class Controller extends BlockController implements UsesFeatureInterface
     {
       // only use the type specific template if there is NOT a custom template defined
       $b = $this->getBlockObject();
-      if ($b->getBlockFilename()) {      
-        // custom template  
+      if ($b->getBlockFilename()) {
+        // custom template
       } else {
         $templateHandle = $this->getTemplateHandle();
         if (in_array($templateHandle, ['date_time', 'boolean'])) {

--- a/concrete/blocks/page_list/controller.php
+++ b/concrete/blocks/page_list/controller.php
@@ -24,6 +24,181 @@ use PageList;
 
 class Controller extends BlockController implements UsesFeatureInterface
 {
+    /**
+     * @var int|string|null
+     */
+    public $num;
+
+    /**
+     * @var string|null
+     */
+    public $orderBy;
+
+    /**
+     * @var int|string|null
+     */
+    public $cParentID;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $cThis;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $cThisParent;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $useButtonForLink;
+
+    /**
+     * @var string|null
+     */
+    public $buttonLinkText;
+
+    /**
+     * @var string|null
+     */
+    public $pageListTitle;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $filterByRelated;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $filterByCustomTopic;
+
+    /**
+     * @var string|null
+     */
+    public $filterDateOption;
+
+    /**
+     * @var int|string|null
+     */
+    public $filterDateDays;
+
+    /**
+     * @var string|null
+     */
+    public $filterDateStart;
+
+    /**
+     * @var string|null
+     */
+    public $filterDateEnd;
+
+    /**
+     * @var string|null
+     */
+    public $relatedTopicAttributeKeyHandle;
+
+    /**
+     * @var string|null
+     */
+    public $customTopicAttributeKeyHandle;
+
+    /**
+     * @var int|string|null
+     */
+    public $customTopicTreeNodeID;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $includeName;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $includeDescription;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $includeDate;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $includeAllDescendents;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $paginate;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $displayAliases;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $displaySystemPages;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $ignorePermissions;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $enableExternalFiltering;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $excludeCurrentPage;
+
+    /**
+     * @var int|string|null
+     */
+    public $ptID;
+
+    /**
+     * @var int|string|null
+     */
+    public $pfID;
+
+    /**
+     * @var int|string|null
+     */
+    public $truncateSummaries;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $displayFeaturedOnly;
+
+    /**
+     * @var string|null
+     */
+    public $noResultsMessage;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $displayThumbnail;
+
+    /**
+     * @var int|string|null
+     */
+    public $truncateChars;
+
+    /**
+     * @var string|null
+     */
+    public $titleFormat;
+
     protected $btTable = 'btPageList';
     protected $btInterfaceWidth = 700;
     protected $btInterfaceHeight = 525;
@@ -36,22 +211,19 @@ class Controller extends BlockController implements UsesFeatureInterface
     protected $btCacheBlockOutputLifetime = 300;
     protected $list;
 
-    public $orderBy;
-    public $filterDateOption;
-    public $displayFeaturedOnly;
-    public $displayAliases;
-    public $displaySystemPages;
-    public $excludeCurrentPage;
-    public $ptID;
-    public $filterByRelated;
-    public $filterByCustomTopic;
-    public $cParentID;
-    public $num;
-    public $pfID;
-    public $truncateSummaries;
-    public $displayThumbnail;
-    public $includeName;
-    public $paginate;
+    /**
+     * @deprecated What's deprecated is the "public" part.
+     *
+     * @var int|null
+     */
+    public $cID;
+
+    /**
+     * @deprecated What's deprecated is the "public" part.
+     *
+     * @var int|null
+     */
+    public $cPID;
 
     public function getRequiredFeatures(): array
     {
@@ -143,7 +315,7 @@ class Controller extends BlockController implements UsesFeatureInterface
         $this->list->disableAutomaticSorting();
         $this->list->setNameSpace('b' . $this->bID);
         $expr = $this->list->getQueryObject()->expr(); // Get Query Expression Object
-        
+
         $cArray = [];
 
         switch ($this->orderBy) {

--- a/concrete/blocks/page_title/controller.php
+++ b/concrete/blocks/page_title/controller.php
@@ -11,37 +11,57 @@ use Concrete\Core\Tree\Node\Type\Topic;
 class Controller extends BlockController implements UsesFeatureInterface
 {
     /**
-     * @var string
-     */
-    public $titleText = '';
-
-    /**
-     * @var bool
+     * @var int|string|null
      */
     public $useCustomTitle = false;
 
     /**
-     * @var bool
+     * @var int|string|null
      */
     public $useFilterTitle = false;
 
     /**
-     * @var bool
+     * @var int|string|null
      */
     public $useFilterTopic = false;
 
     /**
-     * @var bool
+     * @var int|string|null
      */
     public $useFilterTag = false;
 
     /**
-     * @var bool
+     * @var int|string|null
      */
     public $useFilterDate = false;
 
     /**
-     * @var string
+     * @var string|null
+     */
+    public $topicTextFormat;
+
+    /**
+     * @var string|null
+     */
+    public $tagTextFormat;
+
+    /**
+     * @var string|null
+     */
+    public $dateTextFormat;
+
+    /**
+     * @var string|null
+     */
+    public $filterDateFormat;
+
+    /**
+     * @var string|null
+     */
+    public $titleText = '';
+
+    /**
+     * @var string|null
      */
     public $formatting = 'h1';
 

--- a/concrete/blocks/rss_displayer/controller.php
+++ b/concrete/blocks/rss_displayer/controller.php
@@ -9,10 +9,41 @@ use Core;
 
 class Controller extends BlockController implements UsesFeatureInterface
 {
-    public $itemsToDisplay = "5";
-    public $showSummary = "1";
-    public $launchInNewWindow = "1";
-    public $title = "";
+    /**
+     * @var string|null
+     */
+    public $title = '';
+
+    /**
+     * @var string|null
+     */
+    public $url;
+
+    /**
+     * @var string|null
+     */
+    public $dateFormat;
+
+    /**
+     * @var int|string|null
+     */
+    public $itemsToDisplay = 5;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $showSummary = 1;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $launchInNewWindow = 1;
+
+    /**
+     * @var string|null
+     */
+    public $titleFormat;
+
     protected $btTable = 'btRssDisplay';
     protected $btInterfaceWidth = 400;
     protected $btInterfaceHeight = 550;
@@ -25,7 +56,7 @@ class Controller extends BlockController implements UsesFeatureInterface
     /**
      * Default number of seconds that the output of this block should be cached
      * (Can be overridden by the user within C5 UI).
-     * 
+     *
      * @var int
      */
     protected $btCacheBlockOutputLifetime = 3600;
@@ -33,17 +64,17 @@ class Controller extends BlockController implements UsesFeatureInterface
     /**
      * Number of seconds that the RSS feed itself should be cached before fetching
      * a fresh copy.
-     * 
+     *
      * (Perhaps this could eventually become a user-setting?)
-     * 
+     *
      * Caching is important as fetching a remote URL can significantly delay
      * the rendering of a PHP page.
-     * 
+     *
      * Setting to "null" should cache it indefinitely until cache is manually cleared.
-     * 
+     *
      * Should probably be less than $btCacheBlockOutputLifetime above, otherwise the
      * block will be re-rendered using the same stale RSS data.
-     * 
+     *
      * @var int
      */
     protected $rssFeedCacheLifetime = 1800;

--- a/concrete/blocks/share_this_page/controller.php
+++ b/concrete/blocks/share_this_page/controller.php
@@ -13,6 +13,21 @@ defined('C5_EXECUTE') or die("Access Denied.");
 
 class Controller extends BlockController implements UsesFeatureInterface
 {
+    /**
+     * @var int|string|null
+     */
+    public $btShareThisPageID;
+
+    /**
+     * @var string|null
+     */
+    public $service;
+
+    /**
+     * @var int|string|null
+     */
+    public $displayOrder;
+
     public $helpers = array('form');
 
     protected $btInterfaceWidth = 400;

--- a/concrete/blocks/social_links/controller.php
+++ b/concrete/blocks/social_links/controller.php
@@ -12,6 +12,21 @@ defined('C5_EXECUTE') or die("Access Denied.");
 
 class Controller extends BlockController implements UsesFeatureInterface
 {
+    /**
+     * @var int|string|null
+     */
+    public $btSocialLinkID;
+
+    /**
+     * @var int|string|null
+     */
+    public $slID;
+
+    /**
+     * @var int|string|null
+     */
+    public $displayOrder;
+
     public $helpers = ['form'];
 
     protected $btInterfaceWidth = 400;

--- a/concrete/blocks/tags/controller.php
+++ b/concrete/blocks/tags/controller.php
@@ -10,6 +10,31 @@ use Page;
 
 class Controller extends BlockController implements UsesFeatureInterface
 {
+    /**
+     * @var string|null
+     */
+    public $title;
+
+    /**
+     * @var int|string|null
+     */
+    public $targetCID;
+
+    /**
+     * @var string|null
+     */
+    public $displayMode = 'page';
+
+    /**
+     * @var int|string|null
+     */
+    public $cloudCount = 10;
+
+    /**
+     * @var string|null
+     */
+    public $titleFormat;
+
     protected $btTable = 'btTags';
     protected $btInterfaceWidth = "450";
     protected $btInterfaceHeight = "439";
@@ -23,8 +48,6 @@ class Controller extends BlockController implements UsesFeatureInterface
     protected $btWrapperClass = 'ccm-ui';
 
     public $attributeHandle = 'tags';
-    public $displayMode = 'page';
-    public $cloudCount = 10;
     public $helpers = array('navigation');
 
     /**

--- a/concrete/blocks/top_navigation_bar/controller.php
+++ b/concrete/blocks/top_navigation_bar/controller.php
@@ -23,15 +23,62 @@ defined('C5_EXECUTE') or die('Access Denied.');
 
 class Controller extends BlockController implements UsesFeatureInterface, FileTrackableInterface
 {
-    public $helpers = ['form'];
+    /**
+     * @var string|null
+     */
+    public $brandingText;
 
+    /**
+     * @var int|string|null
+     */
     public $brandingLogo = 0;
+
+    /**
+     * @var int|string|null
+     */
     public $brandingTransparentLogo = 0;
-    public $includeBrandLogo = false;
+
+    /**
+     * @var bool|int|string|null
+     */
     public $includeBrandText = false;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $includeBrandLogo = false;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $includeTransparency;
+
+    /**
+     * @var bool|int|string|null
+     */
     public $includeStickyNav = false;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $includeNavigation;
+
+    /**
+     * @var bool|int|string|null
+     */
     public $includeNavigationDropdowns = false;
+
+    /**
+     * @var bool|int|string|null
+     */
     public $includeSearchInput;
+
+    /**
+     * @var int|string|null
+     */
+    public $searchInputFormActionPageID;
+
+    public $helpers = ['form'];
 
     protected $btInterfaceWidth = 640;
     protected $btInterfaceHeight = 500;
@@ -293,7 +340,7 @@ class Controller extends BlockController implements UsesFeatureInterface, FileTr
         }
         return $files;
     }
-    
+
     public function getPageItemNavTarget($pageItem) // Respect nav_target Page Attribute & External Link targets
     {
 	if (!is_object($pageItem) || !$pageItem instanceof \Concrete\Core\Navigation\Item\PageItem) {

--- a/concrete/blocks/topic_list/controller.php
+++ b/concrete/blocks/topic_list/controller.php
@@ -14,13 +14,6 @@ defined('C5_EXECUTE') or die('Access Denied.');
 
 class Controller extends BlockController implements UsesFeatureInterface
 {
-    public $helpers = ['form', 'form/page_selector'];
-
-    /**
-     * @var int|null
-     */
-    public $topicTreeID;
-
     /**
      * @var string|null
      */
@@ -32,7 +25,12 @@ class Controller extends BlockController implements UsesFeatureInterface
     public $topicAttributeKeyHandle;
 
     /**
-     * @var int|null
+     * @var int|string|null
+     */
+    public $topicTreeID;
+
+    /**
+     * @var int|string|null
      */
     public $cParentID;
 
@@ -40,6 +38,13 @@ class Controller extends BlockController implements UsesFeatureInterface
      * @var string|null
      */
     public $title;
+
+    /**
+     * @var string|null
+     */
+    public $titleFormat;
+
+    public $helpers = ['form', 'form/page_selector'];
 
     protected $btInterfaceWidth = 400;
 

--- a/concrete/blocks/video/controller.php
+++ b/concrete/blocks/video/controller.php
@@ -10,6 +10,41 @@ use Concrete\Core\File\File;
 class Controller extends BlockController implements UsesFeatureInterface
 {
     /**
+     * @var int|string|null
+     */
+    protected $webmfID;
+
+    /**
+     * @var int|string|null
+     */
+    protected $oggfID;
+
+    /**
+     * @var int|string|null
+     */
+    protected $posterfID;
+
+    /**
+     * @var int|string|null
+     */
+    protected $mp4fID;
+
+    /**
+     * @var int|string|null
+     */
+    protected $videoSize;
+
+    /**
+     * @var int|string|null
+     */
+    protected $width;
+
+    /**
+     * @var string|null
+     */
+    public $title;
+
+    /**
      * @var int
      */
     protected $btInterfaceWidth = 450;
@@ -43,36 +78,6 @@ class Controller extends BlockController implements UsesFeatureInterface
      * @var string
      */
     protected $btWrapperClass = 'ccm-ui';
-
-    /**
-     * @var int|null
-     */
-    protected $mp4fID;
-
-    /**
-     * @var int|null
-     */
-    protected $webmfID;
-
-    /**
-     * @var int|null
-     */
-    protected $oggfID;
-
-    /**
-     * @var int|null
-     */
-    protected $posterfID;
-
-    /**
-     * @var int|null
-     */
-    protected $videoSize;
-
-    /**
-     * @var int|null
-     */
-    protected $width;
 
     /**
      * @var string[]

--- a/concrete/blocks/youtube/controller.php
+++ b/concrete/blocks/youtube/controller.php
@@ -11,7 +11,17 @@ class Controller extends BlockController implements UsesFeatureInterface
     /**
      * @var string|null
      */
+    public $title;
+
+    /**
+     * @var string|null
+     */
     public $videoURL;
+
+    /**
+     * @var string|null
+     */
+    public $vHeight;
 
     /**
      * @var string|null
@@ -21,7 +31,67 @@ class Controller extends BlockController implements UsesFeatureInterface
     /**
      * @var string|null
      */
-    public $vHeight;
+    public $sizing;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $startTimeEnabled;
+
+    /**
+     * @var string|null
+     */
+    public $startTime;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $noCookie;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $autoplay;
+
+    /**
+     * @var string|null
+     */
+    public $color;
+
+    /**
+     * @var int|string|null
+     */
+    public $controls;
+
+    /**
+     * @var int|string|null
+     */
+    public $iv_load_policy;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $loopEnd;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $modestbranding;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $lazyLoad;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $rel;
+
+    /**
+     * @var bool|int|string|null
+     */
+    public $showCaptions;
 
     protected $btTable = 'btYouTube';
 

--- a/concrete/controllers/dialog/area/design.php
+++ b/concrete/controllers/dialog/area/design.php
@@ -8,6 +8,13 @@ use Concrete\Controller\Backend\UserInterface\Page as BackendPageController;
 
 class Design extends BackendPageController
 {
+    /**
+     * @deprecated What's deprecated is the "public" part.
+     *
+     * @var \Concrete\Core\Area\Area
+     */
+    public $area;
+
     protected $viewPath = '/dialogs/area/design';
 
     public function on_start()

--- a/concrete/controllers/dialog/page/add_block.php
+++ b/concrete/controllers/dialog/page/add_block.php
@@ -20,6 +20,13 @@ class AddBlock extends BackendInterfacePageController
 {
     protected $viewPath = '/dialogs/page/add_block';
 
+    /**
+     * @deprecated What's deprecated is the "public" part.
+     *
+     * @var \Concrete\Core\Area\Area
+     */
+    public $area;
+
     public function on_start()
     {
         parent::on_start();

--- a/concrete/src/Application/UserInterface/Menu/Item/Item.php
+++ b/concrete/src/Application/UserInterface/Menu/Item/Item.php
@@ -5,9 +5,54 @@ use Concrete\Core\Package\Package;
 
 class Item implements ItemInterface
 {
+    /**
+     * @deprecated What's deprecated is the "public" part.
+     *
+     * @var string|null
+     */
+    public $handle;
+
+    /**
+     * @deprecated What's deprecated is the "public" part.
+     *
+     * @var string|false|null
+     */
+    public $pkgHandle;
+
+    /**
+     * @var \Concrete\Core\Application\UserInterface\Menu\Item\ControllerInterface|null
+     */
     protected $controller;
 
     protected $linkAttributes = [];
+
+    /**
+     * @deprecated What's deprecated is the "public" part.
+     *
+     * @var string|null
+     */
+    public $position;
+
+    /**
+     * @deprecated What's deprecated is the "public" part.
+     *
+     * @var string|null
+     */
+    public $href;
+
+    /**
+     * @deprecated What's deprecated is the "public" part.
+     *
+     * @var string|null
+     */
+    public $label;
+
+    /**
+     * @deprecated What's deprecated is the "public" part.
+     *
+     * @var string|null
+     */
+    public $icon;
 
     public function __construct($handle, $pkgHandle = false)
     {
@@ -17,12 +62,12 @@ class Item implements ItemInterface
 
     public function getHandle()
     {
-        return isset($this->handle) ? $this->handle : null;
+        return $this->handle;
     }
 
     public function getLabel()
     {
-        return isset($this->label) ? $this->label : null;
+        return $this->label;
     }
 
     public function setLabel($label)
@@ -32,12 +77,12 @@ class Item implements ItemInterface
 
     public function getPosition()
     {
-        return isset($this->position) ? $this->position : null;
+        return $this->position;
     }
 
     public function getLinkAttributes()
     {
-        return isset($this->linkAttributes) ? $this->linkAttributes : null;
+        return $this->linkAttributes;
     }
 
     public function setLinkAttributes($linkAttributes)
@@ -52,7 +97,7 @@ class Item implements ItemInterface
 
     public function getLink()
     {
-        return isset($this->href) ? $this->href : null;
+        return $this->href;
     }
 
     public function setIcon($icon)
@@ -62,7 +107,7 @@ class Item implements ItemInterface
 
     public function getIcon()
     {
-        return isset($this->icon) ? $this->icon : null;
+        return $this->icon;
     }
 
     public function setPosition($position)
@@ -72,7 +117,7 @@ class Item implements ItemInterface
 
     public function getPackageHandle()
     {
-        return isset($this->pkgHandle) ? $this->pkgHandle : null;
+        return $this->pkgHandle;
     }
 
     public function getPackageObject()
@@ -82,7 +127,7 @@ class Item implements ItemInterface
 
     public function getController()
     {
-        if (!isset($this->controller)) {
+        if ($this->controller === null) {
             $handle = $this->getHandle();
             $class = overrideable_core_class(
                 'MenuItem\\' . camelcase($handle) . '\\Controller',

--- a/concrete/src/Attribute/Controller.php
+++ b/concrete/src/Attribute/Controller.php
@@ -20,6 +20,13 @@ class Controller extends AbstractController implements AttributeInterface
     protected $entityManager;
 
     /**
+     * @deprecated What's deprecated is the "public" part.
+     *
+     * @var \Concrete\Core\Entity\Attribute\Type|null
+     */
+    public $attributeType;
+
+    /**
      * @var \Concrete\Core\Entity\Attribute\Key\Key|null
      */
     protected $attributeKey;

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/AbstractPageStructureRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/AbstractPageStructureRoutine.php
@@ -9,7 +9,7 @@ use Concrete\Core\StyleCustomizer\Inline\StyleSet;
 abstract class AbstractPageStructureRoutine extends AbstractRoutine
 {
 
-    public function setupPageNodeOrder($pageNodeA, $pageNodeB)
+    public static function setupPageNodeOrder($pageNodeA, $pageNodeB)
     {
         $pathA = (string) $pageNodeA['path'];
         $pathB = (string) $pageNodeB['path'];

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportPageStructureRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportPageStructureRoutine.php
@@ -35,7 +35,9 @@ class ImportPageStructureRoutine extends AbstractPageStructureRoutine implements
                 $nodes[] = $p;
                 ++$i;
             }
-            usort($nodes, array('static', 'setupPageNodeOrder'));
+            usort($nodes, static function($nodeA, $nodeB): int {
+                return static::setupPageNodeOrder($nodeA, $nodeB);
+            });
             if (isset($this->home)) {
                 $home = $this->home;
                 $siteTree = $this->home->getSiteTreeObject();

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportStacksStructureRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportStacksStructureRoutine.php
@@ -36,7 +36,9 @@ class ImportStacksStructureRoutine extends AbstractPageStructureRoutine implemen
                 $nodes[] = $p;
                 ++$i;
             }
-            usort($nodes, array('static', 'setupPageNodeOrder'));
+            usort($nodes, static function($nodeA, $nodeB): int {
+                return static::setupPageNodeOrder($nodeA, $nodeB);
+            });
 
             foreach ($nodes as $p) {
 

--- a/concrete/src/Block/BlockController.php
+++ b/concrete/src/Block/BlockController.php
@@ -61,6 +61,11 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
     protected $btID;
     /** @var array */
     protected $requestArray;
+    /**
+     * @deprecated What's deprecated is the "public" part.
+     * @var string|null
+     */
+    public $btCachedBlockRecord;
 
     /**
      * @internal
@@ -74,6 +79,13 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
      * @var bool
      */
     protected $supportSavingNullValues = false;
+
+    /**
+     * @deprecated What's deprecated is the "public" part.
+     *
+     * @var \Concrete\Core\Area\Area|null
+     */
+    public $area;
 
     public function getBlockTypeInSetName()
     {

--- a/concrete/src/Block/CustomStyle.php
+++ b/concrete/src/Block/CustomStyle.php
@@ -10,6 +10,13 @@ class CustomStyle extends AbstractCustomStyle
     protected $set;
     protected $theme;
 
+    /**
+     * @deprecated What's deprecated is the "public" part.
+     *
+     * @var \Concrete\Core\Block\Block
+     */
+    public $block;
+
     public function __construct(StyleSet $set = null, Block $b, $theme = null)
     {
         $this->block = $b;

--- a/concrete/src/Database/Connection/Connection.php
+++ b/concrete/src/Database/Connection/Connection.php
@@ -103,9 +103,9 @@ class Connection extends \Doctrine\DBAL\Connection
         $args = func_get_args();
         if (isset($args) && isset($args[1]) && (is_string($args[1]) || is_array($args[1]))) {
             return $this->executeQuery($args[0], $args[1]);
-        } else {
-            return call_user_func_array('parent::query', $args);
         }
+
+        return parent::query(... $args);
     }
 
     /**

--- a/concrete/src/Entity/Board/Board.php
+++ b/concrete/src/Entity/Board/Board.php
@@ -100,8 +100,6 @@ class Board implements ObjectInterface, AssignableObjectInterface, \JsonSerializ
     public function __construct()
     {
         $this->data_sources = new ArrayCollection();
-        $this->items = new ArrayCollection();
-        $this->batches = new ArrayCollection();
         $this->instances = new ArrayCollection();
         $this->custom_slot_templates = new ArrayCollection();
     }

--- a/concrete/src/Entity/Board/InstanceSlot.php
+++ b/concrete/src/Entity/Board/InstanceSlot.php
@@ -45,7 +45,6 @@ class InstanceSlot
 
     public function __construct()
     {
-        $this->content_slots = new ArrayCollection();
     }
 
     /**
@@ -102,22 +101,6 @@ class InstanceSlot
     public function setInstance($instance): void
     {
         $this->instance = $instance;
-    }
-
-    /**
-     * @return mixed
-     */
-    public function getContentSlots()
-    {
-        return $this->content_slots;
-    }
-
-    /**
-     * @param mixed $content_slots
-     */
-    public function setContentSlots($content_slots): void
-    {
-        $this->content_slots = $content_slots;
     }
 
     /**

--- a/concrete/src/Entity/File/Version.php
+++ b/concrete/src/Entity/File/Version.php
@@ -280,6 +280,13 @@ class Version implements ObjectInterface
     protected $fvHasDetailThumbnail = false;
 
     /**
+     * @deprecated What's deprecates is the "public" part.
+     *
+     * @var int|null
+     */
+    public $fvGenericType;
+
+    /**
      * The currently loaded Image instance.
      *
      * @var \Imagine\Image\ImageInterface|false|null null: still not loaded; false: load failed; ImageInterface otherwise

--- a/concrete/src/Foundation/ConcreteObject.php
+++ b/concrete/src/Foundation/ConcreteObject.php
@@ -1,6 +1,7 @@
 <?php
 namespace Concrete\Core\Foundation;
 
+#[\AllowDynamicProperties]
 class ConcreteObject
 {
     public $error = '';

--- a/concrete/src/Http/ResponseAssetGroup.php
+++ b/concrete/src/Http/ResponseAssetGroup.php
@@ -25,6 +25,20 @@ class ResponseAssetGroup
     protected $outputAssets = array();
 
     /**
+     * @deprecated What's deprecated is the "public" part.
+     *
+     * @var \Concrete\Core\Asset\AssetGroup
+     */
+    public $requiredAssetGroup;
+
+    /**
+     * @deprecated What's deprecated is the "public" part.
+     *
+     * @var \Concrete\Core\Asset\AssetGroup
+     */
+    public $providedAssetGroup;
+
+    /**
      * Get an instance of this singleton.
      *
      * @return self
@@ -152,8 +166,6 @@ class ResponseAssetGroup
                 } else {
                     return 0;
                 }
-                
-
             });
 
             foreach ($assets as $object) {

--- a/concrete/src/Legacy/Model.php
+++ b/concrete/src/Legacy/Model.php
@@ -4,6 +4,7 @@ namespace Concrete\Core\Legacy;
 /**
  * @deprecated
  */
+#[\AllowDynamicProperties]
 class Model
 {
     protected $_table;

--- a/concrete/src/Localization/Translator/TranslatorAdapterRepository.php
+++ b/concrete/src/Localization/Translator/TranslatorAdapterRepository.php
@@ -14,6 +14,13 @@ class TranslatorAdapterRepository implements TranslatorAdapterRepositoryInterfac
 {
     const KEY_SEPARATOR = '@';
 
+    /**
+     * @deprecated What's deprecated is the "public" part.
+     *
+     * @var TranslatorAdapterFactoryInterface
+     */
+    public $translatorAdapterFactory;
+
     /** @var Application */
     protected $app;
 

--- a/concrete/src/Messenger/Transport/FailedTransportManager.php
+++ b/concrete/src/Messenger/Transport/FailedTransportManager.php
@@ -36,6 +36,7 @@ class FailedTransportManager extends TransportManager
         return new class($this->failureRoutes, $this->senders) implements ContainerInterface {
 
             protected $routes;
+            protected $senders;
 
             public function __construct($routes, $senders)
             {

--- a/concrete/src/Package/StartingPointInstallRoutine.php
+++ b/concrete/src/Package/StartingPointInstallRoutine.php
@@ -3,6 +3,27 @@ namespace Concrete\Core\Package;
 
 class StartingPointInstallRoutine
 {
+    /**
+     * @deprecated What's deprecated is the "public" part.
+     *
+     * @var string
+     */
+    public $method;
+
+    /**
+     * @deprecated What's deprecated is the "public" part.
+     *
+     * @var int
+     */
+    public $progress;
+
+    /**
+     * @deprecated What's deprecated is the "public" part.
+     *
+     * @var string
+     */
+    public $text;
+
     public function __construct($method, $progress, $text = '')
     {
         $this->method = $method;

--- a/concrete/src/Page/Collection/Version/Event.php
+++ b/concrete/src/Page/Collection/Version/Event.php
@@ -3,6 +3,13 @@ namespace Concrete\Core\Page\Collection\Version;
 
 class Event extends \Concrete\Core\Page\Event
 {
+    /**
+     * @deprecated What's deprecated is the "public" part.
+     *
+     * @var \Concrete\Core\Page\Collection\Version\Version
+     */
+    public $version;
+
     public function setCollectionVersionObject($version)
     {
         $this->version = $version;

--- a/concrete/src/Page/Collection/Version/VersionList.php
+++ b/concrete/src/Page/Collection/Version/VersionList.php
@@ -17,6 +17,13 @@ use Concrete\Core\Legacy\DatabaseItemList;
  */
 class VersionList extends DatabaseItemList
 {
+    /**
+     * @deprecated What's deprecated is the "public" part.
+     *
+     * @var \Concrete\Core\Page\Collection\Collection
+     */
+    public $c;
+
     public function __construct($c)
     {
         $this->c = $c;

--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -159,6 +159,118 @@ class Page extends Collection implements CategoryMemberInterface,
     protected $siteTreeID;
 
     /**
+     * @deprecated What's deprecated is the "public" part.
+     *
+     * @var int|null
+     */
+    public $pkgID;
+
+    /**
+     * @deprecated What's deprecated is the "public" part.
+     *
+     * @var string|false|null
+     */
+    public $pkgHandle;
+
+    /**
+     * @deprecated What's deprecated is the "public" part.
+     *
+     * @var int|null
+     */
+    public $cPointerID;
+
+    /**
+     * @deprecated What's deprecated is the "public" part.
+     *
+     * @var int|bool|null
+     */
+    public $cIsDraft;
+
+    /**
+     * @deprecated What's deprecated is the "public" part.
+     *
+     * @var int|bool|null
+     */
+    public $cIsActive;
+
+    /**
+     * @deprecated What's deprecated is the "public" part.
+     *
+     * @var string|null
+     */
+    public $cFilename;
+
+    /**
+     * @deprecated What's deprecated is the "public" part.
+     *
+     * @var int|null
+     */
+    public $ptID;
+
+    /**
+     * @deprecated What's deprecated is the "public" part.
+     *
+     * @var int|null
+     */
+    public $cDisplayOrder;
+
+    /**
+     * @deprecated What's deprecated is the "public" part.
+     *
+     * @var string|null
+     */
+    public $cInheritPermissionsFrom;
+
+    /**
+     * @deprecated What's deprecated is the "public" part.
+     *
+     * @var bool|int|null
+     */
+    public $cOverrideTemplatePermissions;
+
+    /**
+     * @deprecated What's deprecated is the "public" part.
+     *
+     * @var int|bool|null
+     */
+    public $cIsTemplate;
+
+    /**
+     * @deprecated What's deprecated is the "public" part.
+     *
+     * @var int|null
+     */
+    public $uID;
+
+    /**
+     * @deprecated What's deprecated is the "public" part.
+     *
+     * @var string|null
+     */
+    public $cPath;
+
+    /**
+     * @deprecated What's deprecated is the "public" part.
+     *
+     * @var int|null
+     */
+    public $cParentID;
+
+    /**
+     * @deprecated What's deprecated is the "public" part.
+     *
+     * @var int|null
+     */
+    public $cChildren;
+
+    /**
+     * @deprecated What's deprecated is the "public" part.
+     *
+     * @var int|null
+     */
+    public $cCacheFullPageContent;
+
+    /**
      * The custom name of the alias page.
      *
      * @var string|null NULL if the page is not an alias, empty string if we should use the name of the aliased page, the custom alias name otherwise.
@@ -1310,7 +1422,7 @@ class Page extends Collection implements CategoryMemberInterface,
      */
     public function getCollectionPath()
     {
-        return isset($this->cPath) ? $this->cPath : null;
+        return $this->cPath;
     }
 
     /**

--- a/tests/tests/Block/ControllerPropertiesTest.php
+++ b/tests/tests/Block/ControllerPropertiesTest.php
@@ -1,0 +1,160 @@
+<?php
+
+namespace Concrete\Tests\Block;
+
+use Concrete\Core\Database\Connection\Connection;
+use Concrete\Core\Utility\Service\Text;
+use Concrete\Tests\TestCase;
+use DoctrineXml\Parser;
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Types\Types;
+use ReflectionClass;
+
+class ControllerPropertiesTest extends TestCase
+{
+    /**
+     * @var \Doctrine\DBAL\Platforms\AbstractPlatform
+     */
+    private static $platform;
+
+    /**
+     * @var \Concrete\Core\Utility\Service\Text
+     */
+    private static $textService;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$platform = app(Connection::class)->getDatabasePlatform();
+        self::$textService = app(Text::class);
+    }
+
+    /**
+     * Return the directory names of the blocks that have database tables.
+     *
+     * @return string[]
+     */
+    public static function provideBlocksWithDB(): array
+    {
+        $result = [];
+        foreach (scandir(DIR_BASE_CORE . '/' . DIRNAME_BLOCKS) as $item) {
+            if (is_file(DIR_BASE_CORE . '/' . DIRNAME_BLOCKS . '/' . $item . '/' . FILENAME_BLOCK_DB)) {
+                $result[] = [$item];
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * @dataProvider provideBlocksWithDB
+     */
+    public function testBlockControllerDefinesDBFields(string $dirname): void
+    {
+        $dbFile = FILENAME_BLOCK_DB;
+        $controllerClass = 'Concrete\\Block\\' . self::$textService->camelcase($dirname) . '\\Controller';
+        $tableName = self::getTableNameFromController($controllerClass);
+        $this->assertNotEmpty($tableName, "The block in directory {$dirname} comes with a {$dbFile} file, but its controller getBlockTypeDatabaseTable() method returned an empty value");
+        $table = self::getTableDefinition($dirname, $tableName);
+        $this->assertNotNull($table, "The block controller in '{$dirname}' says it uses the {$tableName} table, but it's not present in the {$dbFile} file");
+        $properties = self::getPropertiesFromController($controllerClass);
+        foreach ($table->getColumns() as $column) {
+            $property = $properties[$column->getName()] ?? null;
+            $this->assertNotNull($property, "{$controllerClass} must define the '{$column->getName()}' property, accordingly to {$dbFile}.\nThe full list of properties should be:\n" . self::buildPHPProperties($table));
+        }
+    }
+
+    private static function getTableNameFromController(string $controllerClassName): string
+    {
+        $instance = app($controllerClassName);
+        $tableName = $instance->getBlockTypeDatabaseTable();
+
+        return is_string($tableName) ? $tableName : '';
+    }
+
+    /**
+     * @return \ReflectionProperty[] array keys are the property names
+     */
+    private static function getPropertiesFromController(string $controllerClassName): array
+    {
+        $class = new ReflectionClass($controllerClassName);
+        $result = [];
+        foreach ($class->getProperties() as $property) {
+            $result[$property->getName()] = $property;
+        }
+
+        return $result;
+    }
+
+    private static function getTableDefinition(string $dirname, string $tableName): ?Table
+    {
+        $schema = Parser::fromFile(DIR_BASE_CORE . '/' . DIRNAME_BLOCKS . '/' . $dirname . '/' . FILENAME_BLOCK_DB, self::$platform);
+        foreach ($schema->getTables() as $table) {
+            if ($table->getName() === $tableName) {
+                return $table;
+            }
+        }
+
+        return null;
+    }
+
+    private static function buildPHPProperties(Table $table): string
+    {
+        $properties = [];
+
+        foreach ($table->getColumns() as $column) {
+            switch ($column->getName()) {
+                case 'bID':
+                    break;
+                default:
+                    $properties[] = self::buildPHPProperty($column);
+                    break;
+            }
+        }
+
+        return implode("\n\n", $properties);
+    }
+
+    private static function buildPHPProperty(Column $column): string
+    {
+        $indent = '    ';
+        $phpDocType = '';
+        switch ($column->getType()->getName()) {
+            case Types::ARRAY:
+                $phpDocType = 'array|null';
+                break;
+            case Types::BIGINT:
+            case Types::INTEGER:
+            case Types::SMALLINT:
+                $phpDocType = 'int|string|null';
+                break;
+            case Types::DECIMAL:
+            case Types::FLOAT:
+                $phpDocType = 'float|string|null';
+                break;
+            case Types::BOOLEAN:
+                $phpDocType = 'bool|int|string|null';
+                break;
+            case Types::ASCII_STRING:
+            case Types::GUID:
+            case Types::STRING:
+            case Types::TEXT:
+                $phpDocType = 'string|null';
+                break;
+        }
+        $result = '';
+        if ($phpDocType !== '') {
+            $result = <<<EOT
+{$indent}/**
+{$indent} * @var {$phpDocType}
+{$indent} */
+
+EOT;
+        }
+        $result .= <<<EOT
+{$indent}public \${$column->getName()};
+EOT
+        ;
+
+        return $result;
+    }
+}

--- a/tests/tests/Cache/Page/PageCacheTest.php
+++ b/tests/tests/Cache/Page/PageCacheTest.php
@@ -63,7 +63,7 @@ class PageCacheTest extends TestCase
 
     public function testGetCacheKeyForPage()
     {
-        return; // broken since I reworked this for multi-site page caching.
+        $this->markTestSkipped('Broken since this has been reworked for multi-site page caching.');
 
         $app = Facade::getFacadeApplication();
 

--- a/tests/tests/Page/PageControllerTest.php
+++ b/tests/tests/Page/PageControllerTest.php
@@ -114,7 +114,7 @@ class PageControllerTest extends PageTestCase
         $p->setPackageID(1);
         SinglePage::add('/testerson/foo', $p);
         $fooPage = Page::getByPath('/testerson/foo');
-        $fooPage->pkgHandle = 'awesome_package';
+        self::setNonPublicPropertyValue($fooPage, 'pkgHandle', 'awesome_package');
         $controller = $fooPage->getPageController();
 
         $fs = new Filesystem();
@@ -142,7 +142,7 @@ class PageControllerTest extends PageTestCase
 
         SinglePage::add('/testerson/foo', $pkg);
         $fooPage = Page::getByPath('/testerson/foo');
-        $fooPage->pkgHandle = 'awesome_package';
+        self::setNonPublicPropertyValue($fooPage, 'pkgHandle', 'awesome_package');
         $controller = $fooPage->getPageController();
         $fooPage->delete();
 

--- a/tests/tests/Routing/URLTest.php
+++ b/tests/tests/Routing/URLTest.php
@@ -32,16 +32,20 @@ class URLTest extends TestCase
         $siteTree->setLocale($locale);
         $service = Core::make('helper/navigation');
         $page = new Page();
-        $page->siteTree = $siteTree;
-        $page->cPath = '/path/to/my/page';
-        $page->error = false;
+        self::setNonPublicPropertyValues($page, [
+            'siteTree' => $siteTree,
+            'cPath' => '/path/to/my/page',
+            'error' => false,
+            'siteTree' => $siteTree,
+        ]);
         $dashboard = new Page();
-        $dashboard->cPath = '/dashboard/my/awesome/page';
-        $dashboard->error = false;
+        self::setNonPublicPropertyValues($dashboard, [
+            'cPath' => '/dashboard/my/awesome/page',
+            'error' => false,
+            'siteTree' => $siteTree,
+        ]);
         $this->page = $page;
         $this->dashboard = $dashboard;
-        $page->siteTree = $siteTree;
-        $dashboard->siteTree = $siteTree;
         $this->service = $service;
 
         $app = \Concrete\Core\Support\Facade\Facade::getFacadeApplication();
@@ -306,9 +310,11 @@ class URLTest extends TestCase
         $siteTree->setLocale($locale);
 
         $home = new Page();
-        $home->cID = 1;
-        $home->cPath = '';
-        $home->siteTree = $siteTree;
+        self::setNonPublicPropertyValues($home, [
+            'cID' => 1,
+            'cPath' => '',
+            'siteTree' => $siteTree,
+        ]);
 
         $url = \URL::to($home);
         $this->assertEquals('http://dummyurl.com/path/to/server/index.php?cID=' . $home->cID, (string) $url);
@@ -317,10 +323,11 @@ class URLTest extends TestCase
         $this->assertEquals('http://dummyurl.com/path/to/server/index.php', (string) $url);
 
         $page = new Page();
-        $page->cPath = null;
-        $page->cID = 777;
-        $page->siteTree = $siteTree;
-
+        self::setNonPublicPropertyValues($page, [
+            'cID' => 777,
+            'cPath' => null,
+            'siteTree' => $siteTree,
+        ]);
         $url = \URL::to($page);
         $this->assertEquals('http://dummyurl.com/path/to/server/index.php?cID=777', (string) $url);
     }

--- a/tests/tests/TestCase.php
+++ b/tests/tests/TestCase.php
@@ -2,10 +2,24 @@
 
 namespace Concrete\Tests;
 
-
 use Mockery\Adapter\Phpunit\MockeryTestCase as PHPUnitTestCase;
+use ReflectionProperty;
 
 class TestCase extends PHPUnitTestCase
 {
+    protected static function setNonPublicPropertyValues(object $object, array $properties): void
+    {
+        foreach ($properties as $propertyName => $propertyValue) {
+            self::setNonPublicPropertyValue($object, $propertyName, $propertyValue);
+        }
+    }
 
+    protected static function setNonPublicPropertyValue(object $object, string $propertyName, $propertyValue): void
+    {
+        $property = new ReflectionProperty($object, $propertyName);
+        if (PHP_VERSION_ID < 80100) { // As of PHP 8.1.0, calling this method has no effect
+            $property->setAccessible(true);
+        }
+        $property->setValue($object, $propertyValue);
+    }
 }


### PR DESCRIPTION
- Creation of dynamic properties is deprecated
- Use of "static" in callables is deprecated

There's still something to be fixed: I'm going to update this PR with dependency patches.