### PR TITLE
Fix undefined variable: $index-level-stage-notice

### DIFF
--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -1,0 +1,50 @@
+name: Build assets
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  build-assets:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            nodejs-version: 18
+    name: Build assets (node ${{ matrix.nodejs-version }} on ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Setup NodeJS
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.nodejs-version }}
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install NodeJS dependencies
+        run: |
+          cd "${{ github.workspace }}/build"
+          npm ci
+      - name: Build assets (dev)
+        run: |
+          cd "${{ github.workspace }}/build"
+          npm run-script dev
+      - name: Tell git to ignore the built files
+        run: |
+          cd "${{ github.workspace }}/build"
+          npm run-script git-skip
+      - name: Check that git thinks the repo is clean
+        run: |
+          cd "${{ github.workspace }}"
+          git diff --exit-code --name-status
+      - name: Revert changed files
+        run: |
+          cd "${{ github.workspace }}/build"
+          npm run-script git-revert
+      - name: Check that git thinks the repo is clean
+        run: |
+          cd "${{ github.workspace }}"
+          git diff --exit-code --name-status
+      - name: Build assets (prod)
+        run: |
+          cd "${{ github.workspace }}/build"
+          npm run-script prod

--- a/build/libraries/built-assets.js
+++ b/build/libraries/built-assets.js
@@ -78,6 +78,7 @@ function getBuiltFiles()
         'css/features/profile/frontend.css',
         'css/features/search/frontend.css',
         'css/features/social/frontend.css',
+        'css/features/staging/frontend.css',
         'css/features/taxonomy/frontend.css',
         'css/features/testimonials/frontend.css',
         'css/features/video/frontend.css',

--- a/concrete/themes/atomik/css/scss/features/staging/_staging.scss
+++ b/concrete/themes/atomik/css/scss/features/staging/_staging.scss
@@ -1,3 +1,4 @@
+@import 'variables';
 
 div.ccm-production-notice-staging {
   background-color: $accent;

--- a/concrete/themes/atomik/css/scss/features/staging/_variables.scss
+++ b/concrete/themes/atomik/css/scss/features/staging/_variables.scss
@@ -1,0 +1,1 @@
+$index-level-stage-notice: 820 !default;


### PR DESCRIPTION
I've tried to build the assets, and I've received this error:

```
SassError: Undefined variable.
   ╷
11 │   z-index: $index-level-stage-notice;
   │            ^^^^^^^^^^^^^^^^^^^^^^^^^
   ╵
  ../concrete/themes/atomik/css/scss/features/staging/_staging.scss 11:12  @import
```

I don't know why it happens on my Windows PC (on another linux server it works).

I've also included in this PR a brand new GitHub Action that:

- checks that building the assets works
- checks that `git-skip` and `git-revert` work (they weren't working: [I've added a fix for this](https://github.com/concretecms/concretecms/commit/f50e2781e692e006ce5b0613d5c26d493788b424#diff-63a72236c0d3bc535b577739a2da6a5be7754bd656bd4253c6cf699f652969c3R81))

We could also easily extend this new GitHub action to update the repo if the built assets needs to be updated: it could be as easy as adding a new step like this:

```yaml
      - name: Update repo
        if: github.event_name == 'push' && github.repository == 'concretecms/concretecms'
        run: |
          cd "${{ github.workspace }}"
          if git diff --exit-code --name-status; then
              echo 'No changes detected'
          else
              echo 'Changes detected!'
              git config --local user.name 'GitHub Action'
              git config --local user.email 'noreply@concretecms.org'
              git commit -a -m 'Update built assets'
              git push
          fi
```
