### PR TITLE
CIF: fix importing treenodetypes

### DIFF
--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportTreeNodeTypesRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportTreeNodeTypesRoutine.php
@@ -12,7 +12,7 @@ class ImportTreeNodeTypesRoutine extends AbstractRoutine
 
     public function import(\SimpleXMLElement $sx)
     {
-        if (isset($sx->treetypes)) {
+        if (isset($sx->treenodetypes)) {
             foreach ($sx->treenodetypes->treenodetype as $t) {
                 $type = NodeType::getByHandle((string) $t['handle']);
                 if (!$type) {


### PR DESCRIPTION
[We export](https://github.com/concretecms/migration_tool/blob/03f1ed0ee95f1d2a1f051e805b44591a5596a8ab/src/PortlandLabs/Concrete5/MigrationTool/Exporter/Item/Type/TreeNodeType.php#L21) `treenodetypes`/`treenodetype` and not `treetypes`/`treenodetype`