### PR TITLE
Remove no-more used conversation fields

### DIFF
--- a/concrete/blocks/core_conversation/controller.php
+++ b/concrete/blocks/core_conversation/controller.php
@@ -93,16 +93,6 @@ class Controller extends BlockController implements UsesFeatureInterface
     public $customDateFormat;
 
     /**
-     * @var int|null
-     */
-    public $maxFilesRegistered;
-
-    /**
-     * @var int|null
-     */
-    public $maxFilesGuest;
-
-    /**
      * @var int
      */
     protected $btInterfaceWidth = 450;

--- a/concrete/config/install/packages/elemental_full/content.xml
+++ b/concrete/config/install/packages/elemental_full/content.xml
@@ -287,11 +287,6 @@
                                                 <addMessageLabel><![CDATA[Add Message]]></addMessageLabel>
                                                 <dateFormat><![CDATA[default]]></dateFormat>
                                                 <customDateFormat><![CDATA[]]></customDateFormat>
-                                                <maxFilesGuest><![CDATA[0]]></maxFilesGuest>
-                                                <maxFilesRegistered><![CDATA[0]]></maxFilesRegistered>
-                                                <maxFileSizeGuest><![CDATA[0]]></maxFileSizeGuest>
-                                                <maxFileSizeRegistered><![CDATA[0]]></maxFileSizeRegistered>
-                                                <fileExtensions><![CDATA[]]></fileExtensions>
                                             </record>
                                         </data>
                                     </block>
@@ -2263,11 +2258,6 @@
                                 <addMessageLabel><![CDATA[Add Message]]></addMessageLabel>
                                 <dateFormat><![CDATA[default]]></dateFormat>
                                 <customDateFormat><![CDATA[]]></customDateFormat>
-                                <maxFilesGuest><![CDATA[0]]></maxFilesGuest>
-                                <maxFilesRegistered><![CDATA[0]]></maxFilesRegistered>
-                                <maxFileSizeGuest><![CDATA[0]]></maxFileSizeGuest>
-                                <maxFileSizeRegistered><![CDATA[0]]></maxFileSizeRegistered>
-                                <fileExtensions><![CDATA[]]></fileExtensions>
                             </record>
                         </data>
                     </block>
@@ -2334,11 +2324,6 @@
                                 <addMessageLabel><![CDATA[Add Message]]></addMessageLabel>
                                 <dateFormat><![CDATA[default]]></dateFormat>
                                 <customDateFormat><![CDATA[]]></customDateFormat>
-                                <maxFilesGuest><![CDATA[0]]></maxFilesGuest>
-                                <maxFilesRegistered><![CDATA[0]]></maxFilesRegistered>
-                                <maxFileSizeGuest><![CDATA[0]]></maxFileSizeGuest>
-                                <maxFileSizeRegistered><![CDATA[0]]></maxFileSizeRegistered>
-                                <fileExtensions><![CDATA[]]></fileExtensions>
                             </record>
                         </data>
                     </block>
@@ -2405,11 +2390,6 @@
                                 <addMessageLabel><![CDATA[Add Message]]></addMessageLabel>
                                 <dateFormat><![CDATA[default]]></dateFormat>
                                 <customDateFormat><![CDATA[]]></customDateFormat>
-                                <maxFilesGuest><![CDATA[0]]></maxFilesGuest>
-                                <maxFilesRegistered><![CDATA[0]]></maxFilesRegistered>
-                                <maxFileSizeGuest><![CDATA[0]]></maxFileSizeGuest>
-                                <maxFileSizeRegistered><![CDATA[0]]></maxFileSizeRegistered>
-                                <fileExtensions><![CDATA[]]></fileExtensions>
                             </record>
                         </data>
                     </block>

--- a/concrete/controllers/frontend/conversations/update_message.php
+++ b/concrete/controllers/frontend/conversations/update_message.php
@@ -136,13 +136,13 @@ class UpdateMessage extends FrontendController
             return [];
         }
         $attachments = [];
-        $pp = new Checker($message->getConversationObject());
-        if (!$pp->canAddConversationMessageAttachments()) {
+        $conversation = $message->getConversationObject();
+        $pp = new Checker($conversation);
+        if (!$conversation || !$pp->canAddConversationMessageAttachments()) {
             $errors[] = t('You do not have permission to add attachments.');
         } else {
-            $blockController = $this->getBlockController();
             $u = $this->app->make(User::class);
-            $maxFiles = $u->isRegistered() ? $blockController->maxFilesRegistered : $blockController->maxFilesGuest;
+            $maxFiles = $u->isRegistered() ? $conversation->getConversationMaxFilesRegistered() : $conversation->getConversationMaxFilesGuest();
             $messageAttachmentCount = count($message->getAttachments($message->getConversationMessageID()));
             $totalCurrentAttachments = $messageAttachmentCount + count($attachmentIDs);
             if ($maxFiles > 0 && $totalCurrentAttachments > $maxFiles) {


### PR DESCRIPTION
We removed these fields from the Core Conversation block type [back in 2014](https://github.com/concretecms/concrete5-legacy/commit/9a558f053ca78461b619a36f61b7f094ff3aa0ab):

- `maxFilesGuest`
- `maxFilesRegistered`
- `maxFileSizeGuest`
- `maxFileSizeRegistered`
- `fileExtensions`

This PR also fixes the handling of maximum number of attachments when updating a conversation.