### PR TITLE
Fix bulk sets action

### DIFF
--- a/concrete/elements/files/bulk/add_to_sets.php
+++ b/concrete/elements/files/bulk/add_to_sets.php
@@ -50,7 +50,7 @@ View::element(
             $checkbox->addClass("form-check-input");
             $checkbox->setAttribute("id", $id);
 
-            $input = new Input('hidden', 'fsID:' . $fileset->getFileSetID(), $fileset->getFileSetID());
+            $input = new Input('hidden', 'fsID:' . $fileset->getFileSetID());
             $input->setAttribute('data-set-input', $fileset->getFileSetID());
 
             $found = 0;


### PR DESCRIPTION
If set has id 2 than on submit it's acted as checked because of `concrete/controllers/dialog/file/bulk/sets.php` submit function:

```
 if ($fsp->canAddFile($file)) {
      switch ($value) {
          case '0':
              if ($file->inFileSet($fs)) {
                  $fs->removeFileFromSet($file);
              }
              break;
          case '1':
              // do nothing
              break;
          case '2':
              $fs->addFileToSet($file);
              break;
      }
      $fv = $file->getApprovedVersion();
      if ($fv) {
          $fv->releaseImagineImage();
      }
  }
```
