### PR TITLE
Declare width and height ccmi18n_filemanager property that's in use

### DIFF
--- a/concrete/controllers/frontend/assets_localization.php
+++ b/concrete/controllers/frontend/assets_localization.php
@@ -319,6 +319,8 @@ var ccmi18n_filemanager = ' . json_encode([
     'uploadProgress' => t('Upload Progress'),
     'view' => t('View'),
     'uploadFiles' => t('Upload Files'),
+    'width' => t('Width'),
+    'height' => t('Height'),
 ]) . ';
 
 var ccmi18n_chosen = ' . json_encode([

--- a/concrete/controllers/frontend/assets_localization.php
+++ b/concrete/controllers/frontend/assets_localization.php
@@ -321,6 +321,7 @@ var ccmi18n_filemanager = ' . json_encode([
     'uploadFiles' => t('Upload Files'),
     'width' => t('Width'),
     'height' => t('Height'),
+    'size' => t('Size'),
 ]) . ';
 
 var ccmi18n_chosen = ' . json_encode([


### PR DESCRIPTION
Declare width, height and size in ccmi18n_filemanager object is used in ConcreteFileChooser component
See this file https://github.com/concretecms/bedrock/blob/master/assets/cms/components/file-manager/Chooser/Files.vue