### PR TITLE
Add a config option to disable asciify for uploaded files

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -888,6 +888,10 @@ return [
          * Don't resize the files with these mime types (space-separated list)
          */
         'dont_resize_mimetypes' => 'image/gif',
+        /**
+         * Enable asciify to sanitize name of uploaded files
+         */
+        'enable_filename_asciify' => true,
     ],
 
     'search_users' => [

--- a/concrete/controllers/single_page/dashboard/system/files/uploads.php
+++ b/concrete/controllers/single_page/dashboard/system/files/uploads.php
@@ -29,6 +29,7 @@ class Uploads extends DashboardPageController
             }
         }
         $this->set('maxImageSizePage', $maxImageSizePage);
+        $this->set('enableFilenameAsciify', $this->app['config']->get('concrete.file_manager.enable_filename_asciify', true));
         return null;
     }
 
@@ -79,6 +80,9 @@ class Uploads extends DashboardPageController
         } else {
             $service->setChunkingEnabled(false);
         }
+
+        $this->app['config']->save('concrete.file_manager.enable_filename_asciify', (bool) $this->post('enableFilenameAsciify'));
+
         $this->flash('success', t('Options saved successfully.'));
 
         return $this->app->make(ResponseFactoryInterface::class)->redirect($this->action(''), 302);

--- a/concrete/single_pages/dashboard/system/files/uploads.php
+++ b/concrete/single_pages/dashboard/system/files/uploads.php
@@ -15,6 +15,7 @@ use Punic\Unit;
  * @var int|null $chunkSize
  * @var int|null $phpMaxUploadSize
  * @var int $parallelUploads
+ * @var bool $enableFilenameAsciify
  * @var Concrete\Core\Page\Page|null $maxImageSizePage
  */
 $units = [
@@ -99,6 +100,19 @@ foreach (array_reverse(array_keys($units)) as $unit) {
         <?php
     }
     ?>
+
+    <fieldset class="mt-4">
+        <legend><?= t('Sanitize Filename') ?></legend>
+        <p class="form-text"><?= t('Translate multibyte characters to ASCII characters when generating a file name (e.g. Bänke & Sitzbänke.jpg to Banke_and_Sitzbanke.jpg).') ?><br>
+            <?= t('Remove multibyte characters when this option is disabled (e.g. Concrete CMS ロゴ.jpg to Concrete_CMS_.jpg). It may be better for some languages especially using Kanji characters.') ?></p>
+        <div class="form-group">
+            <div class="form-check">
+                <?= $form->checkbox('enableFilenameAsciify', 1, $enableFilenameAsciify) ?>
+                <?= $form->label('enableFilenameAsciify', t('Enable asciify to sanitize the name of the uploaded file
+')) ?>
+            </div>
+        </div>
+    </fieldset>
 
     <div class="ccm-dashboard-form-actions-wrapper">
         <div class="ccm-dashboard-form-actions">

--- a/concrete/single_pages/dashboard/system/files/uploads.php
+++ b/concrete/single_pages/dashboard/system/files/uploads.php
@@ -108,8 +108,7 @@ foreach (array_reverse(array_keys($units)) as $unit) {
         <div class="form-group">
             <div class="form-check">
                 <?= $form->checkbox('enableFilenameAsciify', 1, $enableFilenameAsciify) ?>
-                <?= $form->label('enableFilenameAsciify', t('Enable asciify to sanitize the name of the uploaded file
-')) ?>
+                <?= $form->label('enableFilenameAsciify', t('Enable asciify to sanitize the name of the uploaded file')) ?>
             </div>
         </div>
     </fieldset>

--- a/concrete/src/File/Service/File.php
+++ b/concrete/src/File/Service/File.php
@@ -371,8 +371,13 @@ class File
      */
     public function sanitize($file)
     {
-        // Let's build an ASCII-only version of name, to avoid filesystem-specific encoding issues.
-        $asciiName = Core::make('helper/text')->asciify($file);
+        $app = CoreApplication::getFacadeApplication();
+        if ($app['config']->get('concrete.file_manager.enable_filename_asciify', true)) {
+            // Let's build an ASCII-only version of name, to avoid filesystem-specific encoding issues.
+            $asciiName = $app->make('helper/text')->asciify($file);
+        } else {
+            $asciiName = $file;
+        }
         // Let's keep only letters, numbers, underscore and dots.
         $asciiName = trim(preg_replace(["/[\\s]/", "/[^0-9A-Z_a-z-.]/"], ["_", ""], $asciiName));
         // Trim underscores at start and end


### PR DESCRIPTION
Please include this PR in the 9.2 release!

Before version 9, multibyte characters were removed from the file name on sanitization.

![Screenshot 2023-03-16 at 16 33 38](https://user-images.githubusercontent.com/514294/225555417-47e226c3-7c1a-4079-bcf0-9e4126c5f9f0.png)

However, version 9 generates weird file names for Japanese users because it happening to start using asciify on sanitizing file names (It looks like a mix of Chinese words and Japanese words). 

![Screenshot 2023-03-16 at 16 32 56](https://user-images.githubusercontent.com/514294/225555456-95e7c04f-322d-42de-92b9-c95a833b6697.png)

Please accept adding a config option to sanitize file names without asciify as same as before.

![Screenshot 2023-03-16 at 17 15 38](https://user-images.githubusercontent.com/514294/225555626-4ea4797f-4453-428d-8eb0-1dc4b0a2cfd7.png)

Related issue: #10183
Related PR: #11083