### PR TITLE
Check that package controllers extend Package, show why a package is broken

### DIFF
--- a/concrete/single_pages/dashboard/extend/install.php
+++ b/concrete/single_pages/dashboard/extend/install.php
@@ -317,7 +317,7 @@ if ($this->controller->getTask() == 'install_package' && isset($showInstallOptio
                         <?php
                         if ($obj instanceof Concrete\Core\Package\BrokenPackage) {
                             ?>
-                            <div class="ms-auto launch-tooltip float-end" title="<?=t('This package is corrupted. Make sure it has a valid controller.php file and that it has been updated for Concrete 5.7.0 and later.')?>">
+                            <div class="ms-auto launch-tooltip float-end" title="<?= h($obj->getInstallErrorMessage()) ?>">
                                 <button type="button" disabled="disabled" class="btn btn-sm btn-secondary"><i class="fas fa-exclamation-circle"></i> <?= t('Can\'t Install!'); ?></button>
                             </div>
                             <?php

--- a/concrete/src/Package/BrokenPackage.php
+++ b/concrete/src/Package/BrokenPackage.php
@@ -7,12 +7,18 @@ use Concrete\Core\Error\UserMessageException;
 
 class BrokenPackage extends Package
 {
-    public function __construct($pkgHandle, Application $application)
+    /**
+     * @var string
+     */
+    private $errorDetails;
+
+    public function __construct($pkgHandle, Application $application, string $errorDetails = '')
     {
         $this->pkgHandle = $pkgHandle;
         $this->pkgVersion = '0.0';
         $this->pkgName = 'Unknown Package';
         $this->pkgDescription = sprintf('Broken package (handle %s).', $pkgHandle);
+        $this->errorDetails = $errorDetails;
         parent::__construct($application);
     }
 
@@ -43,6 +49,11 @@ class BrokenPackage extends Package
 
     public function getInstallErrorMessage()
     {
-        return t('Unable to install %s. Please check that this package has been updated for 5.7.', $this->pkgHandle);
+        $result = t('Unable to install %s. Make sure it has a valid controller.php file and that it has been updated for Concrete 5.7.0 and later.', $this->pkgHandle);
+        if ($this->errorDetails !== '') {
+            $result .= "\n\n" . t('Error Details: %s', $this->errorDetails);
+        }
+
+        return $result;
     }
 }

--- a/concrete/src/Package/Package.php
+++ b/concrete/src/Package/Package.php
@@ -824,7 +824,7 @@ abstract class Package implements LocalizablePackageInterface
 
         // Step 1 does that package exist ?
         if ($this instanceof BrokenPackage) {
-            $errors->add($this->getErrorText(self::E_PACKAGE_NOT_FOUND));
+            $errors->add($this->getInstallErrorMessage());
         } elseif ($this->getPackageHandle() === '' || !is_dir($this->getPackagePath())) {
             $errors->add($this->getErrorText(self::E_PACKAGE_NOT_FOUND));
         }

--- a/concrete/src/Package/PackageService.php
+++ b/concrete/src/Package/PackageService.php
@@ -6,6 +6,7 @@ use Concrete\Core\Application\Application;
 use Concrete\Core\Database\EntityManager\Provider\PackageProviderFactory;
 use Concrete\Core\Database\EntityManagerConfigUpdater;
 use Concrete\Core\Error\ErrorList\ErrorList;
+use Concrete\Core\Error\UserMessageException;
 use Concrete\Core\Foundation\ClassLoader;
 use Concrete\Core\Localization\Localization;
 use Concrete\Core\User\User;
@@ -278,6 +279,9 @@ class PackageService
             $class = '\\Concrete\\Package\\' . camelcase($pkgHandle) . '\\Controller';
             try {
                 $cl = $this->application->make($class);
+                if (!$cl instanceof Package) {
+                    throw new UserMessageException(t('The package controller does not extend the PHP class %s', Package::class));
+                }
             } catch (\Throwable $ex) {
                 $cl = $this->application->make('Concrete\Core\Package\BrokenPackage', ['pkgHandle' => $pkgHandle]);
             }

--- a/concrete/src/Package/PackageService.php
+++ b/concrete/src/Package/PackageService.php
@@ -283,7 +283,7 @@ class PackageService
                     throw new UserMessageException(t('The package controller does not extend the PHP class %s', Package::class));
                 }
             } catch (\Throwable $ex) {
-                $cl = $this->application->make('Concrete\Core\Package\BrokenPackage', ['pkgHandle' => $pkgHandle]);
+                $cl = $this->application->make('Concrete\Core\Package\BrokenPackage', ['pkgHandle' => $pkgHandle, 'errorDetails' => $ex->getMessage()]);
             }
             $cache->save($item->set($cl));
         }


### PR DESCRIPTION
Examples:

1. When a package `controller.php` file does exist, or does not define the correct class name (`Controller`) in the correct namespace (`Concrete\Package\PascalCasePackageHandle`):   
   ![immagine](https://github.com/concretecms/concretecms/assets/928116/1960073b-0fca-45a0-a534-b753e46ccf3c)
2. When the package controller does not extend `Concrete\Core\Package\Package`:   
   ![immagine](https://github.com/concretecms/concretecms/assets/928116/9bcb397f-22db-4586-8b2a-9de7f584581d)
3. When PHP can't correctly parse the package controller:   
   ![immagine](https://github.com/concretecms/concretecms/assets/928116/78ab9d21-6bca-4e18-94ff-7ec28cd92d71)
