### PR TITLE
Add getDefaultOptions() to HTTP client factory

### DIFF
--- a/concrete/src/Http/Client/Factory.php
+++ b/concrete/src/Http/Client/Factory.php
@@ -108,4 +108,14 @@ class Factory
 
         return $client;
     }
+
+    /**
+     * Get the default options for the HTTP client.
+     *
+     * @return array
+     */
+    public function getDefaultOptions(Repository $config)
+    {
+        return $this->getOptions($config);
+    }
 }


### PR DESCRIPTION
At the moment, it's not possible to create an HTTP client adding some some custom options to the default one.

For example, let's say we'd like to use the default options, but specifying a custom User Agent: we can't.

Indeed, at the moment, to create a client we can only:

- [use the default options](https://github.com/concretecms/concretecms/blob/9.2.0/concrete/src/Http/Client/Factory.php#L75), without the possibility to use custom ones
- [use custom options](https://github.com/concretecms/concretecms/blob/9.2.0/concrete/src/Http/Client/Factory.php#L90), without the possibility to use the default ones

In theory, we could make the [`getOptions()` method](https://github.com/concretecms/concretecms/blob/9.2.0/concrete/src/Http/Client/Factory.php#LL39C24-L39C34) public, but that would break any class that extends `Concrete\Core\Http\Client\Factory` and overrides the `getOptions()` method.

So, let's introduce a new `getDefaultOptions()` method to get the default configuration.

That way, we could for example have some code like this:

```php
$factory = app(Concrete\Core\Http\Client\Factory::class);
$client = $factory->createFromOptions(
    ['custom' => 'option'] + $factory->getDefaultOptions()
);
```
