### PR TITLE
CIF: trim values containing "<![CDATA[ ... ]]"

### DIFF
--- a/concrete/config/install/packages/atomik_full/content.xml
+++ b/concrete/config/install/packages/atomik_full/content.xml
@@ -187,10 +187,8 @@
                                                             <filterDateDays><![CDATA[0]]></filterDateDays>
                                                             <filterDateStart><![CDATA[]]></filterDateStart>
                                                             <filterDateEnd><![CDATA[]]></filterDateEnd>
-                                                            <relatedTopicAttributeKeyHandle>
-                                                                <![CDATA[]]></relatedTopicAttributeKeyHandle>
-                                                            <customTopicAttributeKeyHandle>
-                                                                <![CDATA[]]></customTopicAttributeKeyHandle>
+                                                            <relatedTopicAttributeKeyHandle><![CDATA[]]></relatedTopicAttributeKeyHandle>
+                                                            <customTopicAttributeKeyHandle><![CDATA[]]></customTopicAttributeKeyHandle>
                                                             <customTopicTreeNodeID><![CDATA[0]]></customTopicTreeNodeID>
                                                             <includeName><![CDATA[1]]></includeName>
                                                             <includeDescription><![CDATA[1]]></includeDescription>
@@ -200,8 +198,7 @@
                                                             <displayAliases><![CDATA[0]]></displayAliases>
                                                             <displaySystemPages><![CDATA[0]]></displaySystemPages>
                                                             <ignorePermissions><![CDATA[0]]></ignorePermissions>
-                                                            <enableExternalFiltering>
-                                                                <![CDATA[0]]></enableExternalFiltering>
+                                                            <enableExternalFiltering><![CDATA[0]]></enableExternalFiltering>
                                                             <ptID>{ccm:export:pagetype:blog_entry}</ptID>
                                                             <pfID/>
                                                             <truncateSummaries><![CDATA[0]]></truncateSummaries>
@@ -844,8 +841,7 @@ Aenean eu enim justo. Vestibulum aliquam hendrerit molestie.</p>
                                             <filterDateDays><![CDATA[0]]></filterDateDays>
                                             <filterDateStart><![CDATA[]]></filterDateStart>
                                             <filterDateEnd><![CDATA[]]></filterDateEnd>
-                                            <relatedTopicAttributeKeyHandle>
-                                                <![CDATA[]]></relatedTopicAttributeKeyHandle>
+                                            <relatedTopicAttributeKeyHandle><![CDATA[]]></relatedTopicAttributeKeyHandle>
                                             <customTopicAttributeKeyHandle><![CDATA[]]></customTopicAttributeKeyHandle>
                                             <customTopicTreeNodeID><![CDATA[0]]></customTopicTreeNodeID>
                                             <includeName><![CDATA[0]]></includeName>
@@ -1755,8 +1751,7 @@ Maecenas consequat lectus a euismod pellentesque. Pellentesque commodo quam nec 
                                             <filterDateDays><![CDATA[0]]></filterDateDays>
                                             <filterDateStart><![CDATA[]]></filterDateStart>
                                             <filterDateEnd><![CDATA[]]></filterDateEnd>
-                                            <relatedTopicAttributeKeyHandle>
-                                                <![CDATA[]]></relatedTopicAttributeKeyHandle>
+                                            <relatedTopicAttributeKeyHandle><![CDATA[]]></relatedTopicAttributeKeyHandle>
                                             <customTopicAttributeKeyHandle><![CDATA[]]></customTopicAttributeKeyHandle>
                                             <customTopicTreeNodeID><![CDATA[0]]></customTopicTreeNodeID>
                                             <includeName><![CDATA[1]]></includeName>
@@ -2423,8 +2418,7 @@ Nam massa mauris, euismod vel tortor vel, finibus accumsan sem. Sed varius vulpu
                                 <setMode><![CDATA[any]]></setMode>
                                 <onlyCurrentUser><![CDATA[0]]></onlyCurrentUser>
                                 <tags><![CDATA[]]></tags>
-                                <viewProperties>
-                                    <![CDATA[{"thumbnail":"1","filename":"5","tags":"-1","date":"5","extension":"-1","size":"5","description":"-1","ak_16":"-1","ak_17":"-1","ak_19":"-1"}]]></viewProperties>
+                                <viewProperties><![CDATA[{"thumbnail":"1","filename":"5","tags":"-1","date":"5","extension":"-1","size":"5","description":"-1","ak_16":"-1","ak_17":"-1","ak_19":"-1"}]]></viewProperties>
                                 <expandableProperties><![CDATA[[]]]></expandableProperties>
                                 <searchProperties></searchProperties>
                                 <orderBy><![CDATA[title]]></orderBy>
