### PR TITLE
[Fix] Load fresh version object instead of cached one

### DIFF
--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -2555,15 +2555,15 @@ EOT
             $r->execute($v);
         }
 
-        // load new version object
-        $this->loadVersionObject($cvID);
-
         $db->executeQuery('update Pages set ptID = ?, uID = ?, pkgID = ?, cFilename = ?, cCacheFullPageContent = ?, cCacheFullPageContentLifetimeCustom = ?, cCacheFullPageContentOverrideLifetime = ? where cID = ?', [$ptID, $uID, $pkgID, $cFilename, $cCacheFullPageContent, $cCacheFullPageContentLifetimeCustom, $cCacheFullPageContentOverrideLifetime, $this->cID]);
 
         $cache = PageCache::getLibrary();
         $cache->purge($this);
 
         $this->refreshCache();
+
+        // load new version object
+        $this->loadVersionObject($cvID);
 
         $pe = new Event($this);
         Events::dispatch('on_page_update', $pe);


### PR DESCRIPTION
The `loadVersionObject` function retrieves the version from the cache due to the `\Concrete\Core\Page\Collection\Version\Version::get` function. Though we purge this cache, it happens too late - the version has already been loaded from the cache.

Because of this bug, if we attempt to retrieve, for instance, `getVersionObject()->getVersionName()` within the current request, we end up getting the cached (and outdated) name.

We could also invoke `refreshCache` before executing the entire `update` function, but this minor change should suffice for now.
