### PR TITLE
Pass the attribute owner to attribute controllers when creating values from request

### DIFF
--- a/concrete/blocks/tags/controller.php
+++ b/concrete/blocks/tags/controller.php
@@ -167,9 +167,7 @@ class Controller extends BlockController implements UsesFeatureInterface
             if (!$this->isValidStack($c)) {
                 $nvc = $c->getVersionToModify();
                 $controller = $ak->getController();
-                if (method_exists($controller, 'setAttributeObject')) {
-                    $controller->setAttributeObject($nvc);
-                }
+                $controller->setAttributeObject($nvc);
                 $value = $controller->createAttributeValueFromRequest();
                 $nvc->setAttribute($ak, $value);
                 $nvc->refreshCache();

--- a/concrete/blocks/tags/controller.php
+++ b/concrete/blocks/tags/controller.php
@@ -167,6 +167,9 @@ class Controller extends BlockController implements UsesFeatureInterface
             if (!$this->isValidStack($c)) {
                 $nvc = $c->getVersionToModify();
                 $controller = $ak->getController();
+                if (method_exists($controller, 'setAttributeObject')) {
+                    $controller->setAttributeObject($nvc);
+                }
                 $value = $controller->createAttributeValueFromRequest();
                 $nvc->setAttribute($ak, $value);
                 $nvc->refreshCache();

--- a/concrete/controllers/dialog/event/edit.php
+++ b/concrete/controllers/dialog/event/edit.php
@@ -179,9 +179,7 @@ class Edit extends BackendInterfaceController
                 $keys = $set->getAttributeKeys();
                 foreach($keys as $ak) {
                     $controller = $ak->getController();
-                    if (method_exists($controller, 'setAttributeObject')) {
-                        $controller->setAttributeObject($eventVersion);
-                    }
+                    $controller->setAttributeObject($eventVersion);
                     $value = $controller->createAttributeValueFromRequest();
                     $eventVersion->setAttribute($ak, $value);
                 }

--- a/concrete/controllers/dialog/event/edit.php
+++ b/concrete/controllers/dialog/event/edit.php
@@ -179,6 +179,9 @@ class Edit extends BackendInterfaceController
                 $keys = $set->getAttributeKeys();
                 foreach($keys as $ak) {
                     $controller = $ak->getController();
+                    if (method_exists($controller, 'setAttributeObject')) {
+                        $controller->setAttributeObject($eventVersion);
+                    }
                     $value = $controller->createAttributeValueFromRequest();
                     $eventVersion->setAttribute($ak, $value);
                 }

--- a/concrete/controllers/panel/detail/page/attributes.php
+++ b/concrete/controllers/panel/detail/page/attributes.php
@@ -115,9 +115,7 @@ class Attributes extends BackendInterfacePageController
                     // Is this item in the selectedAKIDs array? If so then it is being saved
                     if (in_array($ak->getAttributeKeyID(), $selected)) {
                         $controller = $ak->getController();
-                        if (method_exists($controller, 'setAttributeObject')) {
-                            $controller->setAttributeObject($nvc);
-                        }
+                        $controller->setAttributeObject($nvc);
                         $value = $controller->createAttributeValueFromRequest();
                         $nvc->setAttribute($ak, $value, false);
                     } else {
@@ -132,9 +130,7 @@ class Attributes extends BackendInterfacePageController
                 if ($akID > 0 && in_array($akID, $asl->getAttributesAllowedArray())) {
                     $ak = CollectionAttributeKey::getByID($akID);
                     $controller = $ak->getController();
-                    if (method_exists($controller, 'setAttributeObject')) {
-                        $controller->setAttributeObject($nvc);
-                    }
+                    $controller->setAttributeObject($nvc);
                     $value = $controller->createAttributeValueFromRequest();
                     $nvc->setAttribute($ak, $value, false);
                 }

--- a/concrete/controllers/panel/detail/page/attributes.php
+++ b/concrete/controllers/panel/detail/page/attributes.php
@@ -115,6 +115,9 @@ class Attributes extends BackendInterfacePageController
                     // Is this item in the selectedAKIDs array? If so then it is being saved
                     if (in_array($ak->getAttributeKeyID(), $selected)) {
                         $controller = $ak->getController();
+                        if (method_exists($controller, 'setAttributeObject')) {
+                            $controller->setAttributeObject($nvc);
+                        }
                         $value = $controller->createAttributeValueFromRequest();
                         $nvc->setAttribute($ak, $value, false);
                     } else {
@@ -129,6 +132,9 @@ class Attributes extends BackendInterfacePageController
                 if ($akID > 0 && in_array($akID, $asl->getAttributesAllowedArray())) {
                     $ak = CollectionAttributeKey::getByID($akID);
                     $controller = $ak->getController();
+                    if (method_exists($controller, 'setAttributeObject')) {
+                        $controller->setAttributeObject($nvc);
+                    }
                     $value = $controller->createAttributeValueFromRequest();
                     $nvc->setAttribute($ak, $value, false);
                 }

--- a/concrete/controllers/panel/detail/page/seo.php
+++ b/concrete/controllers/panel/detail/page/seo.php
@@ -59,9 +59,7 @@ class Seo extends BackendInterfacePageController
             $attributes = $as->getAttributeKeys();
             foreach ($attributes as $ak) {
                 $controller = $ak->getController();
-                if (method_exists($controller, 'setAttributeObject')) {
-                    $controller->setAttributeObject($nvc);
-                }
+                $controller->setAttributeObject($nvc);
                 $value = $controller->createAttributeValueFromRequest();
                 $nvc->setAttribute($ak, $value);
             }

--- a/concrete/controllers/panel/detail/page/seo.php
+++ b/concrete/controllers/panel/detail/page/seo.php
@@ -59,6 +59,9 @@ class Seo extends BackendInterfacePageController
             $attributes = $as->getAttributeKeys();
             foreach ($attributes as $ak) {
                 $controller = $ak->getController();
+                if (method_exists($controller, 'setAttributeObject')) {
+                    $controller->setAttributeObject($nvc);
+                }
                 $value = $controller->createAttributeValueFromRequest();
                 $nvc->setAttribute($ak, $value);
             }

--- a/concrete/controllers/single_page/dashboard/system/basics/name.php
+++ b/concrete/controllers/single_page/dashboard/system/basics/name.php
@@ -44,9 +44,7 @@ class Name extends DashboardSitePageController
                 $attributes = SiteKey::getList();
                 foreach ($attributes as $ak) {
                     $controller = $ak->getController();
-                    if (method_exists($controller, 'setAttributeObject')) {
-                        $controller->setAttributeObject($this->site);
-                    }
+                    $controller->setAttributeObject($this->site);
                     $value = $controller->createAttributeValueFromRequest();
                     $this->site->setAttribute($ak, $value);
                 }

--- a/concrete/controllers/single_page/dashboard/system/basics/name.php
+++ b/concrete/controllers/single_page/dashboard/system/basics/name.php
@@ -44,6 +44,9 @@ class Name extends DashboardSitePageController
                 $attributes = SiteKey::getList();
                 foreach ($attributes as $ak) {
                     $controller = $ak->getController();
+                    if (method_exists($controller, 'setAttributeObject')) {
+                        $controller->setAttributeObject($this->site);
+                    }
                     $value = $controller->createAttributeValueFromRequest();
                     $this->site->setAttribute($ak, $value);
                 }

--- a/concrete/src/Attribute/AttributeInterface.php
+++ b/concrete/src/Attribute/AttributeInterface.php
@@ -109,4 +109,9 @@ interface AttributeInterface
      * @return string
      */
     public function getAttributeValueClass();
+
+    /**
+     * Set the subject for which the value is being managed.
+     */
+    public function setAttributeObject(ObjectInterface $object);
 }

--- a/concrete/src/Attribute/Command/SaveAttributesCommandHandler.php
+++ b/concrete/src/Attribute/Command/SaveAttributesCommandHandler.php
@@ -10,6 +10,9 @@ class SaveAttributesCommandHandler
         $keys = $command->getAttributeKeys();
         foreach($keys as $key) {
             $controller = $key->getController();
+            if (method_exists($controller, 'setAttributeObject')) {
+                $controller->setAttributeObject($command->getObject());
+            }
             $value = $controller->createAttributeValueFromRequest();
             $command->getObject()->setAttribute($key, $value);
         }

--- a/concrete/src/Attribute/Command/SaveAttributesCommandHandler.php
+++ b/concrete/src/Attribute/Command/SaveAttributesCommandHandler.php
@@ -10,9 +10,7 @@ class SaveAttributesCommandHandler
         $keys = $command->getAttributeKeys();
         foreach($keys as $key) {
             $controller = $key->getController();
-            if (method_exists($controller, 'setAttributeObject')) {
-                $controller->setAttributeObject($command->getObject());
-            }
+            $controller->setAttributeObject($command->getObject());
             $value = $controller->createAttributeValueFromRequest();
             $command->getObject()->setAttribute($key, $value);
         }

--- a/concrete/src/Attribute/Controller.php
+++ b/concrete/src/Attribute/Controller.php
@@ -99,7 +99,9 @@ class Controller extends AbstractController implements AttributeInterface
     }
 
     /**
-     * @param ObjectInterface $object
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Attribute\AttributeInterface::setAttributeObject()
      */
     public function setAttributeObject(ObjectInterface $object)
     {

--- a/concrete/src/Express/Form/Control/SaveHandler/AttributeKeySaveHandler.php
+++ b/concrete/src/Express/Form/Control/SaveHandler/AttributeKeySaveHandler.php
@@ -13,6 +13,9 @@ class AttributeKeySaveHandler implements SaveHandlerInterface
     {
         $controller = $control->getAttributeKey()->getController();
         $controller->setAttributeKey($control->getAttributeKey());
+        if (method_exists($controller, 'setAttributeObject')) {
+            $controller->setAttributeObject($entry);
+        }
         $value = $controller->createAttributeValueFromRequest();
         $entry->setAttribute($control->getAttributeKey(), $value);
     }

--- a/concrete/src/Express/Form/Control/SaveHandler/AttributeKeySaveHandler.php
+++ b/concrete/src/Express/Form/Control/SaveHandler/AttributeKeySaveHandler.php
@@ -13,9 +13,7 @@ class AttributeKeySaveHandler implements SaveHandlerInterface
     {
         $controller = $control->getAttributeKey()->getController();
         $controller->setAttributeKey($control->getAttributeKey());
-        if (method_exists($controller, 'setAttributeObject')) {
-            $controller->setAttributeObject($entry);
-        }
+        $controller->setAttributeObject($entry);
         $value = $controller->createAttributeValueFromRequest();
         $entry->setAttribute($control->getAttributeKey(), $value);
     }

--- a/concrete/src/Page/Type/Composer/Control/CollectionAttributeControl.php
+++ b/concrete/src/Page/Type/Composer/Control/CollectionAttributeControl.php
@@ -162,9 +162,7 @@ class CollectionAttributeControl extends Control
         $ak = $this->getAttributeKeyObject();
         if (is_object($ak)) {
             $controller = $ak->getController();
-            if (method_exists($controller, 'setAttributeObject')) {
-                $controller->setAttributeObject($c->getVersionObject());
-            }
+            $controller->setAttributeObject($c->getVersionObject());
             $value = $controller->createAttributeValueFromRequest();
             $c->setAttribute($ak, $value);
         }

--- a/concrete/src/Page/Type/Composer/Control/CollectionAttributeControl.php
+++ b/concrete/src/Page/Type/Composer/Control/CollectionAttributeControl.php
@@ -162,6 +162,9 @@ class CollectionAttributeControl extends Control
         $ak = $this->getAttributeKeyObject();
         if (is_object($ak)) {
             $controller = $ak->getController();
+            if (method_exists($controller, 'setAttributeObject')) {
+                $controller->setAttributeObject($c->getVersionObject());
+            }
             $value = $controller->createAttributeValueFromRequest();
             $c->setAttribute($ak, $value);
         }

--- a/concrete/src/User/UserInfo.php
+++ b/concrete/src/User/UserInfo.php
@@ -1014,9 +1014,7 @@ class UserInfo extends ConcreteObject implements AttributeObjectInterface, Permi
     {
         foreach ($attributes as $uak) {
             $controller = $uak->getController();
-            if (method_exists($controller, 'setAttributeObject')) {
-                $controller->setAttributeObject($this);
-            }
+            $controller->setAttributeObject($this);
             $value = $controller->createAttributeValueFromRequest();
             $this->setAttribute($uak, $value);
         }

--- a/concrete/src/User/UserInfo.php
+++ b/concrete/src/User/UserInfo.php
@@ -1014,6 +1014,9 @@ class UserInfo extends ConcreteObject implements AttributeObjectInterface, Permi
     {
         foreach ($attributes as $uak) {
             $controller = $uak->getController();
+            if (method_exists($controller, 'setAttributeObject')) {
+                $controller->setAttributeObject($this);
+            }
             $value = $controller->createAttributeValueFromRequest();
             $this->setAttribute($uak, $value);
         }


### PR DESCRIPTION
When we render the attributes, [we pass the attribute owner to attribute controllers](https://github.com/concretecms/concretecms/blob/9.1.3/concrete/src/Attribute/View.php#L157).

What about doing the same when creating attribute values from request?