### PR TITLE
CIF: Remove unused type node from number attributes

### DIFF
--- a/concrete/config/install/base/attributes.xml
+++ b/concrete/config/install/base/attributes.xml
@@ -230,9 +230,7 @@
         <attributekey handle="meta_keywords" name="Meta Keywords" package="" searchable="1" indexed="0" type="textarea" category="collection">
             <type mode=""/>
         </attributekey>
-        <attributekey handle="desktop_priority" name="Desktop Priority" package="" searchable="0" indexed="0" type="number" internal="1" category="collection">
-            <type mode=""/>
-        </attributekey>
+        <attributekey handle="desktop_priority" name="Desktop Priority" package="" searchable="0" indexed="0" type="number" internal="1" category="collection" />
         <attributekey handle="is_desktop" name="Is Desktop" package="" searchable="0" indexed="0" type="boolean" internal="1" category="collection">
             <type mode=""/>
         </attributekey>


### PR DESCRIPTION
The number attribute controller doesn't have a `importKey()` method, so the `<attributekey>` CIF element shouldn't have any child nodes.

PS: this should also be backported to 8.5.x