### PR TITLE
EditResponse: add support for reloading the current page

### DIFF
--- a/concrete/src/Application/EditResponse.php
+++ b/concrete/src/Application/EditResponse.php
@@ -60,6 +60,13 @@ class EditResponse implements JsonSerializable
     public $redirectURL;
 
     /**
+     * The current page should be reloaded.
+     *
+     * @var bool
+     */
+    private $reloadCurrentPage = false;
+
+    /**
      * Additional response data.
      *
      * @var array
@@ -217,6 +224,26 @@ class EditResponse implements JsonSerializable
     }
 
     /**
+     * The current page should be reloaded?
+     *
+     * @return $this
+     */
+    public function setReloadCurrentPage(bool $value): object
+    {
+        $this->reloadCurrentPage = $value;
+
+        return $this;
+    }
+
+    /**
+     * The current page should be reloaded?
+     */
+    public function isReloadCurrentPage(): bool
+    {
+        return $this->reloadCurrentPage;
+    }
+
+    /**
      * Set additional response data.
      *
      * @param string $key
@@ -276,6 +303,7 @@ class EditResponse implements JsonSerializable
         $o->message = $this->getMessage();
         $o->title = $this->getTitle();
         $o->redirectURL = (string) $this->getRedirectURL();
+        $o->reloadCurrentPage = $this->isReloadCurrentPage();
         foreach ($this->additionalData as $key => $value) {
             $o->{$key} = $value;
         }

--- a/concrete/src/Application/EditResponse.php
+++ b/concrete/src/Application/EditResponse.php
@@ -53,7 +53,7 @@ class EditResponse implements JsonSerializable
     /**
      * The redirect URL of the response.
      *
-     * @var string|\League\URL\URLInterface|null
+     * @var string|\League\Url\UrlInterface|null
      *
      * @deprecated since concrete5 8.5.0a3 (what's deprecated is the "public part") - use setMessage/getMessage
      */
@@ -202,7 +202,7 @@ class EditResponse implements JsonSerializable
     /**
      * Set the redirect URL of the response.
      *
-     * @param string|\League\URL\URLInterface|null $url
+     * @param string|\League\Url\UrlInterface|null $url
      *
      * @return $this
      */
@@ -216,7 +216,7 @@ class EditResponse implements JsonSerializable
     /**
      * Get the redirect URL of the response.
      *
-     * @return string|\League\URL\URLInterface|null
+     * @return string|\League\Url\UrlInterface|null
      */
     public function getRedirectURL()
     {


### PR DESCRIPTION
At the moment there's no way to let `EditResponse`s force the reload of the current page.

Reloading the current page may be useful when we don't know the exact URL to be loaded (think for example a paginated list, where the current page depends on querystring parameters - for example `/dashboard/users/groups`).