### PR TITLE
Let packages declare their minimum supported PHP version

### DIFF
--- a/concrete/src/Package/Offline/PackageInfo.php
+++ b/concrete/src/Package/Offline/PackageInfo.php
@@ -43,11 +43,18 @@ class PackageInfo
     private $description = '';
 
     /**
-     * The minimum concrete5 version.
+     * The minimum Concrete version.
      *
      * @var string
      */
     private $minimumCoreVersion = '';
+
+    /**
+     * The minimum PHP version.
+     *
+     * @var string
+     */
+    private $minimumPHPVersion = '';
 
     /**
      * Create a new instance of this class.
@@ -180,7 +187,7 @@ class PackageInfo
     }
 
     /**
-     * Get the minimum concrete5 version.
+     * Get the minimum Concrete version.
      *
      * @return string
      */
@@ -190,7 +197,7 @@ class PackageInfo
     }
 
     /**
-     * Get the mayor minimum concrete5 version.
+     * Get the major minimum Concrete version.
      *
      * @return string
      *
@@ -208,7 +215,7 @@ class PackageInfo
     }
 
     /**
-     * Set the minimum concrete5 version.
+     * Set the minimum Concrete version.
      *
      * @param string $value
      *
@@ -217,6 +224,26 @@ class PackageInfo
     public function setMinimumCoreVersion($value)
     {
         $this->minimumCoreVersion = $value;
+
+        return $this;
+    }
+
+    /**
+     * Get the minimum PHP version.
+     */
+    public function getMinimumPHPVersion(): string
+    {
+        return $this->minimumPHPVersion;
+    }
+
+    /**
+     * Set the minimum PHP version.
+     *
+     * @return $this
+     */
+    public function setMinimumPHPVersion(string $value): self
+    {
+        $this->minimumPHPVersion = $value;
 
         return $this;
     }

--- a/concrete/src/Package/Offline/Parser.php
+++ b/concrete/src/Package/Offline/Parser.php
@@ -54,6 +54,7 @@ abstract class Parser
             ->setName($this->getPackageName($tokens, $className, $classStart, $classEnd))
             ->setDescription($this->getPackageDescription($tokens, $className, $classStart, $classEnd))
             ->setMinimumCoreVersion($this->getPackageMinimumCodeVersion($tokens, $className, $classStart, $classEnd))
+            ->setMinimumPHPVersion($this->getPackageMinimumPHPVersion($tokens, $className, $classStart, $classEnd))
         ;
     }
 
@@ -249,7 +250,7 @@ abstract class Parser
     }
 
     /**
-     * Get the minimum supported core version version.
+     * Get the minimum supported core version.
      *
      * @param array $tokens the PHP tokens of the package controlller.php file
      * @param string $className the  class name of the package controller
@@ -265,6 +266,25 @@ abstract class Parser
         $fromProperty = $this->getPropertyValue($tokens, '$appVersionRequired', $classStart, $classEnd);
 
         return (string) $fromProperty === '' ? $this->getDefaultPackageMinimumCodeVersion() : $fromProperty;
+    }
+
+    /**
+     * Get the minimum supported PHP version.
+     *
+     * @param array $tokens the PHP tokens of the package controlller.php file
+     * @param string $className the  class name of the package controller
+     * @param int $classStart the index of the first PHP token of the class body (its first '{')
+     * @param int $classEnd the index of the last PHP token of the class body (its last '}'}
+     *
+     * @throws \Concrete\Core\Package\Offline\Exception in case of problems
+     *
+     * @return string
+     */
+    protected function getPackageMinimumPHPVersion(array $tokens, string $className, int $classStart, int $classEnd): string
+    {
+        $fromProperty = $this->getPropertyValue($tokens, '$phpVersionRequired', $classStart, $classEnd);
+        
+        return (string) $fromProperty;
     }
 
     /**

--- a/concrete/src/Package/Offline/Parser/FiveSeven.php
+++ b/concrete/src/Package/Offline/Parser/FiveSeven.php
@@ -80,6 +80,6 @@ class FiveSeven extends Parser
      */
     protected function getDefaultPackageMinimumCodeVersion()
     {
-        return '5.7.0'; // https://github.com/concrete5/concrete5/blob/8.5.1/concrete/src/Package/Package.php#L183
+        return '5.7.0'; // https://github.com/concretecms/concretecms/blob/8.5.1/concrete/src/Package/Package.php#L183
     }
 }

--- a/concrete/src/Package/Offline/Parser/Legacy.php
+++ b/concrete/src/Package/Offline/Parser/Legacy.php
@@ -50,6 +50,6 @@ class Legacy extends Parser
      */
     protected function getDefaultPackageMinimumCodeVersion()
     {
-        return '5.0.0'; // https://github.com/concrete5/concrete5-legacy/blob/5.6.4.0/web/concrete/core/models/package.php#L144
+        return '5.0.0'; // https://github.com/concretecms/concrete5-legacy/blob/5.6.4.0/web/concrete/core/models/package.php#L144
     }
 }

