### PR TITLE
[v9][Fix] CollectionSearchIndexAttributes table is being updated without approving the page version

### DIFF
--- a/concrete/src/Page/Search/Index/PageIndexer.php
+++ b/concrete/src/Page/Search/Index/PageIndexer.php
@@ -65,18 +65,18 @@ class PageIndexer implements IndexingDriverInterface, ApplicationAwareInterface
     /**
      * Get a page based on criteria
      * @param string|int|Page|Collection $page
-     * @return \Concrete\Core\Page\Page
+     * @return \Concrete\Core\Page\Page|null
      */
     protected function getPage($page)
     {
         // Handle passed cID
         if (is_numeric($page)) {
-            return Page::getByID($page);
+            return Page::getByID($page, 'ACTIVE');
         }
 
         // Handle passed /path/to/collection
         if (is_string($page)) {
-            return Page::getByPath($page);
+            return Page::getByPath($page, 'ACTIVE');
         }
 
         // If it's a page, just return the page
@@ -84,10 +84,11 @@ class PageIndexer implements IndexingDriverInterface, ApplicationAwareInterface
             return $page;
         }
 
-        // If it's not a page but it's a collection, lets try getting a page by id
+        // If it's not a page, but it's a collection, lets try getting a page by id
         if ($page instanceof Collection) {
             return $this->getPage($page->getCollectionID());
         }
-    }
 
+        return null;
+    }
 }


### PR DESCRIPTION
This pull request addresses the following issue:

The problem occurs in several instances:

1. After editing a page using the composer form and saving the changes, it promptly updates the `CollectionSearchIndexAttributes` table.
2. While editing a page using the attributes form and saving it, the update doesn't take immediate effect but updates the `CollectionSearchIndexAttributes` table when the `index_search` job is executed.
3. The `index_search` job, upon execution, indexes the `recent` version of a page instead of the `active` version.

This issue has an impact on the page list blocks that utilize attribute filtering. Consequently, it displays pages before they have been approved.

I noticed that a similar issue https://github.com/concretecms/concretecms/issues/10051 had been resolved in version 9. However, this resolution only addressed the issue outlined in point `1`. The concerns raised in points `2` and `3` remain unaddressed.