### PR TITLE
Enhance DeleteGroupCommand to customize its handling of sub-groups

### DIFF
--- a/concrete/src/User/Group/Command/DeleteGroupCommand.php
+++ b/concrete/src/User/Group/Command/DeleteGroupCommand.php
@@ -11,9 +11,11 @@ class DeleteGroupCommand extends Command
 
     public const ONCHILDGROUPS_MOVETOROOT = 1;
 
-    public const ONCHILDGROUPS_ABORT = 2;
+    public const ONCHILDGROUPS_MOVETOPARENT = 2;
 
-    public const ONCHILDGROUPS_DELETE = 3;
+    public const ONCHILDGROUPS_ABORT = 3;
+
+    public const ONCHILDGROUPS_DELETE = 4;
 
     /**
      * @var bool
@@ -69,6 +71,7 @@ class DeleteGroupCommand extends Command
      * @return $this
      *
      * @see \Concrete\Core\User\Group\Command\DeleteGroupCommand::ONCHILDGROUPS_MOVETOROOT
+     * @see \Concrete\Core\User\Group\Command\DeleteGroupCommand::ONCHILDGROUPS_MOVETOPARENT
      * @see \Concrete\Core\User\Group\Command\DeleteGroupCommand::ONCHILDGROUPS_ABORT
      * @see \Concrete\Core\User\Group\Command\DeleteGroupCommand::ONCHILDGROUPS_DELETE
      */
@@ -81,6 +84,7 @@ class DeleteGroupCommand extends Command
 
     /**
      * @see \Concrete\Core\User\Group\Command\DeleteGroupCommand::ONCHILDGROUPS_MOVETOROOT
+     * @see \Concrete\Core\User\Group\Command\DeleteGroupCommand::ONCHILDGROUPS_MOVETOPARENT
      * @see \Concrete\Core\User\Group\Command\DeleteGroupCommand::ONCHILDGROUPS_ABORT
      * @see \Concrete\Core\User\Group\Command\DeleteGroupCommand::ONCHILDGROUPS_DELETE
      */

