### PR TITLE
Enhancement: Display the UserID's length conditions on dashboard/users/add

### DIFF
--- a/concrete/single_pages/dashboard/users/add.php
+++ b/concrete/single_pages/dashboard/users/add.php
@@ -27,6 +27,18 @@ $fileFolderSelector = $app->make(FileFolderSelector::class);
             <div class="float-end">
             <span class="text-muted small">
                 <?php echo t('Required') ?>
+                <?php 
+                    $config  = $app->make( 'config' );
+                    $minimumLength = $config->get( 'concrete.user.username.minimum' );
+                    $maximumLength = $config->get( 'concrete.user.username.maximum' );
+                    if ( $minimumLength && $maximumLength ) {
+                        echo t( 'Between %s and %s characters long.', $minimumLength, $maximumLength );
+                    } elseif ( $minimumLength ) {
+                        echo t( 'At least %s characters long.', $minimumLength );
+                    } elseif ( $maximumLength ) {
+                        echo t( 'At most %s characters long.', $maximumLength );
+                    }
+                ?>
             </span>
             </div>
             <?= $form->text('uName', ['autofocus' => 'autofocus', 'autocomplete' => 'off']); ?>


### PR DESCRIPTION
This PR displays the UserID's length conditions on dashboard/users/add page. I hope it will be more user-friendly.

