### PR TITLE
Replaced allowist to allowlist in all files, Now it is consistent.

### DIFF
--- a/concrete/controllers/single_page/dashboard/system/permissions/antispam.php
+++ b/concrete/controllers/single_page/dashboard/system/permissions/antispam.php
@@ -32,7 +32,7 @@ class Antispam extends DashboardPageController
         }
         $this->groups = $groups;
         $this->set('groups', $groups);
-        $this->set('allowlistGroup', Config::get('concrete.spam.allowist_group', Config::get('concrete.spam.whitelist_group')));
+        $this->set('allowlistGroup', Config::get('concrete.spam.allowlist_group', Config::get('concrete.spam.whitelist_group')));
     }
 
     public function saved()

--- a/concrete/src/Antispam/Service.php
+++ b/concrete/src/Antispam/Service.php
@@ -31,7 +31,7 @@ class Service
      */
     public function getAllowlistGroup()
     {
-        return Group::getByID(Config::get('concrete.spam.allowist_group', Config::get('concrete.spam.whitelist_group')));
+        return Group::getByID(Config::get('concrete.spam.allowlist_group', Config::get('concrete.spam.whitelist_group')));
     }
 
     /**


### PR DESCRIPTION
It is incorrectly spelled in two file, I have changed it.
closes issue : #11352

In antispam.php :

from
        $this->set('allowlistGroup', Config::get('concrete.spam.allowist_group', Config::get('concrete.spam.whitelist_group')));
to
        $this->set('allowlistGroup', Config::get('concrete.spam.allowlist_group', Config::get('concrete.spam.whitelist_group')));

In service.php : 

from
        return Group::getByID(Config::get('concrete.spam.allowist_group', Config::get('concrete.spam.whitelist_group')));
to
        return Group::getByID(Config::get('concrete.spam.allowlist_group', Config::get('concrete.spam.whitelist_group')));
