### PR TITLE
make PageItem respect replace_link_with_first_in_nav attribute

### DIFF
--- a/concrete/src/Navigation/Item/PageItem.php
+++ b/concrete/src/Navigation/Item/PageItem.php
@@ -59,6 +59,9 @@ class PageItem extends Item
         $p = Page::getByID($this->pageID);
         if ($p->isExternalLink()) {
             $url = $p->getCollectionPointerExternalLink();
+        } else if ($p->getAttribute('replace_link_with_first_in_nav')) {
+            $child = $p->getFirstChild();
+            $url = $child instanceof Page ? $child->getCollectionLink() : $p->getCollectionLink();
         } else {
             $url = $p->getCollectionLink();
         }


### PR DESCRIPTION
This only addresses one of the items mentioned in #10556. The PageItem::getURL() method appears to be used in more places than just the Top Navigation Bar block so this will also impact other parts of Concrete CMS. This may or may not be desired.
