### PR TITLE
use the Express Entry's publicIdentifier after submitting a public form

### DIFF
--- a/concrete/blocks/express_form/controller.php
+++ b/concrete/blocks/express_form/controller.php
@@ -702,7 +702,7 @@ class Controller extends BlockController implements NotificationProviderInterfac
                     if (is_object($c) && !$c->isError()) {
                         $r = Redirect::page($c);
                         $target = strpos($r->getTargetUrl(),"?") === false ? $r->getTargetUrl()."?" : $r->getTargetUrl()."&";
-                        $r->setTargetUrl($target . 'form_success=1&entry=' . $entry->getID());
+                        $r->setTargetUrl($target . 'form_success=1&entry=' . $entry->getPublicIdentifier());
                     }
                 }
 


### PR DESCRIPTION
closes #11355 