### PR TITLE
Allow for setting/ altering the User Logged by the Logging Service

### DIFF
--- a/concrete/src/Logging/Handler/DatabaseHandler.php
+++ b/concrete/src/Logging/Handler/DatabaseHandler.php
@@ -17,7 +17,7 @@ class DatabaseHandler extends AbstractProcessingHandler
             $this->initialize();
         }
 
-        $uID = ($record['extra'] && $record['extra']['user'])?$record['extra']['user'][0]:0;
+        $uID = $record['extra']['user'][0] ?? 0;
 
         $this->statement->execute(
             array(

--- a/concrete/src/Logging/Handler/DatabaseHandler.php
+++ b/concrete/src/Logging/Handler/DatabaseHandler.php
@@ -17,7 +17,7 @@ class DatabaseHandler extends AbstractProcessingHandler
             $this->initialize();
         }
 
-        $uID = ($record['extra']['user'][0])?$record['extra']['user'][0]:0;
+        $uID = ($record['extra'] && $record['extra']['user'])?$record['extra']['user'][0]:0;
 
         $this->statement->execute(
             array(

--- a/concrete/src/Logging/Handler/DatabaseHandler.php
+++ b/concrete/src/Logging/Handler/DatabaseHandler.php
@@ -17,9 +17,7 @@ class DatabaseHandler extends AbstractProcessingHandler
             $this->initialize();
         }
 
-        $app = Application::getFacadeApplication();
-        $u = $app->make(User::class);
-        $uID = $u->isRegistered() ? $u->getUserID() : 0;
+        $uID = $record['extra']['user'][0];
 
         $this->statement->execute(
             array(

--- a/concrete/src/Logging/Handler/DatabaseHandler.php
+++ b/concrete/src/Logging/Handler/DatabaseHandler.php
@@ -17,7 +17,7 @@ class DatabaseHandler extends AbstractProcessingHandler
             $this->initialize();
         }
 
-        $uID = $record['extra']['user'][0];
+        $uID = ($record['extra']['user'][0])?$record['extra']['user'][0]:0;
 
         $this->statement->execute(
             array(


### PR DESCRIPTION
The way the associated user is determined and set in the Logging DatabaseHandler made it impossible to
change the **User** a Log Message is logged for on runtime. - This PR changes this.

Taking the User Id from the $records array that is passed along by the ConcreteUserProcessor instead of using the currently Signed on user allows us to alter that information if needed.

Before this change, the following code woudn't have any effect. - Now it set's/ alters the User, shown in the Message Protocoll as intended:


> $app = Application::getFacadeApplication();
> 
> $this->logger = $app->make(LoggerFactory::class)->createLogger($this->getLoggerChannel());
> 
> $this->logger->pushProcessor(function($record){
>     $record['extra']['user'] = [$this->user->getUserID(), $this->user->getUserName()];
>     return $record;
> });
> 
> $this->logger->notice('User did XY')


**The Use Case for this:**

If we have an Endpoint that answers Webhook Calls, for example by Payment providers, it won't have a Logged in User to List in the Log Message. - This change, along with the code snippet above, allows us to determine the associated User from the Webhook Payload and assign it to the a Log Message.