### PR TITLE
Fix PHP 8 bug for attribute date_time controller validateForm function

### DIFF
--- a/concrete/attributes/date_time/controller.php
+++ b/concrete/attributes/date_time/controller.php
@@ -140,7 +140,11 @@ class Controller extends AttributeTypeController implements SimpleTextExportable
 
                 return true;
             default:
-                return $data['value'] != '';
+                if (array_key_exists('value', $data) && $data['value'] !== '') {
+                    return $data['value'];
+                } else {
+                    return null;
+                }
         }
     }
 

--- a/concrete/attributes/date_time/controller.php
+++ b/concrete/attributes/date_time/controller.php
@@ -140,11 +140,7 @@ class Controller extends AttributeTypeController implements SimpleTextExportable
 
                 return true;
             default:
-                if (array_key_exists('value', $data) && $data['value'] !== '') {
-                    return $data['value'];
-                } else {
-                    return null;
-                }
+                return !empty($data['value']);
         }
     }
 


### PR DESCRIPTION
Fix bug when new attributes of type date_time are added and StandardValidator is extended. In this case it product an 'Undefined array key "value"' bug on $data['value']. This fix the problem.