### PR TITLE
CIF: remove unused "chooseCalendar" from Calendar block

### DIFF
--- a/concrete/themes/atomik/documentation/calendar.xml
+++ b/concrete/themes/atomik/documentation/calendar.xml
@@ -61,7 +61,6 @@
                 <data table="btCalendar">
                     <record>
                         <caID><![CDATA[0]]></caID>
-                        <chooseCalendar><![CDATA[]]></chooseCalendar>
                         <calendarAttributeKeyHandle><![CDATA[]]></calendarAttributeKeyHandle>
                         <filterByTopicAttributeKeyID><![CDATA[0]]></filterByTopicAttributeKeyID>
                         <filterByTopicID><![CDATA[0]]></filterByTopicID>
@@ -87,7 +86,6 @@
                 <data table="btEventList">
                     <record>
                         <caID><![CDATA[0]]></caID>
-                        <chooseCalendar><![CDATA[]]></chooseCalendar>
                         <calendarAttributeKeyHandle><![CDATA[]]></calendarAttributeKeyHandle>
                         <totalToRetrieve><![CDATA[9]]></totalToRetrieve>
                         <totalPerPage><![CDATA[3]]></totalPerPage>


### PR DESCRIPTION
There isn't a `chooseCalendar` field in the [`db.xml` file](https://github.com/concretecms/concretecms/blob/9.2.2/concrete/blocks/calendar/db.xml) of the Calendar block type.