### PR TITLE
Remove HTML from user_group attribute form

### DIFF
--- a/concrete/attributes/user_group/form.php
+++ b/concrete/attributes/user_group/form.php
@@ -4,6 +4,6 @@ defined('C5_EXECUTE') or die('Access Denied.');
 $noneText = t('** Select Group');
 $selectGroups = ['' => $noneText];
 foreach($groups as $group) {
-    $selectGroups[$group->getGroupID()] = $group->getGroupDisplayName();
+    $selectGroups[$group->getGroupID()] = $group->getGroupDisplayName(false);
 }
 echo $form->select($view->field('value'), $selectGroups, $value);


### PR DESCRIPTION
The current `user_group` attribute form calls `->getGroupDisplayName()` which [returns HTML by default](https://github.com/concretecms/concretecms/blob/41f94e319c3f51ce961ef92474fdc6eabe0006c7/concrete/src/User/Group/Group.php#L609).

Before:
![image](https://github.com/concretecms/concretecms/assets/1007419/178a2386-cf8b-4b2b-8105-84c9782ec92b)

After:
![image](https://github.com/concretecms/concretecms/assets/1007419/6e0d4df5-dd5e-4885-9ca5-bb8878161cee)
