### PR TITLE
Remove useless package in permissionaccessentitytype > category

### DIFF
--- a/concrete/config/install/base/permissions.xml
+++ b/concrete/config/install/base/permissions.xml
@@ -632,7 +632,7 @@
             <categories>
                 <category handle="page" />
                 <category handle="page_type" />
-                <category handle="basic_workflow" package=""/>
+                <category handle="basic_workflow" />
             </categories>
         </permissionaccessentitytype>
     </permissionaccessentitytypes>


### PR DESCRIPTION
We [only use `handle`](https://github.com/concretecms/concretecms/blob/2d83929752cb641f5b18e8a68aa829433e696361/concrete/src/Backup/ContentImporter/Importer/Routine/ImportPermissionAccessEntityTypesRoutine.php#L30): `package` is totally useless

PS: this should also be backported to 8.5.x