### PR TITLE
Update version number; bug fixes with announcements

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -6,8 +6,8 @@ return [
      *
      * @var string
      */
-    'version' => '9.2.1',
-    'version_installed' => '9.2.1',
+    'version' => '9.2.2a1',
+    'version_installed' => '9.2.2a1',
     'version_db' => '20230503095900', // the key of the latest database migration
 
     /*

--- a/concrete/src/Announcement/Controller/AbstractController.php
+++ b/concrete/src/Announcement/Controller/AbstractController.php
@@ -13,7 +13,7 @@ abstract class AbstractController implements ControllerInterface, ApplicationAwa
 
     use ApplicationAwareTrait;
 
-    public function shouldDisplayAnnouncementToUser(User $user, array $announcements): bool
+    public function shouldDisplayAnnouncementToUser(User $user): bool
     {
         return true;
     }

--- a/concrete/src/Announcement/Controller/CollectSiteInformationController.php
+++ b/concrete/src/Announcement/Controller/CollectSiteInformationController.php
@@ -14,7 +14,7 @@ class CollectSiteInformationController extends AbstractController
 
     use SingleSlideTrait;
 
-    public function shouldDisplayAnnouncementToUser(User $user, array $announcements): bool
+    public function shouldDisplayAnnouncementToUser(User $user): bool
     {
         return $user->isSuperUser();
     }

--- a/concrete/src/Announcement/Controller/ControllerInterface.php
+++ b/concrete/src/Announcement/Controller/ControllerInterface.php
@@ -16,7 +16,7 @@ interface ControllerInterface
      * @param array $announcements
      * @return bool
      */
-    public function shouldDisplayAnnouncementToUser(User $user, array $announcements): bool;
+    public function shouldDisplayAnnouncementToUser(User $user): bool;
 
     public function onViewAnnouncement(User $user);
 


### PR DESCRIPTION
* Make the checking of announcements pull against the current user instead of the hard-coded super user.
* Remove unnecessary parameter from `shouldDisplayAnnouncementToUser`.
* Actually check `shouldDisplayAnnouncementToUser` when collecting the list of announcements to display. 