--- a/concrete/src/Package/Package.php
+++ b/concrete/src/Package/Package.php
@@ -17,7 +17,6 @@ use Concrete\Core\Page\Theme\Theme;
 use Concrete\Core\Support\Facade\Application as ApplicationFacade;
 use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Doctrine\Common\Proxy\ProxyGenerator;
-use Doctrine\DBAL\Driver\PDOConnection;
 use Doctrine\DBAL\Schema\Comparator as SchemaComparator;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
@@ -97,6 +96,13 @@ abstract class Package implements LocalizablePackageInterface
      * @var int
      */
     const E_PACKAGE_THEME_ACTIVE = 21;
+
+    /**
+     * Error code: This package requires PHP version %1$s or greater (the current PHP version is %2$s).
+     *
+     * @var int
+     */
+    const E_PACKAGE_PHP_VERSION = 22;
 
     /**
      * Absolute path to the /concrete/packages directory.
@@ -183,6 +189,15 @@ abstract class Package implements LocalizablePackageInterface
      * @var string
      */
     protected $appVersionRequired = '5.7.0';
+
+    /**
+     * The minimum PHP version compatible with the package.
+     * Override this value according to the minimum required version for your package.
+     *
+     * @var string
+     * @var string
+     */
+    protected $phpVersionRequired = '';
 
     /**
      * Override this value and set it to true if your package clears all existing website content when it's being installed.
@@ -460,6 +475,21 @@ abstract class Package implements LocalizablePackageInterface
     public function getApplicationVersionRequired()
     {
         return $this->appVersionRequired;
+    }
+
+    /**
+     * Get the minimum PHP version compatible with the package.
+     *
+     * @return string
+     *
+     * @example '' if the package is compatible with any PHP version that's already compatible with the core
+     * @example '8' if the package requires PHP 8.0.0 and later
+     * @example '8.1' if the package requires PHP 8.1.0 and later
+     * @example '8.1.20' if the package requires PHP 8.1.20 and later
+     */
+    public function getPHPVersionRequired(): string
+    {
+        return $this->phpVersionRequired;
     }
 
     /**
@@ -812,6 +842,10 @@ abstract class Package implements LocalizablePackageInterface
             $applicationVersionRequired = $this->getApplicationVersionRequired();
             if (version_compare(APP_VERSION, $applicationVersionRequired, '<')) {
                 $errors->add($this->getErrorText([self::E_PACKAGE_VERSION, $applicationVersionRequired]));
+            }
+            $phpVersionRequired = $this->getPHPVersionIDRequired();
+            if ($phpVersionRequired !== null && $phpVersionRequired > PHP_VERSION_ID) {
+                $errors->add($this->getErrorText([self::E_PACKAGE_PHP_VERSION, $this->getPHPVersionRequired(), PHP_VERSION]));
             }
 
             // Step 4 - Check for package dependencies
@@ -1206,6 +1240,7 @@ abstract class Package implements LocalizablePackageInterface
                 self::E_PACKAGE_MIGRATE_BACKUP => t('Unable to backup old package directory to %s', $config->get('concrete.misc.package_backup_directory')),
                 self::E_PACKAGE_INVALID_APP_VERSION => t('This package isn\'t currently available for this version of Concrete. Please contact the maintainer of this package for assistance.'),
                 self::E_PACKAGE_THEME_ACTIVE => t('This package contains the active site theme, please change the theme before uninstalling.'),
+                self::E_PACKAGE_PHP_VERSION => t('This package requires PHP version %1$s or greater (the current PHP version is %2$s).'),
             ];
             if (isset($dictionary[$errorCode])) {
                 $result = $dictionary[$errorCode];
@@ -1239,5 +1274,28 @@ abstract class Package implements LocalizablePackageInterface
                 @unlink($proxyFileName);
             }
         }
+    }
+
+    /**
+     * Get the minimum PHP version compatible with the package.
+     *
+     * @return int|null
+     *
+     * @example null if the package is compatible with any PHP version that's already compatible with the core
+     * @example 80000 if the package requires PHP 8.0.0 and later
+     * @example 80100 if the package requires PHP 8.1.0 and later
+     * @example 80120 if the package requires PHP 8.1.20 and later
+     */
+    protected function getPHPVersionIDRequired(): ?int
+    {
+        $matches = null;
+        if (!preg_match('/^(?<major>\d+)(\.(?<minor>\d+)(\.(?<patch>\d+))?)?$/', $this->getPHPVersionRequired(), $matches)) {
+            return null;
+        }
+        $major = (int) $matches['major'];
+        $minor = empty($matches['minor']) ? 0 : (int) $matches['minor'];
+        $patch = empty($matches['patch']) ? 0 : (int) $matches['patch'];
+
+        return $major * 10000 + $minor * 100 + $patch;
     }
 }

--- a/tests/helpers/Package/PackageForTestingPHPVersion.php
+++ b/tests/helpers/Package/PackageForTestingPHPVersion.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Concrete\TestHelpers\Package;
+
+use Concrete\Core\Package\Package;
+
+class PackageForTestingPHPVersion extends Package
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Package\Package::getPackagePath()
+     */
+    public function getPackagePath()
+    {
+        return __DIR__;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Package\Package::getPackageHandle()
+     */
+    public function getPackageHandle()
+    {
+        return 'handle';
+    }
+
+    public function setPHPVersionRequired(string $value): self
+    {
+        $this->phpVersionRequired = $value;
+
+        return $this;
+    }
+}

