### PR TITLE
Fix accessing undefined array index in dialog/block/design.php

### DIFF
--- a/concrete/controllers/dialog/block/design.php
+++ b/concrete/controllers/dialog/block/design.php
@@ -70,7 +70,7 @@ class Design extends BackendInterfaceBlockController
 
             if ($this->permissions->canEditBlockCustomTemplate()) {
                 $data = [];
-                $data['bFilename'] = $r['bFilename'];
+                $data['bFilename'] = $r['bFilename'] ?? null;
                 $b->updateBlockInformation($data);
             }
 


### PR DESCRIPTION
I see this error in the logs:

concrete/controllers/dialog/block/design.php:73: Undefined array key "bFilename"

Let's fix this issue.