### PR TITLE
Add redirect URL parameter to check out command.

### DIFF
--- a/concrete/controllers/backend/page.php
+++ b/concrete/controllers/backend/page.php
@@ -82,6 +82,9 @@ class Page extends Controller
                 break;
         }
 
+        if ($this->request->query->has('redirect')) {
+            $redirectUrl = $this->app->make(ResolverManagerInterface::class)->resolve([$this->request->query->get('redirect')]);
+        }
         return $this->buildRedirect($redirectUrl);
     }
 

--- a/concrete/elements/page_controls_footer.php
+++ b/concrete/elements/page_controls_footer.php
@@ -94,12 +94,13 @@ if (isset($cp) && $cp->canViewToolbar() && (!$dh->inDashboard()) && !$view->isEd
                         </li>
                         <?php
                     } elseif ($permissions->canEditPageContents()) {
+                        $request = Request::createFromGlobals();
                         ?>
                         <li data-guide-toolbar-action="edit-page" class="ccm-toolbar-page-edit float-start d-none d-md-block">
                             <a <?php if ($show_tooltips) { ?>class="launch-tooltip"<?php } ?> data-bs-toggle="tooltip" data-bs-placement="bottom"
                                 <?php if ($c->isMasterCollection()) { ?>data-disable-panel="check-in"<?php } ?>
                                 data-toolbar-action="check-out"
-                                href="<?= h($resolver->resolve(["/ccm/system/page/checkout/{$cID}/-/" . $valt->generate()])) ?>"
+                                href="<?= h($resolver->resolve(["/ccm/system/page/checkout/{$cID}/-/" . $valt->generate()])) ?>?redirect=<?=h($request->getPath())?>"
                                 title="<?= t('Edit This Page') ?>"
                             >
                                 <svg><use xlink:href="#icon-pencil" /></svg><span class="ccm-toolbar-accessibility-title ccm-toolbar-accessibility-title-edit-mode"><?= tc('toolbar', 'Edit Mode') ?></span>


### PR DESCRIPTION
Making redirect a parameter that can be passed to the check out command, in which case we redirect back to _exactly_ where the user was coming from. Better supports block actions, custom development, etc