### PR TITLE
Add missing package attribute in tasks->task CIF, remove useless package

### DIFF
--- a/concrete/config/install/base/tasks.xml
+++ b/concrete/config/install/base/tasks.xml
@@ -13,9 +13,9 @@
         <task handle="generate_thumbnails" package=""/>
         <task handle="remove_old_file_attachments" package=""/>
         <task handle="remove_unvalidated_users" package=""/>
-        <task handle="production_status"/>
-        <task handle="page_cache_report"/>
-        <task handle="custom_javascript_report"/>
+        <task handle="production_status" package=""/>
+        <task handle="page_cache_report" package=""/>
+        <task handle="custom_javascript_report" package=""/>
     </tasks>
     <tasksets>
         <taskset handle="maintenance" name="Maintenance" package="">
@@ -23,7 +23,7 @@
             <task handle="rescan_files"/>
             <task handle="remove_old_page_versions"/>
             <task handle="remove_old_file_attachments"/>
-            <task handle="generate_thumbnails" package=""/>
+            <task handle="generate_thumbnails"/>
         </taskset>
         <taskset handle="seo" name="SEO and Search" package="">
             <task handle="generate_sitemap"/>


### PR DESCRIPTION
In `tasks`>`task`: what about adding an empty `package` attribute like we do everywhere else?

In `taskset`>`task`: we [only use `handle`](https://github.com/concretecms/concretecms/blob/2d83929752cb641f5b18e8a68aa829433e696361/concrete/src/Backup/ContentImporter/Importer/Routine/ImportTaskSetsRoutine.php#L46), `package` is useless

~PS: this should also be backported to 8.5.x~