### PR TITLE
Add on_before_user_logout, enable customization of post-logout URL

### DIFF
--- a/concrete/src/User/Event/Logout.php
+++ b/concrete/src/User/Event/Logout.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Concrete\Core\User\Event;
+
+use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Component\HttpFoundation\Response;
+
+class Logout extends GenericEvent
+{
+    protected const RESPONSE_ARGUMENT_KEY = 'response';
+
+    public function __construct(?int $userID)
+    {
+        parent::__construct($userID, [static::RESPONSE_ARGUMENT_KEY => null]);
+    }
+
+    /**
+     * Get the response to be sent to clients after the logout process (if available).
+     */
+    public function getResponse(): ?Response
+    {
+        $response = $this->getArgument(static::RESPONSE_ARGUMENT_KEY);
+
+        return $response instanceof Response ? $response : null;
+    }
+
+    /**
+     * Set the response to be sent to clients after the logout process.
+     *
+     * @return $this
+     */
+    public function setResponse(?Response $response): self
+    {
+        return $this->setArgument(static::RESPONSE_ARGUMENT_KEY, $response);
+    }
+}


### PR DESCRIPTION
This PR:
- introduces a new `on_before_user_logout` event
- pass an instance of `Concrete\Core\User\Event\Logout` to the `on_before_user_logout`/`on_user_logout` events
- let people hook one of those two events to define the URL to be called after the current user has been logged out
