### PR TITLE
CIF: fix importing/exporting skeleton site types

### DIFF
--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportSiteTypeSkeletonsRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportSiteTypeSkeletonsRoutine.php
@@ -109,7 +109,7 @@ class ImportSiteTypeSkeletonsRoutine extends AbstractRoutine
 
                         $importer = new ContentImporter();
                         $importer->setHomePage($home);
-                        $importer->importXml($type->skeleton->locale);
+                        $importer->importXml($localeNode);
 
                     }
 

--- a/concrete/src/Export/Item/SiteType.php
+++ b/concrete/src/Export/Item/SiteType.php
@@ -95,28 +95,28 @@ class SiteType implements ItemInterface
                 /**
                  * @var $locale SkeletonLocale
                  */
+                $exporter = new Exporter();
+                
                 $localeExporter = $locale->getExporter();
-                $skeletonLocalesNode = $localeExporter->export($locale, $skeletonNode);
-                $skeletonPagesNode = $skeletonLocalesNode->addChild('pages');
+                $skeletonLocaleNode = $localeExporter->export($locale, $skeletonNode);
 
                 $list = new PageList();
                 $list->setSiteTreeObject($locale->getSiteTree());
                 $list->ignorePermissions();
                 $list->sortByDisplayOrder();
                 $pages = $list->getResults();
-
-                $exporter = new Exporter();
-
-                foreach($pages as $page) {
-                    $exporter->export($page, $skeletonPagesNode);
+                if ($pages !== []) {
+                    $skeletonPagesNode = $skeletonLocaleNode->addChild('pages');
+                    foreach($pages as $page) {
+                        $exporter->export($page, $skeletonPagesNode);
+                    }
                 }
 
                 $stackList = new StackList();
                 $stackList->setSiteTreeObject($locale->getSiteTree());
                 $stacks = $stackList->getResults();
-
-                if (count($stacks)) {
-                    $skeletonStacksNode = $skeletonNode->addChild('stacks');
+                if ($stacks !== []) {
+                    $skeletonStacksNode = $skeletonLocaleNode->addChild('stacks');
                     foreach($stacks as $stack) {
                         $exporter->export($stack, $skeletonStacksNode);
                     }


### PR DESCRIPTION
In case we have a site with 2 locales, we currently export as

```xml
<skeleton>
    <locale>
        <pages><!-- ... --></pages>
    </locale>
    <locale>
        <pages><!-- ... --></pages>
    </locale>
    <stacks><!-- ... --></stacks>
    <stacks><!-- ... --></stacks>
</skeleton>
```

and we import assuming that there's only one `<locale>` node containing both `<pages>` and `<stacks>`.

This PR fixes the export as:

```xml
<skeleton>
    <locale>
        <pages><!-- ... --></pages>
        <stacks><!-- ... --></stacks>
    </locale>
    <locale>
        <pages><!-- ... --></pages>
        <stacks><!-- ... --></stacks>
    </locale>
</skeleton>
```

and make it so we import all the `<locale>` nodes, not just the first.

PS: superseedes #11796

