### PR TITLE
blocks/top_navigation_bar: Make vertical menu possible

### DIFF
--- a/concrete/blocks/top_navigation_bar/controller.php
+++ b/concrete/blocks/top_navigation_bar/controller.php
@@ -74,6 +74,15 @@ class Controller extends BlockController implements UsesFeatureInterface, FileTr
     public $includeSearchInput;
 
     /**
+     * @var bool|int|string|null
+     *
+     * True => Horizontal menu
+     * False => Vertical menu
+     * Default: True
+     */
+    public $toggleVerticalHorizontal;
+
+    /**
      * @var int|string|null
      */
     public $searchInputFormActionPageID;
@@ -121,6 +130,7 @@ class Controller extends BlockController implements UsesFeatureInterface, FileTr
         $site = $this->app->make('site')->getSite();
         $brandingText = $site->getSiteName();
 
+        $this->set('toggleVerticalHorizontal', true); // Horizontal by default
         $this->set('includeTransparency', false);
         $this->set('includeStickyNav', false);
         $this->set('includeNavigation', true);
@@ -262,6 +272,7 @@ class Controller extends BlockController implements UsesFeatureInterface, FileTr
     public function save($args)
     {
         $data = [];
+        $data['toggleVerticalHorizontal'] = !empty($args['toggleVerticalHorizontal']) ? 1 : 0;
         $data['includeNavigation'] = !empty($args['includeNavigation']) ? 1 : 0;
         $data['includeNavigationDropdowns'] = !empty($args['includeNavigationDropdowns']) ? 1 : 0;
         $data['includeTransparency'] = !empty($args['includeTransparency']) ? 1 : 0;

--- a/concrete/blocks/top_navigation_bar/db.xml
+++ b/concrete/blocks/top_navigation_bar/db.xml
@@ -18,5 +18,6 @@
         <field name="includeNavigationDropdowns" type="boolean" />
         <field name="includeSearchInput" type="boolean" />
         <field name="searchInputFormActionPageID" type="integer" />
+        <field name="toggleVerticalHorizontal" type="boolean" />
     </table>
 </schema>

--- a/concrete/blocks/top_navigation_bar/edit.php
+++ b/concrete/blocks/top_navigation_bar/edit.php
@@ -19,6 +19,10 @@ if ($includeBrandText && $includeBrandLogo) {
         <div class="mb-3">
             <legend><?=t('Options')?></legend>
             <div class="form-check form-switch">
+                <input type="checkbox" class="form-check-input" id="toggleVerticalHorizontal" name="toggleVerticalHorizontal" value="1" v-model="toggleVerticalHorizontal">
+                <label class="form-check-label" for="toggleVerticalHorizontal"><?=t('Vertical [off] or horizontal [on] menu.')?></label>
+            </div>
+            <div class="form-check form-switch">
                 <input type="checkbox" class="form-check-input" id="includeNavigation" name="includeNavigation" value="1" v-model="includeNavigation">
                 <label class="form-check-label" for="includeNavigation"><?=t('Show pages in the navigation bar.')?></label>
             </div>
@@ -87,6 +91,7 @@ if ($includeBrandText && $includeBrandLogo) {
             el: 'div[data-view=edit-top-navigation-bar-block]',
             components: config.components,
             data: {
+                toggleVerticalHorizontal: <?=$toggleVerticalHorizontal ? 'true' : 'false'?>,
                 includeTransparency: <?=$includeTransparency ? 'true' : 'false'?>,
                 includeNavigation: <?=$includeNavigation ? 'true' : 'false'?>,
                 includeNavigationDropdowns: <?=$includeNavigationDropdowns ? 'true' : 'false'?>,

--- a/concrete/blocks/top_navigation_bar/view.php
+++ b/concrete/blocks/top_navigation_bar/view.php
@@ -3,7 +3,7 @@ $c = Page::getCurrentPage();
 ?>
 
 <div class="ccm-block-top-navigation-bar" <?php if ($includeTransparency) { ?>style="display: none" data-transparency="navbar"<?php } ?>>
-    <nav class="navbar navbar-expand-lg navbar-light <?php if ($includeStickyNav && !$c->isEditMode()) { ?>fixed-top<?php } ?>">
+    <nav class="navbar <?php if ($toggleVerticalHorizontal) { ?>navbar-expand-lg<?php } ?> navbar-light <?php if ($includeStickyNav && !$c->isEditMode()) { ?>fixed-top<?php } ?>">
         <div class="container-fluid">
             <a class="navbar-brand" href="<?=$home->getCollectionLink()?>">
                 <?php if ($logo && ($includeBrandLogo && $includeBrandText)) { ?>


### PR DESCRIPTION
The class 'navbar-expand-lg' makes the navbar horizontal.  But what if
someone wants a vertical menu?  Making this class togglable makes that
possible.
