### PR TITLE
Fix exception when icon is not set in PHP 8.x

### DIFF
--- a/concrete/blocks/feature/controller.php
+++ b/concrete/blocks/feature/controller.php
@@ -147,7 +147,7 @@ class Controller extends BlockController implements UsesFeatureInterface
         $args['paragraph'] = LinkAbstractor::translateTo($args['paragraph']);
         /** @var SanitizeService $security */
         $security = $this->app->make('helper/security');
-        $args['icon'] = $security->sanitizeString($args['icon']);
+        $args['icon'] = isset($args['icon']) ? $security->sanitizeString($args['icon']) : '';
         $args['title'] = $security->sanitizeString($args['title']);
         $args['titleFormat'] = $security->sanitizeString($args['titleFormat']);
         $args['internalLinkCID'] = $security->sanitizeInt($args['internalLinkCID']);


### PR DESCRIPTION
Using the feature block, if the icon is not selected, an exception occurs with PHP 8.x due to an undefined array index. This happened to me when I installed a marketplace theme that swapped content, that used invalid icon names.
