### PR TITLE
Show installed packages alpha sorted.

### DIFF
--- a/concrete/single_pages/dashboard/extend/install.php
+++ b/concrete/single_pages/dashboard/extend/install.php
@@ -262,6 +262,9 @@ if ($this->controller->getTask() == 'install_package' && isset($showInstallOptio
         <h3><?= t('Currently Installed'); ?></h3>
         <?php
         if (count($pkgArray) > 0) {
+            usort($pkgArray, function($a,$b){
+                return $a->getPackageName() <=> $b->getPackageName();
+            });
             foreach ($pkgArray as $pkg) {
                 ?>
                 <div class="d-flex border p-3">

--- a/concrete/single_pages/dashboard/extend/install.php
+++ b/concrete/single_pages/dashboard/extend/install.php
@@ -263,7 +263,7 @@ if ($this->controller->getTask() == 'install_package' && isset($showInstallOptio
         <?php
         if (count($pkgArray) > 0) {
             usort($pkgArray, function($a,$b){
-                return $a->getPackageName() <=> $b->getPackageName();
+                return t($a->getPackageName()) <=> t($b->getPackageName());
             });
             foreach ($pkgArray as $pkg) {
                 ?>


### PR DESCRIPTION
An alpha sort of packages installed got lost at some past core update. Here it is reimplemented. https://github.com/concretecms/concretecms/issues/11773
