### PR TITLE
Site Health: fix checking HTTPS canonical URL

### DIFF
--- a/concrete/src/Health/Report/Test/Test/CheckConfigUrlSettingsForProductionTest.php
+++ b/concrete/src/Health/Report/Test/Test/CheckConfigUrlSettingsForProductionTest.php
@@ -32,7 +32,7 @@ class CheckConfigUrlSettingsForProductionTest implements TestInterface
             );
         } else {
             $url = Url::createFromUrl($url);
-            if ($url->getScheme() !== 'https') {
+            if ((string) $url->getScheme() !== 'https') {
                 $report->warning(
                     t('Canonical URL set but not running SSL. SSL is strongly encouraged.'),
                     $report->button(new UrlSettingsLocation())


### PR DESCRIPTION
`League\Url\Url::getScheme()` returns an instance of `League\Url\Components\ComponentInterface` and not a `string`, so this strict equality check always fails.

Let's fix it.