### PR TITLE
Cif booleans

### DIFF
--- a/concrete/src/Backup/ContentImporter/ImportFromCifTrait.php
+++ b/concrete/src/Backup/ContentImporter/ImportFromCifTrait.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\Core\Backup\ContentImporter;
+
+use SimpleXMLElement;
+
+trait ImportFromCifTrait
+{
+    protected static function getBoolFromCif(?SimpleXMLElement $elementOrAttribute): bool
+    {
+        return $elementOrAttribute === null ? false : filter_var((string) $elementOrAttribute, FILTER_VALIDATE_BOOLEAN);
+    }
+}

--- a/concrete/src/Backup/ContentImporter/ImportFromCifTrait.php
+++ b/concrete/src/Backup/ContentImporter/ImportFromCifTrait.php
@@ -8,8 +8,12 @@ use SimpleXMLElement;
 
 trait ImportFromCifTrait
 {
-    protected static function getBoolFromCif(?SimpleXMLElement $elementOrAttribute): bool
+    protected static function getBoolFromCif(?SimpleXMLElement $elementOrAttribute, bool $default = false): bool
     {
-        return $elementOrAttribute === null ? false : filter_var((string) $elementOrAttribute, FILTER_VALIDATE_BOOLEAN);
+        if ($elementOrAttribute === null || $elementOrAttribute->getName() === '') {
+            return $default;
+        }
+
+        return filter_var((string) $elementOrAttribute, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? $default;
     }
 }

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/AbstractRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/AbstractRoutine.php
@@ -2,10 +2,13 @@
 
 namespace Concrete\Core\Backup\ContentImporter\Importer\Routine;
 
+use Concrete\Core\Backup\ContentImporter\ImportFromCifTrait;
 use Concrete\Core\Package\PackageService;
 
 abstract class AbstractRoutine implements RoutineInterface
 {
+    use ImportFromCifTrait;
+
     /**
      * Get a package entity given its handle.
      *

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportPackagesRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportPackagesRoutine.php
@@ -32,7 +32,7 @@ class ImportPackagesRoutine extends AbstractRoutine
 
                         $data = [];
 
-                        if (isset($p['full-content-swap'])) {
+                        if (self::getBoolFromCif($p['full-content-swap'])) {
                             $data["pkgDoFullContentSwap"] = true;
                             // set this token to perform a full content swap when installing starting point packages
                             $data["ccm_token"] = $token->generate("install_options_selected");

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportSinglePageStructureRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportSinglePageStructureRoutine.php
@@ -25,13 +25,10 @@ class ImportSinglePageStructureRoutine extends AbstractRoutine implements Specif
             foreach ($sx->singlepages->page as $p) {
                 $pkg = static::getPackageObject($p['package']);
 
-                if (isset($p['global']) && (string) $p['global'] === 'true') {
+                if (self::getBoolFromCif($p['global'])) {
                     $spl = Single::addGlobal($p['path'], $pkg);
                 } else {
-                    $root = false;
-                    if (isset($p['root']) && (string) $p['root'] === 'true') {
-                        $root = true;
-                    }
+                    $root = self::getBoolFromCif($p['root']);
 
                     $siteTree = null;
                     if (isset($this->home)) {

--- a/tests/tests/Backup/ImportFromCifTraitTest.php
+++ b/tests/tests/Backup/ImportFromCifTraitTest.php
@@ -32,18 +32,18 @@ class ImportFromCifTraitTest extends TestCase
             ['<foo> yes </foo>', true],
             ['<foo> on </foo>', true],
             ['<foo> 1 </foo>', true],
-            ['<foo>unrecognized</foo>', false],
+            ['<foo>unrecognized</foo>', false, '', true],
             ['<foo><bar>false</bar><baz>true</baz></foo>', false],
             ['<foo><bar>false</bar><baz>true</baz></foo>', false, 'bar'],
             ['<foo><bar>false</bar><baz>true</baz></foo>', true, 'baz'],
-            ['<foo><bar>false</bar><baz>true</baz></foo>', false, 'qux'],
+            ['<foo><bar>false</bar><baz>true</baz></foo>', false, 'qux', true],
         ];
     }
 
     /**
      * @dataProvider provideBooleanValuesCases
      */
-    public function testBooleanValues(string $xml, bool $expected, string $childName = ''): void
+    public function testBooleanValues(string $xml, bool $expected, string $childName = '', bool $isDefaultFallback = false): void
     {
         $element = $this->parseXml($xml);
         if ($childName !== '') {
@@ -51,12 +51,16 @@ class ImportFromCifTraitTest extends TestCase
         }
         $actual = self::getBoolFromCif($element);
         $this->assertSame($expected, $actual);
+        if ($isDefaultFallback) {
+            $actual = self::getBoolFromCif($element, true);
+            $this->assertSame(true, $actual);
+        }
     }
 
     public static function provideBooleanAttributeCases(): array
     {
         return [
-            ['<foo />', 'bar', false],
+            ['<foo />', 'bar', false, true],
             ['<foo bar="" />', 'bar', false],
             ['<foo bar="false" />', 'bar', false],
             ['<foo bar="no" />', 'bar', false],
@@ -66,26 +70,30 @@ class ImportFromCifTraitTest extends TestCase
             ['<foo bar="yes" />', 'bar', true],
             ['<foo bar="on" />', 'bar', true],
             ['<foo bar="1" />', 'bar', true],
-            ['<foo bar="" />', 'baz', false],
-            ['<foo bar="false" />', 'baz', false],
-            ['<foo bar="no" />', 'baz', false],
-            ['<foo bar="off" />', 'baz', false],
-            ['<foo bar="0" />', 'baz', false],
-            ['<foo bar="true" />', 'baz', false],
-            ['<foo bar="yes" />', 'baz', false],
-            ['<foo bar="on" />', 'baz', false],
-            ['<foo bar="1" />', 'baz', false],
+            ['<foo bar="" />', 'baz', false, true],
+            ['<foo bar="false" />', 'baz', false, true],
+            ['<foo bar="no" />', 'baz', false, true],
+            ['<foo bar="off" />', 'baz', false, true],
+            ['<foo bar="0" />', 'baz', false, true],
+            ['<foo bar="true" />', 'baz', false, true],
+            ['<foo bar="yes" />', 'baz', false, true],
+            ['<foo bar="on" />', 'baz', false, true],
+            ['<foo bar="1" />', 'baz', false, true],
         ];
     }
 
     /**
      * @dataProvider provideBooleanAttributeCases
      */
-    public function testBooleanAttributes(string $xml, string $attributeName, bool $expected): void
+    public function testBooleanAttributes(string $xml, string $attributeName, bool $expected, bool $isDefaultFallback = false): void
     {
         $element = $this->parseXml($xml);
         $actual = self::getBoolFromCif($element[$attributeName]);
         $this->assertSame($expected, $actual);
+        if ($isDefaultFallback) {
+            $actual = self::getBoolFromCif($element[$attributeName], true);
+            $this->assertSame(true, $actual);
+        }
     }
 
     private function parseXml(string $xml): SimpleXMLElement

--- a/tests/tests/Backup/ImportFromCifTraitTest.php
+++ b/tests/tests/Backup/ImportFromCifTraitTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\Tests\Backup;
+
+use Concrete\Core\Backup\ContentImporter\ImportFromCifTrait;
+use Concrete\Tests\TestCase;
+use SimpleXMLElement;
+
+class ImportFromCifTraitTest extends TestCase
+{
+    use ImportFromCifTrait;
+
+    public static function provideBooleanValuesCases(): array
+    {
+        return [
+            ['<foo />', false],
+            ['<foo>false</foo>', false],
+            ['<foo>no</foo>', false],
+            ['<foo>off</foo>', false],
+            ['<foo>0</foo>', false],
+            ['<foo>true</foo>', true],
+            ['<foo>yes</foo>', true],
+            ['<foo>on</foo>', true],
+            ['<foo>1</foo>', true],
+            ['<foo> false </foo>', false],
+            ['<foo> no </foo>', false],
+            ['<foo> off </foo>', false],
+            ['<foo> 0 </foo>', false],
+            ['<foo> true </foo>', true],
+            ['<foo> yes </foo>', true],
+            ['<foo> on </foo>', true],
+            ['<foo> 1 </foo>', true],
+            ['<foo>unrecognized</foo>', false],
+            ['<foo><bar>false</bar><baz>true</baz></foo>', false],
+            ['<foo><bar>false</bar><baz>true</baz></foo>', false, 'bar'],
+            ['<foo><bar>false</bar><baz>true</baz></foo>', true, 'baz'],
+            ['<foo><bar>false</bar><baz>true</baz></foo>', false, 'qux'],
+        ];
+    }
+
+    /**
+     * @dataProvider provideBooleanValuesCases
+     */
+    public function testBooleanValues(string $xml, bool $expected, string $childName = ''): void
+    {
+        $element = $this->parseXml($xml);
+        if ($childName !== '') {
+            $element = $element->{$childName};
+        }
+        $actual = self::getBoolFromCif($element);
+        $this->assertSame($expected, $actual);
+    }
+
+    public static function provideBooleanAttributeCases(): array
+    {
+        return [
+            ['<foo />', 'bar', false],
+            ['<foo bar="" />', 'bar', false],
+            ['<foo bar="false" />', 'bar', false],
+            ['<foo bar="no" />', 'bar', false],
+            ['<foo bar="off" />', 'bar', false],
+            ['<foo bar="0" />', 'bar', false],
+            ['<foo bar="true" />', 'bar', true],
+            ['<foo bar="yes" />', 'bar', true],
+            ['<foo bar="on" />', 'bar', true],
+            ['<foo bar="1" />', 'bar', true],
+            ['<foo bar="" />', 'baz', false],
+            ['<foo bar="false" />', 'baz', false],
+            ['<foo bar="no" />', 'baz', false],
+            ['<foo bar="off" />', 'baz', false],
+            ['<foo bar="0" />', 'baz', false],
+            ['<foo bar="true" />', 'baz', false],
+            ['<foo bar="yes" />', 'baz', false],
+            ['<foo bar="on" />', 'baz', false],
+            ['<foo bar="1" />', 'baz', false],
+        ];
+    }
+
+    /**
+     * @dataProvider provideBooleanAttributeCases
+     */
+    public function testBooleanAttributes(string $xml, string $attributeName, bool $expected): void
+    {
+        $element = $this->parseXml($xml);
+        $actual = self::getBoolFromCif($element[$attributeName]);
+        $this->assertSame($expected, $actual);
+    }
+
+    private function parseXml(string $xml): SimpleXMLElement
+    {
+        $element = simplexml_load_string($xml);
+        $this->assertInstanceOf(\SimpleXMLElement::class, $element, "Failed to process XML: [$xml}");
+
+        return $element;
+    }
+}


### PR DESCRIPTION
Two fixes here:

1. Consider CIF chunk:
   ```xml
   <concrete5-cif version="1.0">
       <packages>
           <package handle="my_handle" full-content-swap="0">
           </package>
       </packages>
   </concrete5-cif>
   ```
   I'd expect that full-content-swap is turned off, but it's on because it's enough to have the "full-content-swap" attribute with any value (even empty).
2. Consider this CIF chunk:
   ```xml
   <concrete5-cif version="1.0">
       <singlepages>
           <page name="Name" path="/path" root="1" global="1" />
       </singlepages>
   </concrete5-cif>
   ```
   I'd expect that "root" and "global" are considered as "true" like everywhere else in the CIF file, but they are considered as "false".

I've fixed both issues by introducing a service trait that accepts boolean-like strings - see [`FILTER_VALIDATE_BOOLEAN`](https://www.php.net/manual/en/filter.filters.validate.php).