### PR TITLE
Fix #11460

### DIFF
--- a/concrete/elements/page_types/composer/form/output/buttons.php
+++ b/concrete/elements/page_types/composer/form/output/buttons.php
@@ -142,7 +142,7 @@ $publishDate = $v->getPublishDate();
                 title: '<?=t('Revert Page to Draft')?>',
                 height: 'auto',
                 onOpen: function() {
-                    $('[data-dialog-revert-page=submit').on('click', function () {
+                    $('[data-dialog-revert-page=submit]').on('click', function () {
                         ConcreteRevertPageToDraft.sendRequest();
                     });
                 }


### PR DESCRIPTION
Attempting to revert a page to draft doesn't work. JS Console shows an error about an unrecognised expression. This is due to a missing "]". See #11460 