### PR TITLE
Suggest browser to remember the correct username when installing Concrete

### DIFF
--- a/concrete/controllers/install.php
+++ b/concrete/controllers/install.php
@@ -168,7 +168,7 @@ class Install extends Controller
         $passwordMinLength = (int) $config->get('concrete.user.password.minimum', 5);
         $passwordMaxLength = (int) $config->get('concrete.user.password.maximum');
         $passwordAttributes = [
-            'autocomplete' => 'off',
+            'autocomplete' => 'new-password',
         ];
         if ($passwordMinLength > 0) {
             $passwordAttributes['required'] = 'required';

--- a/concrete/views/frontend/install.php
+++ b/concrete/views/frontend/install.php
@@ -379,6 +379,9 @@ if ($install_config) {
                             </div>
                             <div class="col-md-6">
                                 <div class="form-group">
+                                    <div class="d-none">
+                                        <input type="text" name="username" value="admin" autocomplete="username" />
+                                    </div>
                                     <label for="uPassword"
                                            class="control-label form-label"><?= t('Administrator Password') ?></label>
                                     <?= $form->password('uPassword', $passwordAttributes) ?>

--- a/concrete/views/frontend/install.php
+++ b/concrete/views/frontend/install.php
@@ -380,7 +380,7 @@ if ($install_config) {
                             <div class="col-md-6">
                                 <div class="form-group">
                                     <div class="d-none">
-                                        <input type="text" name="username" value="admin" autocomplete="username" />
+                                        <input type="text" name="username" value="<?= h(USER_SUPER) ?>" autocomplete="username" readonly="readonly" />
                                     </div>
                                     <label for="uPassword"
                                            class="control-label form-label"><?= t('Administrator Password') ?></label>


### PR DESCRIPTION
Every time I install Concrete via the web interface, the browser keeps suggesting me to save the login and the password.

The problem is that the browser suggests saving the password for the admin user (correct) and the username to be used to access the database (wrong).

For newbies, that may be a problem: if they accept the browser suggestion, at logon the browser suggests using the database username instead of "admin".

What about fixing this?