### PR TITLE
Fix a couple of wrong migration names

### DIFF
--- a/concrete/src/Updater/Migrations/Migrations/Version20220909000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20220909000000.php
@@ -6,7 +6,7 @@ use Concrete\Core\Site\Service;
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-class Version20220519000000 extends AbstractMigration implements RepeatableMigrationInterface
+class Version20220909000000 extends AbstractMigration implements RepeatableMigrationInterface
 {
     /**
      * Refresh PageTypes table

--- a/concrete/src/Updater/Migrations/Migrations/Version20220909100000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20220909100000.php
@@ -8,7 +8,7 @@ use Concrete\Core\Application\UserInterface\Dashboard\Navigation\NavigationCache
 use Concrete\Core\Updater\Migrations\AbstractMigration;
 use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
 
-final class Version20220809215454 extends AbstractMigration implements RepeatableMigrationInterface
+final class Version20220909100000 extends AbstractMigration implements RepeatableMigrationInterface
 {
 
     public function upgradeDatabase()


### PR DESCRIPTION
In #11401 we renamed the file name but not the class name of a couple of migrations