### PR TITLE
Health: add a link from reports to the "Start a New Report" page

### DIFF
--- a/concrete/controllers/single_page/dashboard/reports/health.php
+++ b/concrete/controllers/single_page/dashboard/reports/health.php
@@ -1,10 +1,14 @@
 <?php
+
 namespace Concrete\Controller\SinglePage\Dashboard\Reports;
 
 use Concrete\Core\Health\Report\Result\ResultList;
 use Concrete\Core\Localization\Service\Date;
 use Concrete\Core\Page\Controller\DashboardPageController;
+use Concrete\Core\Page\Page;
+use Concrete\Core\Permission\Checker;
 use Concrete\Core\Search\Pagination\PaginationFactory;
+use Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface;
 
 class Health extends DashboardPageController
 {
@@ -18,6 +22,12 @@ class Health extends DashboardPageController
         if ($pagination->getTotalResults() > 0) {
             $this->setThemeViewTemplate('full.php');
         }
+        $newReportPage = Page::getByPath('/dashboard/welcome/health');
+        if ($newReportPage && !$newReportPage->isError() && (new Checker($newReportPage))->canRead()) {
+            $newReportPageUrl = (string) $this->app->make(ResolverManagerInterface::class)->resolve([$newReportPage]);
+        } else {
+            $newReportPageUrl = '';
+        }
+        $this->set('newReportPageUrl', $newReportPageUrl);
     }
-
 }

--- a/concrete/single_pages/dashboard/reports/health.php
+++ b/concrete/single_pages/dashboard/reports/health.php
@@ -1,49 +1,63 @@
-<?php defined('C5_EXECUTE') or die("Access Denied.");
+<?php
+
+defined('C5_EXECUTE') or die('Access Denied.');
 
 /**
  * @var Concrete\Core\Localization\Service\Date $dateService
  * @var Concrete\Core\Search\Pagination\Pagination $pagination
+ * @var string $newReportPageUrl
  */
-if ($pagination->getTotalResults() > 0) { ?>
 
+if ($newReportPageUrl !== '') {
+    ?>
+    <div class="ccm-dashboard-header-buttons btn-group">
+        <a href="<?= h($newReportPageUrl) ?>" class="btn btn-sm btn-primary"><?= t('New Report') ?></a>
+    </div>
+    <?php
+}
+
+if ($pagination->getTotalResults() > 0) {
+    ?>
     <table class="ccm-search-results-table">
         <thead>
         <tr>
-            <th><?=t('Name')?></th>
-            <th><?=t('Date Started')?></th>
-            <th><?=t('Date Completed')?></th>
-            <th class="text-center"><?=t('Findings')?></th>
+            <th><?= t('Name') ?></th>
+            <th><?= t('Date Started') ?></th>
+            <th><?= t('Date Completed') ?></th>
+            <th class="text-center"><?= t('Findings') ?></th>
             <th></th>
         </tr>
         </thead>
         <tbody>
-        <?php foreach ($pagination->getCurrentPageResults() as $result) { ?>
-            <tr data-details-url="<?=URL::to('/dashboard/reports/health/details', $result->getID())?>">
-                <td class="ccm-search-results-name w-50"><?=$result->getName()?></td>
+        <?php
+        foreach ($pagination->getCurrentPageResults() as $result) {
+            ?>
+            <tr data-details-url="<?= URL::to('/dashboard/reports/health/details', $result->getID()) ?>">
+                <td class="ccm-search-results-name w-50"><?= $result->getName() ?></td>
                 <td class="text-nowrap"><?= h($dateService->formatDateTime($result->getDateStarted())) ?></td>
-                <td class="text-nowrap"><?= h($dateService->formatDateTime($result->getDateCompleted())) ?: '<span class="text-muted">' . t('Running...') . '</span>'?></td>
-                <td class="text-nowrap text-center"><?=$result->getTotalFindings()?></td>
+                <td class="text-nowrap"><?= h($dateService->formatDateTime($result->getDateCompleted())) ?: '<span class="text-muted">' . t('Running...') . '</span>' ?></td>
+                <td class="text-nowrap text-center"><?= $result->getTotalFindings() ?></td>
                 <td class="text-nowrap text-center">
                     <?php
                     $grade = $result->getGrade();
                     if ($grade) {
                         $gradeFormatter = $grade->getFormatter();
-                        echo $gradeFormatter->getResultsListIcon();?>
-
-                    <?php }
+                        echo $gradeFormatter->getResultsListIcon();
+                    }
                     ?>
                 </td>
             </tr>
-        <?php } ?>
+            <?php
+        }
+        ?>
         </tbody>
     </table>
-
-    <?php if ($pagination->getTotalPages() > 1) { ?>
-        <?php echo $pagination->renderView('dashboard'); ?>
-    <?php } ?>
-
-<?php } else { ?>
-
-    <p><?=t('No health report results found.')?></p>
-
-<?php } ?>
+    <?php
+    if ($pagination->getTotalPages() > 1) {
+        echo $pagination->renderView('dashboard');
+    }
+} else {
+    ?>
+    <p><?= t('No health report results found.') ?></p>
+    <?php
+}


### PR DESCRIPTION
We can create new Site Health reports at the page `/dashboard/welcome/health`.

We can view those reports at the page `/dashboard/reports/health`

We can already easily go from the welcome page to the reports page thanks to the "Latest Health Reports" section:

![immagine](https://github.com/concretecms/concretecms/assets/928116/f0d5dbd3-0ecc-43ab-966d-617858d33614)

But it's not that easy to go from the reports page to the welcome page.

What about adding a link for that?

![screenshot](https://github.com/concretecms/concretecms/assets/928116/35d9372d-5852-47f4-8ab9-94796ca0d7d4)