### PR TITLE
Fix Group::getParentGroup()

### DIFF
--- a/concrete/src/User/Group/Group.php
+++ b/concrete/src/User/Group/Group.php
@@ -597,13 +597,15 @@ class Group extends ConcreteObject implements \Concrete\Core\Permission\ObjectIn
         return $children;
     }
 
+    /**
+     * @return \Concrete\Core\User\Group\Group|null
+     */
     public function getParentGroup()
     {
         $node = GroupTreeNode::getTreeNodeByGroupID($this->getGroupID());
         $parent = $node->getTreeNodeParentObject();
-        if ($parent) {
-            return $parent->getTreeNodeGroupObject();
-        }
+
+        return $parent instanceof \Concrete\Core\Tree\Node\Type\Group ? $parent->getTreeNodeGroupObject() : null;
     }
 
     public function getGroupDisplayName($includeHTML = true, $includePath = true)

--- a/tests/tests/User/GroupTest.php
+++ b/tests/tests/User/GroupTest.php
@@ -7,6 +7,7 @@ use Concrete\Core\Tree\Node\NodeType as TreeNodeType;
 use Concrete\Core\Tree\TreeType;
 use Concrete\Core\Tree\Type\Group as GroupTreeType;
 use Concrete\Core\User\Group\Command;
+use Concrete\Core\User\Group\FolderManager;
 use Concrete\Core\User\Group\Group;
 use Concrete\Core\User\UserList;
 use Concrete\TestHelpers\User\UserTestCase;
@@ -21,6 +22,7 @@ class GroupTest extends UserTestCase
         TreeNodeType::add('group');
         TreeType::add('group');
         GroupTreeType::add();
+        (new FolderManager())->create();
         Group::add(
             tc('GroupName', 'Guest'),
             tc('GroupDescription', 'The guest group represents unregistered visitors to your site.'),
@@ -574,6 +576,8 @@ class GroupTest extends UserTestCase
     {
         $this->tables = array_values(array_unique(array_merge($this->tables, [
             'GroupSelectedRoles',
+            'TreeGroupFolderNodes',
+            'TreeGroupFolderNodeSelectedGroupTypes',
         ])));
 
         return parent::getTables();

--- a/tests/tests/User/GroupTest.php
+++ b/tests/tests/User/GroupTest.php
@@ -106,6 +106,11 @@ class GroupTest extends UserTestCase
         $group3 = Group::add('Approvers', 'This is a test group 1', $group2);
         $group4 = Group::add('Group 10', 'This is a test group 10', $group1);
 
+        $parentOfGroup2 = $group2->getParentGroup();
+        $this->assertNotNull($parentOfGroup2);
+        $this->assertSame($group1->getGroupID(), $parentOfGroup2->getGroupID());
+        $this->assertNull($group1->getParentGroup());
+
         $newPath = $group3->getGroupPath();
         $this->assertEquals('/HGroup/Group 1/Approvers', $newPath);
 


### PR DESCRIPTION
Fix #11617
