### PR TITLE
OAuth service provider: avoid deprecated methods, display errors

### DIFF
--- a/concrete/src/Authentication/Type/OAuth/ServiceProvider.php
+++ b/concrete/src/Authentication/Type/OAuth/ServiceProvider.php
@@ -57,19 +57,22 @@ class ServiceProvider extends Provider
         }
         try {
             $controller = $type->getController();
-            if ($controller instanceof GenericOauthTypeController) {
-                switch ($action) {
-                    case 'attempt_auth':
-                        return $controller->handle_authentication_attempt();
-                    case 'callback':
-                        return $controller->handle_authentication_callback();
-                    case 'attempt_attach':
-                        return $controller->handle_attach_attempt();
-                    case 'attach_callback':
-                        return $controller->handle_attach_callback();
-                    case 'attempt_detach':
-                        return $controller->handle_detach_attempt();
-                }
+            if (!$controller instanceof GenericOauthTypeController) {
+                throw new UserMessageException(t('Invalid OAuth2 controller'));
+            }
+            switch ($action) {
+                case 'attempt_auth':
+                    return $controller->handle_authentication_attempt();
+                case 'callback':
+                    return $controller->handle_authentication_callback();
+                case 'attempt_attach':
+                    return $controller->handle_attach_attempt();
+                case 'attach_callback':
+                    return $controller->handle_attach_callback();
+                case 'attempt_detach':
+                    return $controller->handle_detach_attempt();
+                default:
+                    throw new UserMessageException(t('Invalid OAuth2 action'));
             }
         } catch (Throwable $e) {
             $logger = $this->app->make('log/factory')->createLogger(Channels::CHANNEL_AUTHENTICATION);

--- a/tests/tests/Authentication/OAuth/ServiceProviderTest.php
+++ b/tests/tests/Authentication/OAuth/ServiceProviderTest.php
@@ -4,11 +4,12 @@ namespace Concrete\Tests\Authentication\OAuth;
 
 use Concrete\Core\Application\Application;
 use Concrete\Core\Authentication\Type\OAuth\ServiceProvider;
+use Concrete\Core\Routing\RoutingServiceProvider;
 use Concrete\TestHelpers\Authentication\OAuth\Fixture\ExtractorFixture;
 use Concrete\TestHelpers\Authentication\OAuth\Fixture\ServiceFixture;
-use OAuth\UserData\Extractor\ExtractorInterface;
-use OAuth\UserData\ExtractorFactoryInterface;
 use Concrete\Tests\TestCase;
+use OAuth\UserData\ExtractorFactoryInterface;
+use OAuth\UserData\Extractor\ExtractorInterface;
 
 class ServiceProviderTest extends TestCase
 {
@@ -16,6 +17,7 @@ class ServiceProviderTest extends TestCase
     {
         $app = new Application();
 
+        (new RoutingServiceProvider($app))->register();
         $provider = new ServiceProvider($app);
         $provider->register();
 


### PR DESCRIPTION
When we have a problem with the oauth authentication, people will see an empty page.

That's because the `ccm/system/authentication/oauth2/...` route callback simply returns nothing.

What about handling errors the standard Concrete way (display the error details if the system is configured so, or the generic "An error occurred" message otherwise)?

In addition:

- let's use static closures whenever possible (they require less memory)
- let's use app->singleton() instead of the deprecated app->bindShared()
- let's avoid aliases and closures