### PR TITLE
Add a path for rebinding accounts and disable twitter oauth installation

### DIFF
--- a/concrete/authentication/concrete/controller.php
+++ b/concrete/authentication/concrete/controller.php
@@ -107,6 +107,7 @@ class Controller extends AuthenticationTypeController
      */
     public function view()
     {
+        $this->set('user', $this->app->make(User::class));
     }
 
     /**

--- a/concrete/authentication/concrete/form.php
+++ b/concrete/authentication/concrete/form.php
@@ -2,71 +2,88 @@
 $form = Core::make('helper/form');
 $dh = Core::make('helper/date');  /* @var $dh \Concrete\Core\Localization\Service\Date */
 /* @var Concrete\Core\Form\Service\Form $form */
+
+$loggedIn = isset($user) && $user->isRegistered();
 ?>
 
-<form class="concrete-login-form" method="post" action="<?= URL::to('/login', 'authenticate', $this->getAuthenticationTypeHandle()); ?>">
-
-    <div class="mb-3 row">
-        <label class="col-sm-3 col-form-label" for="uName">
-            <?=Config::get('concrete.user.registration.email_registration') ? t('Email Address') : t('User Name'); ?>
-        </label>
-        <div class="col-sm-9">
-            <input name="uName" id="uName" class="form-control" autofocus="autofocus" />
-        </div>
-    </div>
-    <div class="mb-3 row">
-        <label class="col-sm-3 col-form-label" for="uPassword">
-            <?=t('Password'); ?>
-        </label>
-        <div class="col-sm-9">
-            <input name="uPassword" id="uPassword" class="form-control" type="password" autocomplete="off" />
-        </div>
-    </div>
-    <div class="mb-3 row">
-        <label class="col-sm-3 col-form-label" for="uPassword">
-        </label>
-        <div class="col-sm-9 text-end">
-            <a href="<?= URL::to('/login', 'concrete', 'forgot_password'); ?>" class="btn-link"><?= t('Forgot Password'); ?></a>
-        </div>
-    </div>
-    <?php if (Config::get('concrete.session.remember_me.lifetime') > 0) {
+<?php
+if (!$loggedIn) {
     ?>
-    <div class="mb-3 row">
-        <div class="col-sm-3 col-form-label pt-0"><?=t('Remember Me'); ?></div>
-        <div class="col-sm-9">
-            <div class="form-check">
-                <input class="form-check-input" type="checkbox" id="uMaintainLogin" name="uMaintainLogin" value="1">
-                <label class="form-check-label form-check-remember-me" for="uMaintainLogin">
-                    <?php echo t('Stay signed in for %s', $dh->describeInterval(Config::get('concrete.session.remember_me.lifetime'))); ?>
-                </label>
+    <form class="concrete-login-form" method="post" action="<?= URL::to('/login', 'authenticate', $this->getAuthenticationTypeHandle()); ?>">
+
+        <div class="mb-3 row">
+            <label class="col-sm-3 col-form-label" for="uName">
+                <?=Config::get('concrete.user.registration.email_registration') ? t('Email Address') : t('User Name'); ?>
+            </label>
+            <div class="col-sm-9">
+                <input name="uName" id="uName" class="form-control" autofocus="autofocus" />
             </div>
         </div>
-    </div>
-    <?php
-} ?>
-    <?php if (isset($locales) && is_array($locales) && count($locales) > 0) {
-        ?>
-        <div class="mb-3">
-            <label for="USER_LOCALE" class="control-label form-label"><?= t('Language'); ?></label>
-            <?= $form->select('USER_LOCALE', $locales); ?>
+        <div class="mb-3 row">
+            <label class="col-sm-3 col-form-label" for="uPassword">
+                <?=t('Password'); ?>
+            </label>
+            <div class="col-sm-9">
+                <input name="uPassword" id="uPassword" class="form-control" type="password" autocomplete="off" />
+            </div>
         </div>
-    <?php
-    } ?>
-    <div class="mb-3 row">
-        <div class="col-sm-12 text-end">
-            <a href="<?= \URL::to('/'); ?>" class="btn btn-secondary"> <?= t('Cancel'); ?> </a>
-            <button class="btn btn-primary"><?= t('Sign In'); ?></button>
-            <?php Core::make('helper/validation/token')->output('login_' . $this->getAuthenticationTypeHandle()); ?>
+        <div class="mb-3 row">
+            <label class="col-sm-3 col-form-label" for="uPassword">
+            </label>
+            <div class="col-sm-9 text-end">
+                <a href="<?= URL::to('/login', 'concrete', 'forgot_password'); ?>" class="btn-link"><?= t('Forgot Password'); ?></a>
+            </div>
         </div>
-    </div>
+        <?php
+        if (Config::get('concrete.session.remember_me.lifetime') > 0) {
+            ?>
+            <div class="mb-3 row">
+                <div class="col-sm-3 col-form-label pt-0"><?=t('Remember Me'); ?></div>
+                <div class="col-sm-9">
+                    <div class="form-check">
+                        <input class="form-check-input" type="checkbox" id="uMaintainLogin" name="uMaintainLogin" value="1">
+                        <label class="form-check-label form-check-remember-me" for="uMaintainLogin">
+                            <?php echo t('Stay signed in for %s', $dh->describeInterval(Config::get('concrete.session.remember_me.lifetime'))); ?>
+                        </label>
+                    </div>
+                </div>
+            </div>
+            <?php
+        }
 
-    <?php if (Config::get('concrete.user.registration.enabled')) {
+        if (isset($locales) && is_array($locales) && count($locales) > 0) {
+            ?>
+            <div class="mb-3">
+                <label for="USER_LOCALE" class="control-label form-label"><?= t('Language'); ?></label>
+                <?= $form->select('USER_LOCALE', $locales); ?>
+            </div>
+            <?php
+        }
         ?>
-        <hr/>
-        <div class="text-center sign-up-container">
-            <?=t("Don't have an account?"); ?>
-            <a href="<?=URL::to('/register'); ?>" class="btn-link"><?=t('Sign up'); ?></a>
+        <div class="mb-3 row">
+            <div class="col-sm-12 text-end">
+                <a href="<?= \URL::to('/'); ?>" class="btn btn-secondary"> <?= t('Cancel'); ?> </a>
+                <button class="btn btn-primary"><?= t('Sign In'); ?></button>
+                <?php Core::make('helper/validation/token')->output('login_' . $this->getAuthenticationTypeHandle()); ?>
+            </div>
         </div>
+
+        <?php
+        if (Config::get('concrete.user.registration.enabled')) {
+            ?>
+            <hr/>
+            <div class="text-center sign-up-container">
+                <?=t("Don't have an account?"); ?>
+                <a href="<?=URL::to('/register'); ?>" class="btn-link"><?=t('Sign up'); ?></a>
+            </div>
+            <?php
+        }
+        ?>
+    </form>
     <?php
-    } ?>
-</form>
+} else {
+    ?>
+    <div class="alert alert-danger"><?= t('You are already logged in.') ?></div>
+    <?php
+}
+?>

