### PR TITLE
Fixes #11570

### DIFF
--- a/concrete/themes/atomik/elements/summary/templates/blog_entry_card.php
+++ b/concrete/themes/atomik/elements/summary/templates/blog_entry_card.php
@@ -8,7 +8,7 @@
         </div>
         <div class="card-body">
             <h5 class="card-title"><?=$title?></h5>
-            <?php if ($date) { ?>
+            <?php if (isset($date)) { ?>
                 <p class="card-text text-center"><small class="text-muted"><?=date('F d, Y', (string) $date)?></small></p>
             <?php } ?>
         </div>

--- a/concrete/themes/atomik/elements/summary/templates/blog_image_left.php
+++ b/concrete/themes/atomik/elements/summary/templates/blog_image_left.php
@@ -11,9 +11,11 @@ $view->setViewTheme('atomik');
         <div class="col-md-6">
             <h5 class=""><a href="<?=$link?>"><?=$title?></a></h5>
             <?php
-            $view->inc('elements/byline.php', ['author' => $author, 'date' => $date]);
+            if (isset($author) || isset($date)) {
+                $view->inc('elements/byline.php', ['author' => $author ?? '', 'date' => $date ?? '']);
+            }
             ?>
-            <?php if ($description) { ?>
+            <?php if (isset($description)) { ?>
                 <p><?=$description?></p>
             <?php } ?>
         </div>

--- a/concrete/themes/atomik/elements/summary/templates/blog_image_right.php
+++ b/concrete/themes/atomik/elements/summary/templates/blog_image_right.php
@@ -8,9 +8,11 @@ $view->setViewTheme('atomik');
         <div class="col-md-6 order-2 order-md-1">
             <h5 class=""><a href="<?=$link?>"><?=$title?></a></h5>
             <?php
-            $view->inc('elements/byline.php', ['author' => $author, 'date' => $date]);
+            if (isset($author) || isset($date)) {
+                $view->inc('elements/byline.php', ['author' => $author ?? '', 'date' => $date ?? '']);
+            }
             ?>
-            <?php if ($description) { ?>
+            <?php if (isset($description)) { ?>
                 <p><?=$description?></p>
             <?php } ?>
         </div>

--- a/concrete/themes/atomik/elements/summary/templates/blog_image_top.php
+++ b/concrete/themes/atomik/elements/summary/templates/blog_image_top.php
@@ -7,9 +7,11 @@ $view->setViewTheme('atomik');
     <img class="img-fluid mb-3" src="<?=$thumbnail->getThumbnailURL('blog_entry_thumbnail')?>">
     <h5 class=""><a href="<?=$link?>"><?=$title?></a></h5>
     <?php
-    $view->inc('elements/byline.php', ['author' => $author, 'date' => $date]);
+    if (isset($author) || isset($date)) {
+        $view->inc('elements/byline.php', ['author' => $author ?? '', 'date' => $date ?? '']);
+    }
     ?>
-    <?php if ($description) { ?>
+    <?php if (isset($description)) { ?>
         <p><?=$description?></p>
     <?php } ?>
 </div>


### PR DESCRIPTION
Checks for set variables in templates

I can't think of a situation where `$date` wouldn't be set, but I added a check for that as well.