--- a/tests/tests/Package/MinimumPHPVersionTest.php
+++ b/tests/tests/Package/MinimumPHPVersionTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Concrete\Tests\Package;
+
+use Concrete\Core\Application\Application;
+use Concrete\Core\Error\ErrorList\ErrorList;
+use Concrete\Core\Package\Dependency\DependencyChecker;
+use Concrete\Core\Package\Package;
+use Concrete\TestHelpers\Package\PackageForTestingPHPVersion;
+use Concrete\Tests\TestCase;
+use Mockery as M;
+
+class MinimumPHPVersionTest extends TestCase
+{
+    public function installProvider(): array
+    {
+        return [
+            [
+                self::createPackage(''),
+                true,
+            ],
+            [
+                self::createPackage(implode('.', [PHP_MAJOR_VERSION])),
+                true,
+            ],
+            [
+                self::createPackage(implode('.', [PHP_MAJOR_VERSION - 1])),
+                true,
+            ],
+            [
+                self::createPackage(implode('.', [PHP_MAJOR_VERSION + 1])),
+                false,
+            ],
+            [
+                self::createPackage(implode('.', [PHP_MAJOR_VERSION, PHP_MINOR_VERSION])),
+                true,
+            ],
+            [
+                self::createPackage(implode('.', [PHP_MAJOR_VERSION, PHP_MINOR_VERSION - 1])),
+                true,
+            ],
+            [
+                self::createPackage(implode('.', [PHP_MAJOR_VERSION, PHP_MINOR_VERSION + 1])),
+                false,
+            ],
+            [
+                self::createPackage(implode('.', [PHP_MAJOR_VERSION - 1, PHP_MINOR_VERSION])),
+                true,
+            ],
+            [
+                self::createPackage(implode('.', [PHP_MAJOR_VERSION + 1, PHP_MINOR_VERSION])),
+                false,
+            ],
+            [
+                self::createPackage(implode('.', [PHP_MAJOR_VERSION, PHP_MINOR_VERSION, PHP_RELEASE_VERSION])),
+                true,
+            ],
+            [
+                self::createPackage(implode('.', [PHP_MAJOR_VERSION, PHP_MINOR_VERSION, PHP_RELEASE_VERSION - 1])),
+                true,
+            ],
+            [
+                self::createPackage(implode('.', [PHP_MAJOR_VERSION, PHP_MINOR_VERSION, PHP_RELEASE_VERSION + 1])),
+                false,
+            ],
+            [
+                self::createPackage(implode('.', [PHP_MAJOR_VERSION, PHP_MINOR_VERSION - 1, PHP_RELEASE_VERSION])),
+                true,
+            ],
+            [
+                self::createPackage(implode('.', [PHP_MAJOR_VERSION, PHP_MINOR_VERSION + 1, PHP_RELEASE_VERSION])),
+                false,
+            ],
+            [
+                self::createPackage(implode('.', [PHP_MAJOR_VERSION - 1, PHP_MINOR_VERSION, PHP_RELEASE_VERSION])),
+                true,
+            ],
+            [
+                self::createPackage(implode('.', [PHP_MAJOR_VERSION + 1, PHP_MINOR_VERSION, PHP_RELEASE_VERSION])),
+                false,
+            ],
+            [
+                self::createPackage('99.1.2'),
+                false,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider installProvider
+     */
+    public function testTestForInstall(Package $package, bool $shouldInstall)
+    {
+        $actual = $package->testForInstall(false);
+        if ($shouldInstall) {
+            $this->assertSame(true, $actual);
+        } else {
+            $this->assertInstanceOf(ErrorList::class, $actual);
+            $this->assertNotSame('', (string) $actual);
+        }
+    }
+
+    private function createPackage(string $minPHPVersion): Package
+    {
+        $dependencyChecker = M::mock(Application::class);
+        /** @var \Mockery\MockInterface $dependencyChecker */
+        $dependencyChecker->shouldReceive('testForInstall')->andReturn(app('error'));
+        $app = M::mock(Application::class);
+        /** @var \Mockery\MockInterface $app */
+        $app->shouldReceive('make')->with('error')->andReturn(app('error'));
+        $app->shouldReceive('make')->zeroOrMoreTimes()->with('config')->andReturn(app('config'));
+        $app->shouldReceive('build')->with(DependencyChecker::class)->andReturn($dependencyChecker);
+        $package = new PackageForTestingPHPVersion($app);
+        $package->setPHPVersionRequired($minPHPVersion);
+        
+        return $package;
+    }
+}


### PR DESCRIPTION
Package developers may require that users have a PHP version greater than the minimum PHP version required by the core (think for example about packages developed for concrete5 v8 that require PHP 7.4 instead of PHP 5.5).

So, what about adding a way to let packages declare the minimum PHP version they are meant to be used with?