### PR TITLE
Use User->isRegistered() instead of User->isLoggedIn()

### DIFF
--- a/concrete/src/Authentication/Type/OAuth/OAuth1a/GenericOauth1aTypeController.php
+++ b/concrete/src/Authentication/Type/OAuth/OAuth1a/GenericOauth1aTypeController.php
@@ -19,7 +19,7 @@ abstract class GenericOauth1aTypeController extends GenericOauthTypeController
     public function handle_authentication_callback()
     {
         $user = $this->app->make(User::class);
-        if ($user && !$user->isError() && $user->isLoggedIn()) {
+        if ($user && !$user->isError() && $user->isRegistered()) {
             // We should NOT allow you to complete the authentication flow and potentially rebind the
             // logged-in user here. Instead we halt the authentication flow.
             $this->showError(t('You are already logged in.'));
@@ -62,7 +62,7 @@ abstract class GenericOauth1aTypeController extends GenericOauthTypeController
     public function handle_attach_callback()
     {
         $user = $this->app->make(User::class);
-        if (!$user->isLoggedIn()) {
+        if (!$user->isRegistered()) {
             id(new RedirectResponse(\URL::to('')))->send();
             exit;
         }
@@ -107,6 +107,6 @@ abstract class GenericOauth1aTypeController extends GenericOauthTypeController
      */
     public function isAuthenticated(User $u)
     {
-        return $u->isLoggedIn();
+        return $u->isRegistered();
     }
 }

--- a/concrete/src/Authentication/Type/OAuth/OAuth2/GenericOauth2TypeController.php
+++ b/concrete/src/Authentication/Type/OAuth/OAuth2/GenericOauth2TypeController.php
@@ -40,7 +40,7 @@ abstract class GenericOauth2TypeController extends GenericOauthTypeController
             }
 
             $user = $this->app->make(User::class);
-            if ($user && !$user->isError() && $user->isLoggedIn()) {
+            if ($user && !$user->isError() && $user->isRegistered()) {
                 // We should NOT allow you to complete the authentication flow and potentially rebind the
                 // logged-in user here. Instead we halt the authentication flow.
                 $this->showError(t('You are already logged in.'));
@@ -169,6 +169,6 @@ abstract class GenericOauth2TypeController extends GenericOauthTypeController
      */
     public function isAuthenticated(User $u)
     {
-        return $u->isLoggedIn();
+        return $u->isRegistered();
     }
 }

--- a/concrete/src/User/User.php
+++ b/concrete/src/User/User.php
@@ -1031,7 +1031,7 @@ class User extends ConcreteObject
      */
     public function refreshCollectionEdit(&$c)
     {
-        if ($this->isLoggedIn() && $c->getCollectionCheckedOutUserID() == $this->getUserID()) {
+        if ($this->isRegistered() && $c->getCollectionCheckedOutUserID() == $this->getUserID()) {
             $app = Application::getFacadeApplication();
             $db = $app['database']->connection();
             $cID = $c->getCollectionID();


### PR DESCRIPTION
The `User::isLoggedIn()` static method [is just a wrapper](https://github.com/concretecms/concretecms/blob/9.1.3/concrete/src/User/User.php#L87-L96) around `User->isRegistered()` instance method.