--- a/concrete/authentication/external_concrete/hook.php
+++ b/concrete/authentication/external_concrete/hook.php
@@ -8,7 +8,7 @@
 </div>
 <div class="form-group">
     <a href="<?= $attachUrl ?>" class="btn btn-primary btn-success btn-external-concrete">
-        <img src="<?= $assetUrl ?>/concrete/images/logo.svg" class="concrete-icon" />
+        <img src="<?= $assetUrl ?? '' ?>/concrete/images/logo.svg" class="concrete-icon" />
         <?= t('Attach your %s account', h($name)) ?>
     </a>
 </div>

--- a/concrete/single_pages/login.php
+++ b/concrete/single_pages/login.php
@@ -24,18 +24,12 @@ if (!isset($authTypeParams)) {
 
 $attribute_mode = (isset($required_attributes) && count($required_attributes));
 
-// See if we have a user object and if that user is registered
-$loggedIn = !$attribute_mode && isset($user) && $user->isRegistered();
-
 // Determine login header title
 $title = t('Please sign in here.');
-$alreadyLoggedInMessage = t('You are already logged in.');
 if ($attribute_mode) {
     $title = t('Required Attributes');
-}
-
-if ($loggedIn) {
-    $title = $alreadyLoggedInMessage;
+} elseif (isset($user) && $user->isRegistered()) {
+    $title = t('You are already logged in.');
 }
 ?>
 
@@ -56,49 +50,45 @@ if ($loggedIn) {
             <div class="row">
                 <div class="col-12">
                     <h2 class="login-page-title">
-                        <?php if (!$attribute_mode) {
-                ?>
-                            <?=t('Welcome back!'); ?>
                         <?php
-            }?>
+                        if (!$attribute_mode) {
+                            echo t('Welcome back!');
+                        }
+                        ?>
                         <?= $title; ?>
                     </h2>
                 </div>
             </div>
         </div>
 
-        <?php if ($attribute_mode) {
-                $attribute_helper = new Concrete\Core\Form\Service\Widget\Attribute(); ?>
+        <?php
+        if ($attribute_mode) {
+            $attribute_helper = new Concrete\Core\Form\Service\Widget\Attribute();
+            ?>
             <div class="row login-page-content attribute-mode">
                 <form action="<?= View::action('fill_attributes'); ?>" method="POST">
                     <div data-handle="required_attributes"
                     class="authentication-type authentication-type-required-attributes">
-                    <div class="ccm-required-attribute-form">
-                        <?php
-                        foreach ($required_attributes as $key) {
-                            echo $attribute_helper->display($key, true);
-                        } ?>
-                    </div>
-                    <div class="form-group clearfix">
-                        <button class="btn btn-primary float-end"><?= t('Submit'); ?></button>
-                    </div>
+                        <div class="ccm-required-attribute-form">
+                            <?php
+                            foreach ($required_attributes as $key) {
+                                echo $attribute_helper->display($key, true);
+                            }
+                            ?>
+                        </div>
+                        <div class="form-group clearfix">
+                            <button class="btn btn-primary float-end"><?= t('Submit'); ?></button>
+                        </div>
 
-                </div>
-            </form>
-        </div>
-        <?php
-            } else {
-                ?>
-        <div class="row login-page-content">
-            <div class="col-12">
-                <?php if ($loggedIn) {
-                    ?>
-                    <div class="text-center">
-                        <h3><?=$alreadyLoggedInMessage; ?></h3>
-                        <?= Core::make('helper/navigation')->getLogInOutLink(); ?>
                     </div>
-                <?php
-                } else {
+                </form>
+            </div>
+            <?php
+        } else {
+            ?>
+            <div class="row login-page-content">
+                <div class="col-12">
+                    <?php
                     $i = 0;
                     foreach ($activeAuths as $auth) {
                         ?>
@@ -115,11 +105,11 @@ if ($loggedIn) {
                         }
                         ++$i;
                     }
-                } ?>
+                    ?>
+                </div>
             </div>
-        </div>
-        <?php
-            } // END OPENING IF STATEMENT
+            <?php
+        } // END OPENING IF STATEMENT
     ?>
     </div>
 </div>

--- a/concrete/src/Authentication/Type/OAuth/OAuth2/GenericOauth2TypeController.php
+++ b/concrete/src/Authentication/Type/OAuth/OAuth2/GenericOauth2TypeController.php
@@ -25,14 +25,6 @@ abstract class GenericOauth2TypeController extends GenericOauthTypeController
 
     public function handle_authentication_callback()
     {
-        $user = $this->app->make(User::class);
-        if ($user && !$user->isError() && $user->isLoggedIn()) {
-            // We should NOT allow you to complete the authentication flow and potentially rebind the
-            // logged-in user here. Instead we halt the authentication flow.
-            $this->showError(t('You are already logged in.'));
-            return false;
-        }
-
         try {
             $service = $this->getService();
             $code = \Request::getInstance()->get('code');
@@ -41,6 +33,18 @@ abstract class GenericOauth2TypeController extends GenericOauthTypeController
             // If state is required update this variable to be never null
             if ($service->needsStateParameterInAuthUrl()) {
                 $state = $state ?: '';
+
+                if (substr($state, 0, 7) === 'attach:') {
+                    return $this->handle_attach_callback();
+                }
+            }
+
+            $user = $this->app->make(User::class);
+            if ($user && !$user->isError() && $user->isLoggedIn()) {
+                // We should NOT allow you to complete the authentication flow and potentially rebind the
+                // logged-in user here. Instead we halt the authentication flow.
+                $this->showError(t('You are already logged in.'));
+                return false;
             }
 
             $token = $service->requestAccessToken($code, $state);
@@ -78,7 +82,15 @@ abstract class GenericOauth2TypeController extends GenericOauthTypeController
 
     public function handle_attach_attempt()
     {
-        $url = $this->getService()->getAuthorizationUri($this->getAdditionalRequestParameters());
+        $user = $this->app->make(User::class);
+
+        if (!$user->isRegistered()) {
+            $this->showError(t('A user must be logged in to attach a remote OAuth account.'));
+            exit;
+        }
+
+        $state = 'attach:' . bin2hex(random_bytes(16));
+        $url = $this->getService()->getAuthorizationUri($this->getAdditionalRequestParameters() + ['state' => $state]);
 
         id(new RedirectResponse((string) $url))->send();
         exit;
@@ -108,6 +120,9 @@ abstract class GenericOauth2TypeController extends GenericOauthTypeController
             exit;
         } catch (InvalidAuthorizationStateException $e) {
             $this->showError(t('Invalid state token provided, please try again.'));
+            exit;
+        } catch (\Throwable $e) {
+            $this->showError($e->getMessage());
             exit;
         }
 

--- a/concrete/src/Package/StartingPointPackage.php
+++ b/concrete/src/Package/StartingPointPackage.php
@@ -480,12 +480,10 @@ class StartingPointPackage extends Package
         $cba = AuthenticationType::add('concrete', 'Standard');
         $coa = AuthenticationType::add('community', 'community.concretecms.com');
         $fba = AuthenticationType::add('facebook', 'Facebook');
-        $twa = AuthenticationType::add('twitter', 'Twitter');
         $gat = AuthenticationType::add('google', 'Google');
         $ext = AuthenticationType::add('external_concrete', 'External Concrete Site');
 
         $fba->disable();
-        $twa->disable();
         $coa->disable();
         $gat->disable();
         $ext->disable();


### PR DESCRIPTION
Resolves #11053 

This PR leverages the "state" parameter we pass through for all oauth2 providers installed by default (Twitter is an oauth1 provider for some reason) in order to handle "attach"ing rather than authenticating a user.

Previously we just sent already logged in users through the attach flow automatically. This had the unintended effect of rebinding user accounts when a user accidentally triggered the login flow while logged in.

With this PR we're tracking the fact that attaching is intended in the "state" parameter which will only be set properly if the OAuth flow originates through the `attempt_attach` method. That way we can safely send the callback through to the attach handler since we can be sure the flow was started by an attach request and not a general log in request.

This change doesn't work for OAuth1 services, or OAuth2 services that don't support the state parameter, and so I've disabled installing the twitter authentication type by default until we can build an OAuth2 service for it. 

Some other ways we could fix it:

- Store the intended handler in session. This is essentially what we're doing now, the only difference is we're leveraging the OAuth2 client library and the general state flow OAuth2 supports so that we don't have to manage the lifecycle on our own.
- Just have two callback urls. One for attaching and one for logging in. Most OAuth2 providers already offer the ability to set multiple authorized callback urls if not just wildcard support. That way we can just specify a separate redirect endpoint for handling attach so that we never have overlap.

I also cleaned up some formatting issues in the files I was in so I recommend viewing the changes in github with the `?w=1` query parameter.
