### PR TITLE
Fix $bcc member variable description

### DIFF
--- a/concrete/src/Mail/Service.php
+++ b/concrete/src/Mail/Service.php
@@ -64,7 +64,7 @@ class Service
     protected $cc;
 
     /**
-     * List of "CC" recipients (every item is an array with at key 0 the email address and at key 1 an optional name).
+     * List of "BCC" recipients (every item is an array with at key 0 the email address and at key 1 an optional name).
      *
      * @var array[array]
      */


### PR DESCRIPTION
Just something we noticed consulting the documentation https://documentation.concretecms.org/api/9.1.3/Concrete/Core/Mail/Service.html