### PR TITLE
Fix support for C5_ENVIRONMENT_ONLY env variable

### DIFF
--- a/concrete/src/Application/Application.php
+++ b/concrete/src/Application/Application.php
@@ -302,7 +302,7 @@ class Application extends Container
      */
     public static function isRunThroughCommandLineInterface()
     {
-        return defined('C5_ENVIRONMENT_ONLY') && C5_ENVIRONMENT_ONLY || PHP_SAPI == 'cli' || PHP_SAPI === 'phpdbg';
+        return PHP_SAPI == 'cli' || PHP_SAPI === 'phpdbg';
     }
 
     /**

--- a/concrete/src/Foundation/Runtime/Run/CLIRunner.php
+++ b/concrete/src/Foundation/Runtime/Run/CLIRunner.php
@@ -65,6 +65,10 @@ class CLIRunner implements RunInterface, ApplicationAwareInterface
         $registry->setApplication($this->app);
         $registry->registerCommands();
 
+        if ($this->shouldRunCommands() === false) {
+            return;
+        }
+
         // Load the console commands
 
         \Events::dispatch('on_before_console_run');
@@ -72,5 +76,10 @@ class CLIRunner implements RunInterface, ApplicationAwareInterface
         $console->run($input);
 
         \Events::dispatch('on_after_console_run');
+    }
+
+    protected function shouldRunCommands(): bool
+    {
+        return defined('C5_ENVIRONMENT_ONLY') && C5_ENVIRONMENT_ONLY ? false : true;
     }
 }

--- a/concrete/src/Foundation/Runtime/Run/DefaultRunner.php
+++ b/concrete/src/Foundation/Runtime/Run/DefaultRunner.php
@@ -122,6 +122,9 @@ class DefaultRunner implements RunInterface, ApplicationAwareInterface
         $request = $this->createRequest();
 
         if (!$response) {
+            if ($this->shouldProcessRequest($request) === false) {
+                return null;
+            }
             $response = $this->server->handleRequest($request);
         }
 
@@ -543,5 +546,10 @@ class DefaultRunner implements RunInterface, ApplicationAwareInterface
         $this->eventDispatcher = $urlResolver;
 
         return $this;
+    }
+
+    protected function shouldProcessRequest(Request $request): bool
+    {
+        return defined('C5_ENVIRONMENT_ONLY') && C5_ENVIRONMENT_ONLY ? false : true;
     }
 }


### PR DESCRIPTION
We used to use the `C5_ENVIRONMENT_ONLY` php constant to setup the Concrete environment, without doing anything.

At the moment, this is only partially supported: we use `C5_ENVIRONMENT_ONLY` to determine [if we are running via CLI](https://github.com/concretecms/concretecms/blob/9.2.0/concrete/src/Application/Application.php#L305), but we don't actually respect this setting later on.

For example, we could use some code like this:

```php

const C5_ENVIRONMENT_ONLY = true;
const DIR_APPLICATION = '/path/to/project/root';

$app = require_once DIR_BASE . '/concrete/dispatcher.php';

echo "Here we are!\n";
echo '$app is an instance of ', get_class($app), "\n";
```

At the moment, Concrete thinks we are in a normal CLI environment, doesn't see the command to be executed, and quits showing the list of available CLI commands.

With this PR, the CLI runner simply initializes itself and our custom code can be executed.

Here's the output of the above sample code before and after this change:

<details>
  <summary>Before</summary>

```
concrete 9.2.1b1

Usage:
  command [options] [arguments]

Options:
  -h, --help            Display help for the given command. When no command is given display help for the list command
[...omissis...]
  -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

Available commands:
  completion                         Dump the shell completion script
  help                               Display help for a command
  list                               List commands
 c5
  c5:boards:refresh                  Add content to boards and board instances.
[...omissis...]
  task:update-statistics-trackers    Scan the sitemap for file usage and stack usage to update statistics trackers.
```
</details>

<details>
  <summary>After</summary>

```
Here we are!
$app is an instance of Concrete\Core\Application\Application
```
</details>
