### PR TITLE
[10.0.x] Fix XML for category under permissionaccessentitytypes

### DIFF
--- a/concrete/features/base/permissions/boards.xml
+++ b/concrete/features/base/permissions/boards.xml
@@ -8,20 +8,28 @@
 
     <permissionaccessentitytypes>
         <permissionaccessentitytype handle="group">
-            <category handle="board_admin" package=""/>
-            <category handle="board" package=""/>
+            <categories>
+                <category handle="board_admin" package=""/>
+                <category handle="board" package=""/>
+            </categories>
         </permissionaccessentitytype>
         <permissionaccessentitytype handle="user">
-            <category handle="board_admin" package=""/>
-            <category handle="board" package=""/>
+            <categories>
+                <category handle="board_admin" package=""/>
+                <category handle="board" package=""/>
+            </categories>
         </permissionaccessentitytype>
         <permissionaccessentitytype handle="group_set">
-            <category handle="board_admin" package=""/>
-            <category handle="board" package=""/>
+            <categories>
+                <category handle="board_admin" package=""/>
+                <category handle="board" package=""/>
+            </categories>
         </permissionaccessentitytype>
         <permissionaccessentitytype handle="group_combination">
-            <category handle="board_admin" package=""/>
-            <category handle="board" package=""/>
+            <categories>
+                <category handle="board_admin" package=""/>
+                <category handle="board" package=""/>
+            </categories>
         </permissionaccessentitytype>
     </permissionaccessentitytypes>
 

--- a/concrete/features/base/permissions/calendar.xml
+++ b/concrete/features/base/permissions/calendar.xml
@@ -8,20 +8,28 @@
 
     <permissionaccessentitytypes>
         <permissionaccessentitytype handle="group">
-            <category handle="calendar_admin" package=""/>
-            <category handle="calendar" package=""/>
+            <categories>
+                <category handle="calendar_admin" package=""/>
+                <category handle="calendar" package=""/>
+            </categories>
         </permissionaccessentitytype>
         <permissionaccessentitytype handle="user">
-            <category handle="calendar_admin" package=""/>
-            <category handle="calendar" package=""/>
+            <categories>
+                <category handle="calendar_admin" package=""/>
+                <category handle="calendar" package=""/>
+            </categories>
         </permissionaccessentitytype>
         <permissionaccessentitytype handle="group_set">
-            <category handle="calendar_admin" package=""/>
-            <category handle="calendar" package=""/>
+            <categories>
+                <category handle="calendar_admin" package=""/>
+                <category handle="calendar" package=""/>
+            </categories>
         </permissionaccessentitytype>
         <permissionaccessentitytype handle="group_combination">
-            <category handle="calendar_admin" package=""/>
-            <category handle="calendar" package=""/>
+            <categories>
+                <category handle="calendar_admin" package=""/>
+                <category handle="calendar" package=""/>
+            </categories>
         </permissionaccessentitytype>
     </permissionaccessentitytypes>
 

--- a/concrete/features/base/permissions/conversations.xml
+++ b/concrete/features/base/permissions/conversations.xml
@@ -8,20 +8,28 @@
 
     <permissionaccessentitytypes>
         <permissionaccessentitytype handle="group">
-            <category handle="conversation" package=""/>
-            <category handle="conversation_message" package=""/>
+            <categories>
+                <category handle="conversation" package=""/>
+                <category handle="conversation_message" package=""/>
+            </categories>
         </permissionaccessentitytype>
         <permissionaccessentitytype handle="user">
-            <category handle="conversation" package=""/>
-            <category handle="conversation_message" package=""/>
+            <categories>
+                <category handle="conversation" package=""/>
+                <category handle="conversation_message" package=""/>
+            </categories>
         </permissionaccessentitytype>
         <permissionaccessentitytype handle="group_set">
-            <category handle="conversation" package=""/>
-            <category handle="conversation_message" package=""/>
+            <categories>
+                <category handle="conversation" package=""/>
+                <category handle="conversation_message" package=""/>
+            </categories>
         </permissionaccessentitytype>
         <permissionaccessentitytype handle="group_combination">
-            <category handle="conversation" package=""/>
-            <category handle="conversation_message" package=""/>
+            <categories>
+                <category handle="conversation" package=""/>
+                <category handle="conversation_message" package=""/>
+            </categories>
         </permissionaccessentitytype>
         <permissionaccessentitytype handle="conversation_message_author" name="Message Author" package="">
             <categories>

--- a/concrete/features/base/permissions/express.xml
+++ b/concrete/features/base/permissions/express.xml
@@ -8,20 +8,28 @@
 
     <permissionaccessentitytypes>
         <permissionaccessentitytype handle="group">
-            <category handle="express_tree_node" />
-            <category handle="express_entry" />
+            <categories>
+                <category handle="express_tree_node" />
+                <category handle="express_entry" />
+            </categories>
         </permissionaccessentitytype>
         <permissionaccessentitytype handle="user">
-            <category handle="express_tree_node" />
-            <category handle="express_entry" />
+            <categories>
+                <category handle="express_tree_node" />
+                <category handle="express_entry" />
+            </categories>
         </permissionaccessentitytype>
         <permissionaccessentitytype handle="group_set">
-            <category handle="express_tree_node" />
-            <category handle="express_entry" />
+            <categories>
+                <category handle="express_tree_node" />
+                <category handle="express_entry" />
+            </categories>
         </permissionaccessentitytype>
         <permissionaccessentitytype handle="group_combination">
-            <category handle="express_tree_node" />
-            <category handle="express_entry" />
+            <categories>
+                <category handle="express_tree_node" />
+                <category handle="express_entry" />
+            </categories>
         </permissionaccessentitytype>
     </permissionaccessentitytypes>
 


### PR DESCRIPTION
We [read `category` nodes](https://github.com/concretecms/concretecms/blob/834d253d83a015863303d52a5f2182aa85e25cf3/concrete/src/Backup/ContentImporter/Importer/Routine/ImportPermissionAccessEntityTypesRoutine.php#L28) wth this xpath

```
/concrete5-cif/permissionaccessentitytypes/permissionaccessentitytype/categories/category
```

and not with

```
/concrete5-cif/permissionaccessentitytypes/permissionaccessentitytype/category
```
