### PR TITLE
added shortcut to running tasks from the cli

### DIFF
--- a/concrete/src/Command/Task/Input/Definition/Field.php
+++ b/concrete/src/Command/Task/Input/Definition/Field.php
@@ -34,7 +34,7 @@ class Field implements FieldInterface
     protected $isRequired = false;
 
     /**
-     * @var string
+     * @var string|null
      */
     protected $shortcut;
 
@@ -71,9 +71,6 @@ class Field implements FieldInterface
         return $this->description;
     }
 
-    /**
-     * @return string|null
-     */
     public function getShortcut(): ?string
     {
         return $this->shortcut;
@@ -134,11 +131,7 @@ class Field implements FieldInterface
         if ($this->isRequired()) {
             $command->addArgument($this->getKey(), InputArgument::REQUIRED, $this->getDescription());
         } else {
-            $command->addOption($this->getKey(), null, InputOption::VALUE_REQUIRED, $this->getDescription());
-        }
-
-        if ($this->getShortcut()) {
-            $command->addOption($this->getShortcut(), null, InputOption::VALUE_REQUIRED, $this->getDescription());
+            $command->addOption($this->getKey(), $this->getShortcut(), InputOption::VALUE_REQUIRED, $this->getDescription());
         }
     }
 }

--- a/concrete/src/Command/Task/Input/Definition/Field.php
+++ b/concrete/src/Command/Task/Input/Definition/Field.php
@@ -1,18 +1,18 @@
 <?php
+
 namespace Concrete\Core\Command\Task\Input\Definition;
 
-use Concrete\Core\Command\Task\Input\FieldInterface as LoadedFieldInterface;
 use Concrete\Core\Command\Task\Input\Field as LoadedField;
+use Concrete\Core\Command\Task\Input\FieldInterface as LoadedFieldInterface;
 use Concrete\Core\Console\Command\TaskCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 
-defined('C5_EXECUTE') or die("Access Denied.");
+defined('C5_EXECUTE') or die('Access Denied.');
 
 class Field implements FieldInterface
 {
-
     /**
      * @var string
      */
@@ -33,12 +33,18 @@ class Field implements FieldInterface
      */
     protected $isRequired = false;
 
-    public function __construct(string $key, string $label, string $description, bool $isRequired = false)
+    /**
+     * @var string
+     */
+    protected $shortcut;
+
+    public function __construct(string $key, string $label, string $description, bool $isRequired = false, ?string $shortcut = null)
     {
         $this->key = $key;
         $this->label = $label;
         $this->description = $description;
         $this->isRequired = $isRequired;
+        $this->shortcut = $shortcut;
     }
 
     /**
@@ -65,11 +71,20 @@ class Field implements FieldInterface
         return $this->description;
     }
 
+    /**
+     * @return string|null
+     */
+    public function getShortcut(): ?string
+    {
+        return $this->shortcut;
+    }
+
     public function isValid(LoadedFieldInterface $loadedField): bool
     {
         if ($this->isRequired() && !$loadedField->getValue()) {
             throw new \Exception(t('Field "%s" is required.', $loadedField->getKey()));
         }
+
         return true;
     }
 
@@ -90,6 +105,7 @@ class Field implements FieldInterface
                 return new LoadedField($this->getKey(), $consoleInput->getOption($this->getKey()));
             }
         }
+
         return null;
     }
 
@@ -120,6 +136,9 @@ class Field implements FieldInterface
         } else {
             $command->addOption($this->getKey(), null, InputOption::VALUE_REQUIRED, $this->getDescription());
         }
-    }
 
+        if ($this->getShortcut()) {
+            $command->addOption($this->getShortcut(), null, InputOption::VALUE_REQUIRED, $this->getDescription());
+        }
+    }
 }


### PR DESCRIPTION
This pull request introduces a new feature to the Concrete5 CLI that allows developers to use shortcut parameters when executing commands. This enhancement aims to improve the developer experience by reducing the amount of typing required to execute commands.

Previously, executing a command required typing the complete parameter handle. For example, to send an email, one would have to type:

`concrete/bin/concrete task:sendMail --emailRecipient=ex@mail.com
`

With this update, a custom "shortcut" parameter can be added to the Field object when defining a command. This shortcut acts as an alias for the full parameter handle. For example:

`$definition->addField(new Field("emailRecipient", t("Recipient Email"), t("Email address of the recipient."), false, "r"));
`

Now, the same command can be executed using the shortcut parameter:

`concrete/bin/concrete task:sendMail --r=ex@mail.com
`

This implementation is backward compatible. If both the shortcut and the full handle are passed, the long form is taken. This ensures that existing functionality is not disrupted.

This feature enhances the usability of the CLI and makes it more efficient for developers to execute commands. We believe this is a valuable addition to the Concrete5 CLI and look forward to your feedback. Once this pull request is approved, I plan to update the documentation to reflect this new feature. This will ensure that all developers are aware of this new functionality and can utilize it effectively.