### PR TITLE
CIF: remove forceImageToMatchDimensions from Image blocks

### DIFF
--- a/concrete/config/install/packages/elemental_full/content.xml
+++ b/concrete/config/install/packages/elemental_full/content.xml
@@ -2172,7 +2172,6 @@
                                                 <maxHeight><![CDATA[0]]></maxHeight>
                                                 <externalLink><![CDATA[]]></externalLink>
                                                 <internalLinkCID><![CDATA[0]]></internalLinkCID>
-                                                <forceImageToMatchDimensions><![CDATA[0]]></forceImageToMatchDimensions>
                                                 <altText><![CDATA[Blank Image]]></altText>
                                                 <title><![CDATA[Blank Image]]></title>
                                             </record>
@@ -2542,7 +2541,6 @@
                                                 <maxHeight><![CDATA[0]]></maxHeight>
                                                 <externalLink><![CDATA[]]></externalLink>
                                                 <internalLinkCID><![CDATA[0]]></internalLinkCID>
-                                                <forceImageToMatchDimensions><![CDATA[0]]></forceImageToMatchDimensions>
                                                 <altText><![CDATA[]]></altText>
                                             </record>
                                         </data>
@@ -2635,7 +2633,6 @@
                                                 <maxHeight><![CDATA[0]]></maxHeight>
                                                 <externalLink><![CDATA[]]></externalLink>
                                                 <internalLinkCID><![CDATA[0]]></internalLinkCID>
-                                                <forceImageToMatchDimensions><![CDATA[0]]></forceImageToMatchDimensions>
                                                 <altText><![CDATA[]]></altText>
                                             </record>
                                         </data>
@@ -2694,7 +2691,6 @@
                                                 <maxHeight><![CDATA[0]]></maxHeight>
                                                 <externalLink><![CDATA[]]></externalLink>
                                                 <internalLinkCID><![CDATA[0]]></internalLinkCID>
-                                                <forceImageToMatchDimensions><![CDATA[0]]></forceImageToMatchDimensions>
                                                 <altText><![CDATA[]]></altText>
                                             </record>
                                         </data>
@@ -2728,7 +2724,6 @@
                                                 <maxHeight><![CDATA[0]]></maxHeight>
                                                 <externalLink><![CDATA[]]></externalLink>
                                                 <internalLinkCID><![CDATA[0]]></internalLinkCID>
-                                                <forceImageToMatchDimensions><![CDATA[0]]></forceImageToMatchDimensions>
                                                 <altText><![CDATA[]]></altText>
                                             </record>
                                         </data>
@@ -2771,7 +2766,6 @@
                                 <maxHeight><![CDATA[0]]></maxHeight>
                                 <externalLink><![CDATA[]]></externalLink>
                                 <internalLinkCID><![CDATA[0]]></internalLinkCID>
-                                <forceImageToMatchDimensions><![CDATA[0]]></forceImageToMatchDimensions>
                                 <altText><![CDATA[]]></altText>
                             </record>
                         </data>


### PR DESCRIPTION
We removed that field in https://github.com/concretecms/concrete5-legacy/commit/3456016adbc38670f841c04dcf4bcced4cc66b25