### PR TITLE
Group and sort site attributes by set in dashboard

### DIFF
--- a/concrete/controllers/single_page/dashboard/system/basics/name.php
+++ b/concrete/controllers/single_page/dashboard/system/basics/name.php
@@ -1,16 +1,18 @@
 <?php
+
 namespace Concrete\Controller\SinglePage\Dashboard\System\Basics;
 
+use Concrete\Core\Attribute\Category\SiteCategory;
 use Concrete\Core\Attribute\Context\DashboardFormContext;
 use Concrete\Core\Attribute\Form\Renderer;
+use Concrete\Core\Attribute\Key\Category as AttributeKeyCategory;
 use Concrete\Core\Attribute\Key\SiteKey;
+use Concrete\Core\Entity\Attribute\Category;
 use Concrete\Core\Page\Controller\DashboardSitePageController;
 use Concrete\Core\Site\Service;
-use Config;
 
 class Name extends DashboardSitePageController
 {
-
     protected $service;
 
     public function __construct(\Concrete\Core\Page\Page $c, Service $service)
@@ -21,21 +23,31 @@ class Name extends DashboardSitePageController
 
     public function view()
     {
-        $attributes = SiteKey::getList();
-        $this->set('attributes', $attributes);
+        /**
+         * @var Category $category
+         * @var SiteCategory $controller
+         */
+        $category = AttributeKeyCategory::getByHandle('site');
+        $controller = $category->getController();
+        $sets = $controller->getSetManager()->getAttributeSets();
+        $unassignedAttributes = $controller->getSetManager()->getUnassignedAttributeKeys();
+
+        $this->set('sets', $sets);
+        $this->set('unassignedAttributes', $unassignedAttributes);
+        $this->set('totalAttributes', count(SiteKey::getList()));
         $this->set('site', $this->getSite());
         $this->set('renderer', new Renderer(new DashboardFormContext(), $this->getSite()));
     }
 
     public function sitename_saved()
     {
-        $this->set('success', t("Your site's name has been saved."));
+        $this->set('success', t("Your site's name and attributes have been saved."));
         $this->view();
     }
 
     public function update_sitename()
     {
-        if ($this->token->validate("update_sitename")) {
+        if ($this->token->validate('update_sitename')) {
             if ($this->isPost()) {
                 $this->site->setSiteName($this->request->request->get('SITE'));
                 $this->entityManager->persist($this->site);
@@ -53,7 +65,6 @@ class Name extends DashboardSitePageController
             }
         } else {
             $this->error->add($this->token->getErrorMessage());
-
         }
         $this->view();
     }

--- a/concrete/single_pages/dashboard/system/basics/name.php
+++ b/concrete/single_pages/dashboard/system/basics/name.php
@@ -1,39 +1,66 @@
-<?php defined('C5_EXECUTE') or die("Access Denied.");?>
+<?php defined('C5_EXECUTE') or die('Access Denied.');
+
+/**
+ * @var \Concrete\Core\Entity\Attribute\Set[] $sets
+ * @var \Concrete\Core\Page\View\PageView $view
+ * @var \Concrete\Core\Form\Service\Form $form
+ * @var \Concrete\Core\Entity\Site\Site $site
+ * @var \Concrete\Core\Attribute\Form\Renderer $renderer
+ * @var \Concrete\Core\Entity\Attribute\Key\SiteKey[] $unassignedAttributes
+ * @var int $totalAttributes
+ */
+?>
 
 <div class="ccm-dashboard-header-buttons">
-	<a href="<?php echo View::url('/dashboard/system/basics/attributes')?>" class="btn btn-secondary"><?php echo t("Manage Attributes")?></a>
+    <a href="<?= View::url('/dashboard/system/basics/attributes') ?>"
+       class="btn btn-secondary"
+    ><?= t('Manage Attributes') ?></a>
 </div>
 
-<form method="post" class="ccm-dashboard-content-form" action="<?=$view->action('update_sitename')?>">
-	<?=$this->controller->token->output('update_sitename')?>
+<form method="post" class="ccm-dashboard-content-form" action="<?= $view->action('update_sitename') ?>">
+    <?= $this->controller->token->output('update_sitename') ?>
 
-	<fieldset>
-		<legend><?= t('Core Properties') ?></legend>
-		<div class="form-group">
-			<label for="SITE" class="launch-tooltip control-label form-label" data-bs-placement="right" title="<?=t('By default, site name is displayed in the browser title bar. It is also the default name for your project on marketplace.concretecms.com')?>"><?=t('Site Name')?></label>
-			<?=$form->text('SITE', $site->getSiteName())?>
-		</div>
-	</fieldset>
+    <fieldset>
+        <legend><?= t('Core Properties') ?></legend>
+        <div class="form-group">
+            <label for="SITE"
+                   class="launch-tooltip control-label form-label"
+                   data-bs-placement="right"
+                   title="<?= t('By default, site name is displayed in the browser title bar. It is also the default name for your project on marketplace.concretecms.com') ?>"
+            ><?= t('Site Name') ?></label>
+            <?= $form->text('SITE', $site->getSiteName()) ?>
+        </div>
+    </fieldset>
 
-	<fieldset>
-		<legend><?=t('Custom Attributes')?></legend>
-		<?php
-		if (count($attributes) > 0) {
-			foreach ($attributes as $ak) {
-				echo $renderer->render($ak);
-			}
-		} else { ?>
-			<div class="mt-3">
-				<p><?=t('You have not defined any <a href="%s">custom attributes</a> for this site.', URL::to('/dashboard/system/basics/attributes'))?></p>
-			</div>
-		<?php } ?>
-	</fieldset>
+    <fieldset>
+        <legend><?= t('Custom Attributes') ?></legend>
+        <?php if ($totalAttributes > 0) { ?>
+            <?php foreach ($sets as $set) { ?>
+                <h4><?= $set->getAttributeSetDisplayName() ?></h4>
+                <?php
+                $attributes = $set->getAttributeKeys();
+                foreach ($attributes as $ak) {
+                    $renderer->render($ak);
+                }
+                ?>
+            <?php } ?>
+            <h4><?= t('Other') ?></h4>
+            <?php
+            foreach ($unassignedAttributes as $ak) {
+                $renderer->render($ak);
+            }
+            ?>
+        <?php } else { ?>
+            <div class="mt-3">
+                <p><?= t('You have not defined any <a href="%s">custom attributes</a> for this site.', URL::to('/dashboard/system/basics/attributes')) ?></p>
+            </div>
+        <?php } ?>
+    </fieldset>
 
-	<div class="ccm-dashboard-form-actions-wrapper">
-	<div class="ccm-dashboard-form-actions">
-		<button class="float-end btn btn-primary" type="submit" ><?=t('Save')?></button>
-	</div>
-	</div>
-
+    <div class="ccm-dashboard-form-actions-wrapper">
+        <div class="ccm-dashboard-form-actions">
+            <button class="float-end btn btn-primary" type="submit"><?= t('Save') ?></button>
+        </div>
+    </div>
 
 </form>

--- a/concrete/single_pages/dashboard/system/basics/name.php
+++ b/concrete/single_pages/dashboard/system/basics/name.php
@@ -34,27 +34,36 @@
 
     <fieldset>
         <legend><?= t('Custom Attributes') ?></legend>
-        <?php if ($totalAttributes > 0) { ?>
-            <?php foreach ($sets as $set) { ?>
-                <h4><?= $set->getAttributeSetDisplayName() ?></h4>
-                <?php
+        <?php
+        if ($totalAttributes > 0) {
+            foreach ($sets as $set) {
                 $attributes = $set->getAttributeKeys();
-                foreach ($attributes as $ak) {
+                if (count($attributes)) {
+                    ?>
+                    <h4><?= $set->getAttributeSetDisplayName() ?></h4>
+                    <?php
+                    foreach ($attributes as $ak) {
+                        $renderer->render($ak);
+                    }
+                }
+            }
+
+            if (count($unassignedAttributes)) {
+                ?>
+                <h4><?= t('Other') ?></h4>
+                <?php
+                foreach ($unassignedAttributes as $ak) {
                     $renderer->render($ak);
                 }
-                ?>
-            <?php } ?>
-            <h4><?= t('Other') ?></h4>
-            <?php
-            foreach ($unassignedAttributes as $ak) {
-                $renderer->render($ak);
             }
+        } else {
             ?>
-        <?php } else { ?>
             <div class="mt-3">
                 <p><?= t('You have not defined any <a href="%s">custom attributes</a> for this site.', URL::to('/dashboard/system/basics/attributes')) ?></p>
             </div>
-        <?php } ?>
+            <?php
+        }
+        ?>
     </fieldset>
 
     <div class="ccm-dashboard-form-actions-wrapper">


### PR DESCRIPTION
Currently, site attributes in Dashboard page are listed as one long list, which is a little problematic if you are using many attributes.

This PR will group them into Sets, so they will be a little easier to manage.

![image](https://github.com/concretecms/concretecms/assets/33052836/c6b41dc4-9e1f-4c1b-8234-90421b2b8f95)
