### PR TITLE
Update CkeditorEditor.php outputSimpleEditor function plugins

### DIFF
--- a/concrete/src/Editor/CkeditorEditor.php
+++ b/concrete/src/Editor/CkeditorEditor.php
@@ -259,7 +259,7 @@ EOL;
      */
     public function outputSimpleEditor($key, $content = null)
     {
-        $simplePlugins = ['basicstyles','dialogadvtab','divarea','image','tab','toolbar','undo','wysiwygarea','normalizeonchange'];
+        $simplePlugins = ['basicstyles','dialogadvtab','divarea','image','tab','toolbar','undo','wysiwygarea','normalizeonchange','concretelink'];
         if ($this->allowFileManager()) {
             $simplePlugins += ['concrete5filemanager', 'concrete5uploadimage'];
         }


### PR DESCRIPTION
Added the 'concretelink' option to the $simplePlugins array. In Concrete v8 the function outputSimpleEditor outputted the redactor editor with the option to create links. In v9 the outputSimpleEditor function contains CKE without link option. I think this option should be active.
