### PR TITLE
Add MemoryOutput for tasks

### DIFF
--- a/concrete/src/Command/Task/Output/MemoryOutput.php
+++ b/concrete/src/Command/Task/Output/MemoryOutput.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Concrete\Core\Command\Task\Output;
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+class MemoryOutput implements OutputInterface
+{
+    /**
+     * @var string[]
+     */
+    protected $messages = [];
+
+    /**
+     * @var callable|null
+     */
+    protected $listener;
+
+    public function __construct(?callable $listener = null)
+    {
+        $this->listener = $listener;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Command\Task\Output\OutputInterface::write()
+     */
+    public function write($message)
+    {
+        $message = (string) $message;
+        $this->messages[] = $message;
+        if ($this->listener !== null) {
+            ($this->listener)($message, $this);
+        }
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getMessages(): array
+    {
+        return $this->messages;
+    }
+}

--- a/concrete/src/Command/Task/Output/MemoryOutput.php
+++ b/concrete/src/Command/Task/Output/MemoryOutput.php
@@ -42,4 +42,14 @@ class MemoryOutput implements OutputInterface
     {
         return $this->messages;
     }
+
+    /**
+     * @return $this
+     */
+    public function reset(): self
+    {
+        $this->messages = [];
+
+        return $this;
+    }
 }


### PR DESCRIPTION
I'm playing with tasks, and I'm missing a way to have a list of task messages.

We currently have output implementations that send messages to the console and to a Mercure instance: what about adding an output that simply stores the messages in memory?