### PR TITLE
Fix check in createUser of Oauth controller

### DIFF
--- a/concrete/src/Authentication/Type/OAuth/GenericOauthTypeController.php
+++ b/concrete/src/Authentication/Type/OAuth/GenericOauthTypeController.php
@@ -334,7 +334,7 @@ abstract class GenericOauthTypeController extends AuthenticationTypeController
     protected function createUser()
     {
         // Make sure that this extractor supports everything we need.
-        if (!$this->supportsEmail() && $this->supportsUniqueId()) {
+        if (!($this->supportsEmail() && $this->supportsUniqueId())) {
             throw new Exception('Email and unique ID support are required for user creation.');
         }
 


### PR DESCRIPTION
`!` has a higher precedence than `&&`
