### PR TITLE
Reload the logs page when the log registry is emptied

### DIFF
--- a/concrete/controllers/dialog/logs/delete_all.php
+++ b/concrete/controllers/dialog/logs/delete_all.php
@@ -11,6 +11,7 @@ use Concrete\Core\Permission\Checker as Permissions;
 use Concrete\Core\Permission\Key\Key;
 use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\User\User;
+use Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface;
 
 
 class DeleteAll extends BackendInterfaceController
@@ -44,7 +45,8 @@ class DeleteAll extends BackendInterfaceController
             /** @noinspection SqlNoDataSourceInspection */
             $db->executeQuery("TRUNCATE TABLE Logs");
 
-            $editResponse->setMessage(t('Log cleared successfully.'));
+            $this->flash('success', t('Log cleared successfully.'));
+            $editResponse->setRedirectURL((string) $this->app->make(ResolverManagerInterface::class)->resolve(['/dashboard/reports/logs']));
         } else {
             $editResponse->setMessage(t('Access denied'));
         }

--- a/concrete/controllers/dialog/logs/delete_all.php
+++ b/concrete/controllers/dialog/logs/delete_all.php
@@ -6,13 +6,8 @@ use Concrete\Controller\Backend\UserInterface as BackendInterfaceController;
 use Concrete\Core\Database\Connection\Connection;
 use Concrete\Core\Http\ResponseFactory;
 use Concrete\Core\Page\EditResponse;
-use Concrete\Core\Page\Page;
-use Concrete\Core\Permission\Checker as Permissions;
 use Concrete\Core\Permission\Key\Key;
-use Concrete\Core\Support\Facade\Application;
-use Concrete\Core\User\User;
 use Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface;
-
 
 class DeleteAll extends BackendInterfaceController
 {


### PR DESCRIPTION
When we clear the logs in the /dashboard/reports/logs dashboard page, we see a nice message telling us that the log has been cleared successfully, but we still see all the logs in the page.

What about reloading the page? That way users will see that the logs have been actually deleted.