### PR TITLE
Catch Throwable instead of Exception in PackageService::getClass()

### DIFF
--- a/concrete/src/Package/PackageService.php
+++ b/concrete/src/Package/PackageService.php
@@ -278,7 +278,7 @@ class PackageService
             $class = '\\Concrete\\Package\\' . camelcase($pkgHandle) . '\\Controller';
             try {
                 $cl = $this->application->make($class);
-            } catch (\Exception $ex) {
+            } catch (\Throwable $ex) {
                 $cl = $this->application->make('Concrete\Core\Package\BrokenPackage', ['pkgHandle' => $pkgHandle]);
             }
             $cache->save($item->set($cl));


### PR DESCRIPTION
What about preventing the core from breaking in case PHP throws `Error`s (which are not `Exception`s but, like `Exception`s, are `Throwable`s)  when trying to load a package `controller.php` file?