### PR TITLE
Fix Spacing Issue From Previous PR

### DIFF
--- a/concrete/blocks/page_list/controller.php
+++ b/concrete/blocks/page_list/controller.php
@@ -411,9 +411,9 @@ class Controller extends BlockController implements UsesFeatureInterface
             $this->list->ignorePermissions();
         }
         if ($this->excludeCurrentPage) {
-	    $ID = Page::getCurrentPage()->getCollectionID();
-	    $this->list->getQueryObject()->andWhere($expr->neq('p.cID', $ID));
-	}
+            $ID = Page::getCurrentPage()->getCollectionID();
+            $this->list->getQueryObject()->andWhere($expr->neq('p.cID', $ID));
+        }
 
         $this->list->filter('cvName', '', '!=');
 


### PR DESCRIPTION
This simply fixes the spacing in my previous PR to add the "Exclude Current Page" option.  Noticed the use of tabs in a downloaded install of the core, which are now spaces...