--- a/concrete/src/User/Group/Command/DeleteGroupCommand.php
+++ b/concrete/src/User/Group/Command/DeleteGroupCommand.php
@@ -9,10 +9,26 @@ class DeleteGroupCommand extends Command
 {
     use ExistingGroupTrait;
 
+    public const ONCHILDGROUPS_MOVETOROOT = 1;
+
+    public const ONCHILDGROUPS_ABORT = 2;
+
+    public const ONCHILDGROUPS_DELETE = 3;
+
     /**
      * @var bool
      */
     private $onlyIfEmpty = false;
+
+    /**
+     * @var bool
+     */
+    private $onChildGroups = self::ONCHILDGROUPS_MOVETOROOT;
+
+    /**
+     * @var bool
+     */
+    private $extendedResults = false;
 
     public function __construct(int $groupId)
     {
@@ -32,5 +48,44 @@ class DeleteGroupCommand extends Command
         $this->onlyIfEmpty = $value;
 
         return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setExtendedResults(bool $value): object
+    {
+        $this->extendedResults = $value;
+
+        return $this;
+    }
+
+    public function isExtendedResults(): bool
+    {
+        return $this->extendedResults;
+    }
+
+    /**
+     * @return $this
+     *
+     * @see \Concrete\Core\User\Group\Command\DeleteGroupCommand::ONCHILDGROUPS_MOVETOROOT
+     * @see \Concrete\Core\User\Group\Command\DeleteGroupCommand::ONCHILDGROUPS_ABORT
+     * @see \Concrete\Core\User\Group\Command\DeleteGroupCommand::ONCHILDGROUPS_DELETE
+     */
+    public function setOnChildGroups(int $value): object
+    {
+        $this->onChildGroups = $value;
+
+        return $this;
+    }
+
+    /**
+     * @see \Concrete\Core\User\Group\Command\DeleteGroupCommand::ONCHILDGROUPS_MOVETOROOT
+     * @see \Concrete\Core\User\Group\Command\DeleteGroupCommand::ONCHILDGROUPS_ABORT
+     * @see \Concrete\Core\User\Group\Command\DeleteGroupCommand::ONCHILDGROUPS_DELETE
+     */
+    public function getOnChildGroups(): int
+    {
+        return $this->onChildGroups;
     }
 }

--- a/concrete/src/User/Group/Command/DeleteGroupCommand/Result.php
+++ b/concrete/src/User/Group/Command/DeleteGroupCommand/Result.php
@@ -14,6 +14,17 @@ final class Result
      */
     private $undeletableGroups = [];
 
+    public function __toString(): string
+    {
+        $lines = [];
+        $lines[] = t2(/*i18n: %s is a number*/ '%s group has been deleted', '%s groups have been deleted', $this->getNumberOfDeletedGroups());
+        foreach ($this->getUndeletableGroups() as $reason) {
+            $lines[] = $reason;
+        }
+
+        return implode("\n", $lines);
+    }
+
     public function isGroupDeleted(int $groupID): bool
     {
         return in_array($groupID, $this->deletedGroupIDs, true);

--- a/concrete/src/User/Group/Command/DeleteGroupCommand/Result.php
+++ b/concrete/src/User/Group/Command/DeleteGroupCommand/Result.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Concrete\Core\User\Group\Command\DeleteGroupCommand;
+
+final class Result
+{
+    /**
+     * @var int[]
+     */
+    private $deletedGroupIDs = [];
+
+    /**
+     * Array keys are the group IDs, array values are the reasons why the group couldn't be deleted.
+     */
+    private $undeletableGroups = [];
+
+    public function isGroupDeleted(int $groupID): bool
+    {
+        return in_array($groupID, $this->deletedGroupIDs, true);
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getDeletedGroupIDs(): array
+    {
+        return $this->deletedGroupIDs;
+    }
+
+    public function getNumberOfDeletedGroups(): int
+    {
+        return count($this->deletedGroupIDs);
+    }
+
+    /**
+     * @return $this
+     */
+    public function addDeletedGroup(int $groupID): object
+    {
+        if (!in_array($groupID, $this->deletedGroupIDs, true)) {
+            $this->deletedGroupIDs[] = $groupID;
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function addUndeletableGrup(int $groupID, string $reason): object
+    {
+        $this->undeletableGroups[$groupID] = $reason;
+
+        return $this;
+    }
+
+    public function getNumberOfUndeletableGroups(): int
+    {
+        return count($this->undeletableGroups);
+    }
+
+    /**
+     * Array keys are the group IDs, array values are the reasons why the group couldn't be deleted.
+     */
+    public function getUndeletableGroups(): array
+    {
+        return $this->undeletableGroups;
+    }
+
+    /**
+     * Merge another Result instance into this one.
+     *
+     * @return $this
+     */
+    public function merge(self $other): object
+    {
+        $this->deletedGroupIDs = array_values(array_unique(array_merge($this->deletedGroupIDs, $other->getDeletedGroupIDs()), SORT_NUMERIC));
+        $this->undeletableGroups += $other->getUndeletableGroups();
+
+        return $this;
+    }
+}

--- a/concrete/src/User/Group/Command/DeleteGroupCommandHandler.php
+++ b/concrete/src/User/Group/Command/DeleteGroupCommandHandler.php
@@ -143,6 +143,39 @@ class DeleteGroupCommandHandler
     {
         $groupNode->populateDirectChildrenOnly();
         switch ($command->getOnChildGroups()) {
+            case DeleteGroupCommand::ONCHILDGROUPS_MOVETOROOT:
+                $groupTree = GroupTree::get();
+                $rootNode = $groupTree->getRootTreeNodeObject();
+                if ($rootNode === null) {
+                    $result->addUndeletableGrup(
+                        $group->getGroupID(),
+                        t("The group \"%s\" can't be deleted because we coulnd't find the root tree node", $group->getGroupDisplayName(false))
+                    );
+
+                    return false;
+                }
+                foreach ($groupNode->getChildNodes() as $childnode) {
+                    $childnode->move($rootNode);
+                }
+                break;
+            case DeleteGroupCommand::ONCHILDGROUPS_MOVETOPARENT:
+                $parentNode = $groupNode->getTreeNodeParentObject();
+                if ($parentNode === null) {
+                    $groupTree = GroupTree::get();
+                    $parentNode = $groupTree->getRootTreeNodeObject();
+                    if ($parentNode === null) {
+                        $result->addUndeletableGrup(
+                            $group->getGroupID(),
+                            t("The group \"%s\" can't be deleted because we coulnd't find the root tree node", $group->getGroupDisplayName(false))
+                        );
+
+                        return false;
+                    }
+                }
+                foreach ($groupNode->getChildNodes() as $childnode) {
+                    $childnode->move($parentNode);
+                }
+                break;
             case DeleteGroupCommand::ONCHILDGROUPS_ABORT:
                 $numChildGroups = count($groupNode->getChildNodes());
                 if ($numChildGroups !== 0) {
@@ -157,21 +190,6 @@ class DeleteGroupCommandHandler
                     );
 
                     return false;
-                }
-                break;
-            case DeleteGroupCommand::ONCHILDGROUPS_MOVETOROOT:
-                $groupTree = GroupTree::get();
-                $rootNode = $groupTree->getRootTreeNodeObject();
-                if ($rootNode === null) {
-                    $result->addUndeletableGrup(
-                        $group->getGroupID(),
-                        t("The group \"%s\" can't be deleted because we coulnd't find the root tree node", $group->getGroupDisplayName(false))
-                    );
-
-                    return false;
-                }
-                foreach ($groupNode->getChildNodes() as $childnode) {
-                    $childnode->move($rootNode);
                 }
                 break;
             case DeleteGroupCommand::ONCHILDGROUPS_DELETE:

--- a/concrete/src/User/Group/Command/DeleteGroupCommandHandler.php
+++ b/concrete/src/User/Group/Command/DeleteGroupCommandHandler.php
@@ -7,16 +7,16 @@ use Concrete\Core\Database\Connection\Connection;
 use Concrete\Core\Entity\User\GroupCreate;
 use Concrete\Core\Entity\User\GroupSignup;
 use Concrete\Core\Entity\User\GroupSignupRequest;
+use Concrete\Core\Events\EventDispatcher;
 use Concrete\Core\Tree\Node\Type\Group as GroupTreeNode;
 use Concrete\Core\Tree\Type\Group as GroupTree;
 use Concrete\Core\User\Group\DeleteEvent;
+use Concrete\Core\User\Group\Group;
 use Concrete\Core\User\Group\GroupRepository;
-use Concrete\Core\Events\EventDispatcher;
 use Doctrine\ORM\EntityManager;
 
 class DeleteGroupCommandHandler
 {
-
     /**
      * @var Connection
      */
@@ -46,10 +46,9 @@ class DeleteGroupCommandHandler
         GroupRepository $groupRepository,
         Connection $connection,
         EventDispatcher $dispatcher,
-        EntityManager  $entityManager,
+        EntityManager $entityManager,
         RequestCache $requestCache
-    )
-    {
+    ) {
         $this->groupRepository = $groupRepository;
         $this->connection = $connection;
         $this->dispatcher = $dispatcher;
@@ -57,67 +56,173 @@ class DeleteGroupCommandHandler
         $this->requestCache = $requestCache;
     }
 
+    /**
+     * @return \Concrete\Core\User\Group\Command\DeleteGroupCommand\Result|bool
+     */
     public function __invoke(DeleteGroupCommand $command)
     {
+        $result = new DeleteGroupCommand\Result();
         $groupID = $command->getGroupID();
-        // we will NOT let you delete the required groups
-        if ($groupID == REGISTERED_GROUP_ID || $groupID == GUEST_GROUP_ID) {
-            return false;
+        $group = $this->checkDeletableGroup($groupID, $command->isOnlyIfEmpty(), $result);
+        if ($group === null) {
+            return $command->isExtendedResults() ? $result : false;
+        }
+        $groupNode = GroupTreeNode::getTreeNodeByGroupID($groupID);
+        if ($groupNode !== null) {
+            if ($this->processChildGroups($command, $group, $groupNode, $result) === false) {
+                return $command->isExtendedResults() ? $result : false;
+            }
+            $groupNode->delete();
+        }
+        $this->cleanupReferences($groupID);
+        $result->addDeletedGroup($groupID);
+
+        return $command->isExtendedResults() ? $result : null;
+    }
+
+    /**
+     * @return \Concrete\Core\User\Group\Group|null returns NULL if the group can't be deleted (the reason will be added to $result)
+     */
+    private function checkDeletableGroup(int $groupID, bool $mustBeWithoutMembers, DeleteGroupCommand\Result $result): ?Group
+    {
+        if ($groupID === REGISTERED_GROUP_ID) {
+            $result->addUndeletableGrup($groupID, t("It's not possible to delete the Registered Users group"));
+
+            return null;
+        }
+
+        if ($groupID == GUEST_GROUP_ID) {
+            $result->addUndeletableGrup($groupID, t("It's not possible to delete the Guest group"));
+
+            return null;
         }
 
         $group = $this->groupRepository->getGroupById($groupID);
         if (!$group) {
-            return false;
+            $result->addUndeletableGrup($groupID, t('Unable to find the group with ID %s', $groupID));
+
+            return null;
         }
 
-        if ($command->isOnlyIfEmpty()) {
-            if ($this->connection->fetchOne('SELECT gID FROM UserGroups gID = ? LIMIT 1', [$groupID]) !== false) {
-                return false;
+        if ($mustBeWithoutMembers) {
+            $numMembers = (int) $this->connection->fetchOne('SELECT COUNT(gID) FROM UserGroups WHERE gID = ?', [$groupID]);
+            if ($numMembers !== 0) {
+                $result->addUndeletableGrup(
+                    $groupID,
+                    t2(
+                        "The group \"%2\$s\" can't be deleted because it contains %1\$s member",
+                        "The group \"%2\$s\" can't be deleted because it contains %1\$s members",
+                        $numMembers,
+                        $group->getGroupDisplayName(false)
+                    )
+                );
+
+                return null;
             }
         }
 
-        // run any internal event we have for group deletion
         $ge = new DeleteEvent($group);
         $ge = $this->dispatcher->dispatch('on_group_delete', $ge);
         if (!$ge->proceed()) {
-            return false;
+            $result->addUndeletableGrup(
+                $groupID,
+                t(
+                    'The removal of the group "%1$s" has been cancelled by the "%2s" event',
+                    $group->getGroupDisplayName(false),
+                    'on_group_delete'
+                )
+            );
+
+            return null;
         }
 
-        $tree = GroupTree::get();
-        $rootNode = $tree->getRootTreeNodeObject();
-        $node = GroupTreeNode::getTreeNodeByGroupID($groupID);
-        if (is_object($node) && is_object($rootNode)) {
-            $node->populateDirectChildrenOnly();
-            foreach ($node->getChildNodes() as $childnode) {
-                $childnode->move($rootNode);
-            }
-            $node = GroupTreeNode::getTreeNodeByGroupID($groupID);
-            $node->delete();
+        return $group;
+    }
+
+    private function processChildGroups(DeleteGroupCommand $command, Group $group, GroupTreeNode $groupNode, DeleteGroupCommand\Result $result): bool
+    {
+        $groupNode->populateDirectChildrenOnly();
+        switch ($command->getOnChildGroups()) {
+            case DeleteGroupCommand::ONCHILDGROUPS_ABORT:
+                $numChildGroups = count($groupNode->getChildNodes());
+                if ($numChildGroups !== 0) {
+                    $result->addUndeletableGrup(
+                        $group->getGroupID(),
+                        t2(
+                            "The group \"%2\$s\" can't be deleted because it contains %1\$s sub-group",
+                            "The group \"%2\$s\" can't be deleted because it contains %1\$s sub-groups",
+                            $numChildGroups,
+                            $group->getGroupDisplayName(false)
+                        )
+                    );
+
+                    return false;
+                }
+                break;
+            case DeleteGroupCommand::ONCHILDGROUPS_MOVETOROOT:
+                $groupTree = GroupTree::get();
+                $rootNode = $groupTree->getRootTreeNodeObject();
+                if ($rootNode === null) {
+                    $result->addUndeletableGrup(
+                        $group->getGroupID(),
+                        t("The group \"%s\" can't be deleted because we coulnd't find the root tree node", $group->getGroupDisplayName(false))
+                    );
+
+                    return false;
+                }
+                foreach ($groupNode->getChildNodes() as $childnode) {
+                    $childnode->move($rootNode);
+                }
+                break;
+            case DeleteGroupCommand::ONCHILDGROUPS_DELETE:
+                $childGroupCommand = clone $command;
+                $childGroupCommand->setExtendedResults(true);
+                foreach ($groupNode->getChildNodes() as $childGroupNode) {
+                    /** @var \Concrete\Core\Tree\Node\Type\Group $childGroupNode */
+                    $childGroupCommand->setGroupID($childGroupNode->getTreeNodeGroupID());
+                    $result->merge($this->__invoke($childGroupCommand));
+                }
+                $numUndeletableGroups = $result->getNumberOfUndeletableGroups();
+                if ($numUndeletableGroups !== 0) {
+                    $result->addUndeletableGrup(
+                        $group->getGroupID(),
+                        t("The group \"%s\" can't be deleted because we coulnd't delete all its child groups", $group->getGroupDisplayName(false))
+                    );
+
+                    return false;
+                }
+                break;
+            default:
+                $result->addUndeletableGrup(
+                    $group->getGroupID(),
+                    t("The group \"%s\" can't be deleted because we don't know how to handle its child groups", $group->getGroupDisplayName(false))
+                );
+
+                return false;
         }
 
-        $groupCreates = $this->entityManager->getRepository(GroupCreate::class)
-            ->findBy(['gID' => $command->getGroupID()]);
+        return true;
+    }
+
+    private function cleanupReferences(int $groupID): void
+    {
+        $groupCreates = $this->entityManager->getRepository(GroupCreate::class)->findBy(['gID' => $groupID]);
         foreach ($groupCreates as $groupCreate) {
             $this->entityManager->remove($groupCreate);
         }
-        $groupSignups = $this->entityManager->getRepository(GroupSignup::class)
-            ->findBy(['gID' => $command->getGroupID()]);
+        $groupSignups = $this->entityManager->getRepository(GroupSignup::class)->findBy(['gID' => $groupID]);
         foreach ($groupSignups as $groupSignup) {
             $this->entityManager->remove($groupSignup);
         }
-        $groupSignupRequests = $this->entityManager->getRepository(GroupSignupRequest::class)
-            ->findBy(['gID' => $command->getGroupID()]);
+        $groupSignupRequests = $this->entityManager->getRepository(GroupSignupRequest::class)->findBy(['gID' => $groupID]);
         foreach ($groupSignupRequests as $groupSignupRequest) {
             $this->entityManager->remove($groupSignupRequest);
         }
         $this->entityManager->flush();
-
         $table = $this->connection->getDatabasePlatform()->quoteSingleIdentifier('Groups');
-        $this->connection->query('DELETE FROM UserGroups WHERE gID = ?', [intval($groupID)]);
-        $this->connection->query('DELETE FROM ' . $table . ' WHERE gID = ?', [(int) $groupID]);
-        $this->connection->query('delete from GroupSelectedRoles where gID = ?', [(int) $groupID]);
+        $this->connection->query('DELETE FROM UserGroups WHERE gID = ?', [$groupID]);
+        $this->connection->query('DELETE FROM ' . $table . ' WHERE gID = ?', [$groupID]);
+        $this->connection->query('delete from GroupSelectedRoles where gID = ?', [$groupID]);
         $this->requestCache->delete('tree/node');
     }
-
-
 }

--- a/tests/tests/User/GroupTest.php
+++ b/tests/tests/User/GroupTest.php
@@ -194,7 +194,7 @@ class GroupTest extends UserTestCase
             } else {
                 $user->enterGroup($groupB);
             }
-            ++$i;
+            $i++;
         }
 
         $user = \UserInfo::getByName('zxsdfer');
@@ -229,7 +229,6 @@ class GroupTest extends UserTestCase
         $user = $user->getUserObject();
         $user->enterGroup($groupD);
 
-
         $user = \UserInfo::getByName('zxcvz1231');
         $user = $user->getUserObject();
         $user->enterGroup($groupC);
@@ -240,12 +239,10 @@ class GroupTest extends UserTestCase
         $results = $list4->getResults();
         $this->assertEquals(7, count($results));
 
-
         $list5 = new UserList();
         $list5->filterByInAnyGroup([$groupC, $groupA], false);
         $results = $list5->getResults();
         $this->assertEquals(5, count($results));
-
 
         $list6 = new UserList();
         $list6->filterByInAnyGroup([$groupB, $groupA], true);

--- a/tests/tests/User/GroupTest.php
+++ b/tests/tests/User/GroupTest.php
@@ -2,9 +2,11 @@
 
 namespace Concrete\Tests\User;
 
+use Concrete\Core\Entity;
 use Concrete\Core\Tree\Node\NodeType as TreeNodeType;
 use Concrete\Core\Tree\TreeType;
 use Concrete\Core\Tree\Type\Group as GroupTreeType;
+use Concrete\Core\User\Group\Command;
 use Concrete\Core\User\Group\Group;
 use Concrete\Core\User\UserList;
 use Concrete\TestHelpers\User\UserTestCase;
@@ -19,21 +21,27 @@ class GroupTest extends UserTestCase
         TreeNodeType::add('group');
         TreeType::add('group');
         GroupTreeType::add();
-        $g1 = Group::add(
+        Group::add(
             tc('GroupName', 'Guest'),
             tc('GroupDescription', 'The guest group represents unregistered visitors to your site.'),
             false,
             false,
             GUEST_GROUP_ID
         );
-        $g2 = Group::add(
+        Group::add(
             tc('GroupName', 'Registered Users'),
             tc('GroupDescription', 'The registered users group represents all user accounts.'),
             false,
             false,
             REGISTERED_GROUP_ID
         );
-        $g3 = Group::add(tc('GroupName', 'Administrators'), '', false, false, ADMIN_GROUP_ID);
+        Group::add(
+            tc('GroupName', 'Administrators'),
+            '',
+            false,
+            false,
+            ADMIN_GROUP_ID
+        );
     }
 
     public function testAutomatedGroupsBase()
@@ -247,7 +255,6 @@ class GroupTest extends UserTestCase
 
     public function testParentChildGroups()
     {
-
         $group1 = Group::add('User Group', 'This is a parent test group 1');
         $group2 = Group::add('User Group Child', 'This is a child test group 1', $group1);
         $group3 = Group::add('User Group Child 2', 'This is a child test group 2', $group1);
@@ -293,6 +300,229 @@ class GroupTest extends UserTestCase
         // Check they are not a member of any children
         $this->assertFalse($fuu4->inGroup($group2));
         $this->assertTrue($fuu4->inGroup($group3));
+    }
 
+    public function testGroupRemoval(): void
+    {
+        /*
+         * Create the following group tree:
+         *
+         * root
+         *  ├── a     (without users)
+         *  ├── b     (without users)
+         *  ├─┬ c     (without users)
+         *  │ ├── c1  (without users)
+         *  │ └── c2  (without users)
+         *  ├─┬ d     (without users)
+         *  │ ├── d1  (without users)
+         *  │ └── d2  (without users)
+         *  ├─┬ e     (with users)
+         *  │ └── e1  (without users)
+         *  ├─┬ f     (without users)
+         *  │ ├── f1  (without users)
+         *  │ ├─┬ f2  (with users)
+         *  │ │ └ f21 (without users)
+         *  │ └─┬ f3 (without users)
+         *  │   └ f31 (without users)
+         */
+        $app = app();
+        $a = Group::add('a', '', null);
+        $b = Group::add('b', '', null);
+        $c = Group::add('c', '', null);
+        $c1 = Group::add('c1', '', $c);
+        $c2 = Group::add('c2', '', $c);
+        $d = Group::add('d', '', null);
+        $d1 = Group::add('d1', '', $d);
+        $d2 = Group::add('d2', '', $d);
+        $e = Group::add('e', '', null);
+        $e1 = Group::add('e1', '', $e);
+        $f = Group::add('f', '', null);
+        $f1 = Group::add('f1', '', $f);
+        $f2 = Group::add('f2', '', $f);
+        $f21 = Group::add('f21', '', $f2);
+        $f3 = Group::add('f3', '', $f);
+        $f31 = Group::add('f31', '', $f3);
+
+        $userInfo = $this->createUser('username', 'user@email.org');
+        $user = $userInfo->getUserObject();
+        foreach ([$e, $f2] as $group) {
+            $user->enterGroup($group);
+        }
+
+        // Let's delete the group /a and check the "non-extended" result (backward compatible)
+        $command = new Command\DeleteGroupCommand($a->getGroupID());
+        $result = $app->executeCommand($command);
+        $this->assertSame(null, $result);
+
+        // Let's try again to delete the group /a
+        $result = $app->executeCommand($command);
+        $this->assertSame(false, $result);
+
+        // Let's delete the group /b and check the new "extended" result
+        $command = (new Command\DeleteGroupCommand($b->getGroupID()))
+            ->setExtendedResults(true)
+        ;
+        $result = $app->executeCommand($command);
+        $this->assertInstanceOf(Command\DeleteGroupCommand\Result::class, $result);
+        /** @var \Concrete\Core\User\Group\Command\DeleteGroupCommand\Result $result */
+        $this->assertSame(true, $result->isGroupDeleted($b->getGroupID()));
+        $this->assertSame([$b->getGroupID()], $result->getDeletedGroupIDs());
+        $this->assertSame(1, $result->getNumberOfDeletedGroups());
+        $this->assertSame(0, $result->getNumberOfUndeletableGroups());
+        $this->assertSame([], $result->getUndeletableGroups());
+
+        // Let's try again to delete the group /b
+        $result = $app->executeCommand($command);
+        $this->assertInstanceOf(Command\DeleteGroupCommand\Result::class, $result);
+        /** @var \Concrete\Core\User\Group\Command\DeleteGroupCommand\Result $result */
+        $this->assertSame(false, $result->isGroupDeleted($b->getGroupID()));
+        $this->assertSame([], $result->getDeletedGroupIDs());
+        $this->assertSame(0, $result->getNumberOfDeletedGroups());
+        $this->assertSame(1, $result->getNumberOfUndeletableGroups());
+        $this->assertSame([$b->getGroupID()], array_keys($result->getUndeletableGroups()));
+
+        // Let's check the "move to root" (backward compatible) option when deleting the group /c
+        $this->assertSame($c1->getGroupID(), Group::getByPath('/c/c1')->getGroupID());
+        $this->assertSame($c2->getGroupID(), Group::getByPath('/c/c2')->getGroupID());
+        $command = (new Command\DeleteGroupCommand($c->getGroupID()))
+            ->setExtendedResults(true)
+        ;
+        $result = $app->executeCommand($command);
+        $this->assertInstanceOf(Command\DeleteGroupCommand\Result::class, $result);
+        /** @var \Concrete\Core\User\Group\Command\DeleteGroupCommand\Result $result */
+        $this->assertSame(true, $result->isGroupDeleted($c->getGroupID()));
+        $this->assertSame([$c->getGroupID()], $result->getDeletedGroupIDs());
+        $this->assertSame(1, $result->getNumberOfDeletedGroups());
+        $this->assertSame(0, $result->getNumberOfUndeletableGroups());
+        $this->assertSame([], $result->getUndeletableGroups());
+        $this->assertNull(Group::getByPath('/c/c1'));
+        $this->assertNull(Group::getByPath('/c/c2'));
+        $this->assertSame($c1->getGroupID(), Group::getByPath('/c1')->getGroupID());
+        $this->assertSame($c2->getGroupID(), Group::getByPath('/c2')->getGroupID());
+
+        // Let's check the "abort" option when deleting the group /d (using the old "non extended" result)
+        $command = (new Command\DeleteGroupCommand($d->getGroupID()))
+            ->setOnChildGroups(Command\DeleteGroupCommand::ONCHILDGROUPS_ABORT)
+        ;
+        $result = $app->executeCommand($command);
+        $this->assertSame(false, $result);
+
+        // Let's check the "abort" option when deleting the group /d (using the new "extended" result)
+        $command = (new Command\DeleteGroupCommand($d->getGroupID()))
+            ->setExtendedResults(true)
+            ->setOnChildGroups(Command\DeleteGroupCommand::ONCHILDGROUPS_ABORT)
+        ;
+        $result = $app->executeCommand($command);
+        $this->assertInstanceOf(Command\DeleteGroupCommand\Result::class, $result);
+        /** @var \Concrete\Core\User\Group\Command\DeleteGroupCommand\Result $result */
+        $this->assertSame(false, $result->isGroupDeleted($d->getGroupID()));
+        $this->assertSame(false, $result->isGroupDeleted($d1->getGroupID()));
+        $this->assertSame(false, $result->isGroupDeleted($d2->getGroupID()));
+        $this->assertSame([], $result->getDeletedGroupIDs());
+        $this->assertSame(0, $result->getNumberOfDeletedGroups());
+        $this->assertSame(1, $result->getNumberOfUndeletableGroups());
+        $this->assertSame([$d->getGroupID()], array_keys($result->getUndeletableGroups()));
+        $this->assertSame($d->getGroupID(), Group::getByPath('/d')->getGroupID());
+        $this->assertSame($d1->getGroupID(), Group::getByPath('/d/d1')->getGroupID());
+        $this->assertSame($d2->getGroupID(), Group::getByPath('/d/d2')->getGroupID());
+
+        // Let's check the "cascade delete" option when deleting the group /d (using the new "extended" result)
+        $command = (new Command\DeleteGroupCommand($d->getGroupID()))
+            ->setExtendedResults(true)
+            ->setOnChildGroups(Command\DeleteGroupCommand::ONCHILDGROUPS_DELETE)
+        ;
+        $result = $app->executeCommand($command);
+        $this->assertInstanceOf(Command\DeleteGroupCommand\Result::class, $result);
+        /** @var \Concrete\Core\User\Group\Command\DeleteGroupCommand\Result $result */
+        $this->assertSame(true, $result->isGroupDeleted($d->getGroupID()));
+        $this->assertSame(true, $result->isGroupDeleted($d1->getGroupID()));
+        $this->assertSame(true, $result->isGroupDeleted($d2->getGroupID()));
+        $this->assertEqualsCanonicalizing([$d->getGroupID(), $d1->getGroupID(), $d2->getGroupID()], $result->getDeletedGroupIDs());
+        $this->assertSame(3, $result->getNumberOfDeletedGroups());
+        $this->assertSame(0, $result->getNumberOfUndeletableGroups());
+        $this->assertSame([], $result->getUndeletableGroups());
+        $this->assertNull(Group::getByID($d->getGroupID()));
+        $this->assertNull(Group::getByID($d1->getGroupID()));
+        $this->assertNull(Group::getByID($d2->getGroupID()));
+
+        // Test skipping deleting a group with members
+        $command = (new Command\DeleteGroupCommand($e->getGroupID()))
+            ->setExtendedResults(true)
+            ->setOnlyIfEmpty(true)
+        ;
+        $result = $app->executeCommand($command);
+        $this->assertInstanceOf(Command\DeleteGroupCommand\Result::class, $result);
+        /** @var \Concrete\Core\User\Group\Command\DeleteGroupCommand\Result $result */
+        $this->assertSame(false, $result->isGroupDeleted($e->getGroupID()));
+        $this->assertSame([], $result->getDeletedGroupIDs());
+        $this->assertSame(0, $result->getNumberOfDeletedGroups());
+        $this->assertSame(1, $result->getNumberOfUndeletableGroups());
+        $this->assertSame([$e->getGroupID()], array_keys($result->getUndeletableGroups()));
+        $this->assertSame($e->getGroupID(), Group::getByPath('/e')->getGroupID());
+        $this->assertSame($e1->getGroupID(), Group::getByPath('/e/e1')->getGroupID());
+
+        // Test deleting a group with members (backward compatible)
+        $command = (new Command\DeleteGroupCommand($e->getGroupID()))
+            ->setExtendedResults(true)
+        ;
+        $result = $app->executeCommand($command);
+        $this->assertInstanceOf(Command\DeleteGroupCommand\Result::class, $result);
+        /** @var \Concrete\Core\User\Group\Command\DeleteGroupCommand\Result $result */
+        $this->assertSame(true, $result->isGroupDeleted($e->getGroupID()));
+        $this->assertSame([$e->getGroupID()], $result->getDeletedGroupIDs());
+        $this->assertSame(1, $result->getNumberOfDeletedGroups());
+        $this->assertSame(0, $result->getNumberOfUndeletableGroups());
+        $this->assertSame([], $result->getUndeletableGroups());
+        $this->assertNull(Group::getByID($e->getGroupID()));
+
+        // Test cascade deleting groups when a child group can't be deleted
+        $command = (new Command\DeleteGroupCommand($f->getGroupID()))
+            ->setExtendedResults(true)
+            ->setOnlyIfEmpty(true)
+            ->setOnChildGroups(Command\DeleteGroupCommand::ONCHILDGROUPS_DELETE)
+        ;
+        $result = $app->executeCommand($command);
+        $this->assertInstanceOf(Command\DeleteGroupCommand\Result::class, $result);
+        /** @var \Concrete\Core\User\Group\Command\DeleteGroupCommand\Result $result */
+        $this->assertSame(false, $result->isGroupDeleted($f->getGroupID()));
+        $this->assertSame(true, $result->isGroupDeleted($f1->getGroupID()));
+        $this->assertSame(false, $result->isGroupDeleted($f2->getGroupID()));
+        $this->assertSame(true, $result->isGroupDeleted($f3->getGroupID()));
+        $this->assertEqualsCanonicalizing([$f1->getGroupID(), $f3->getGroupID(), $f31->getGroupID()], $result->getDeletedGroupIDs());
+        $this->assertSame(3, $result->getNumberOfDeletedGroups());
+        $this->assertSame(2, $result->getNumberOfUndeletableGroups());
+        $this->assertEqualsCanonicalizing([$f->getGroupID(), $f2->getGroupID()], array_keys($result->getUndeletableGroups()));
+        $this->assertSame($f->getGroupID(), Group::getByPath('/f')->getGroupID());
+        $this->assertSame($f2->getGroupID(), Group::getByPath('/f/f2')->getGroupID());
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\TestHelpers\Database\ConcreteDatabaseTestCase::getMetadatas()
+     */
+    protected function getMetadatas()
+    {
+        $this->metadatas = array_values(array_unique(array_merge($this->metadatas, [
+            Entity\User\GroupCreate::class,
+            Entity\User\GroupSignup::class,
+            Entity\User\GroupSignupRequest::class,
+        ])));
+
+        return parent::getMetadatas();
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\TestHelpers\Database\ConcreteDatabaseTestCase::getTables()
+     */
+    protected function getTables()
+    {
+        $this->tables = array_values(array_unique(array_merge($this->tables, [
+            'GroupSelectedRoles',
+        ])));
+
+        return parent::getTables();
     }
 }


### PR DESCRIPTION
At the moment, when `DeleteGroupCommand` is going to delete a group that contains sub-groups, those sub-groups are automatically moved under the root group directory.

What about adding a way to configure this behavior?

This PR introduces 3 options:

- move sub-groups to the root directory (default behavior, compatible with the current one)
- recursively delete sub-groups
- don't delete the group if it contains sub-groups

Also, let's add a way to tell `DeleteGroupCommandHandler` to return a more informative result (at the moment it only reurns `null` if the operation succeedes, `false` otherwise): setting the new "extended" result parameter to true we now receive an instance of `Concrete\Core\User\Group\Command\DeleteGroupCommand\Result` (by default, the "extended" result is turned off to grant backward compatibility).
