### PR TITLE
PHP 8 fix for SiteGroupEntity.php

### DIFF
--- a/concrete/src/Permission/Access/Entity/SiteGroupEntity.php
+++ b/concrete/src/Permission/Access/Entity/SiteGroupEntity.php
@@ -68,7 +68,7 @@ class SiteGroupEntity extends Entity
             $site = $pae->getSite();
         }
 
-        if (!$site) {
+        if (empty($site)) {
             $site = \Core::make('site')->getActiveSiteForEditing();
         }
 


### PR DESCRIPTION
avoid undefined variable

This shows up when running Concrete 9.2 with multisite enabled under PHP 8.x and an admin user tries to log in as another user 