### PR TITLE
Fix issue with filtering by topics attribute

### DIFF
--- a/concrete/attributes/topics/controller.php
+++ b/concrete/attributes/topics/controller.php
@@ -73,7 +73,7 @@ class Controller extends AttributeTypeController implements
                     $topic instanceof \Concrete\Core\Tree\Node\Type\Topic ||
                     $topic instanceof Category)) {
                 $column = 'ak_' . $this->attributeKey->getAttributeKeyHandle();
-                $expressions[] = $qb->expr()->like($column, $qb->createNamedParameter('%||' . $topic->getTreeNodeDisplayPath() . '%||'));
+                $expressions[] = $qb->expr()->like($column, $qb->createNamedParameter('%||' . $topic->getTreeNodeDisplayPath() . '||%'));
             }
         }
 


### PR DESCRIPTION
If topics have similar names like "ABC" and "ABCD" than page list will get pages from both topics. Now it works as intended.  