### PR TITLE
Fix linking checkboxes and labels in CKEditor config page

### DIFF
--- a/concrete/single_pages/dashboard/system/basics/editor.php
+++ b/concrete/single_pages/dashboard/system/basics/editor.php
@@ -51,7 +51,7 @@
                                 <?php
                                 echo $form->checkbox('plugin[]', $key, $manager->isSelected($key), ['class' => 'form-check-input']);
                                 ?>
-                                <label class="form-check-label" for="plugin[]">
+                                <label class="form-check-label" for="plugin_<?= $key ?>">
                                 <?php
                                     if ($description !== '') {
                                         echo '<span class="launch-tooltip" title="', h($description), '">';


### PR DESCRIPTION
In the `/dashboard/system/basics/editor` dashboard page, clicking the plugin labels doesn't toggle the checkboxes.

That's because we have this HTML:

```html
<div class="form-check">
    <input type="checkbox" id="plugin_about" name="plugin[]">
    <label for="plugin[]">
        ...
    </label>
</div>
```

With this fix we have:

```html
<div class="form-check">
    <input type="checkbox" id="plugin_about" name="plugin[]">
    <label for="plugin_about">
        ...
    </label>
</div>
```

and clicking the labels works.