@@ -3018,8 +3012,7 @@ Nam massa mauris, euismod vel tortor vel, finibus accumsan sem. Sed varius vulpu
                             <record>
                                 <brandingText></brandingText>
                                 <brandingLogo>{ccm:export:file:atomik-logo.png}</brandingLogo>
-                                <brandingTransparentLogo>{ccm:export:file:atomik-logo-transparent.png}
-                                </brandingTransparentLogo>
+                                <brandingTransparentLogo>{ccm:export:file:atomik-logo-transparent.png}</brandingTransparentLogo>
                                 <includeBrandText><![CDATA[1]]></includeBrandText>
                                 <includeBrandLogo><![CDATA[1]]></includeBrandLogo>
                                 <includeTransparency>1</includeTransparency>

--- a/concrete/config/install/packages/elemental_full/content.xml
+++ b/concrete/config/install/packages/elemental_full/content.xml
@@ -263,8 +263,7 @@
                                                 <includeDescription><![CDATA[0]]></includeDescription>
                                                 <ptID>{ccm:export:pagetype:blog_entry}</ptID>
                                                 <pageListTitle>Related Posts</pageListTitle>
-                                                <relatedTopicAttributeKeyHandle>blog_entry_topics
-                                                </relatedTopicAttributeKeyHandle>
+                                                <relatedTopicAttributeKeyHandle>blog_entry_topics</relatedTopicAttributeKeyHandle>
                                             </record>
                                         </data>
                                     </block>
@@ -564,8 +563,7 @@
                                                 <pageListTitle>Related Projects</pageListTitle>
                                                 <noResultsMessage>
                                                     <![CDATA[No related projects found.]]></noResultsMessage>
-                                                <relatedTopicAttributeKeyHandle>project_topics
-                                                </relatedTopicAttributeKeyHandle>
+                                                <relatedTopicAttributeKeyHandle>project_topics</relatedTopicAttributeKeyHandle>
                                             </record>
                                         </data>
                                     </block>
@@ -621,8 +619,7 @@
                                                                 <buttonLinkText><![CDATA[]]></buttonLinkText>
                                                                 <includeName><![CDATA[1]]></includeName>
                                                                 <includeDescription><![CDATA[1]]></includeDescription>
-                                                                <includeAllDescendents>
-                                                                    <![CDATA[0]]></includeAllDescendents>
+                                                                <includeAllDescendents><![CDATA[0]]></includeAllDescendents>
                                                                 <paginate><![CDATA[1]]></paginate>
                                                                 <displayAliases><![CDATA[0]]></displayAliases>
                                                                 <ptID>{ccm:export:pagetype:blog_entry}</ptID>
@@ -631,8 +628,7 @@
                                                                 <displayFeaturedOnly><![CDATA[0]]></displayFeaturedOnly>
                                                                 <displayThumbnail><![CDATA[0]]></displayThumbnail>
                                                                 <truncateChars><![CDATA[0]]></truncateChars>
-                                                                <enableExternalFiltering>
-                                                                    <![CDATA[1]]></enableExternalFiltering>
+                                                                <enableExternalFiltering><![CDATA[1]]></enableExternalFiltering>
                                                                 <noResultsMessage>
                                                                     <![CDATA[No posts to this blog.]]></noResultsMessage>
                                                                 <includeDate><![CDATA[1]]></includeDate>

--- a/concrete/themes/atomik/documentation/calendar.xml
+++ b/concrete/themes/atomik/documentation/calendar.xml
@@ -66,8 +66,7 @@
                         <filterByTopicAttributeKeyID><![CDATA[0]]></filterByTopicAttributeKeyID>
                         <filterByTopicID><![CDATA[0]]></filterByTopicID>
                         <viewTypes><![CDATA[["month","basicWeek","basicDay"]]]></viewTypes>
-                        <viewTypesOrder>
-                            <![CDATA[["month_Month","basicWeek_Week","basicDay_Day"]]]></viewTypesOrder>
+                        <viewTypesOrder><![CDATA[["month_Month","basicWeek_Week","basicDay_Day"]]]></viewTypesOrder>
                         <defaultView><![CDATA[month]]></defaultView>
                         <navLinks><![CDATA[0]]></navLinks>
                         <eventLimit><![CDATA[0]]></eventLimit>

