### PR TITLE
Sending over the submission type to the active Antispam service

### DIFF
--- a/concrete/src/Antispam/Service.php
+++ b/concrete/src/Antispam/Service.php
@@ -98,7 +98,7 @@ class Service
             foreach ($additionalArgs as $key => $value) {
                 $args[$key] = $value;
             }
-            if (!isset($args['type']) {
+            if (!isset($args['type'])) {
                 $args['type'] = $type;
             }
             if (isset($args['user']) && is_object($args['user'])) {

--- a/concrete/src/Antispam/Service.php
+++ b/concrete/src/Antispam/Service.php
@@ -98,6 +98,9 @@ class Service
             foreach ($additionalArgs as $key => $value) {
                 $args[$key] = $value;
             }
+            if (!isset($args['type']) {
+                $args['type'] = $type;
+            }
             if (isset($args['user']) && is_object($args['user'])) {
                 $u = $args['user'];
             } else {


### PR DESCRIPTION
The submission type is an important piece of information when judging how to check for Spam. It should be included in the data sent over to the antispam service.

All the core blocks using the antispam service set a type to differentiate them.

That information doesn't reach the active antispam library. This PR fixes this.