### PR TITLE
Allow for null responseObject

### DIFF
--- a/concrete/controllers/single_page/download_file.php
+++ b/concrete/controllers/single_page/download_file.php
@@ -154,7 +154,7 @@ class DownloadFile extends PageController
             $responseObject = $permissionChecker->getResponseObject();
 
             try {
-                if (!$responseObject->validate("view_file")) {
+                if (!is_object($responseObject) || !$responseObject->validate("view_file")) {
                     return false;
                 }
             } catch (Exception $err) {


### PR DESCRIPTION
A site was throwing a method on null exception for $responseObject, presumably due to a dodgy file somewhere before this.  Adding an is_object check to the condition prevents the exception. This does not cure the original problem, somewhere further back a non-file is getting passed in. I have not been able to trace that. However, it does stop the exception.