--- a/concrete/themes/atomik/documentation/forms.xml
+++ b/concrete/themes/atomik/documentation/forms.xml
@@ -125,8 +125,7 @@
                         <linkedProperties><![CDATA[[]]]></linkedProperties>
                         <searchProperties><![CDATA[[]]]></searchProperties>
                         <searchAssociations><![CDATA[[]]]></searchAssociations>
-                        <columns>
-                            <![CDATA[O:48:"Concrete\Core\Express\Search\ColumnSet\ColumnSet":2:{s:10:"]]></columns>
+                        <columns><![CDATA[O:48:"Concrete\Core\Express\Search\ColumnSet\ColumnSet":2:{s:10:"]]></columns>
                         <filterFields><![CDATA[a:0:{}]]></filterFields>
                         <displayLimit><![CDATA[20]]></displayLimit>
                         <enableItemsPerPageSelection><![CDATA[0]]></enableItemsPerPageSelection>

--- a/concrete/themes/atomik/documentation/multimedia.xml
+++ b/concrete/themes/atomik/documentation/multimedia.xml
@@ -274,8 +274,7 @@
                         <setMode><![CDATA[any]]></setMode>
                         <onlyCurrentUser><![CDATA[0]]></onlyCurrentUser>
                         <tags><![CDATA[]]></tags>
-                        <viewProperties>
-                            <![CDATA[{"thumbnail":"1","filename":"5","tags":"-1","date":"5","extension":"-1","size":"5","description":"-1","ak_16":"-1","ak_17":"-1","ak_19":"-1"}]]></viewProperties>
+                        <viewProperties><![CDATA[{"thumbnail":"1","filename":"5","tags":"-1","date":"5","extension":"-1","size":"5","description":"-1","ak_16":"-1","ak_17":"-1","ak_19":"-1"}]]></viewProperties>
                         <expandableProperties><![CDATA[[]]]></expandableProperties>
                         <searchProperties></searchProperties>
                         <orderBy><![CDATA[title]]></orderBy>
@@ -317,8 +316,7 @@
                         <setMode><![CDATA[any]]></setMode>
                         <onlyCurrentUser><![CDATA[0]]></onlyCurrentUser>
                         <tags><![CDATA[]]></tags>
-                        <viewProperties>
-                            <![CDATA[{"thumbnail":"1","filename":"5","tags":"-1","date":"5","extension":"-1","size":"5","description":"-1","ak_16":"-1","ak_17":"-1","ak_19":"-1"}]]></viewProperties>
+                        <viewProperties><![CDATA[{"thumbnail":"1","filename":"5","tags":"-1","date":"5","extension":"-1","size":"5","description":"-1","ak_16":"-1","ak_17":"-1","ak_19":"-1"}]]></viewProperties>
                         <expandableProperties><![CDATA[[]]]></expandableProperties>
                         <searchProperties></searchProperties>
                         <orderBy><![CDATA[title]]></orderBy>

--- a/concrete/themes/atomik/documentation/social.xml
+++ b/concrete/themes/atomik/documentation/social.xml
@@ -203,8 +203,7 @@
                         <company><![CDATA[Testimonial Company]]></company>
                         <companyURL><![CDATA[https://www.concretecms.com]]></companyURL>
                         <paragraph><![CDATA[This is the bio/quote. ]]></paragraph>
-                        <awardImageID>{ccm:export:file:atomik-documentation-image-wide-01.jpg}
-                        </awardImageID>
+                        <awardImageID>{ccm:export:file:atomik-documentation-image-wide-01.jpg}</awardImageID>
                     </record>
                 </data>
             </block>


### PR DESCRIPTION
We have to take care of extra spaces in XML nodes.

Consider this example:

```php
$xml = simplexml_load_string(
<<<'EOT'
<root>
    <child>
        <![CDATA[0]]>
    </child>
</root>
EOT
);

$nodeContent = (string) $xml->child;
var_dump($nodeContent);
$bool = (bool) $nodeContent;
var_dump($bool);
```

[`$bool` will be `true`](https://3v4l.org/Xdcm3)!

The reason is that spaces around CDATA sections are kept, and casting to bool a string that starts with spaces results in true.

We have also to take care of nodes that may contain handles and data we `unserialize()` or `json_decode()`.