### PR TITLE
Remove duplicated attribute keys from Atomik CIF

### DIFF
--- a/concrete/config/install/packages/atomik_full/content.xml
+++ b/concrete/config/install/packages/atomik_full/content.xml
@@ -442,12 +442,6 @@
                       type="topics" category="collection">
             <tree name="Blog Entries" path="/"/>
         </attributekey>
-        <attributekey handle="thumbnail" name="Thumbnail" package="" searchable="1" indexed="1" type="image_file"
-                      category="collection"/>
-        <attributekey handle="exclude_subpages_from_nav" name="Exclude Sub-Pages From Nav" package="" searchable="1"
-                      indexed="1" type="boolean" category="collection">
-            <type checked="0"/>
-        </attributekey>
     </attributekeys>
     <attributesets>
         <attributeset handle="blog" name="Blog" package="" locked="0" category="collection">


### PR DESCRIPTION
In `concrete/config/install/packages/atomik_full/content.xml` we try to create two attribute keys that are already created by `concrete/config/install/base/attributes.xml`:

- [`exclude_subpages_from_nav`](https://github.com/concretecms/concretecms/blob/9.2.2/concrete/config/install/base/attributes.xml#L264-L266)
- [`thumbnail`](https://github.com/concretecms/concretecms/blob/9.2.2/concrete/config/install/base/attributes.xml#L277)
