### PR TITLE
Fix #11644

### DIFF
--- a/concrete/src/User/Search/Field/Field/UserGroupField.php
+++ b/concrete/src/User/Search/Field/Field/UserGroupField.php
@@ -59,7 +59,7 @@ class UserGroupField extends AbstractField
         foreach ($g1 as $g) {
             $gp = new \Permissions($g);
             if ($gp->canSearchUsersInGroup($g)) {
-                $options[$g->getGroupID()] = $g->getGroupDisplayName('text');
+                $options[$g->getGroupID()] = $g->getGroupDisplayName(false);
             }
             if (is_array($this->getData('gID')) && in_array($g->getGroupID(), $this->getData('gID'))) {
                 $selected[] = $g->getGroupID();


### PR DESCRIPTION
fix #11644

[first argument](https://github.com/concretecms/concretecms/blob/develop/concrete/src/User/Group/Group.php#L609) for `getGroupDisplayName` is `$includeHTML = true`, so passing in a string is going to be interpreted as true, whereas we want just text in this scenario.
