### PR TITLE
CIF: Remove unused type[mode] from boolean attributes

### DIFF
--- a/concrete/config/install/base/attributes.xml
+++ b/concrete/config/install/base/attributes.xml
@@ -233,9 +233,7 @@
         <attributekey handle="desktop_priority" name="Desktop Priority" package="" searchable="0" indexed="0" type="number" internal="1" category="collection">
             <type mode=""/>
         </attributekey>
-        <attributekey handle="is_desktop" name="Is Desktop" package="" searchable="0" indexed="0" type="boolean" internal="1" category="collection">
-            <type mode=""/>
-        </attributekey>
+        <attributekey handle="is_desktop" name="Is Desktop" package="" searchable="0" indexed="0" type="boolean" internal="1" category="collection" />
         <attributekey handle="icon_dashboard" name="Dashboard Icon" package="" searchable="0" indexed="0" type="textarea" internal="1" category="collection">
             <type mode=""/>
         </attributekey>


### PR DESCRIPTION
The [`importKey()` method](https://github.com/concretecms/concretecms/blob/9.2.2/concrete/attributes/boolean/controller.php#L91-L106) of the boolean attribute type doesn't recognize the `mode` attribute, so let's avoid using it in the CIF.

PS: this should also be backported to 8.5.x