### PR TITLE
Use concrete.filesystem.permissions.directory instead of DIRECTORY_PERMISSIONS_MODE_COMPUTED

### DIFF
--- a/concrete/src/Database/DatabaseStructureManager.php
+++ b/concrete/src/Database/DatabaseStructureManager.php
@@ -2,9 +2,10 @@
 namespace Concrete\Core\Database;
 
 use Closure;
+use Concrete\Core\Config\Repository\Repository;
+use Core;
 use Doctrine\DBAL\Schema\SchemaDiff;
 use Doctrine\ORM\EntityManagerInterface;
-use Core;
 use Doctrine\ORM\Tools\SchemaTool;
 use Doctrine\Persistence\Mapping\MappingException;
 
@@ -20,14 +21,12 @@ class DatabaseStructureManager
     /**
      * The entity classes and their metadata.
      * 
-     * @var \Doctrine\Common\Persistence\Mapping\ClassMetadata[]
+     * @var \Doctrine\ORM\Mapping\ClassMetadata[]|null
      */
     protected $metadatas;
 
     /**
      * Create a new structure manager.
-     * 
-     * @param \Doctrine\ORM\EntityManagerInterface $em
      */
     public function __construct(EntityManagerInterface $em)
     {
@@ -93,9 +92,10 @@ class DatabaseStructureManager
                         $proxyDir
                     ));
                 }
-                @mkdir($proxyDir, DIRECTORY_PERMISSIONS_MODE_COMPUTED, true);
+                $permissions = app(Repository::class)->get('concrete.filesystem.permissions.directory');
+                @mkdir($proxyDir, $permissions, true);
                 if (is_dir($proxyDir)) {
-                    @chmod($proxyDir, DIRECTORY_PERMISSIONS_MODE_COMPUTED);
+                    @chmod($proxyDir, $permissions);
                 } else {
                     throw new \Exception(t(
                         "Could not create the proxies directory. " .
@@ -354,7 +354,7 @@ class DatabaseStructureManager
      * Returns the entity classes and their metadata. Loads this data if it has
      * not been already loaded by this instancfe.
      * 
-     * @return \Doctrine\Common\Persistence\Mapping\ClassMetadata[]
+     * @return \Doctrine\ORM\Mapping\ClassMetadata[]
      */
     public function getMetadatas()
     {

--- a/concrete/src/File/Service/VolatileDirectory.php
+++ b/concrete/src/File/Service/VolatileDirectory.php
@@ -1,6 +1,7 @@
 <?php
 namespace Concrete\Core\File\Service;
 
+use Concrete\Core\Config\Repository\Repository;
 use Exception;
 use Illuminate\Filesystem\Filesystem;
 
@@ -41,7 +42,8 @@ class VolatileDirectory
         for ($i = 0; ; ++$i) {
             $path = $parentDirectory . '/volatile-' . $i . '-' . uniqid();
             if (!$this->filesystem->exists($path)) {
-                if (@$this->filesystem->makeDirectory($path, DIRECTORY_PERMISSIONS_MODE_COMPUTED)) {
+                $permissions = app(Repository::class)->get('concrete.filesystem.permissions.directory');
+                if (@$this->filesystem->makeDirectory($path, $permissions)) {
                     break;
                 }
             }

--- a/concrete/src/Localization/Service/TranslationsInstaller.php
+++ b/concrete/src/Localization/Service/TranslationsInstaller.php
@@ -143,7 +143,8 @@ class TranslationsInstaller
         }
         $directory = dirname($localStats->getFilename());
         if (!$this->fs->isDirectory($directory)) {
-            if ($this->fs->makeDirectory($directory, DIRECTORY_PERMISSIONS_MODE_COMPUTED, true, true) !== true) {
+            $permissions = $this->config->get('concrete.filesystem.permissions.directory');
+            if ($this->fs->makeDirectory($directory, $permissions, true, true) !== true) {
                 throw new Exception(t('Failed to create the directory for the language file. Please be sure that the %s directory is writable', $shownDirectoryName));
             }
         }


### PR DESCRIPTION
Follow-up of https://github.com/concretecms/concretecms/pull/11677#issuecomment-1740979052

I've checked all the core files, and the only remaining place when we use `DIRECTORY_PERMISSIONS_MODE_COMPUTED` or `FILE_PERMISSIONS_MODE_COMPUTED` is [in the `c5:reset` CLI command](https://github.com/concretecms/concretecms/blob/b011865523ef1af5676d48f5c506bbe4b15abe85/concrete/src/Console/Command/ResetCommand.php#L116), but that's a special case (application configuration files are deleted in that command).