### PR TITLE
Prevents PHP8 undefined key exception in `Snippet::getByHandle()`

### DIFF
--- a/concrete/src/Editor/Snippet.php
+++ b/concrete/src/Editor/Snippet.php
@@ -50,7 +50,7 @@ abstract class Snippet extends ConcreteObject
     {
         $db = Loader::db();
         $r = $db->GetRow('select scsHandle, scsIsActive, pkgID, scsName from SystemContentEditorSnippets where scsHandle = ?', array($scsHandle));
-        if (is_array($r) && $r['scsHandle']) {
+        if (array_key_exists('scsHandle', $r)) {
             $pkgHandle = false;
             if ($r['pkgID']) {
                 $pkgHandle = PackageList::getHandle($r['pkgID']);


### PR DESCRIPTION
`$r` is always an array, so we just need to check if the `scsHandle` key is present
