### PR TITLE
First weekday in dashboard calendar as defined by current locale

### DIFF
--- a/concrete/controllers/single_page/dashboard/calendar/events.php
+++ b/concrete/controllers/single_page/dashboard/calendar/events.php
@@ -47,6 +47,7 @@ class Events extends DashboardCalendarPageController
         $previousLink = URL::to('/dashboard/calendar/events/view', $calendar->getID(), $previousLinkYear, $previousLinkMonth);
         $todayLink = URL::to('/dashboard/calendar/events/view', $calendar->getID());
 
+        $this->set('topic', null);
         if ($topic_id) {
             $topic_id = intval($topic_id, 10);
             $topic = Node::getByID($topic_id);
@@ -84,9 +85,7 @@ class Events extends DashboardCalendarPageController
 
         // Process the given edit ID if there is one
         $initialEdit = (int) $this->request->get('edit');
-        if ($initialEdit > 0) {
-            $this->set('initialEdit', $initialEdit);
-        }
+        $this->set('initialEdit', $initialEdit > 0 ? $initialEdit : null);
 
         $editor = $this->app->make('editor');
         $editor->requireEditorAssets();

--- a/concrete/controllers/single_page/dashboard/calendar/events.php
+++ b/concrete/controllers/single_page/dashboard/calendar/events.php
@@ -8,6 +8,7 @@ use Concrete\Core\Calendar\Calendar;
 use Concrete\Core\Calendar\CalendarServiceProvider;
 use URL;
 use Concrete\Core\Calendar\Utility\Preferences;
+use Punic\Calendar as PunicCalendar;
 
 class Events extends DashboardCalendarPageController
 {
@@ -82,7 +83,11 @@ class Events extends DashboardCalendarPageController
         $serviceProvider = $this->app->make(CalendarServiceProvider::class);
         $this->set('dateFormatter', $serviceProvider->getDateFormatter());
         $this->set('linkFormatter', $serviceProvider->getLinkFormatter());
-
+        $weekdays = [PunicCalendar::getFirstWeekday()];
+        for ($index = 1; $index <= 6; $index++) {
+            $weekdays[$index] = ($weekdays[$index - 1] + 1) % 7;
+        }
+        $this->set('weekdays', $weekdays);
         // Process the given edit ID if there is one
         $initialEdit = (int) $this->request->get('edit');
         $this->set('initialEdit', $initialEdit > 0 ? $initialEdit : null);

--- a/concrete/controllers/single_page/dashboard/calendar/events.php
+++ b/concrete/controllers/single_page/dashboard/calendar/events.php
@@ -73,7 +73,7 @@ class Events extends DashboardCalendarPageController
         $this->set('monthText', $dh->date('F', $monthYearTimestamp, $todayDate->getTimezone()));
         $this->set('month', $month);
         $this->set('year', $year);
-        $this->set('daysInMonth', date('t', $monthYearTimestamp));
+        $this->set('daysInMonth', (int) date('t', $monthYearTimestamp));
         $this->set('firstDayInMonthNum', $firstDayInMonthNum);
         $this->set('nextLink', $nextLink);
         $this->set('previousLink', $previousLink);

--- a/concrete/single_pages/dashboard/calendar/events.php
+++ b/concrete/single_pages/dashboard/calendar/events.php
@@ -1,13 +1,30 @@
 <?php
 
-defined('C5_EXECUTE') or die("Access Denied.");
-
 use Concrete\Core\Calendar\Event\EventOccurrence;
+use Concrete\Core\View\View;
 use Punic\Calendar as PunicCalendar;
 
-if (!isset($topic)) {
-    $topic = null;
-}
+defined('C5_EXECUTE') or die('Access Denied.');
+
+/**
+ * @var Concrete\Core\Tree\Node\Type\Topic[]|null $topics
+ * @var Concrete\Core\Entity\Calendar\Calendar[] $calendars
+ * @var Concrete\Core\Permission\Checker $calendarPermissions
+ * @var Concrete\Core\Entity\Calendar\Calendar $calendar
+ * @var Concrete\Core\Tree\Node\Type\Topic|null $topic
+ * @var string $monthText 'January', ...
+ * @var int|string $month 1 to 12
+ * @var int|string $year
+ * @var int $daysInMonth
+ * @var int $firstDayInMonthNum
+ * @var League\Url\UrlInterface|string $nextLink
+ * @var League\Url\UrlInterface|string $previousLink
+ * @var League\Url\UrlInterface|string $todayLink
+ * @var int $todayDateTimestamp
+ * @var Concrete\Core\Calendar\Event\Formatter\DateFormatter $dateFormatter
+ * @var Concrete\Core\Calendar\Event\Formatter\LinkFormatter $linkFormatter
+ * @var int|null $initialEdit
+ */
 
 Loader::element('calendar/header', array(
     'calendar' => $calendar,

--- a/concrete/single_pages/dashboard/calendar/events.php
+++ b/concrete/single_pages/dashboard/calendar/events.php
@@ -26,7 +26,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
  * @var int|null $initialEdit
  */
 
-Loader::element('calendar/header', array(
+View::element('calendar/header', array(
     'calendar' => $calendar,
     'calendars' => $calendars,
 ));
@@ -136,7 +136,6 @@ Loader::element('calendar/header', array(
         $cols = 0;
         $cellCounter = 0;
         $isToday = false;
-        Loader::helper('text');
         for ($i = 1 - $firstDayInMonthNum; $i <= $daysInMonth; ++$i) {
             ++$cellCounter;
             if ($cols >= 7) {

--- a/concrete/single_pages/dashboard/calendar/events.php
+++ b/concrete/single_pages/dashboard/calendar/events.php
@@ -134,10 +134,8 @@ View::element('calendar/header', array(
     <tr>
         <?php
         $cols = 0;
-        $cellCounter = 0;
         $isToday = false;
         for ($i = 1 - $firstDayInMonthNum; $i <= $daysInMonth; ++$i) {
-            ++$cellCounter;
             if ($cols >= 7) {
                 echo '</tr><tr>';
                 $cols = 0;
@@ -170,9 +168,6 @@ View::element('calendar/header', array(
                         /** @var EventOccurrence $occurrence */
                         foreach ($results as $occurrence) {
                             $menu = new \Concrete\Core\Calendar\Event\Menu\EventOccurrenceMenu($occurrence);
-                            $event = $occurrence->getEvent();
-                            $color = $linkFormatter->getEventOccurrenceBackgroundColor($occurrence);
-                            $date = $dateFormatter->getOccurrenceDateString($occurrence);
                             ?>
                             <div class="ccm-dashboard-calendar-date-event">
                                 <?php print $menu->getMenuElement();?>

--- a/concrete/single_pages/dashboard/calendar/events.php
+++ b/concrete/single_pages/dashboard/calendar/events.php
@@ -23,6 +23,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
  * @var int $todayDateTimestamp
  * @var Concrete\Core\Calendar\Event\Formatter\DateFormatter $dateFormatter
  * @var Concrete\Core\Calendar\Event\Formatter\LinkFormatter $linkFormatter
+ * @var int[] $weekdays
  * @var int|null $initialEdit
  */
 
@@ -124,8 +125,8 @@ View::element('calendar/header', array(
     <thead>
     <tr>
         <?php
-        for($weekday = 0; $weekday < 7; $weekday++) {
-            ?><td width="<?= 100 / 7?>%"><h4><?= PunicCalendar::getWeekdayName($weekday, 'abbreviated', '', true) ?></h4></td><?php
+        foreach ($weekdays as $weekday) {
+            ?><td width="<?= 100 / 7 ?>%"><h4><?= PunicCalendar::getWeekdayName($weekday, 'abbreviated', '', true) ?></h4></td><?php
         }
         ?>
     </tr>
@@ -135,10 +136,16 @@ View::element('calendar/header', array(
         <?php
         $cols = 0;
         $isToday = false;
-        for ($i = 1 - $firstDayInMonthNum; $i <= $daysInMonth; ++$i) {
+        $i = 0;
+        while ($i < $daysInMonth) {
             if ($cols >= 7) {
                 echo '</tr><tr>';
                 $cols = 0;
+            }
+            if ($i === 0 && $weekdays[$cols] === $firstDayInMonthNum) {
+                $i = 1;
+            } elseif ($i > 0) {
+                $i++;
             }
             ++$cols;
             $isToday = (date('Y') == $year && $month == date('m') && $i == date('j'));

--- a/concrete/src/Page/Controller/DashboardCalendarPageController.php
+++ b/concrete/src/Page/Controller/DashboardCalendarPageController.php
@@ -36,6 +36,7 @@ class DashboardCalendarPageController extends DashboardSitePageController
 
         $filterTopics = array();
 
+        $this->set('topics', null);
         $ak = $calendar->getCalendarTopicsAttributeKey();
         if (is_object($ak)) {
             $node = Node::getByID($ak->getController()->getTopicParentNode());


### PR DESCRIPTION
In the /dashboard/calendar/events dashboard page, weeks always start on Sundays.

That's not the case everywhere.

So, let's show the first weekday accordingly to the current locale.