### PR TITLE
Add missing column alias in Collection::getByHandle

### DIFF
--- a/concrete/src/Page/Collection/Collection.php
+++ b/concrete/src/Page/Collection/Collection.php
@@ -138,7 +138,7 @@ class Collection extends ConcreteObject implements TrackableInterface
         /** @var Connection $db */
         $db = $app->make(Connection::class);
         $qb = $db->createQueryBuilder();
-        $qb->select('c.cID', 'p.cID')
+        $qb->select('c.cID', 'p.cID AS pcID')
             ->from('Collections', 'c')
             ->leftJoin('c', 'Pages', 'p', 'c.cID = p.cID')
             ->where('c.cHandle = :cHandle')


### PR DESCRIPTION
This fixes a functionality that was incorrectly refactored, causing a key to be missing from the `$row` array in the function `Collection::getByHandle`, see 8c4bdbd. This error wasn't apparent until run via PHP 8 which will complain about the missing array key a few lines down.