### PR TITLE
CIF: fix exporting stacks for skeleton site types

### DIFF
--- a/concrete/src/Export/Item/SiteType.php
+++ b/concrete/src/Export/Item/SiteType.php
@@ -91,6 +91,7 @@ class SiteType implements ItemInterface
 
         if (is_object($skeleton)) {
             $skeletonNode = $sitetype->addChild('skeleton');
+            $skeletonStacksNode = null;
             foreach($skeleton->getLocales() as $locale) {
                 /**
                  * @var $locale SkeletonLocale
@@ -116,7 +117,9 @@ class SiteType implements ItemInterface
                 $stacks = $stackList->getResults();
 
                 if (count($stacks)) {
-                    $skeletonStacksNode = $skeletonNode->addChild('stacks');
+                    if ($skeletonStacksNode === null) {
+                        $skeletonStacksNode = $skeletonNode->addChild('stacks');
+                    }
                     foreach($stacks as $stack) {
                         $exporter->export($stack, $skeletonStacksNode);
                     }


### PR DESCRIPTION
When we export stacks in skeleton site types, in case we have more than one locale we may result having this CIF:

```xml
<skeleton>
    <locale><!-- ... --></locale>
    <locale><!-- ... --></locale>
    <stacks>
        <stack><!-- ... --></stack>
        <stack><!-- ... --></stack>
    </stacks>
    <stacks>
        <stack><!-- ... --></stack>
        <stack><!-- ... --></stack>
    </stacks>
</skeleton>
```

But the ImportStacks routines assume that we only have one `<stacks>` node containing all the `<stack>` elements:

```xml
<skeleton>
    <locale><!-- ... --></locale>
    <locale><!-- ... --></locale>
    <stacks>
        <stack><!-- ... --></stack>
        <stack><!-- ... --></stack>
        <stack><!-- ... --></stack>
        <stack><!-- ... --></stack>
    </stacks>
</skeleton>
```
