### PR TITLE
Fix importing IP Access Control log channels

### DIFF
--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportIpAccessControlCategoriesRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportIpAccessControlCategoriesRoutine.php
@@ -46,7 +46,7 @@ class ImportIpAccessControlCategoriesRoutine extends AbstractRoutine
                         ->setSiteSpecific($xIpAccessControlCategory['site-specific'])
                         ->setPackage(static::getPackageObject($xIpAccessControlCategory['package']))
                     ;
-                    $logChannelHandle = (string) $xIpAccessControlCategory['logChannelHandle'];
+                    $logChannelHandle = (string) $xIpAccessControlCategory['log-channel-handle'];
                     if ($logChannelHandle !== '') {
                         $category->setLogChannelHandle($logChannelHandle);
                     }


### PR DESCRIPTION
The CIF files [use `log-channel-handle`](https://github.com/concretecms/concretecms/blob/2d83929752cb641f5b18e8a68aa829433e696361/concrete/config/install/base/config.xml#L45) and not `logChannelHandle`.

PS: this should also be backported to 8.5.x
