### PR TITLE
Prevent loading full trees when not needed

### DIFF
--- a/concrete/controllers/backend/tree/node.php
+++ b/concrete/controllers/backend/tree/node.php
@@ -38,7 +38,7 @@ class Node extends UserInterface
 
         if (count($selected) > 0) {
             foreach ($selected as $match) {
-                $node->selectChildrenNodesByID($match, true);
+                $node->selectChildrenNodesByID($match, false);
             }
         }
         return $node;


### PR DESCRIPTION
This PR prevents loading the entire file tree when viewing users.

In my local site viewing a user dashboard page requests `/index.php/ccm/system/tree/node/load_starting` with the following data:
```
displayOnly=file_folder
treeNodeParentID=7
allowFolderSelection=1
cID=13
treeNodeSelectedIDs[]=0
```

which ends up hanging because we load the full tree. After this change we only load the top level and rely on the front-end tree navigation tools to load additional nodes as needed.