### PR TITLE
Add missing import from XML Styles: hideOn...

### DIFF
--- a/concrete/src/StyleCustomizer/Inline/StyleSet.php
+++ b/concrete/src/StyleCustomizer/Inline/StyleSet.php
@@ -74,13 +74,17 @@ class StyleSet
         $o->setRotate((string) $node->rotate);
         $o->setBoxShadowHorizontal((string) $node->boxShadowHorizontal);
         $o->setBoxShadowVertical((string) $node->boxShadowVertical);
-        $o->setBoxShadowSpread((string) $node->boxShadowSpread);
         $o->setBoxShadowBlur((string) $node->boxShadowBlur);
+        $o->setBoxShadowSpread((string) $node->boxShadowSpread);
         $o->setBoxShadowColor((string) $node->boxShadowColor);
-        $o->setBoxShadowInset((bool) $node->boxShadowInset);
+        $o->setBoxShadowInset(filter_var((string) $node->boxShadowInset, FILTER_VALIDATE_BOOLEAN));
         $o->setCustomClass((string) $node->customClass);
         $o->setCustomID((string) $node->customID);
         $o->setCustomElementAttribute((string) $node->customElementAttribute);
+        $o->setHideOnExtraSmallDevice(filter_var((string) $node->hideOnExtraSmallDevice, FILTER_VALIDATE_BOOLEAN));
+        $o->setHideOnSmallDevice(filter_var((string) $node->hideOnSmallDevice, FILTER_VALIDATE_BOOLEAN));
+        $o->setHideOnMediumDevice(filter_var((string) $node->hideOnMediumDevice, FILTER_VALIDATE_BOOLEAN));
+        $o->setHideOnLargeDevice(filter_var((string) $node->hideOnLargeDevice, FILTER_VALIDATE_BOOLEAN));
 
         $o->save();
 


### PR DESCRIPTION
We [export three custom styles](https://github.com/concretecms/concretecms/blob/9.2.2/concrete/src/Entity/StyleCustomizer/Inline/StyleSet.php#L804-L806) that we don't import: let's add them.

I also used `filter_var($foo, FILTER_VALIDATE_BOOLEAN)` instead of `(bool) $foo` since the former [correctly parses](https://3v4l.org/dOoQW) `'false'`, `'no'`, and `'off'`.