### PR TITLE
Fix Tree\Group::ensureGroupNodes

### DIFF
--- a/concrete/src/Tree/Type/Group.php
+++ b/concrete/src/Tree/Type/Group.php
@@ -1,9 +1,9 @@
 <?php
 namespace Concrete\Core\Tree\Type;
 
+use Concrete\Core\Tree\Node\Type\Group as GroupTreeNode;
 use Concrete\Core\Tree\Tree;
 use Database;
-use GroupTreeNode;
 
 class Group extends Tree
 {

--- a/concrete/src/Tree/Type/Group.php
+++ b/concrete/src/Tree/Type/Group.php
@@ -71,9 +71,9 @@ class Group extends Tree
     public static function ensureGroupNodes()
     {
         $db = Database::connection();
-        $tree = GroupTree::get();
+        $tree = static::get();
         $rootNode = $tree->getRootTreeNodeObject();
-        $rows = $db->GetCol('select Groups.gID from ' . $db->getDatabasePlatform()->quoteSingleIdentifier('Groups') . ' left join TreeGroupNodes on Groups.gID = TreeGroupNodes.gID where TreeGroupNodes.gID is null');
+        $rows = $db->fetchFirstColumn('select Groups.gID from ' . $db->getDatabasePlatform()->quoteSingleIdentifier('Groups') . ' left join TreeGroupNodes on Groups.gID = TreeGroupNodes.gID where TreeGroupNodes.gID is null');
         foreach ($rows as $gID) {
             $g = static::getByID($gID);
             GroupTreeNode::add($g, $rootNode);


### PR DESCRIPTION
`GroupTree` doesn't exist in the `Concrete\Core\Tree\Type` namespace: we wanted to use `\GroupTree`, which is an alias of `\Concrete\Core\Tree\Type\Group`, which is the current class (so, let's use `static`)