### PR TITLE
Fix applying multiple PHP CS Fixer rules

### DIFF
--- a/concrete/src/Support/CodingStyle/PhpFixerRuleResolver.php
+++ b/concrete/src/Support/CodingStyle/PhpFixerRuleResolver.php
@@ -553,6 +553,6 @@ class PhpFixerRuleResolver
             $this->fixerFactory->registerBuiltInFixers();
         }
 
-        return $this->fixerFactory;
+        return clone $this->fixerFactory;
     }
 }


### PR DESCRIPTION
The useRuleSet() method of the FixerFactory alters the registered fixers, so, any subsequent use of FixerFactory may result in unregistered fixers.