### PR TITLE
Fix pagination constructor: __construct cannot return a value

### DIFF
--- a/concrete/src/Search/Pagination/Pagination.php
+++ b/concrete/src/Search/Pagination/Pagination.php
@@ -34,7 +34,7 @@ class Pagination extends Pagerfanta
     {
         $this->list = $itemList;
 
-        return parent::__construct($adapter);
+        parent::__construct($adapter);
     }
 
     public function getTotal()

--- a/concrete/src/Search/Pagination/PermissionablePagination.php
+++ b/concrete/src/Search/Pagination/PermissionablePagination.php
@@ -22,7 +22,7 @@ class PermissionablePagination extends Pagination
         $adapter = new ArrayAdapter($results);
         $this->list = $itemList;
 
-        return Pagerfanta::__construct($adapter);
+        parent::__construct($itemList, $adapter);
     }
 
     public function getCurrentPageResults()


### PR DESCRIPTION
It's already been fixed in 9.x. Let's fix it in 8.x as well.
Please let me know if I should open the PR aginst `8.6.x-dev` branch.