### PR TITLE
Fix exporting core_scrapbook_display blocks

### DIFF
--- a/concrete/blocks/core_scrapbook_display/controller.php
+++ b/concrete/blocks/core_scrapbook_display/controller.php
@@ -110,16 +110,26 @@ class Controller extends BlockController
      */
     public function export(\SimpleXMLElement $blockNode)
     {
-        $b = Block::getByID($this->bOriginalID);
-        /** @var BlockController|null $bc */
-        $bc = $b->getInstance();
-        if ($bc) {
-            $blockNode->addAttribute('type', $b->getBlockTypeHandle());
-            $blockNode->addAttribute('name', $b->getBlockName());
-            if ($b->getBlockFilename() != '') {
-                $blockNode->addAttribute('custom-template', $b->getBlockFilename());
+        $block = Block::getByID($this->bOriginalID);
+        if ($block) {
+            $clonedBlock = clone $blockNode;
+            $block->export($clonedBlock);
+            $otherBlockNode = $clonedBlock->children()[0];
+            foreach ($otherBlockNode->attributes() as $attribute) {
+                $blockNode[$attribute->getName()] = (string) $attribute;
             }
-            $bc->export($blockNode);
+            $this->exportChildren($otherBlockNode, $blockNode);
+        }
+    }
+
+    private function exportChildren(\SimpleXMLElement $from, \SimpleXMLElement $to)
+    {
+        foreach ($from->children() as $fromChild) {
+            $toChild = $to->addChild($fromChild->getName(), (string) $fromChild);
+            foreach ($fromChild->attributes() as $attribute) {
+                $toChild[$attribute->getName()] = (string) $attribute;
+            }
+            $this->exportChildren($fromChild, $toChild);
         }
     }
 


### PR DESCRIPTION
Exporting core_scrapbook_display is broken.

For example, exporting a simple page with a Content block and an "alias" of it throws a `SimpleXMLElement::addAttribute(): Attribute already exists` warning, and the resulting CIF is something like this:

```xml
<blocks>
    <block type="content" name="">
        <data table="btContentLocal">
            <record>
                <content><![CDATA[<p>Foo <strong>bar</strong></p>]]></content>
            </record>
        </data>
    </block>
    <block type="core_scrapbook_display" name="">
        <data table="btContentLocal">
            <record>
                <content><![CDATA[<p>Foo <strong>bar</strong></p>]]></content>
            </record>
        </data>
    </block>
</blocks>
```

And there's no way to import the core_scrapbook_display correctly (which is the type of the second block? Who knows!).

With this PR we'd instead have:

```xml
<blocks>
    <block type="content" name="">
        <data table="btContentLocal">
            <record>
                <content><![CDATA[<p>Foo <strong>bar</strong></p>]]></content>
            </record>
        </data>
    </block>
    <block type="content" name="">
        <data table="btContentLocal">
            <record>
                <content>&lt;p&gt;Foo &lt;strong&gt;bar&lt;/strong&gt;&lt;/p&gt;</content>
            </record>
        </data>
    </block>
</blocks>
```

Sure, it's not perfect: we loose the fact that the second block is an alias of the first, but at least it works. But that would be a nightmare to be implemented.