### PR TITLE
Fix Undefined property error on PHP 8 in WorkflowAccess class

### DIFF
--- a/concrete/src/Permission/Access/WorkflowAccess.php
+++ b/concrete/src/Permission/Access/WorkflowAccess.php
@@ -5,6 +5,11 @@ use Concrete\Core\Workflow\Progress\Progress;
 
 class WorkflowAccess extends Access
 {
+    /**
+     * @var Progress
+     */
+    protected $wp;
+
     public function setWorkflowProgressObject(Progress $wp)
     {
         $this->wp = $wp;


### PR DESCRIPTION
Simple fix to avoid undefined property error