### PR TITLE
Ensure the $collections variable is always defined

### DIFF
--- a/concrete/src/Board/Instance/Slot/Content/AvailableObjectCollectionFactory.php
+++ b/concrete/src/Board/Instance/Slot/Content/AvailableObjectCollectionFactory.php
@@ -86,6 +86,7 @@ class AvailableObjectCollectionFactory
             $slots[$i] = $availableObjects;
         }
 
+        $collections = [];
         if ($contentSlots > 1) {
             $combinations = $this->generateCombinations($slots);
             foreach($combinations as $combination) {


### PR DESCRIPTION
The `$collections` variable previously only got defined if the conditional's foreach's iterated. If they don't iterate `$collections` is undefined and an E_WARNING is raised.