### PR TITLE
Fix warnings when viewing /dashboard/reports/logs

### DIFF
--- a/concrete/src/Logging/Search/ColumnSet/DefaultSet.php
+++ b/concrete/src/Logging/Search/ColumnSet/DefaultSet.php
@@ -56,7 +56,7 @@ class DefaultSet extends ColumnSet
      * @return string
      * @noinspection PhpUnused
      */
-    public function getCollectionLevel($logEntry)
+    public static function getCollectionLevel($logEntry)
     {
         return Levels::getLevelDisplayName($logEntry->getLevel());
     }
@@ -66,7 +66,7 @@ class DefaultSet extends ColumnSet
      * @return string
      * @throws \Illuminate\Contracts\Container\BindingResolutionException
      */
-    public function getFormattedMessage($logEntry)
+    public static function getFormattedMessage($logEntry)
     {
         $app = Application::getFacadeApplication();
         /** @var TextService $textHelper */


### PR DESCRIPTION
This PR fixes these two warnings:

```
call_user_func() expects parameter 1 to be a valid callback, non-static method
Concrete\Core\Logging\Search\ColumnSet\DefaultSet::getCollectionLevel()
should not be called statically
```

```
call_user_func() expects parameter 1 to be a valid callback, non-static method
Concrete\Core\Logging\Search\ColumnSet\DefaultSet::getFormattedMessage()
should not be called statically
```
