### PR TITLE
Test build system, automatically commit built assets

### DIFF
--- a/.github/workflows/build-assets.yml
+++ b/.github/workflows/build-assets.yml
@@ -1,0 +1,71 @@
+name: Build assets
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  build-assets:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            nodejs-version: 18
+            # Just one case may have this set to yes
+            update-repo: yes
+    name: Build assets (node ${{ matrix.nodejs-version }} on ${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Setup NodeJS
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.nodejs-version }}
+
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Install NodeJS dependencies
+        run: |
+          cd "${{ github.workspace }}/build"
+          npm ci
+      - name: Build assets (dev)
+        run: |
+          cd "${{ github.workspace }}/build"
+          npm run-script dev
+      - name: Tell git to ignore the built files
+        run: |
+          cd "${{ github.workspace }}/build"
+          npm run-script git-skip
+      - name: Check that git thinks the repo is clean
+        run: |
+          cd "${{ github.workspace }}"
+          git diff --exit-code --name-status
+      - name: Revert changed files
+        run: |
+          cd "${{ github.workspace }}/build"
+          npm run-script git-revert
+      - name: Check that git thinks the repo is clean
+        run: |
+          cd "${{ github.workspace }}"
+          git diff --exit-code --name-status
+      - name: Build assets (prod)
+        run: |
+          cd "${{ github.workspace }}/build"
+          npm run-script prod
+      - name: Update repository
+        if: matrix.update-repo == 'yes'
+        run: |
+          cd '${{ github.workspace }}'
+          if git diff --exit-code --name-status; then
+              echo "Repository not updated because no change has been detected"
+          elif [ '${{ github.event_name }}' != 'push' ]; then
+            echo "Repository not updated because it's a '${{ github.event_name }}' operation and not a 'push' one"
+          elif [ '${{ github.repository }}' != 'concretecms/concretecms' ]; then
+            echo "Repository not updated because it's '${{ github.repository }}' and not 'concretecms/concretecms'"
+          else
+            echo 'Changes detected!'
+            git config --local user.name 'GitHub Action'
+            git config --local user.email 'noreply@concretecms.org'
+            git add -A
+            git commit -m 'Update built assets'
+            git push
+          fi

--- a/build/libraries/built-assets.js
+++ b/build/libraries/built-assets.js
@@ -78,6 +78,7 @@ function getBuiltFiles()
         'css/features/profile/frontend.css',
         'css/features/search/frontend.css',
         'css/features/social/frontend.css',
+        'css/features/staging/frontend.css',
         'css/features/taxonomy/frontend.css',
         'css/features/testimonials/frontend.css',
         'css/features/video/frontend.css',

--- a/build/webpack.mix.js
+++ b/build/webpack.mix.js
@@ -435,7 +435,7 @@ mix.then((stats) => {
     if (!stats?.compilation?.assets) {
         return;
     }
-    const UTF8_BOM = '\xEF\xBB\xBF';
+    const UTF8_BOM = new Uint8Array([0xEF, 0xBB, 0xBF]);
     const outputPath = stats.compilation.compiler.outputPath.replace(/[\/\\]$/, '') + path.sep;
     for (const relativePath in stats.compilation.assets) {
         if (!/\.(js|css|md|html|txt|php|ts)$/i.test(relativePath)) {
@@ -444,12 +444,13 @@ mix.then((stats) => {
             }
         }
         const absolutePath = outputPath + relativePath.replace(/^[\/\\]/, '');
-        let fileContents = fs.readFileSync(absolutePath, {encoding: 'utf-8'});
+        let fileContents = fs.readFileSync(absolutePath);
         let changed = false;
-        if (fileContents.startsWith(UTF8_BOM)) {
-            fileContents = fileContents.substring(UTF8_BOM.length);
+        if (fileContents.length >= UTF8_BOM.length && fileContents.compare(UTF8_BOM, 0, UTF8_BOM.length, 0, UTF8_BOM.length) === 0) {
+            fileContents = fileContents.subarray(UTF8_BOM.length);
             changed = true;
         }
+        fileContents = fileContents.toString('utf8')
         if (fileContents.includes('\r')) {
             fileContents = fileContents.replace(/\r\n/g, '\n').replace(/\r/g, '\n');
             changed = true;


### PR DESCRIPTION
This PR a brand new GitHub Action that:

- checks that building the assets works
- checks that git-skip and git-revert work (they weren't working: I've added a fix for this - see a877e407188ebc57d6feef8dc125fa10b8bf08e7)
- if the built assets are changed, they are committed back to the repository (that way, in order to publish new built assets we only need to fix their source code and/or the dependencies in `build/package-lock.json`)

In addition, I've updated the build process: now the built assets only use Unix line endings (`\n`) instead of a mix of `\r\n` and `\n`.