### PR TITLE
Fully implement webp support for thumbnails

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -753,11 +753,16 @@ return [
          */
         'default_jpeg_image_compression' => 80,
         /*
+         * The WEBP compression level (in range 0... 100)
+         */
+        'default_webp_image_compression' => 80,
+        /*
          * The PNG compression level (in range 0... 9)
          */
         'default_png_image_compression' => 9,
         /*
-         * The default thumbnail format: jpeg, png, auto (if auto: we'll create a jpeg if the source image is jpeg, we'll create a png otherwise).
+         * The default thumbnail format: jpeg, png, webp, auto
+         * (if auto: we'll keep original format if it is supported, we'll create a webp otherwise).
          */
         'default_thumbnail_format' => 'auto',
         /*

--- a/concrete/controllers/single_page/dashboard/system/files/image_uploading.php
+++ b/concrete/controllers/single_page/dashboard/system/files/image_uploading.php
@@ -26,6 +26,7 @@ class ImageUploading extends DashboardPageController
         $this->set('manipulation_library', $config->get('concrete.file_manager.images.manipulation_library'));
 
         $this->set('jpeg_quality', $bitmapFormat->getDefaultJpegQuality());
+        $this->set('webp_quality', $bitmapFormat->getDefaultWebpQuality());
         $this->set('png_compression', $bitmapFormat->getDefaultPngCompressionLevel());
 
         $this->set('restrict_max_width', (int) $config->get('concrete.file_manager.restrict_max_width'));
@@ -102,6 +103,12 @@ class ImageUploading extends DashboardPageController
             } else {
                 $this->error->add(t('Invalid JPEG quality level'));
             }
+            $webp_quality = (int) $post->get('webp_quality');
+            if ($valn->integer($webp_quality, 0, 100)) {
+                $webp_quality = (int) $webp_quality;
+            } else {
+                $this->error->add(t('Invalid WEBP quality level'));
+            }
             $png_compression = $post->get('png_compression');
             if ($valn->integer($png_compression, 0, 9)) {
                 $png_compression = (int) $png_compression;
@@ -134,6 +141,7 @@ class ImageUploading extends DashboardPageController
                 $bitmapFormat = $this->app->make(BitmapFormat::class);
                 $config->save('concrete.file_manager.images.manipulation_library', $manipulation_library);
                 $bitmapFormat->setDefaultJpegQuality($jpeg_quality);
+                $bitmapFormat->setDefaultWebpQuality($webp_quality);
                 $bitmapFormat->setDefaultPngCompressionLevel($png_compression);
                 $config->save('concrete.file_manager.images.use_exif_data_to_rotate_images', $use_exif_data_to_rotate_images);
                 $config->save('concrete.file_manager.images.use_exif_data_for_file_name_attribute', $use_exif_data_for_file_name_attribute);

--- a/concrete/controllers/single_page/dashboard/system/files/thumbnails/options.php
+++ b/concrete/controllers/single_page/dashboard/system/files/thumbnails/options.php
@@ -73,9 +73,10 @@ class Options extends DashboardPageController
     protected function getThumbnailsFormats()
     {
         return [
+            BitmapFormat::FORMAT_WEBP => t('Always create WEBP thumbnails (smallest file size, transparency is kept)'),
             BitmapFormat::FORMAT_PNG => t('Always create PNG thumbnails (slightly bigger file size, transparency is kept)'),
             BitmapFormat::FORMAT_JPEG => t('Always create JPEG thumbnails (slightly smaller file size, transparency is not available)'),
-            ThumbnailFormatService::FORMAT_AUTO => t('Automatic: create a JPEG thumbnail if the source image is in JPEG format, otherwise create a PNG thumbnail'),
+            ThumbnailFormatService::FORMAT_AUTO => t('Automatic: keep source format if it is supported, otherwise create a WEBP thumbnail'),
         ];
     }
 }

--- a/concrete/single_pages/dashboard/system/files/image_uploading.php
+++ b/concrete/single_pages/dashboard/system/files/image_uploading.php
@@ -8,6 +8,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
 /* @var array $manipulation_libraries */
 /* @var string $manipulation_library */
 /* @var int $jpeg_quality */
+/* @var int $webp_quality */
 /* @var int $png_compression */
 /* @var int $restrict_max_width */
 /* @var int $restrict_max_height */
@@ -44,6 +45,11 @@ defined('C5_EXECUTE') or die('Access Denied.');
     <div class="form-group">
         <?= $form->label('jpeg_quality', t('JPEG quality'), ['class' => 'launch-tooltip control-label form-label', 'title' => t('JPEG quality ranges from 0 (worst quality, smaller file) to 100 (best quality, biggest file)')]) ?>
         <?= $form->number('jpeg_quality', $jpeg_quality, ['required' => 'required', 'min' => '0', 'max' => '100']) ?>
+    </div>
+
+    <div class="form-group">
+        <?= $form->label('webp_quality', t('WEBP quality'), ['class' => 'launch-tooltip control-label form-label', 'title' => t('WEBP quality ranges from 0 (worst quality, smaller file) to 100 (best quality, biggest file)')]) ?>
+        <?= $form->number('webp_quality', $webp_quality, ['required' => 'required', 'min' => '0', 'max' => '100']) ?>
     </div>
 
     <div class="form-group">

--- a/concrete/src/File/Image/BasicThumbnailer.php
+++ b/concrete/src/File/Image/BasicThumbnailer.php
@@ -29,6 +29,13 @@ class BasicThumbnailer implements ThumbnailerInterface, ApplicationAwareInterfac
     protected $jpegCompression = null;
 
     /**
+     * The currently configured WEBP compression level.
+     *
+     * @var int|null
+     */
+    protected $webpCompression = null;
+
+    /**
      * The currently configured PNG compression level.
      *
      * @var int|null
@@ -115,6 +122,34 @@ class BasicThumbnailer implements ThumbnailerInterface, ApplicationAwareInterfac
     /**
      * {@inheritdoc}
      *
+     * @see ThumbnailerInterface::setWebpCompression()
+     */
+    public function setWebpCompression($level)
+    {
+        if (is_int($level) || is_float($level) || (is_string($level) && is_numeric($level))) {
+            $this->webpCompression = min(max((int) $level, 0), 100);
+        }
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see ThumbnailerInterface::getWebpCompression()
+     */
+    public function getWebpCompression()
+    {
+        if ($this->webpCompression === null) {
+            $this->webpCompression = $this->app->make(BitmapFormat::class)->getDefaultWebpQuality();
+        }
+
+        return $this->webpCompression;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
      * @see ThumbnailerInterface::setPngCompression()
      */
     public function setPngCompression($level)
@@ -189,6 +224,7 @@ class BasicThumbnailer implements ThumbnailerInterface, ApplicationAwareInterfac
         }
         $thumbnailOptions = [
             'jpeg_quality' => $this->getJpegCompression(),
+            'webp_quality' => $this->getWebpCompression(),
             'png_compression_level' => $this->getPngCompression(),
         ];
         $filesystem = $this->getStorageLocation()->getFileSystemObject();

--- a/concrete/src/File/Image/BitmapFormat.php
+++ b/concrete/src/File/Image/BitmapFormat.php
@@ -25,6 +25,13 @@ class BitmapFormat
     const FORMAT_JPEG = 'jpeg';
 
     /**
+     * Bitmap image format: WEBP.
+     *
+     * @var string
+     */
+    const FORMAT_WEBP = 'webp';
+
+    /**
      * Bitmap image format: GIF.
      *
      * @var string
@@ -51,6 +58,13 @@ class BitmapFormat
      * @var int
      */
     const DEFAULT_JPEG_QUALITY = 80;
+
+    /**
+     * Default WEBP quality (from 0 to 100) - to be used when there's no (valid) configured value.
+     *
+     * @var int
+     */
+    const DEFAULT_WEBP_QUALITY = 80;
 
     /**
      * Default PNG compression level (from 0 to 9) - to be used when there's no (valid) configured value.
@@ -99,6 +113,7 @@ class BitmapFormat
             $this->allImageFormats = [
                 static::FORMAT_PNG,
                 static::FORMAT_JPEG,
+                static::FORMAT_WEBP,
                 static::FORMAT_GIF,
                 static::FORMAT_WBMP,
                 static::FORMAT_XBM,
@@ -134,6 +149,7 @@ class BitmapFormat
         switch ($format) {
             case static::FORMAT_PNG:
             case static::FORMAT_JPEG:
+            case static::FORMAT_WEBP:
             case static::FORMAT_GIF:
             case static::FORMAT_XBM:
                 $result = 'image/' . $format;
@@ -163,6 +179,9 @@ class BitmapFormat
                 break;
             case 'image/jpeg':
                 $result = static::FORMAT_JPEG;
+                break;
+            case 'image/webp':
+                $result = static::FORMAT_WEBP;
                 break;
             case 'image/gif':
                 $result = static::FORMAT_GIF;
@@ -203,6 +222,9 @@ class BitmapFormat
             case static::FORMAT_JPEG:
                 $result['jpeg_quality'] = $this->getDefaultJpegQuality();
                 break;
+            case static::FORMAT_WEBP:
+                $result['webp_quality'] = $this->getDefaultWebpQuality();
+                break;
         }
 
         return $result;
@@ -226,6 +248,9 @@ class BitmapFormat
                 break;
             case static::FORMAT_JPEG:
                 $result = 'jpg';
+                break;
+            case static::FORMAT_WEBP:
+                $result = 'webp';
                 break;
             case static::FORMAT_GIF:
                 $result = 'gif';
@@ -273,6 +298,41 @@ class BitmapFormat
             $result = (int) $result;
         } else {
             $result = static::DEFAULT_JPEG_QUALITY;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Set the default WEBP quality.
+     *
+     * @param int $value an integer from 0 to 100
+     *
+     * @return $this
+     */
+    public function setDefaultWebpQuality($value)
+    {
+        if ($this->valn->integer($value, 0, 100)) {
+            $value = (int) $value;
+            $this->config->set('concrete.misc.default_webp_image_compression', $value);
+            $this->config->save('concrete.misc.default_webp_image_compression', $value);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Get the default WEBP quality.
+     *
+     * @return int an integer from 0 to 100
+     */
+    public function getDefaultWebpQuality()
+    {
+        $result = $this->config->get('concrete.misc.default_webp_image_compression');
+        if ($this->valn->integer($result, 0, 100)) {
+            $result = (int) $result;
+        } else {
+            $result = static::DEFAULT_WEBP_QUALITY;
         }
 
         return $result;

--- a/concrete/src/File/Image/Thumbnail/ThumbnailFormatService.php
+++ b/concrete/src/File/Image/Thumbnail/ThumbnailFormatService.php
@@ -118,7 +118,16 @@ class ThumbnailFormatService
      */
     public function getAutomaticFormatForFileExtension($extension)
     {
-        return preg_match('/^\.?p?jpe?g$/i', $extension) ? BitmapFormat::FORMAT_JPEG : BitmapFormat::FORMAT_PNG;
+        switch (strtolower($extension)) {
+            case 'jpg':
+            case 'jpeg':
+                return BitmapFormat::FORMAT_JPEG;
+            case 'png':
+                return BitmapFormat::FORMAT_PNG;
+            case 'webp':
+            default:
+                return BitmapFormat::FORMAT_WEBP;
+        }
     }
 
     /**

--- a/concrete/src/File/Image/Thumbnail/ThumbnailerInterface.php
+++ b/concrete/src/File/Image/Thumbnail/ThumbnailerInterface.php
@@ -44,6 +44,23 @@ interface ThumbnailerInterface
     public function getJpegCompression();
 
     /**
+     * Overrides the default WEBP compression level per instance of the image helper.
+     * This allows for a single-use for a particularly low or high compression value.
+     *
+     * @param int $level the level of compression (in the range 0...100)
+     *
+     * @return static
+     */
+    public function setWebpCompression($level);
+
+    /**
+     * Get the currently set WEBP compression level.
+     *
+     * @return int
+     */
+    public function getWebpCompression();
+
+    /**
      * Overrides the default PNG compression level per instance of the image helper.
      * This allows for a single-use for a particularly low or high compression value.
      *

--- a/concrete/src/File/Import/ImportingFile.php
+++ b/concrete/src/File/Import/ImportingFile.php
@@ -261,7 +261,7 @@ class ImportingFile
      */
     public function saveImage()
     {
-        $imageType = $this->bitmapFormat->getFormatFromMimeType($this->getMimeType(), BitmapFormat::FORMAT_PNG);
+        $imageType = $this->bitmapFormat->getFormatFromMimeType($this->getMimeType(), BitmapFormat::FORMAT_WEBP);
         $imageOptions = $this->bitmapFormat->getFormatImagineSaveOptions($imageType);
         if ($imageType === BitmapFormat::FORMAT_GIF && $this->image->layers()->count() > 1) {
             $imageOptions['animated'] = true;


### PR DESCRIPTION
This pull request adds webp support for:

- creating image using image helper,
- creating image using Concrete Thumbnails system.

Right now, if webp image is used, thumbnail system and image helper will create .png as fallback.
This is bad for scoring on [PageSpeed Insights](https://pagespeed.web.dev/), since png files are not compressed very well.

After this change you will have wider selection of image creating strategies (Dashboard > System & Settings > Files > Thumbnails > Thumbnail Options):

- Always create WEBP thumbnails (smallest file size, transparency is kept)
- Always create PNG thumbnails (slightly bigger file size, transparency is kept)
- Always create JPEG thumbnails (slightly smaller file size, transparency is not available)
- Automatic: keep source format if it is supported, otherwise create a WEBP thumbnail

I have decided to replace png fallback with webp, since webp is now widely supported (https://caniuse.com/webp).
I can rollback it to png though, if support of those ancient browsers is still required.
Not like that matter much, since this fallback was used only because webp was partially supported by core.

I have set default webp quality to 80 (Dashboard > System & Settings > Files > Image Options).

This PR is related to https://github.com/concretecms/concretecms/issues/10291