### PR TITLE
meta- and link-tags are void elements

### DIFF
--- a/concrete/elements/header_required.php
+++ b/concrete/elements/header_required.php
@@ -97,38 +97,38 @@ if (is_object($c)) {
     $c = null;
 }
 $metaTags = [];
-$metaTags['charset'] = sprintf('<meta http-equiv="content-type" content="text/html; charset=%s"/>', APP_CHARSET);
+$metaTags['charset'] = sprintf('<meta http-equiv="content-type" content="text/html; charset=%s">', APP_CHARSET);
 if ($pageDescription !== '') {
-    $metaTags['description'] = sprintf('<meta name="description" content="%s"/>', htmlspecialchars($pageDescription, ENT_COMPAT, APP_CHARSET));
+    $metaTags['description'] = sprintf('<meta name="description" content="%s">', htmlspecialchars($pageDescription, ENT_COMPAT, APP_CHARSET));
 }
 if ($pageMetaKeywords !== '') {
-    $metaTags['keywords'] = sprintf('<meta name="keywords" content="%s"/>', htmlspecialchars($pageMetaKeywords, ENT_COMPAT, APP_CHARSET));
+    $metaTags['keywords'] = sprintf('<meta name="keywords" content="%s">', htmlspecialchars($pageMetaKeywords, ENT_COMPAT, APP_CHARSET));
 }
 if ($c !== null && $c->getAttribute('exclude_search_index')) {
-    $metaTags['robots'] = sprintf('<meta name="robots" content="%s"/>', 'noindex');
+    $metaTags['robots'] = sprintf('<meta name="robots" content="%s">', 'noindex');
 }
 if ($appConfig->get('concrete.misc.generator_tag_display_in_header')) {
-    $metaTags['generator'] = sprintf('<meta name="generator" content="%s"/>', 'Concrete CMS');
+    $metaTags['generator'] = sprintf('<meta name="generator" content="%s">', 'Concrete CMS');
 }
 if (($modernIconFID = (int) $config->get('misc.modern_tile_thumbnail_fid')) && ($modernIconFile = File::getByID($modernIconFID))) {
-    $metaTags['msapplication-TileImage'] = sprintf('<meta name="msapplication-TileImage" content="%s"/>', $modernIconFile->getURL());
+    $metaTags['msapplication-TileImage'] = sprintf('<meta name="msapplication-TileImage" content="%s">', $modernIconFile->getURL());
     $modernIconBGColor = (string) $config->get('misc.modern_tile_thumbnail_bgcolor');
     if ($modernIconBGColor !== '') {
-        $metaTags['msapplication-TileColor'] = sprintf('<meta name="msapplication-TileColor" content="%s"/>', h($modernIconBGColor));
+        $metaTags['msapplication-TileColor'] = sprintf('<meta name="msapplication-TileColor" content="%s">', h($modernIconBGColor));
     }
 }
 $linkTags = [];
 if (($favIconFID = (int) $config->get('misc.favicon_fid')) && ($favIconFile = File::getByID($favIconFID))) {
     $favIconFileURL = $favIconFile->getURL();
-    $linkTags['shortcut icon'] = sprintf('<link rel="shortcut icon" href="%s" type="image/x-icon"/>', $favIconFileURL);
-    $linkTags['icon'] = sprintf('<link rel="icon" href="%s" type="image/x-icon"/>', $favIconFileURL);
+    $linkTags['shortcut icon'] = sprintf('<link rel="shortcut icon" href="%s" type="image/x-icon">', $favIconFileURL);
+    $linkTags['icon'] = sprintf('<link rel="icon" href="%s" type="image/x-icon">', $favIconFileURL);
 }
 if (($appleIconFID = (int) $config->get('misc.iphone_home_screen_thumbnail_fid')) && ($appleIconFile = File::getByID($appleIconFID))) {
-    $linkTags['apple-touch-icon'] = sprintf('<link rel="apple-touch-icon" href="%s"/>', $appleIconFile->getURL());
+    $linkTags['apple-touch-icon'] = sprintf('<link rel="apple-touch-icon" href="%s">', $appleIconFile->getURL());
 }
 $browserToolbarColor = (string) $config->get('misc.browser_toolbar_color');
 if ($browserToolbarColor !== '') {
-    $metaTags['browserToolbarColor'] = sprintf('<meta name="theme-color" content="%s"/>', h($browserToolbarColor));
+    $metaTags['browserToolbarColor'] = sprintf('<meta name="theme-color" content="%s">', h($browserToolbarColor));
 }
 if ($config->get('seo.canonical_tag.enabled')) {
     if (($canonicalLink = $app->make(SeoCanonical::class)->getPageCanonicalURLTag($c, Request::getInstance())) !== null) {
@@ -146,7 +146,7 @@ if ($c !== null && $config->get('multilingual.set_alternate_hreflang') && !$c->i
                 $relatedPage = Page::getByID($relatedID);
                 if ($relatedPage && !$relatedPage->isError()) {
                     $url = $urlManager->resolve([$relatedPage]);
-                    $alternateHreflangTags[] = '<link rel="alternate" hreflang="'.str_replace('_', '-', $ms->getLocale()).'" href="'.$url.'" />';
+                    $alternateHreflangTags[] = '<link rel="alternate" hreflang="'.str_replace('_', '-', $ms->getLocale()).'" href="'.$url.'">';
                 }
             }
         }

--- a/concrete/src/Page/Controller/DashboardPageController.php
+++ b/concrete/src/Page/Controller/DashboardPageController.php
@@ -71,7 +71,7 @@ class DashboardPageController extends PageController
     {
         $md = new Mobile_Detect();
         if ($md->isMobile()) {
-            $this->addHeaderItem('<meta name="viewport" content="width=device-width,initial-scale=1"/>');
+            $this->addHeaderItem('<meta name="viewport" content="width=device-width,initial-scale=1">');
         }
     }
 

--- a/concrete/themes/concrete/elements/header.php
+++ b/concrete/themes/concrete/elements/header.php
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html lang="<?php echo Localization::activeLanguage() ?>">
 <head>
-    <link rel="stylesheet" type="text/css" href="<?=$view->getThemePath()?>/main.css" />
+    <link rel="stylesheet" type="text/css" href="<?=$view->getThemePath()?>/main.css">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
 <?php

--- a/concrete/themes/concrete/empty.php
+++ b/concrete/themes/concrete/empty.php
@@ -3,7 +3,7 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <link rel="stylesheet" type="text/css" href="<?=$view->getThemePath()?>/main.css" />
+    <link rel="stylesheet" type="text/css" href="<?=$view->getThemePath()?>/main.css">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <?php
     View::element('header_required', array('pageTitle' => isset($pageTitle) ? $pageTitle : ''));

--- a/concrete/themes/core/error.php
+++ b/concrete/themes/core/error.php
@@ -2,8 +2,8 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html lang="<?php echo Localization::activeLanguage() ?>" xmlns="http://www.w3.org/1999/xhtml">
 <head>
-<meta http-equiv="content-type" content="text/html; charset=<?=APP_CHARSET?>" />
-    <link rel="stylesheet" type="text/css" href="<?=DIR_REL?>/concrete/themes/concrete/main.css" />
+<meta http-equiv="content-type" content="text/html; charset=<?=APP_CHARSET?>">
+    <link rel="stylesheet" type="text/css" href="<?=DIR_REL?>/concrete/themes/concrete/main.css">
     <?php
     $view->markHeaderAssetPosition();
     ?>

--- a/concrete/themes/dashboard/elements/header.php
+++ b/concrete/themes/dashboard/elements/header.php
@@ -36,7 +36,7 @@ $large_font = (bool) $config->get('concrete.accessibility.toolbar_large_font');
 ?><!DOCTYPE html>
 <html<?= $hideDashboardPanel ? '' : ' class="ccm-panel-open ccm-panel-right"'; ?> lang="<?php echo Localization::activeLanguage() ?>">
 <head>
-    <link rel="stylesheet" type="text/css" href="<?=$this->getThemePath(); ?>/main.css" />
+    <link rel="stylesheet" type="text/css" href="<?=$this->getThemePath(); ?>/main.css">
     <?php View::element('header_required', ['disableTrackingCode' => true, 'pageTitle' => isset($pageTitle) ? $pageTitle : null]); ?>
 </head>
 <body <?php if (isset($bodyClass)) {

--- a/concrete/views/api/documentation.php
+++ b/concrete/views/api/documentation.php
@@ -4,7 +4,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
 
 ?>
 
-<link rel="stylesheet" type="text/css" href="<?=ASSETS_URL?>/api/swagger/swagger-ui.css" />
+<link rel="stylesheet" type="text/css" href="<?=ASSETS_URL?>/api/swagger/swagger-ui.css">
 
 <div id="swagger-ui"></div>
 <script src="<?=ASSETS_URL?>/api/swagger/swagger-ui-bundle.js" charset="UTF-8"> </script>


### PR DESCRIPTION
https://github.com/validator/validator/wiki/Markup-%C2%BB-Void-elements#trailing-slashes-directly-preceded-by-unquoted-attribute-values

Both have no end tag in the specification, event if mdn is there not sure :
- https://html.spec.whatwg.org/multipage/semantics.html#the-link-element
- https://html.spec.whatwg.org/multipage/semantics.html#the-meta-element
- https://developer.mozilla.org/en-US/docs/Glossary/Void_element