### PR TITLE
Minor change in boardtemplates CIF

### DIFF
--- a/concrete/themes/atomik/content.xml
+++ b/concrete/themes/atomik/content.xml
@@ -74,9 +74,7 @@
         </template>
     </summarytemplates>
     <boardtemplates>
-        <template handle="blog" name="Blog"
-                  icon="blank.png" package="">
-        </template>
+        <template handle="blog" name="Blog" icon="blank.png" package="" />
     </boardtemplates>
     <boardslottemplates>
         <template handle="blog_image_left" name="Blog Image Left"


### PR DESCRIPTION
This is just a minor change in the CIF file that installs board templates.

It doesn't change anything, except that it simplifies the validation of CIF files with the [XSD I'm writing](https://github.com/concrete5-community/concrete-cif).

The reason is that, for XSD, `<element />` and `<element>  </element>` are different.