### PR TITLE
OAuth: Use getExtractor() method instead of accessing $extractor property

### DIFF
--- a/concrete/src/Authentication/Type/OAuth/GenericOauthTypeController.php
+++ b/concrete/src/Authentication/Type/OAuth/GenericOauthTypeController.php
@@ -22,7 +22,7 @@ abstract class GenericOauthTypeController extends AuthenticationTypeController
     protected $service;
 
     /**
-     * @var Extractor
+     * @var Extractor|null
      */
     protected $extractor;
 
@@ -299,7 +299,7 @@ abstract class GenericOauthTypeController extends AuthenticationTypeController
 
     protected function isValid()
     {
-        return $this->extractor->supportsUniqueId();
+        return $this->getExtractor()->supportsUniqueId();
     }
 
     /**


### PR DESCRIPTION
The $extractor property may be null if we don't call getExtractor()