### PR TITLE
Log "user bound" as info instead of warning

### DIFF
--- a/concrete/src/Authentication/Type/OAuth/BindingService.php
+++ b/concrete/src/Authentication/Type/OAuth/BindingService.php
@@ -199,7 +199,7 @@ class BindingService implements LoggerAwareInterface
         }
 
         if ($this->logger) {
-            $this->logger->warning('Bound user: User #{user} is now bound to "{binding}" in "{namespace}".', [
+            $this->logger->info('Bound user: User #{user} is now bound to "{binding}" in "{namespace}".', [
                 'user' => $id,
                 'binding' => $binding,
                 'namespace' => $namespace,


### PR DESCRIPTION
When new users get registered via an OAuth authentication type, we log it as a "warning" event.

This may cause alerting systems to notify warnings, uselessly.

What about recording such events as informative?