### PR TITLE
Optimize getSelectedOptions() method of select attribute

### DIFF
--- a/concrete/attributes/select/controller.php
+++ b/concrete/attributes/select/controller.php
@@ -545,10 +545,13 @@ class Controller extends AttributeTypeController implements
         return $str;
     }
 
+    /**
+     * @return \Doctrine\Common\Collections\Collection|\Concrete\Core\Entity\Attribute\Value\Value\SelectValueOption[]
+     */
     public function getSelectedOptions()
     {
-        if ($this->attributeValue && $this->attributeValue->getValue()) {
-            return $this->attributeValue->getValue()->getSelectedOptions();
+        if ($this->attributeValue && ($value = $this->attributeValue->getValue())) {
+            return $value->getSelectedOptions();
         }
 
         return [];

--- a/concrete/src/Entity/Attribute/Value/Value/SelectValue.php
+++ b/concrete/src/Entity/Attribute/Value/Value/SelectValue.php
@@ -33,7 +33,7 @@ class SelectValue extends AbstractValue implements \IteratorAggregate
     }
 
     /**
-     * @return mixed
+     * @return \Doctrine\Common\Collections\Collection|\Concrete\Core\Entity\Attribute\Value\Value\SelectValueOption[]
      */
     public function getSelectedOptions()
     {


### PR DESCRIPTION
Let's avoid calling `getValue()` twice, and add some phpdoc