### PR TITLE
Make the image editor bigger

### DIFF
--- a/concrete/elements/files/edit/image_editor/toast.php
+++ b/concrete/elements/files/edit/image_editor/toast.php
@@ -19,71 +19,168 @@ foreach ($output as $assets) {
     }
 }
 ?>
+<style>
+#ccm-tui-image-editor-buttons {
+    background-color: hsla(0,0%,100%,.06);
+    border-radius: 20px;
+    padding: 0;
+    position: absolute;
+    right: 10px;
+    top: 0;
+    text-align: center;
+    vertical-align: middle;
+    list-style-type: none;
+    padding: 0 10px;
+}
+#ccm-tui-image-editor-buttons li {
+    display: inline-block;
+    margin: 0;
+    padding: 0;
+}
+#ccm-tui-image-editor-buttons a {
+    color: #fff;
+    font-size: 1.3rem;
+    border-radius: 2px;
+    display: inline-block;
+    font-weight: normal;
+    padding: 10px;
+    opacity: 0.5;
+}
+#ccm-tui-image-editor-buttons a:hover {
+    opacity: 1;
+}
+</style>
 
 <div id="tui-image-editor-container"></div>
 
-<style>
-    .tui-image-editor-download-btn, .tui-image-editor-header-buttons {
-        display: none !important;
-    }
-</style>
-
-<div class="dialog-buttons">
-    <div class="float-start">
-        <button class="tui-image-editor-fullscreen-btn btn btn-secondary">
-            <?= t('Full screen') ?>
-        </button>
-        <button class="tui-image-editor-close-btn btn btn-secondary">
-            <?= t('Cancel') ?>
-        </button>
-    </div>
-    <button class="tui-image-editor-save-btn btn btn-primary">
-        <?= t('Save'); ?>
-    </button>
+<div class="d-none">
+    <ul id="ccm-tui-image-editor-buttons">
+        <li>
+            <a href="#" v-on:click.prevent="cancel" title="<?= t('Cancel') ?>">
+                <i class="far fa-window-close"></i>
+            </a>
+        </li>
+        <li>
+            <a href="#" v-on:click.prevent="toggleFullScreen" title="<?= t('Full screen') ?>">
+                <i v-if="fullscreen" class="fas fa-compress-arrows-alt"></i>
+                <i v-else class="fas fa-expand-arrows-alt"></i>
+            </a>
+        </li>
+        <li>
+            <a href="#" v-on:click.prevent="save" title="<?= t('Save') ?>">
+                <i class="far fa-save"></i>
+            </a>
+        </li>
+    </ul>
 </div>
 
 <script>
 $(document).ready(function() {
-    var imageEditor = new window.tuiImageEditor('#tui-image-editor-container', {
-        usageStatistics: false,
-        includeUI: {
-            loadImage: {
-                path: <?= json_encode((string) $fileVersion->getURL()) ?>,
-                name: <?= json_encode((string) $fileVersion->getFileName()) ?>
-            },
-            menuBarPosition: 'bottom'
-        }
-    });
+'use strict';
 
-    $('.tui-image-editor-fullscreen-btn').on('click', function () {
-        document.getElementById('tui-image-editor-container').requestFullscreen();
-    });
+const imageEditor = new window.tuiImageEditor('#tui-image-editor-container', {
+    usageStatistics: false,
+    includeUI: {
+        loadImage: {
+            path: <?= json_encode((string) $fileVersion->getURL()) ?>,
+            name: <?= json_encode((string) $fileVersion->getFileName()) ?>
+        },
+        menuBarPosition: 'bottom',
+    }
+});
 
-    $('.tui-image-editor-close-btn').on('click', function () {
-        $.fn.dialog.closeTop();
-    });
-
-    $('.tui-image-editor-save-btn').on('click', function () {
-        var url = CCM_DISPATCHER_FILENAME + '/ccm/system/file/edit/save/<?= $fileVersion->getFileID() ?>';
-        <?php if ($fileVersion->getType() == 'JPEG') { ?>
-            var format = 'jpeg'
-        <?php } else { ?>
-            var format = 'png'
-        <?php } ?>
-
-        $.concreteAjax({
-            dataType: 'json',
-            data: {
-                token: CCM_SECURITY_TOKEN,
-                imageData: imageEditor.toDataURL({format: format})
-            },
-            type: 'POST',
-            url: url,
-            success: function (r) {
-                $.fn.dialog.closeTop();
-                window.location.reload();
+$('#tui-image-editor-container .tui-image-editor-header-buttons')
+    .empty()
+    .append($('#ccm-tui-image-editor-buttons'))
+;
+new Vue({
+    el: '#ccm-tui-image-editor-buttons',
+    data() {
+        return {
+            busy: false,
+            fullscreen: false,
+        };
+    },
+    mounted() {
+        document.addEventListener('fullscreenchange', (e) => {
+            this.fullscreen = document.fullscreenElement ? true : false;
+        }, false);
+    },
+    methods: {
+        toggleFullScreen() {
+            if (this.fullscreen) {
+                const showError = (e) => {
+                    ConcreteAlert.error({
+                        plainTextMessage: true,
+                        message: <?= json_encode(t('Failed to exit from full-screen mode: %s')) ?>.replace(/%s/, e.message || e.toString()),
+                    });
+                };
+                try {
+                    document.exitFullscreen().catch((e) => showError(e));
+                } catch (e) {
+                    showError(e);
+                }
+            } else {
+                const showError = (e) => {
+                    ConcreteAlert.error({
+                        plainTextMessage: true,
+                        message: <?= json_encode(t('Failed to switch to full-screen mode: %s')) ?>.replace(/%s/, e.message || e.toString()),
+                    });
+                };
+                try {
+                    document.getElementById('tui-image-editor-container').requestFullscreen().catch((e) => showError(e));
+                } catch (e) {
+                    showError(e);
+                }
             }
-        });
-    });
+        },
+        cancel() {
+            if (this.busy) {
+                return;
+            }
+            this.$destroy();
+            imageEditor.destroy();
+            $.fn.dialog.closeTop();
+        },
+        save() {
+            if (this.busy) {
+                return;
+            }
+            const url = CCM_DISPATCHER_FILENAME + '/ccm/system/file/edit/save/<?= $fileVersion->getFileID() ?>';
+            const format = '<?php
+                switch ($fileVersion->getType()) {
+                    case 'JPEG':
+                        echo 'jpeg';
+                        break;
+                    default:
+                        echo 'png';
+                        break;
+                }
+            ?>';
+            this.busy = true;
+            $.concreteAjax({
+                dataType: 'json',
+                data: {
+                    token: CCM_SECURITY_TOKEN,
+                    imageData: imageEditor.toDataURL({format: format})
+                },
+                type: 'POST',
+                url: url,
+                success: () => {
+                    this.busy = false;
+                    this.$destroy();
+                    imageEditor.destroy();
+                    $.fn.dialog.closeTop();
+                    window.location.reload();
+                },
+                error: (xhr) => {
+                    this.busy = false;
+                    ConcreteAlert.dialog(ccmi18n.error, ConcreteAjaxRequest.renderErrorResponse(xhr, true));
+                }
+            });
+        },
+    },
+});
+
 });
 </script>


### PR DESCRIPTION
What about moving the "Full screen" / "Cancel" / "Save" buttons to the editor area, so that we have more space for editing the images?

| Before | After |
|---|---|
|  ![immagine](https://github.com/concretecms/concretecms/assets/928116/e3e63fcd-1e5c-4eb3-bfcf-c4536580c452) | ![immagine](https://github.com/concretecms/concretecms/assets/928116/6069084f-bf3b-48a4-9e5e-21324539d9ad) |
