### PR TITLE
fix issue variable is not defined (php 8+)

### DIFF
--- a/concrete/elements/page_types/target_types/form/page_type.php
+++ b/concrete/elements/page_types/target_types/form/page_type.php
@@ -45,7 +45,7 @@ if (is_object($pagetype) && $pagetype->getPageTypePublishTargetTypeID() == $conf
         $pl->filterByPageTypeID($configuredTarget->getPageTypeID());
         $pl->sortByName();
 	    
-        if (isset($site) && is_object($site)) {
+        if (is_object($site ?? null)) {
             $pl->filterBySite($site);
         }
 	    

--- a/concrete/elements/page_types/target_types/form/page_type.php
+++ b/concrete/elements/page_types/target_types/form/page_type.php
@@ -44,9 +44,11 @@ if (is_object($pagetype) && $pagetype->getPageTypePublishTargetTypeID() == $conf
         $pl->sortByName();
         $pl->filterByPageTypeID($configuredTarget->getPageTypeID());
         $pl->sortByName();
-        if (is_object($site)) {
+	    
+        if (isset($site) && is_object($site)) {
             $pl->filterBySite($site);
         }
+	    
         $pages = $pl->getResults();
 
         if (count($pages) > 1) {


### PR DESCRIPTION
If `$relevantPage` isn't an object or has errors than we're not creating `$site` object because of that `if`:

```
if (is_object($relevantPage) && !$relevantPage->isError()) {
    $site = $relevantPage->getSite();
    $tree = $relevantPage->getSiteTreeObject();
}
```
If so than in PHP 8+ function `is_object` throws exception if variable isn't defined. 