### PR TITLE
Fix PHP 8.2 warnings

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -323,16 +323,16 @@
         },
         {
             "name": "concretecms/dependency-patches",
-            "version": "1.7.4",
+            "version": "1.7.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/concretecms/dependency-patches.git",
-                "reference": "8dbbdcbfe0ed7aae3dcfb0883ea00e1a0554cb7a"
+                "reference": "a64a78a95d5cefead9744dbabccc130b77710541"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/concretecms/dependency-patches/zipball/8dbbdcbfe0ed7aae3dcfb0883ea00e1a0554cb7a",
-                "reference": "8dbbdcbfe0ed7aae3dcfb0883ea00e1a0554cb7a",
+                "url": "https://api.github.com/repos/concretecms/dependency-patches/zipball/a64a78a95d5cefead9744dbabccc130b77710541",
+                "reference": "a64a78a95d5cefead9744dbabccc130b77710541",
                 "shasum": ""
             },
             "require": {
@@ -341,6 +341,9 @@
             "type": "library",
             "extra": {
                 "patches": {
+                    "anahkiasen/html-object:1.4.4": {
+                        "Add PHP 8.1 compatibility": "anahkiasen/html-object/php8.1-compatibility.patch"
+                    },
                     "doctrine/annotations:1.2.7": {
                         "Fix access array offset on value of type null": "doctrine/annotations/access-array-offset-on-null.patch"
                     },
@@ -351,31 +354,11 @@
                     "egulias/email-validator:1.2.15": {
                         "Fix access array offset on value of type null": "egulias/email-validator/access-array-offset-on-null.patch"
                     },
-                    "zendframework/zend-stdlib:2.7.7": {
-                        "Fix ArrayObject::unserialize()": "zendframework/zend-stdlib/ArrayObject-unserialize-continue.patch"
+                    "gettext/gettext:3.5.9": {
+                        "Fix PHP 8 compatibility": "gettext/gettext/php8-compatibility.patch"
                     },
-                    "sunra/php-simple-html-dom-parser:1.5.2": {
-                        "Fix minus in regular expressions": "sunra/php-simple-html-dom-parser/minus-in-regular-expressions.patch",
-                        "Add PHP 8.1 compatibility": "sunra/php-simple-html-dom-parser/php8.1-compatibility.patch"
-                    },
-                    "phpunit/phpunit:4.8.36": {
-                        "Avoid each() in Getopt": "phpunit/phpunit/Getopt-each.patch"
-                    },
-                    "tedivm/jshrink:1.1.0": {
-                        "Fix continue switch in Minifier": "tedivm/jshrink/fix-minifier-loop.patch",
-                        "Update to upstream version 1.3.2": "tedivm/jshrink/update-upstream-1.3.2.patch"
-                    },
-                    "zendframework/zend-code:2.6.3": {
-                        "Fix continue switch in FileGenerator and MethodReflection": "zendframework/zend-code/switch-continue.patch"
-                    },
-                    "zendframework/zend-http:2.6.0": {
-                        "Remove support for the X-Original-Url and X-Rewrite-Url headers": "zendframework/zend-http/no-x-original-url-x-rewrite.patch"
-                    },
-                    "zendframework/zend-mail:2.7.3": {
-                        "Fix idn_to_ascii deprecation warning": "zendframework/zend-mail/fix-idn_to_ascii-deprecation-warning.patch"
-                    },
-                    "zendframework/zend-validator:2.8.2": {
-                        "Fix idn_to_ascii/idn_to_utf8 deprecation warning": "zendframework/zend-validator/fix-idn_to_-deprecation-warning.patch"
+                    "laminas/laminas-code:3.4.1": {
+                        "Add PHP 8.1 compatibility": "laminas/laminas-code/php8.1-compatibility.patch"
                     },
                     "lcobucci/jwt:3.4.5": {
                         "Add PHP 8 compatibility": "lcobucci/jwt/php8-compatibility.patch"
@@ -386,14 +369,37 @@
                     "league/url:3.3.5": {
                         "Add PHP 8.1 compatibility": "league/url/php8.1-compatibility.patch"
                     },
-                    "laminas/laminas-code:3.4.1": {
-                        "Add PHP 8.1 compatibility": "laminas/laminas-code/php8.1-compatibility.patch"
+                    "phpunit/phpunit:4.8.36": {
+                        "Avoid each() in Getopt": "phpunit/phpunit/Getopt-each.patch"
                     },
-                    "anahkiasen/html-object:1.4.4": {
-                        "Add PHP 8.1 compatibility": "anahkiasen/html-object/php8.1-compatibility.patch"
+                    "primal/color:1.0.1": {
+                        "Fix PHP 8 compatibility": "primal/color/php8-compatibility.patch"
+                    },
+                    "sunra/php-simple-html-dom-parser:1.5.2": {
+                        "Fix minus in regular expressions": "sunra/php-simple-html-dom-parser/minus-in-regular-expressions.patch",
+                        "Add PHP 8.1 compatibility": "sunra/php-simple-html-dom-parser/php8.1-compatibility.patch"
+                    },
+                    "tedivm/jshrink:1.1.0": {
+                        "Fix continue switch in Minifier": "tedivm/jshrink/fix-minifier-loop.patch",
+                        "Update to upstream version 1.3.2": "tedivm/jshrink/update-upstream-1.3.2.patch"
                     },
                     "wikimedia/less.php:1.8.2": {
                         "Add PHP 8.2 compatibility": "wikimedia/less.php/fix-php-8.2-compatibility.patch"
+                    },
+                    "zendframework/zend-code:2.6.3": {
+                        "Fix continue switch in FileGenerator and MethodReflection": "zendframework/zend-code/switch-continue.patch"
+                    },
+                    "zendframework/zend-http:2.6.0": {
+                        "Remove support for the X-Original-Url and X-Rewrite-Url headers": "zendframework/zend-http/no-x-original-url-x-rewrite.patch"
+                    },
+                    "zendframework/zend-mail:2.7.3": {
+                        "Fix idn_to_ascii deprecation warning": "zendframework/zend-mail/fix-idn_to_ascii-deprecation-warning.patch"
+                    },
+                    "zendframework/zend-stdlib:2.7.7": {
+                        "Fix ArrayObject::unserialize()": "zendframework/zend-stdlib/ArrayObject-unserialize-continue.patch"
+                    },
+                    "zendframework/zend-validator:2.8.2": {
+                        "Fix idn_to_ascii/idn_to_utf8 deprecation warning": "zendframework/zend-validator/fix-idn_to_-deprecation-warning.patch"
                     }
                 }
             },
@@ -413,9 +419,9 @@
             "homepage": "https://github.com/concretecms/dependency-patches",
             "support": {
                 "issues": "https://github.com/concretecms/dependency-patches/issues",
-                "source": "https://github.com/concretecms/dependency-patches/tree/1.7.4"
+                "source": "https://github.com/concretecms/dependency-patches/tree/1.7.5"
             },
-            "time": "2023-03-14T20:25:27+00:00"
+            "time": "2023-06-13T12:33:30+00:00"
         },
         {
             "name": "concretecms/doctrine-xml",

--- a/concrete/attributes/address/controller.php
+++ b/concrete/attributes/address/controller.php
@@ -32,6 +32,11 @@ class Controller extends AttributeTypeController implements
 {
     public $helpers = ['form', 'lists/countries'];
 
+    public $akHasCustomCountries;
+    public $akDefaultCountry;
+    public $akCustomCountries;
+    public $akGeolocateCountry;
+    
     protected $searchIndexFieldDefinition = [
         'address1' => [
             'type' => 'string',

--- a/concrete/blocks/form/mini_survey.php
+++ b/concrete/blocks/form/mini_survey.php
@@ -25,6 +25,11 @@ class MiniSurvey
      */
     public $db;
 
+    /**
+     * @var bool|null
+     */
+    public $frontEndMode;
+
     public function __construct()
     {
         $this->db = Database::connection();

--- a/concrete/blocks/form/mini_survey.php
+++ b/concrete/blocks/form/mini_survey.php
@@ -368,7 +368,7 @@ class MiniSurvey
         return $rs->fetch();
     }
 
-    public function reorderQuestions($qsID = 0, $qIDs)
+    public function reorderQuestions($qsID, $qIDs)
     {
         $qIDs = explode(',', $qIDs);
         if (!is_array($qIDs)) {

--- a/concrete/blocks/form/mini_survey.php
+++ b/concrete/blocks/form/mini_survey.php
@@ -20,6 +20,11 @@ class MiniSurvey
 
     public $lastSavedqID = 0;
 
+    /**
+     * @var \Concrete\Core\Database\Connection\Connection
+     */
+    public $db;
+
     public function __construct()
     {
         $this->db = Database::connection();

--- a/concrete/src/Announcement/Announcement/Announcement.php
+++ b/concrete/src/Announcement/Announcement/Announcement.php
@@ -56,6 +56,12 @@ class Announcement implements AnnouncementInterface
         return 'concrete-announcement-modal';
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \JsonSerializable::jsonSerialize()
+     */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/Announcement/Broadcast/Broadcast.php
+++ b/concrete/src/Announcement/Broadcast/Broadcast.php
@@ -37,6 +37,12 @@ class Broadcast implements BroadcastInterface
         return $this->announcements;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \JsonSerializable::jsonSerialize()
+     */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/Announcement/Icon/AbstractIcon.php
+++ b/concrete/src/Announcement/Icon/AbstractIcon.php
@@ -4,7 +4,12 @@ namespace Concrete\Core\Announcement\Icon;
 
 abstract class AbstractIcon implements IconInterface
 {
-
+    /**
+     * {@inheritdoc}
+     *
+     * @see \JsonSerializable::jsonSerialize()
+     */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/Area/Layout/Preset/Preset.php
+++ b/concrete/src/Area/Layout/Preset/Preset.php
@@ -10,6 +10,13 @@ class Preset implements PresetInterface
     protected $identifier;
     protected $formatter;
 
+    /**
+     * @deprecated What's deprecated is the "public" part: use the getColumns() method.
+     *
+     * @var \Concrete\Core\Area\Layout\ColumnInterface[]
+     */
+    public $columns = [];
+
     public function __construct($identifier, $name, FormatterInterface $formatter, $columns = array())
     {
         $this->name = $name;

--- a/concrete/src/Attribute/Value/ValueList.php
+++ b/concrete/src/Attribute/Value/ValueList.php
@@ -33,26 +33,56 @@ class ValueList extends ConcreteObject implements \Iterator
         return $this->attributes[$akHandle];
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Iterator::rewind()
+     */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         reset($this->attributes);
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Iterator::current()
+     */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return current($this->attributes);
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Iterator::key()
+     */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return key($this->attributes);
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Iterator::next()
+     */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         next($this->attributes);
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Iterator::valid()
+     */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return $this->current() !== false;

--- a/concrete/src/Editor/LinkAbstractor.php
+++ b/concrete/src/Editor/LinkAbstractor.php
@@ -98,8 +98,10 @@ class LinkAbstractor extends ConcreteObject
      */
     public static function translateFrom($text)
     {
+        if (($text = (string) $text) === '') {
+            return $text;
+        }
         $app = Application::getFacadeApplication();
-        $entityManager = $app->make(EntityManagerInterface::class);
         $resolver = $app->make(ResolverManagerInterface::class);
 
         $text = preg_replace(
@@ -386,7 +388,6 @@ class LinkAbstractor extends ConcreteObject
     public static function export($text)
     {
         $app = Application::getFacadeApplication();
-        $entityManager = $app->make(EntityManagerInterface::class);
 
         $text = static::replacePlaceholder(
             $text,
@@ -407,6 +408,7 @@ class LinkAbstractor extends ConcreteObject
         $dom = new HtmlDomParser();
         $r = $dom->str_get_html($text, true, true, DEFAULT_TARGET_CHARSET, false);
         if (is_object($r)) {
+            $entityManager = $app->make(EntityManagerInterface::class);
             foreach ($r->find('concrete-picture') as $picture) {
                 $fID = $picture->fid;
                 $f = $entityManager->find(File::class, $fID);

--- a/concrete/src/Encryption/PasswordHasher.php
+++ b/concrete/src/Encryption/PasswordHasher.php
@@ -50,7 +50,7 @@ class PasswordHasher
      */
     public function hashPassword($password)
     {
-        return password_hash($password, $this->algorithm, $this->hashOptions);
+        return password_hash($password ?? '', $this->algorithm, $this->hashOptions);
     }
 
     /**

--- a/concrete/src/Entity/Express/Entry.php
+++ b/concrete/src/Entity/Express/Entry.php
@@ -382,7 +382,6 @@ class Entry implements \JsonSerializable, PermissionObjectInterface, AttributeOb
     {
         $this->attributes = new ArrayCollection();
         $this->associations = new ArrayCollection();
-        $this->containing_associations = new ArrayCollection();
         $this->exEntryDateCreated = new \DateTime();
         $this->exEntryDateModified = new \DateTime();
     }

--- a/concrete/src/Error/ErrorList/ErrorList.php
+++ b/concrete/src/Error/ErrorList/ErrorList.php
@@ -39,6 +39,7 @@ class ErrorList implements ArrayAccess, JsonSerializable
      *
      * @see \ArrayAccess::offsetExists()
      */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return $this->errors[$offset];
@@ -51,6 +52,7 @@ class ErrorList implements ArrayAccess, JsonSerializable
      *
      * @return \Concrete\Core\Error\ErrorList\Error\ErrorInterface|null
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return array_get($this->errors, $offset);
@@ -61,6 +63,7 @@ class ErrorList implements ArrayAccess, JsonSerializable
      *
      * @see \ArrayAccess::offsetSet()
      */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         if ($offset === null) {
@@ -75,6 +78,7 @@ class ErrorList implements ArrayAccess, JsonSerializable
      *
      * @see \ArrayAccess::offsetUnset()
      */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->errors[$offset]);

--- a/concrete/src/Express/Form/Control/View/View.php
+++ b/concrete/src/Express/Form/Control/View/View.php
@@ -7,6 +7,10 @@ use Concrete\Core\Form\Control\FormView as BaseFormView;
 
 abstract class View extends BaseFormView
 {
+    /**
+     * @var \Concrete\Core\Entity\Express\Control\Control
+     */
+    protected $control;
 
     public function __construct(ContextInterface $context, Control $control)
     {

--- a/concrete/src/File/Image/Svg/Sanitizer.php
+++ b/concrete/src/File/Image/Svg/Sanitizer.php
@@ -259,7 +259,9 @@ class Sanitizer
             throw SanitizerException::create(SanitizerException::ERROR_FAILED_TO_PARSE_XML);
         }
 
-        $disabled = libxml_disable_entity_loader(true);
+        // In PHP 8.0 and later, PHP uses libxml versions from 2.9.0, libxml_disable_entity_loader is deprecated.
+        // (it's safe to not call it because we don't set LIBXML_NOENT)
+        $disabled = PHP_VERSION_ID >= 80000 ? null : libxml_disable_entity_loader(true);
         $xml = new DOMDocument();
 
         $error = null;
@@ -270,7 +272,9 @@ class Sanitizer
         } catch (Throwable $x) {
             $error = $x;
         } finally {
-            libxml_disable_entity_loader($disabled);
+            if ($disabled !== null) {
+                libxml_disable_entity_loader($disabled);
+            }
         }
 
         if ($error !== null || $loaded === false) {

--- a/concrete/src/File/Set/File.php
+++ b/concrete/src/File/Set/File.php
@@ -7,6 +7,31 @@ use Loader;
 
 class File
 {
+    /**
+     * @var int|string
+     */
+    public $fsfID;
+
+    /**
+     * @var int|string
+     */
+    public $fID;
+
+    /**
+     * @var int|string
+     */
+    public $fsID;
+
+    /**
+     * @var string
+     */
+    public $timestamp;
+
+    /**
+     * @var int|string
+     */
+    public $fsDisplayOrder;
+
     public static function getFileSetFiles(Set $fs)
     {
         $db = Loader::db();

--- a/concrete/src/File/Set/Set.php
+++ b/concrete/src/File/Set/Set.php
@@ -52,9 +52,11 @@ class Set
     public $fsName;
 
     /**
+     * @deprecated this field is not used anymore since ConcreteCMS 8
+     *
      * @var int
      */
-    //public $fsOverrideGlobalPermissions;
+    public $fsOverrideGlobalPermissions;
 
     /**
      * @var int

--- a/concrete/src/File/Set/Set.php
+++ b/concrete/src/File/Set/Set.php
@@ -218,7 +218,7 @@ class Set
     public static function __callStatic($name, $arguments)
     {
         if (strcasecmp($name, 'add') === 0) {
-            return call_user_func_array('static::create', $arguments);
+            return static::create(... $arguments);
         }
         trigger_error("Call to undefined method ".__CLASS__."::$name()", E_USER_ERROR);
     }

--- a/concrete/src/Health/Report/Finding/Control/ButtonControl.php
+++ b/concrete/src/Health/Report/Finding/Control/ButtonControl.php
@@ -39,6 +39,12 @@ class ButtonControl implements ControlInterface
         return new ButtonFormatter();
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \JsonSerializable::jsonSerialize()
+     */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $data = [

--- a/concrete/src/Health/Report/Finding/Control/DropdownControl.php
+++ b/concrete/src/Health/Report/Finding/Control/DropdownControl.php
@@ -24,6 +24,12 @@ class DropdownControl implements ControlInterface
         return new DropdownFormatter();
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \JsonSerializable::jsonSerialize()
+     */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $data = [

--- a/concrete/src/Health/Report/Finding/Control/Location.php
+++ b/concrete/src/Health/Report/Finding/Control/Location.php
@@ -55,6 +55,12 @@ class Location implements LocationInterface
         $this->url = $url;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \JsonSerializable::jsonSerialize()
+     */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/concrete/src/Health/Report/Finding/Control/Traits/SimpleSerializableAndDenormalizableClassTrait.php
+++ b/concrete/src/Health/Report/Finding/Control/Traits/SimpleSerializableAndDenormalizableClassTrait.php
@@ -10,7 +10,12 @@ use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
  */
 trait SimpleSerializableAndDenormalizableClassTrait
 {
-
+    /**
+     * {@inheritdoc}
+     *
+     * @see \JsonSerializable::jsonSerialize()
+     */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $data = [

--- a/concrete/src/Health/Report/Finding/Message/Message.php
+++ b/concrete/src/Health/Report/Finding/Message/Message.php
@@ -18,6 +18,12 @@ class Message implements MessageInterface
         $this->message = $message;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \JsonSerializable::jsonSerialize()
+     */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $data = [

--- a/concrete/src/Health/Report/Finding/Message/Search/AttributeMessage.php
+++ b/concrete/src/Health/Report/Finding/Message/Search/AttributeMessage.php
@@ -23,6 +23,12 @@ class AttributeMessage implements MessageInterface
         $this->value = $value;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \JsonSerializable::jsonSerialize()
+     */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $data = [

--- a/concrete/src/Health/Report/Finding/Message/Search/BlockMessage.php
+++ b/concrete/src/Health/Report/Finding/Message/Search/BlockMessage.php
@@ -27,7 +27,12 @@ class BlockMessage implements MessageInterface
         $this->content = $content;
     }
 
-
+    /**
+     * {@inheritdoc}
+     *
+     * @see \JsonSerializable::jsonSerialize()
+     */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $data = [

--- a/concrete/src/Html/Object/Collection.php
+++ b/concrete/src/Html/Object/Collection.php
@@ -7,21 +7,45 @@ class Collection implements \ArrayAccess, \Iterator
 {
     protected $elements = array();
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \ArrayAccess::offsetExists()
+     */
+    #[\ReturnTypeWillChange]
     public function offsetExists($offset)
     {
         return isset($this->elements[$offset]);
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \ArrayAccess::offsetGet()
+     */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         return $this->elements[$offset];
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \ArrayAccess::offsetSet()
+     */
+    #[\ReturnTypeWillChange]
     public function offsetSet($offset, $value)
     {
         $this->elements[$offset] = $value;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \ArrayAccess::offsetUnset()
+     */
+    #[\ReturnTypeWillChange]
     public function offsetUnset($offset)
     {
         unset($this->elements[$offset]);

--- a/concrete/src/Html/Object/Collection.php
+++ b/concrete/src/Html/Object/Collection.php
@@ -51,26 +51,56 @@ class Collection implements \ArrayAccess, \Iterator
         unset($this->elements[$offset]);
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Iterator::rewind()
+     */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         reset($this->elements);
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Iterator::current()
+     */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return current($this->elements);
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Iterator::key()
+     */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return key($this->elements);
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Iterator::next()
+     */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         next($this->elements);
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Iterator::valid()
+     */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return $this->current() !== false;

--- a/concrete/src/Html/Object/Picture.php
+++ b/concrete/src/Html/Object/Picture.php
@@ -32,7 +32,7 @@ class Picture extends Element
     //////////////////////////// CORE METHODS //////////////////////////
     ////////////////////////////////////////////////////////////////////
 
-    public function __construct(array $sources = [], $fallbackSrc, $attributes = [], $lazyLoadNative = false, $lazyLoadJavaScript = false)
+    public function __construct(array $sources = [], $fallbackSrc = '', $attributes = [], $lazyLoadNative = false, $lazyLoadJavaScript = false)
     {
         $this->sources($sources, $lazyLoadJavaScript);
 

--- a/concrete/src/Localization/Service/AddressFormat.php
+++ b/concrete/src/Localization/Service/AddressFormat.php
@@ -116,7 +116,7 @@ class AddressFormat
 
         // Addressing does not currently support a third address line.
         // See: https://github.com/commerceguys/addressing/pull/121
-        $line2 = trim($addressData['address2']);
+        $line2 = trim($addressData['address2'] ?? '');
         if (!empty($addressData['address3'])) {
             if (!empty($line2)) {
                 $line2 .= ', ';
@@ -303,7 +303,7 @@ class AddressFormat
         $postalAreaLine = '';
         if (isset($addressData['city'])) {
             $postalAreaLine = $addressData['city'];
-            if ($addressData['state_province']) {
+            if ($addressData['state_province'] ?? '') {
                 // The country is unknown, so the text representation of the
                 // state or the provice cannot be determined. Fall back to the
                 // code.

--- a/concrete/src/Logging/GroupLogger.php
+++ b/concrete/src/Logging/GroupLogger.php
@@ -7,7 +7,12 @@ use Monolog\Logger as Monolog;
 class GroupLogger
 {
     protected $level;
-    protected $messages = array();
+    protected $messages = [];
+
+    /**
+     * @var \Psr\Log\LoggerInterface
+     */
+    protected $logger;
 
     public function __construct($channel = false, $level = Logger::DEBUG)
     {
@@ -25,8 +30,7 @@ class GroupLogger
     public function close($context = array())
     {
         $method = 'add' . ucfirst(strtolower(Monolog::getLevelName($this->level)));
-        $arguments = array(implode("\n", $this->messages), $context);
 
-        return call_user_func_array(array($this->logger, $method), $arguments);
+        return call_user_func([$this->logger, $method], implode("\n", $this->messages), $context);
     }
 }

--- a/concrete/src/Logging/LogEntry.php
+++ b/concrete/src/Logging/LogEntry.php
@@ -286,10 +286,7 @@ class LogEntry
         $db = $app->make('database')->connection();
         $row = $db->fetchAssoc('select * from Logs where logID = ?', [$logID]);
         if ($row) {
-            $obj = new static();
-            $obj = array_to_object($obj, $row);
-
-            return $obj;
+            return new static($row);
         }
     }
 

--- a/concrete/src/Navigation/Breadcrumb/Dashboard/DashboardBreadcrumb.php
+++ b/concrete/src/Navigation/Breadcrumb/Dashboard/DashboardBreadcrumb.php
@@ -71,26 +71,56 @@ class DashboardBreadcrumb implements BreadcrumbInterface, \Iterator
         return $this;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Iterator::rewind()
+     */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         reset($this->items);
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Iterator::current()
+     */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return current($this->items);
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Iterator::key()
+     */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return key($this->items);
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Iterator::next()
+     */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         next($this->items);
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Iterator::valid()
+     */
+    #[\ReturnTypeWillChange]
     public function valid()
     {
         return $this->current() !== false;

--- a/concrete/src/Navigation/Breadcrumb/PageBreadcrumb.php
+++ b/concrete/src/Navigation/Breadcrumb/PageBreadcrumb.php
@@ -52,41 +52,59 @@ class PageBreadcrumb implements BreadcrumbInterface, \Iterator
     }
 
     /**
-     * @return void
+     * {@inheritdoc}
+     *
+     * @see \Iterator::rewind()
      */
+    #[\ReturnTypeWillChange]
     public function rewind()
     {
         reset($this->items);
     }
 
     /**
+     * {@inheritdoc}
+     *
+     * @see \Iterator::current()
+     *
      * @return \Concrete\Core\Navigation\Item\ItemInterface|false
      */
+    #[\ReturnTypeWillChange]
     public function current()
     {
         return current($this->items);
     }
 
     /**
+     * {@inheritdoc}
+     *
+     * @see \Iterator::key()
+     *
      * @return int|string
      */
+    #[\ReturnTypeWillChange]
     public function key()
     {
         return key($this->items);
     }
 
     /**
-     * @return void
+     * {@inheritdoc}
+     *
+     * @see \Iterator::next()
      */
+    #[\ReturnTypeWillChange]
     public function next()
     {
         next($this->items);
     }
 
     /**
-     * @return bool
+     * {@inheritdoc}
+     *
+     * @see \Iterator::valid()
      */
-    public function valid():bool
+    public function valid(): bool
     {
         return $this->current() !== false;
     }

--- a/concrete/src/Notification/Subscription/Manager.php
+++ b/concrete/src/Notification/Subscription/Manager.php
@@ -1,13 +1,14 @@
 <?php
 namespace Concrete\Core\Notification\Subscription;
 
-use Concrete\Core\Application\Application;
-use Concrete\Core\Support\Manager as CoreManager;
-
-defined('C5_EXECUTE') or die("Access Denied.");
+defined('C5_EXECUTE') or die('Access Denied.');
 
 class Manager
 {
+    /**
+     * @var \Concrete\Core\Notification\Type\Manager
+     */
+    protected $typeManager;
 
     public function __construct(\Concrete\Core\Notification\Type\Manager $manager)
     {

--- a/concrete/src/Page/Type/Saver/StandardSaver.php
+++ b/concrete/src/Page/Type/Saver/StandardSaver.php
@@ -15,6 +15,11 @@ class StandardSaver implements SaverInterface
 
     protected $ptDraftVersionsToSave = 10;
 
+    /**
+     * @var \Concrete\Core\Page\Type\Type|null
+     */
+    protected $type;
+
     public function setPageTypeObject(Type $type)
     {
         $this->type = $type;

--- a/concrete/src/Page/Type/Validator/StandardValidator.php
+++ b/concrete/src/Page/Type/Validator/StandardValidator.php
@@ -12,6 +12,13 @@ use Core;
 
 class StandardValidator implements ValidatorInterface
 {
+    /**
+     * @deprecated What's deprecated is the "public" part: use the setPageTypeObject()/getPageTypeObject() methods instead
+     *
+     * @var \Concrete\Core\Page\Type\Type|null
+     */
+    public $type;
+
     public function setPageTypeObject(Type $type)
     {
         $this->type = $type;

--- a/concrete/src/Search/ItemList/Pager/QueryString/VariableFactory.php
+++ b/concrete/src/Search/ItemList/Pager/QueryString/VariableFactory.php
@@ -11,6 +11,13 @@ class VariableFactory
 
     protected $itemList;
 
+    /**
+     * @deprecated What's deprecated is the "public" part
+     *
+     * @var array
+     */
+    public $requestData;
+
     public function getCursorVariableName()
     {
         return 'ccm_cursor';

--- a/concrete/src/Search/ItemList/Pager/QueryString/VariableFactory.php
+++ b/concrete/src/Search/ItemList/Pager/QueryString/VariableFactory.php
@@ -40,9 +40,7 @@ class VariableFactory
 
     public function getCursorValue()
     {
-        if (isset($this->requestData[$this->getCursorVariableName()])) {
-            return $this->requestData[$this->getCursorVariableName()];
-        }
+        return $this->requestData[$this->getCursorVariableName()] ?? '';
     }
 
     public function getCurrentCursor()

--- a/concrete/src/Search/Pagination/Adapter/PagerAdapter.php
+++ b/concrete/src/Search/Pagination/Adapter/PagerAdapter.php
@@ -11,6 +11,11 @@ class PagerAdapter implements AdapterInterface
 
     protected $itemList;
 
+    /**
+     * @var mixed|null
+     */
+    public $firstResult;
+
     public function __construct(ItemList $itemList)
     {
         $this->itemList = $itemList;
@@ -54,7 +59,7 @@ class PagerAdapter implements AdapterInterface
             foreach($results as $result) {
                 if ($this->checkPermissions($checker, $result)) {
 
-                    if (!isset($this->firstResult)) {
+                    if ($this->firstResult === null) {
                         $this->firstResult = $result;
                     }
 

--- a/concrete/src/Session/Storage/Handler/RedisSessionHandler.php
+++ b/concrete/src/Session/Storage/Handler/RedisSessionHandler.php
@@ -60,9 +60,6 @@ class RedisSessionHandler extends SessionHandler
         $this->prefix = $options['prefix'] ? $options['prefix'] : 'sf_s';
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function doRead($sessionId)
     {
         return $this->redis->get($this->prefix.$sessionId) ?: '';
@@ -70,15 +67,15 @@ class RedisSessionHandler extends SessionHandler
 
     /**
      * {@inheritdoc}
+     *
+     * @see \SessionHandler::read()
      */
+    #[\ReturnTypeWillChange]
     public function read($session_id)
     {
         return $this->doRead($session_id);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function doWrite($sessionId, $data)
     {
         $result = $this->redis->setex($this->prefix.$sessionId, (int) ini_get('session.gc_maxlifetime'), $data);
@@ -88,7 +85,10 @@ class RedisSessionHandler extends SessionHandler
 
     /**
      * {@inheritdoc}
+     *
+     * @see \SessionHandler::write()
      */
+    #[\ReturnTypeWillChange]
     public function write($session_id, $session_data)
     {
         return $this->doWrite($session_id, $session_data);
@@ -96,15 +96,15 @@ class RedisSessionHandler extends SessionHandler
 
     /**
      * {@inheritdoc}
+     *
+     * @see \SessionHandler::destroy()
      */
+    #[\ReturnTypeWillChange]
     public function destroy($session_id)
     {
         return $this->doDestroy($session_id);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function doDestroy($sessionId)
     {
         $this->redis->del($this->prefix.$sessionId);
@@ -114,7 +114,10 @@ class RedisSessionHandler extends SessionHandler
 
     /**
      * {@inheritdoc}
+     *
+     * @see \SessionHandler::close()
      */
+    #[\ReturnTypeWillChange]
     public function close()
     {
         return true;
@@ -122,15 +125,15 @@ class RedisSessionHandler extends SessionHandler
 
     /**
      * {@inheritdoc}
+     *
+     * @see \SessionHandler::gc()
      */
+    #[\ReturnTypeWillChange]
     public function gc($maxlifetime)
     {
         return true;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function updateTimestamp($sessionId, $data)
     {
         return (bool) $this->redis->expire($this->prefix.$sessionId, (int) ini_get('session.gc_maxlifetime'));

--- a/concrete/src/User/Group/GroupAutomationController.php
+++ b/concrete/src/User/Group/GroupAutomationController.php
@@ -5,11 +5,21 @@ use Concrete\Core\User\User;
 
 abstract class GroupAutomationController
 {
+    /**
+     * @deprecated What's deprecated is the "public" part: use the getGroupObject() method instead.
+     *
+     * @var \Concrete\Core\User\Group\Group
+     */
+    public $group;
+
     /** 
      * Return true to automatically enter the current ux into the group.
      */
     abstract public function check(User $ux);
 
+    /**
+     * @return \Concrete\Core\User\Group\Group
+     */
     public function getGroupObject()
     {
         return $this->group;

--- a/concrete/src/User/RegistrationService.php
+++ b/concrete/src/User/RegistrationService.php
@@ -90,7 +90,7 @@ class RegistrationService implements RegistrationServiceInterface
             $uIsFullRecord = 1;
         }
 
-        $password_to_insert = isset($data['uPassword']) ? $data['uPassword'] : null;
+        $password_to_insert = $data['uPassword'] ?? '';
         $hash = $hasher->hashPassword($password_to_insert);
 
         $uDefaultLanguage = null;

--- a/concrete/src/View/View.php
+++ b/concrete/src/View/View.php
@@ -206,11 +206,11 @@ class View extends AbstractView
             switch ($this->themeHandle) {
                 case VIEW_CORE_THEME:
                     $this->themeObject = new \Concrete\Theme\Concrete\PageTheme();
-                    $this->pkgHandle = false;
+                    $this->themePkgHandle = false;
                     break;
                 case 'dashboard':
                     $this->themeObject = new \Concrete\Theme\Dashboard\PageTheme();
-                    $this->pkgHandle = false;
+                    $this->themePkgHandle = false;
                     break;
                 default:
                     if (!isset($this->themeObject)) {

--- a/concrete/src/Workflow/BasicWorkflow.php
+++ b/concrete/src/Workflow/BasicWorkflow.php
@@ -315,7 +315,7 @@ class BasicWorkflow extends \Concrete\Core\Workflow\Workflow implements Assignab
         return $buttons;
     }
 
-    private function getTranslatedMessage($message = null, $date)
+    private function getTranslatedMessage($message, $date)
     {
 
         if (is_array($message)) {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,6 @@
 <phpunit
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/sebastianbergmann/phpunit/4.8.36/phpunit.xsd"
+        xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/sebastianbergmann/phpunit/8.5.20/phpunit.xsd"
         bootstrap="./tests/bootstrap.php"
         colors="true"
         convertErrorsToExceptions="true"
@@ -34,5 +34,6 @@
     </groups>
     <php>
         <ini name="memory_limit" value="-1"/>
+        <ini name="error_reporting" value="-1"/>
     </php>
 </phpunit>

--- a/tests/assets/Localization/Adapter/Laminas/translations.php
+++ b/tests/assets/Localization/Adapter/Laminas/translations.php
@@ -29,6 +29,6 @@ return [
         0 => '%d X %s',
         1 => '%d X %s',
     ],
-    "context${cs}Welcome!" => 'E!',
-    "context${cs}Welcome %s!" => 'E %s!',
+    "context{$cs}Welcome!" => 'E!',
+    "context{$cs}Welcome %s!" => 'E %s!',
 ];

--- a/tests/assets/Page/package/awesome_package.php
+++ b/tests/assets/Page/package/awesome_package.php
@@ -6,4 +6,8 @@ use Concrete\Core\Package\Package;
 
 class Controller extends Package
 {
+    /**
+     * @var string|null
+     */
+    public $pkgHandle;
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -50,9 +50,6 @@ Request::setInstance(new Request(
 $app = require DIR_BASE_CORE . '/bootstrap/start.php';
 /* @var Concrete\Core\Application\Application $app */
 
-// Configure error reporting (test more strictly than core settings)
-error_reporting(E_ALL & ~E_STRICT & ~E_DEPRECATED);
-
 // Initialize the database
 $cn = $app->make('database')->connection('ccm_testWithoutDB');
 $cn->connect();

--- a/tests/helpers/Area/HtmlColumn.php
+++ b/tests/helpers/Area/HtmlColumn.php
@@ -7,6 +7,8 @@ use HtmlObject\Element;
 
 class HtmlColumn implements ColumnInterface
 {
+    public $class;
+
     public function __construct($class)
     {
         $this->class = $class;

--- a/tests/helpers/Attribute/AttributeValueTestCase.php
+++ b/tests/helpers/Attribute/AttributeValueTestCase.php
@@ -39,6 +39,16 @@ abstract class AttributeValueTestCase extends ConcreteDatabaseTestCase
         'Groups',
     ];
 
+    /**
+     * @var \Concrete\Core\Attribute\Category\CategoryInterface
+     */
+    protected $category;
+
+    /**
+     * @var \Concrete\Core\Page\Page|\Concrete\Core\Attribute\ObjectInterface
+     */
+    protected $object;
+
     public function setUp(): void
     {
         $service = Core::make('site/type');

--- a/tests/tests/Database/EntityManager/Driver/CoreDriverTest.php
+++ b/tests/tests/Database/EntityManager/Driver/CoreDriverTest.php
@@ -25,9 +25,9 @@ class CoreDriverTest extends TestCase
     protected $coreDriver;
 
     /**
-     * @var \Doctrine\Common\Persistence\Mapping\Driver\MappingDriverChain
+     * @var \Doctrine\Persistence\Mapping\Driver\MappingDriverChain
      */
-    protected $dirverChain;
+    protected $driverChain;
 
     /**
      * Setup.

--- a/tests/tests/Database/EntityManager/Driver/DriverTest.php
+++ b/tests/tests/Database/EntityManager/Driver/DriverTest.php
@@ -14,6 +14,11 @@ use Concrete\Tests\TestCase;
  */
 class DriverTest extends TestCase
 {
+    /**
+     * @var \Concrete\Core\Database\EntityManager\Driver\Driver
+     */
+    protected $driver;
+
     public function setUp():void
     {
         parent::setUp();

--- a/tests/tests/Database/EntityManager/Provider/XmlProviderTest.php
+++ b/tests/tests/Database/EntityManager/Provider/XmlProviderTest.php
@@ -30,8 +30,8 @@ class XmlProviderTest extends TestCase
      */
     public function setUp():void
     {
-        $this->app = Application::getFacadeApplication();
-        $this->packageStub = new PackageControllerXml($this->app);
+        $app = Application::getFacadeApplication();
+        $this->packageStub = new PackageControllerXml($app);
         parent::setUp();
     }
 

--- a/tests/tests/Database/EntityManager/Provider/YamlProviderTest.php
+++ b/tests/tests/Database/EntityManager/Provider/YamlProviderTest.php
@@ -30,8 +30,8 @@ class YamlProviderTest extends TestCase
      */
     public function setUp():void
     {
-        $this->app = Application::getFacadeApplication();
-        $this->packageStub = new PackageControllerYaml($this->app);
+        $app = Application::getFacadeApplication();
+        $this->packageStub = new PackageControllerYaml($app);
         parent::setUp();
     }
 

--- a/tests/tests/Database/EntityManagerClassLoaderTest.php
+++ b/tests/tests/Database/EntityManagerClassLoaderTest.php
@@ -6,6 +6,11 @@ use Concrete\Tests\TestCase;
 
 class EntityManagerClassLoaderTest extends TestCase
 {
+    /**
+     * @var \Concrete\Core\Application\Application
+     */
+    protected $app;
+
     public function setUp():void
     {
         parent::setUp();

--- a/tests/tests/File/Service/ZipTest.php
+++ b/tests/tests/File/Service/ZipTest.php
@@ -14,9 +14,15 @@ class ZipTest extends TestCase
      */
     protected $zipHelper;
 
-    protected $rootDir = null;
+    /**
+     * @var string|null
+     */
+    protected $workDir;
 
-    protected $fileSystemProblem = null;
+    /**
+     * @var string|null
+     */
+    protected $fileSystemProblem;
 
     public function setUp():void
     {

--- a/tests/tests/Localization/Adapter/Laminas/Translation/Loader/Gettext/PackagesTranslationLoaderTest.php
+++ b/tests/tests/Localization/Adapter/Laminas/Translation/Loader/Gettext/PackagesTranslationLoaderTest.php
@@ -25,6 +25,16 @@ class PackagesTranslationLoaderTest extends ConcreteDatabaseTestCase
     private static $packagesInstalled = false;
 
     /**
+     * @var \Concrete\Core\Localization\Translator\TranslatorAdapterInterface|null
+     */
+    protected $adapter;
+
+    /**
+     * @var \Concrete\Core\Localization\Translator\Translation\TranslationLoaderInterface|null
+     */
+    protected $loader;
+
+    /**
      * Move a couple of test packages to the packages folder to be used by
      * these tests.
      */
@@ -81,7 +91,7 @@ class PackagesTranslationLoaderTest extends ConcreteDatabaseTestCase
         $installPackages = self::getTestPackages();
         foreach ($installPackages as $pkg => $dir) {
             $package = Package::getClass($pkg);
-            $p = $package->install();
+            $package->install();
         }
 
         $factory = new TranslatorAdapterFactory();

--- a/tests/tests/Localization/Adapter/Laminas/Translation/Loader/Gettext/SiteTranslationLoaderTest.php
+++ b/tests/tests/Localization/Adapter/Laminas/Translation/Loader/Gettext/SiteTranslationLoaderTest.php
@@ -17,6 +17,16 @@ use Illuminate\Filesystem\Filesystem;
  */
 class SiteTranslationLoaderTest extends LocalizationTestsBase
 {
+    /**
+     * @var \Concrete\Core\Localization\Translator\TranslatorAdapterFactoryInterface
+     */
+    protected $adapter;
+
+    /**
+     * @var \Concrete\Core\Localization\Translator\Translation\TranslationLoaderInterface
+     */
+    protected $loader;
+
     public static function setUpBeforeClass():void
     {
         parent::setUpBeforeClass();

--- a/tests/tests/Logging/LogTest.php
+++ b/tests/tests/Logging/LogTest.php
@@ -36,6 +36,11 @@ class LogTest extends ConcreteDatabaseTestCase
     protected $tables = ['Logs'];
     protected $app;
 
+    /**
+     * @var \Concrete\Core\Database\Connection\Connection
+     */
+    protected $db;
+
     public function setUp(): void
     {
         parent::setUp();

--- a/tests/tests/Logging/LogTest.php
+++ b/tests/tests/Logging/LogTest.php
@@ -2,38 +2,33 @@
 
 namespace Concrete\Tests\Logging;
 
-use Cascade\Cascade;
 use Concrete\Core\Application\Application;
-use Concrete\Core\Config\Repository\Repository;
 use Concrete\Core\Database\Connection\Connection;
-use Concrete\Core\Entity\Site\Site;
 use Concrete\Core\Logging\Channels;
 use Concrete\Core\Logging\Configuration\AdvancedConfiguration;
 use Concrete\Core\Logging\Configuration\ConfigurationFactory;
-use Concrete\Core\Logging\Configuration\SimpleConfiguration;
 use Concrete\Core\Logging\Configuration\SimpleDatabaseConfiguration;
 use Concrete\Core\Logging\Configuration\SimpleFileConfiguration;
 use Concrete\Core\Logging\GroupLogger;
 use Concrete\Core\Logging\Handler\DatabaseHandler;
 use Concrete\Core\Logging\LoggerFactory;
 use Concrete\Core\Logging\Processor\ConcreteUserProcessor;
-use Concrete\Core\Site\Service;
 use Concrete\Core\Support\Facade\Facade;
 use Concrete\Core\Support\Facade\Log;
 use Concrete\TestHelpers\Database\ConcreteDatabaseTestCase;
 use Illuminate\Filesystem\Filesystem;
 use Mockery as M;
 use Monolog\Formatter\LineFormatter;
-use Monolog\Handler\NullHandler;
-use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 use Concrete\Core\Logging\LogEntry;
 use Monolog\Processor\PsrLogMessageProcessor;
+use Concrete\Core\Entity\User;
 
 class LogTest extends ConcreteDatabaseTestCase
 {
     protected $fixtures = [];
     protected $tables = ['Logs'];
+    protected $metadatas = [User\User::class, User\UserSignup::class];
     protected $app;
 
     /**

--- a/tests/tests/Routing/URLTest.php
+++ b/tests/tests/Routing/URLTest.php
@@ -12,6 +12,26 @@ use URL;
 class URLTest extends TestCase
 {
     /**
+     * @var \Concrete\Core\Page\Page
+     */
+    protected $page;
+
+    /**
+     * @var \Concrete\Core\Page\Page
+     */
+    protected $dashboard;
+
+    /**
+     * @var \Concrete\Core\Html\Service\Navigation
+     */
+    protected $service;
+
+    /**
+     * @var string|null
+     */
+    protected $oldUrl;
+
+    /**
      * Here's the expected behavior.
      * All URLs generated should have index.php in front of them if
      * concrete.seo.url_rewriting is false.


### PR DESCRIPTION
We still have some PHP 8.2 warnings in the core, and to be sure that Concrete will work in future PHP versions too we should fix them.

Let's start by making the tests stricter: they should fail.

I'll update this PR with the appropriate fixes.