### PR TITLE
Add getSearchableContent method to Express Detail block

### DIFF
--- a/concrete/src/Express/EntryList.php
+++ b/concrete/src/Express/EntryList.php
@@ -153,8 +153,7 @@ class EntryList extends DatabaseItemList implements PagerProviderInterface, Pagi
 
     public function checkPermissions($mixed)
     {
-
-        if ($this->permissionsChecker != null) {
+        if ($this->permissionsChecker !== null) {
             if ($this->permissionsChecker === -1) {
                 return true;
             } else {
@@ -178,7 +177,7 @@ class EntryList extends DatabaseItemList implements PagerProviderInterface, Pagi
 
     public function enablePermissions()
     {
-        unset($this->permissionsChecker);
+        $this->permissionsChecker = null;
     }
 
     public function ignorePermissions()

--- a/concrete/src/Logging/LogList.php
+++ b/concrete/src/Logging/LogList.php
@@ -125,7 +125,7 @@ class LogList extends ItemList implements PagerProviderInterface, PaginationProv
 
     public function getTotalResults()
     {
-        if ($this->permissionsChecker === -1) {
+        if (isset($this->permissionsChecker) && $this->permissionsChecker === -1) {
             return $this->deliverQueryObject()
                 ->resetQueryParts(['groupBy', 'orderBy'])
                 ->select('count(distinct l.logID)')

--- a/concrete/src/Package/PackageList.php
+++ b/concrete/src/Package/PackageList.php
@@ -36,7 +36,7 @@ class PackageList extends ConcreteObject
         }
         $packageList = CacheLocal::getEntry('packageHandleList', false);
         if (is_array($packageList)) {
-            return $packageList[$pkgID];
+            return $packageList[$pkgID] ?? null;
         }
 
         $packageList = array();
@@ -48,7 +48,7 @@ class PackageList extends ConcreteObject
 
         CacheLocal::set('packageHandleList', false, $packageList);
 
-        return $packageList[$pkgID];
+        return $packageList[$pkgID] ?? null;
     }
 
     public static function refreshCache()

--- a/concrete/src/Page/PageList.php
+++ b/concrete/src/Page/PageList.php
@@ -301,7 +301,7 @@ class PageList extends DatabaseItemList implements PagerProviderInterface, Pagin
 
     public function getTotalResults()
     {
-        if ($this->permissionsChecker === -1) {
+        if (isset($this->permissionsChecker) && $this->permissionsChecker === -1) {
             $query = $this->deliverQueryObject();
             // We need to reset the potential custom order by here because otherwise, if we've added
             // items to the select parts, and we're ordering by them, we get a SQL error
@@ -331,21 +331,22 @@ class PageList extends DatabaseItemList implements PagerProviderInterface, Pagin
      */
     public function getResult($queryRow)
     {
+        $permissionsDisabled = isset($this->permissionsChecker) && $this->permissionsChecker === -1;
         $c = Page::getByID($queryRow['cID']);
         if (is_object($c) && $this->checkPermissions($c)) {
             if ($this->pageVersionToRetrieve == self::PAGE_VERSION_RECENT) {
                 $cp = new \Permissions($c);
-                if ($cp->canViewPageVersions() || $this->permissionsChecker === -1) {
+                if ($cp->canViewPageVersions() || $permissionsDisabled) {
                     $c->loadVersionObject('RECENT');
                 }
             } elseif ($this->pageVersionToRetrieve == self::PAGE_VERSION_SCHEDULED) {
                 $cp = new \Permissions($c);
-                if ($cp->canViewPageVersions() || $this->permissionsChecker === -1) {
+                if ($cp->canViewPageVersions() || $permissionsDisabled) {
                     $c->loadVersionObject('SCHEDULED');
                 }
             } elseif ($this->pageVersionToRetrieve == self::PAGE_VERSION_RECENT_UNAPPROVED) {
                 $cp = new \Permissions($c);
-                if ($cp->canViewPageVersions() || $this->permissionsChecker === -1) {
+                if ($cp->canViewPageVersions() || $permissionsDisabled) {
                     $c->loadVersionObject('RECENT_UNAPPROVED');
                 }
             } else {

--- a/concrete/src/Permission/Access/Entity/SiteGroupEntity.php
+++ b/concrete/src/Permission/Access/Entity/SiteGroupEntity.php
@@ -63,6 +63,7 @@ class SiteGroupEntity extends Entity
 
     public function validate(PermissionAccess $pae)
     {
+        $site = null;
         if ($pae instanceof SiteAccessInterface) {
             $site = $pae->getSite();
         }

--- a/concrete/src/Workflow/Description.php
+++ b/concrete/src/Workflow/Description.php
@@ -5,6 +5,30 @@ use Concrete\Core\Foundation\ConcreteObject;
 
 class Description extends ConcreteObject
 {
+    /**
+     * @var ?string
+     * @deprecated Will become protected
+     */
+    public $text = null;
+
+    /**
+     * @var ?string
+     * @deprecated Will become protected
+     */
+    public $emailtext = null;
+
+    /**
+     * @var ?string
+     * @deprecated Will become protected
+     */
+    public $status = null;
+
+    /**
+     * @var ?string
+     * @deprecated Will become protected
+     */
+    public $incontext = null;
+
     public function getDescription()
     {
         return $this->text;


### PR DESCRIPTION
Makes it so that pages with the Express detail block configured on them will return their content to the search index. Not exactly related to #11139 but this problem was discussed there so I'm tagging that issue here as well. 