### PR TITLE
Don't force zendframework/zend-i18n 2.10 since it requires PHP 5.6+

### DIFF
--- a/concrete/composer.json
+++ b/concrete/composer.json
@@ -65,7 +65,7 @@
     "zendframework/zend-cache": "2.7.*",
     "zendframework/zend-http": "2.6.*",
     "zendframework/zend-feed": "2.7.*",
-    "zendframework/zend-i18n": "2.10.*",
+    "zendframework/zend-i18n": "^2.7",
     "nesbot/carbon": "~1.15",
     "egulias/email-validator": "1.*",
     "punic/punic": "^3.0.1",


### PR DESCRIPTION
concrete5 version 8 is compatible with PHP 5.5+

zendframework/zend-i18n 2.10.* requires PHP 5.6+.
