### PR TITLE
Fix Undefined array key "scheme" in redis drivers

### DIFF
--- a/concrete/src/Cache/Driver/RedisStashDriver.php
+++ b/concrete/src/Cache/Driver/RedisStashDriver.php
@@ -211,7 +211,7 @@ class RedisStashDriver extends AbstractDriver
                 yield $server;
             }
         } else {
-            yield ['host' => '127.0.0.1', 'port' => '6379', 'timeout' => 5, 'database'=>$database];
+            yield ['scheme' => 'tcp', 'host' => '127.0.0.1', 'port' => 6379, 'timeout' => 5, 'database' => $database];
         }
     }
 

--- a/concrete/src/Session/SessionFactory.php
+++ b/concrete/src/Session/SessionFactory.php
@@ -418,7 +418,7 @@ class SessionFactory implements SessionFactoryInterface
                 yield $server;
             }
         } else {
-            yield ['host' => '127.0.0.1', 'port' => '6379', 'timeout' => 5, 'database'=>$database];
+            yield ['scheme' => 'tcp', 'host' => '127.0.0.1', 'port' => 6379, 'timeout' => 5, 'database' => $database];
         }
     }
 }


### PR DESCRIPTION
This fixes the following error:

```
Undefined array key "scheme"
in concrete/src/Cache/Driver/RedisStashDriver.php:132
```
