### PR TITLE
Work on CIF import/export

### DIFF
--- a/concrete/attributes/calendar/controller.php
+++ b/concrete/attributes/calendar/controller.php
@@ -7,6 +7,7 @@ use Concrete\Core\Api\Resources;
 use Concrete\Core\Attribute\FontAwesomeIconFormatter;
 use Concrete\Core\Calendar\Calendar;
 use Concrete\Core\Entity\Attribute\Value\Value\NumberValue;
+use Concrete\Core\Utility\Service\Xml;
 use League\Fractal\Resource\Item;
 use League\Fractal\Resource\ResourceInterface;
 
@@ -39,11 +40,8 @@ class Controller extends \Concrete\Attribute\Number\Controller implements ApiRes
     public function exportValue(\SimpleXMLElement $akv)
     {
         $val = $this->attributeValue->getValue();
-        $cnode = $akv->addChild('value');
-        $node = dom_import_simplexml($cnode);
-        $no = $node->ownerDocument;
-        $node->appendChild($no->createCDataSection($val->getName()));
-        return $cnode;
+
+        return $this->app->make(Xml::class)->createChildElement($akv, 'value', $val->getName());
     }
 
     public function createAttributeValueFromRequest()

--- a/concrete/attributes/topics/controller.php
+++ b/concrete/attributes/topics/controller.php
@@ -116,12 +116,11 @@ class Controller extends AttributeTypeController implements
 
     public function exportValue(\SimpleXMLElement $akn)
     {
-        /** @var Xml $xml */
-        $xml = \Core::make('helper/xml');
+        $xml = $this->app->make(Xml::class);
         $avn = $akn->addChild('topics');
         $nodes = $this->attributeValue->getValue();
         foreach ($nodes as $topic) {
-            $xml->createCDataNode($avn, 'topic', $topic->getTreeNodeDisplayPath());
+            $xml->createChildElement($avn, 'topic', $topic->getTreeNodeDisplayPath());
         }
     }
 

--- a/concrete/blocks/content/controller.php
+++ b/concrete/blocks/content/controller.php
@@ -8,6 +8,7 @@ use Concrete\Core\Feature\Features;
 use Concrete\Core\Feature\UsesFeatureInterface;
 use Concrete\Core\File\Tracker\FileTrackableInterface;
 use Concrete\Core\Page\Page;
+use Concrete\Core\Utility\Service\Xml;
 
 /**
  * The controller for the content block.
@@ -168,12 +169,8 @@ class Controller extends BlockController implements FileTrackableInterface, Uses
         $data = $blockNode->addChild('data');
         $data->addAttribute('table', $this->btTable);
         $record = $data->addChild('record');
-        $cnode = $record->addChild('content');
-        $node = dom_import_simplexml($cnode);
-        $no = $node->ownerDocument;
         $content = LinkAbstractor::export($this->content);
-        $cdata = $no->createCDataSection($content);
-        $node->appendChild($cdata);
+        $this->app->make(Xml::class)->createChildElement($record, 'content', $content);
     }
 
     /**

--- a/concrete/blocks/core_stack_display/controller.php
+++ b/concrete/blocks/core_stack_display/controller.php
@@ -8,6 +8,7 @@ use Concrete\Core\Page\Page;
 use Concrete\Core\Page\Stack\Stack;
 use Concrete\Core\Permission\Checker;
 use Concrete\Core\Statistics\UsageTracker\TrackableInterface;
+use Concrete\Core\Utility\Service\Xml;
 
 /**
  * The controller for the stack display block. This is an internal proxy block that is inserted when a stack's contents are displayed in a page.
@@ -208,10 +209,7 @@ class Controller extends BlockController implements TrackableInterface
     {
         $stack = $this->getStack(false);
         if ($stack !== null) {
-            $cnode = $blockNode->addChild('stack');
-            $node = dom_import_simplexml($cnode);
-            $no = $node->ownerDocument;
-            $node->appendChild($no->createCDataSection($stack->getCollectionName()));
+            $this->app->make(Xml::class)->createChildElement($blockNode, 'stack', $stack->getCollectionName());
         }
     }
 

--- a/concrete/blocks/gallery/controller.php
+++ b/concrete/blocks/gallery/controller.php
@@ -60,7 +60,7 @@ class Controller extends BlockController implements FileTrackableInterface, Uses
         // now we can do the entries.
         $entries = $this->getEntries();
         $entriesNode = $blockNode->addChild('entries');
-        $xml = new Xml();
+        $xml = $this->app->make(Xml::class);
         foreach ($entries as $entry) {
             $entryNode = $entriesNode->addChild('entry');
             $entryNode->addChild('fID', ContentExporter::replaceFileWithPlaceHolder($entry['id']));
@@ -69,7 +69,7 @@ class Controller extends BlockController implements FileTrackableInterface, Uses
                 foreach ($entry['displayChoices'] as $dckey => $displayChoice) {
                     $choiceNode = $choicesNode->addChild('choice');
                     $choiceNode->addChild('dckey', $dckey);
-                    $xml->createCDataNode($choiceNode, 'value', $displayChoice['value']);
+                    $xml->createChildElement($choiceNode, 'value', $displayChoice['value']);
                 }
             }
         }

--- a/concrete/src/Attribute/Controller.php
+++ b/concrete/src/Attribute/Controller.php
@@ -8,6 +8,7 @@ use Concrete\Core\Controller\AbstractController;
 use Concrete\Core\Entity\Attribute\Key\Settings\EmptySettings;
 use Concrete\Core\Form\Context\ContextInterface;
 use Concrete\Core\Search\ItemList\Database\AttributedItemList;
+use Concrete\Core\Utility\Service\Xml;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityNotFoundException;
 use SimpleXMLElement;
@@ -400,12 +401,7 @@ class Controller extends AbstractController implements AttributeInterface
             $val = json_encode($val);
         }
 
-        $cnode = $akv->addChild('value');
-        $node = dom_import_simplexml($cnode);
-        $no = $node->ownerDocument;
-        $node->appendChild($no->createCDataSection($val));
-
-        return $cnode;
+        return $this->app->make(Xml::class)->createChildElement($akv, 'value', $val);
     }
 
     /**

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportPackagesRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportPackagesRoutine.php
@@ -6,6 +6,7 @@ use Concrete\Core\Block\BlockType\BlockType;
 use Concrete\Core\Package\Package;
 use Concrete\Core\Permission\Category;
 use Concrete\Core\Support\Facade\Facade;
+use Concrete\Core\Utility\Service\Xml;
 use Concrete\Core\Validation\BannedWord\BannedWord;
 use Concrete\Core\Package\PackageService;
 use Concrete\Core\Validation\CSRF\Token;
@@ -20,6 +21,7 @@ class ImportPackagesRoutine extends AbstractRoutine
     public function import(\SimpleXMLElement $sx)
     {
         if (isset($sx->packages)) {
+            $xml = app(Xml::class);
             foreach ($sx->packages->package as $p) {
                 $pkg = Package::getByHandle((string) $p['handle']);
                 if (!$pkg) {
@@ -32,7 +34,7 @@ class ImportPackagesRoutine extends AbstractRoutine
 
                         $data = [];
 
-                        if (isset($p['full-content-swap'])) {
+                        if ($xml->getBool($p['full-content-swap'])) {
                             $data["pkgDoFullContentSwap"] = true;
                             // set this token to perform a full content swap when installing starting point packages
                             $data["ccm_token"] = $token->generate("install_options_selected");

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportSinglePageStructureRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportSinglePageStructureRoutine.php
@@ -3,6 +3,7 @@ namespace Concrete\Core\Backup\ContentImporter\Importer\Routine;
 
 use Concrete\Core\Page\Single;
 use Concrete\Core\Support\Facade\Application;
+use Concrete\Core\Utility\Service\Xml;
 
 class ImportSinglePageStructureRoutine extends AbstractRoutine implements SpecifiableHomePageRoutineInterface
 {
@@ -18,20 +19,17 @@ class ImportSinglePageStructureRoutine extends AbstractRoutine implements Specif
 
     public function import(\SimpleXMLElement $sx)
     {
-
         if (isset($sx->singlepages)) {
             $app = Application::getFacadeApplication();
+            $xml = $app->make(Xml::class);
             $defaultSite = $app->make('site')->getDefault();
             foreach ($sx->singlepages->page as $p) {
                 $pkg = static::getPackageObject($p['package']);
 
-                if (isset($p['global']) && (string) $p['global'] === 'true') {
+                if ($xml->getBool($p['global'])) {
                     $spl = Single::addGlobal($p['path'], $pkg);
                 } else {
-                    $root = false;
-                    if (isset($p['root']) && (string) $p['root'] === 'true') {
-                        $root = true;
-                    }
+                    $root = $xml->getBool($p['root']);
 
                     $siteTree = null;
                     if (isset($this->home)) {

--- a/concrete/src/Block/BlockController.php
+++ b/concrete/src/Block/BlockController.php
@@ -13,6 +13,7 @@ use Concrete\Core\Page\Type\Type;
 use Concrete\Core\Permission\Checker;
 use Concrete\Core\Statistics\UsageTracker\AggregateTracker;
 use Concrete\Core\StyleCustomizer\Inline\StyleSet;
+use Concrete\Core\Utility\Service\Xml;
 use Config;
 use Database;
 use Events;
@@ -378,6 +379,7 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
             $data = $blockNode->addChild('data');
             $data->addAttribute('table', $tbl);
             $columns = $db->MetaColumns($tbl);
+            $xml = $this->app->make(Xml::class);
             // remove columns we don't want
             unset($columns['bid']);
             $r = $db->Execute('select * from ' . $tbl . ' where bID = ?', [$this->bID]);
@@ -396,10 +398,7 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
                         } elseif (in_array($key, $this->btExportFileFolderColumns)) {
                             $tableRecord->addChild($key, ContentExporter::replaceFileFolderWithPlaceHolder($value));
                         } else {
-                            $cnode = $tableRecord->addChild($key);
-                            $node = dom_import_simplexml($cnode);
-                            $no = $node->ownerDocument;
-                            $node->appendChild($no->createCDataSection($value));
+                            $xml->createChildElement($tableRecord, $key, $value);
                         }
                     }
                 }

--- a/concrete/src/Entity/Board/DataSource/Configuration/PageConfiguration.php
+++ b/concrete/src/Entity/Board/DataSource/Configuration/PageConfiguration.php
@@ -2,7 +2,6 @@
 
 namespace Concrete\Core\Entity\Board\DataSource\Configuration;
 
-use Concrete\Core\Utility\Service\Xml;
 use Doctrine\ORM\Mapping as ORM;
 
 /**

--- a/concrete/src/Entity/Search/Query.php
+++ b/concrete/src/Entity/Search/Query.php
@@ -4,7 +4,6 @@ namespace Concrete\Core\Entity\Search;
 use Concrete\Core\Foundation\Serializer\JsonSerializer;
 use Concrete\Core\Search\Field\FieldInterface;
 use Concrete\Core\Search\ProviderInterface;
-use Concrete\Core\Utility\Service\Xml;
 use Doctrine\ORM\Mapping as ORM;
 use Symfony\Component\Serializer\Normalizer\DenormalizableInterface;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;

--- a/concrete/src/Export/Item/Express/Control/AuthorControl.php
+++ b/concrete/src/Export/Item/Express/Control/AuthorControl.php
@@ -3,7 +3,6 @@ namespace Concrete\Core\Export\Item\Express\Control;
 
 use Concrete\Core\Export\Item\Express\Control;
 use Concrete\Core\Export\ExportableInterface;
-use Concrete\Core\Utility\Service\Xml;
 
 class AuthorControl extends Control
 {

--- a/concrete/src/Export/Item/Express/Control/PublicIdentifierControl.php
+++ b/concrete/src/Export/Item/Express/Control/PublicIdentifierControl.php
@@ -3,7 +3,6 @@ namespace Concrete\Core\Export\Item\Express\Control;
 
 use Concrete\Core\Export\Item\Express\Control;
 use Concrete\Core\Export\ExportableInterface;
-use Concrete\Core\Utility\Service\Xml;
 
 class PublicIdentifierControl extends Control
 {

--- a/concrete/src/Export/Item/Express/Control/TextControl.php
+++ b/concrete/src/Export/Item/Express/Control/TextControl.php
@@ -18,9 +18,9 @@ class TextControl extends Control
     {
         $node = parent::export($control, $xml);
         $node->addAttribute('type-id', 'text');
-        $service = new Xml();
-        $service->createCDataNode($node, 'headline', $control->getHeadline());
-        $service->createCDataNode($node, 'body', $control->getBody());
+        $xml = app(Xml::class);
+        $xml->createChildElement($node, 'headline', $control->getHeadline());
+        $xml->createChildElement($node, 'body', $control->getBody());
     }
 
 }

--- a/concrete/src/Form/Service/DestinationPicker/DestinationPicker.php
+++ b/concrete/src/Form/Service/DestinationPicker/DestinationPicker.php
@@ -7,6 +7,7 @@ use Concrete\Core\Application\Application;
 use Concrete\Core\Block\BlockController;
 use Concrete\Core\Form\Service\Form;
 use Concrete\Core\Http\Request;
+use Concrete\Core\Utility\Service\Xml;
 use RuntimeException;
 
 class DestinationPicker
@@ -253,20 +254,11 @@ EOT
     public function export(string $key, string $selectedPickerHandle, $value, BlockController $blockController, \SimpleXMLElement $blockNode): void
     {
         if (isset($blockNode->data)) {
+            $xml = $this->app->make(Xml::class);
             foreach ($blockNode->data as $data) {
                 if (isset($data->record) && ((string)$data['table'] === $blockController->getBlockTypeDatabaseTable())) {
-                    $which = $data->record->addChild($key . '__which');
-                    $node = dom_import_simplexml($which);
-                    if ($node) {
-                        $no = $node->ownerDocument;
-                        $node->appendChild($no->createCDataSection($selectedPickerHandle));
-                    }
-                    $valueNode = $data->record->addChild($key . '_' . $selectedPickerHandle);
-                    $node = dom_import_simplexml($valueNode);
-                    if ($node) {
-                        $no = $node->ownerDocument;
-                        $node->appendChild($no->createCDataSection($value));
-                    }
+                    $xml->createChildElement($data->record, "{$key}__which", $selectedPickerHandle);
+                    $xml->createChildElement($data->record, "{$key}_{$selectedPickerHandle}", $value);
                 }
             }
         }

--- a/concrete/src/Search/Field/AbstractField.php
+++ b/concrete/src/Search/Field/AbstractField.php
@@ -73,10 +73,9 @@ abstract class AbstractField implements FieldInterface
 
     public function export(\SimpleXMLElement $element)
     {
-        $xml = new Xml();
         $fieldNode = $element->addChild('field');
         $fieldNode->addAttribute('key', $this->getKey());
-        $xml->createCDataNode($fieldNode, 'data', json_encode($this->data));
+        app(Xml::class)->createChildElement($fieldNode, 'data', json_encode($this->data));
     }
 
     public function denormalize(DenormalizerInterface $denormalizer, $data, $format = null, array $context = [])

--- a/concrete/src/Utility/Service/Xml.php
+++ b/concrete/src/Utility/Service/Xml.php
@@ -1,15 +1,102 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Concrete\Core\Utility\Service;
+
+use DateTimeInterface;
+use SimpleXMLElement;
 
 class Xml
 {
-    public function createCDataNode(\SimpleXMLElement $x, $nodeName, $content)
-    {
-        $node = $x->addChild($nodeName);
-        $node = dom_import_simplexml($node);
-        $no = $node->ownerDocument;
-        $node->appendChild($no->createCDataSection($content));
+    public const FLAG_PRESERVE_CARRIAGE_RETURNS = 0b1;
 
-        return $node;
+    /**
+     * Extract a boolean from an element or an attribute value.
+     *
+     * @param bool $default what should be returned if the element/attribute does not exist, or if it does not contain a boolean representation ('true', 'yes', 'on', '1', 'false', 'no', '0', '')
+     *
+     */
+    public function getBool(?SimpleXMLElement $elementOrAttribute, bool $default = false): bool
+    {
+        /*
+         * $element['nonExistingAttribute'] returns null
+         * $element->nonExistingChildElement returns a SimpleXMLElement whose name is an empty string
+         * (yep! "isset($element->nonExistingChildElement)" return false, but "$element->nonExistingChildElement" is a SimpleXMLElement !) 
+         */
+        if ($elementOrAttribute === null || $elementOrAttribute->getName() === '') {
+            return $default;
+        }
+
+        return filter_var((string) $elementOrAttribute, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE) ?? $default;
+    }
+
+    /**
+     * Create a new element with the specified value.
+     *
+     * @param scalar|\DateTimeInterface|\Stringable $value
+     */
+    public function createChildElement(SimpleXMLElement $parentElement, string $childName, $value, int $flags = 0): SimpleXMLElement
+    {
+        $serialized = $this->serialize($value);
+        $hasCarriageReturns = str_contains($serialized, "\r");
+        if ($hasCarriageReturns && ($flags & static::FLAG_PRESERVE_CARRIAGE_RETURNS) === static::FLAG_PRESERVE_CARRIAGE_RETURNS) {
+            // We can't use CDATA if we want to preserve \r - see https://www.w3.org/TR/2008/REC-xml-20081126/#sec-line-ends
+            $newElement = $parentElement->addChild($childName, $serialized);
+        } elseif ($this->shouldUseCData($serialized)) {
+            $newElement = $parentElement->addChild($childName);
+            $this->appendCData($newElement, $serialized);
+        } else {
+            if ($hasCarriageReturns) {
+                $serialized = strtr($serialized, ["\r\n" => "\n", "\r" => "\n"]);
+            }
+            $newElement = $parentElement->addChild($childName, $serialized);
+        }
+
+        return $newElement;
+    }
+
+    /**
+     * Append a new CDATA section to an existing element.
+     * Please remark that \r\n and \r sequences will be converted to \n - see https://www.w3.org/TR/2008/REC-xml-20081126/#sec-line-ends
+     *
+     * @param scalar|\DateTimeInterface|\Stringable $value
+     */
+    public function appendCData(SimpleXMLElement $element, string $value): void
+    {
+        $domElement = dom_import_simplexml($element);
+        $domElement->appendChild($domElement->ownerDocument->createCDataSection($this->serialize($value)));
+    }
+
+    /**
+     * @deprecated use the createChildElement() method
+     */
+    public function createCDataNode(SimpleXMLElement $x, $nodeName, $content)
+    {
+        return $this->createChildElement($x, (string) $nodeName, (string) $content);
+    }
+
+    /**
+     * @param scalar|\DateTimeInterface|\Stringable $value
+     */
+    protected function serialize($value): string
+    {
+        if ($value instanceof DateTimeInterface) {
+            return $value->format('Y-m-d H:i:s');
+        }
+
+        return (string) $value;
+    }
+
+    /**
+     * Using a CDATA section is not mandatory: it'd be enough to call htmlentities(..., ENT_XML1).
+     * But CDATA is much more readable, so let's use it when values contains characters that
+     * must be escaped).
+     *
+     * @see https://www.w3.org/TR/2008/REC-xml-20081126/#syntax
+     */
+    protected function shouldUseCData(string $value): bool
+    {
+        return strpbrk($value, "&<>") !== false; // '>' is not strictly required, only ']]>' is, but libxml2 escapes even '>' alone
     }
 }

--- a/concrete/src/Utility/UtilityServiceProvider.php
+++ b/concrete/src/Utility/UtilityServiceProvider.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\Utility;
 
 use Concrete\Core\Foundation\Service\Provider as ServiceProvider;
@@ -7,17 +8,16 @@ class UtilityServiceProvider extends ServiceProvider
 {
     public function register()
     {
-        $singletons = array(
-            'helper/text' => '\Concrete\Core\Utility\Service\Text',
-            'helper/arrays' => '\Concrete\Core\Utility\Service\Arrays',
-            'helper/number' => '\Concrete\Core\Utility\Service\Number',
-            'helper/xml' => '\Concrete\Core\Utility\Service\Xml',
-            'helper/url' => '\Concrete\Core\Utility\Service\Url',
-
-        );
-
-        foreach ($singletons as $key => $value) {
-            $this->app->singleton($key, $value);
+        $singletons = [
+            'helper/text' => Service\Text::class,
+            'helper/arrays' => Service\Arrays::class,
+            'helper/number' => Service\Number::class,
+            'helper/xml' => Service\Xml::class,
+            'helper/url' => Service\Url::class,
+        ];
+        foreach ($singletons as $alias => $className) {
+            $this->app->alias($className, $alias);
+            $this->app->singleton($className);
         }
     }
 }

--- a/tests/tests/Block/ContentFileTranslateTest.php
+++ b/tests/tests/Block/ContentFileTranslateTest.php
@@ -81,7 +81,7 @@ class ContentFileTranslateTest extends FileStorageTestCase
         $this->assertEquals('background-slider-blue-sky.png', $r->getFilename());
         $this->assertEquals($to, $translated);
 
-        $c = new \Concrete\Block\Content\Controller();
+        $c = app(\Concrete\Block\Content\Controller::class);
         $c->content = $from;
         $sx = new SimpleXMLElement('<test />');
         $c->export($sx);

--- a/tests/tests/Utility/Service/XmlTest.php
+++ b/tests/tests/Utility/Service/XmlTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\Tests\Utility\Service;
+
+use Concrete\Core\Utility\Service\Xml;
+use Concrete\Tests\TestCase;
+use DateTimeImmutable;
+use DateTimeInterface;
+use SimpleXMLElement;
+
+class XmlTest extends TestCase
+{
+    /**
+     * @var \Concrete\Core\Utility\Service\Xml
+     */
+    protected static $xml;
+
+    public static function setupBeforeClass(): void
+    {
+        self::$xml = app(Xml::class);
+    }
+    public static function provideBooleanValuesCases(): array
+    {
+        return [
+            ['<foo />', false],
+            ['<foo>false</foo>', false],
+            ['<foo>no</foo>', false],
+            ['<foo>off</foo>', false],
+            ['<foo>0</foo>', false],
+            ['<foo>true</foo>', true],
+            ['<foo>yes</foo>', true],
+            ['<foo>on</foo>', true],
+            ['<foo>1</foo>', true],
+            ['<foo> false </foo>', false],
+            ['<foo> no </foo>', false],
+            ['<foo> off </foo>', false],
+            ['<foo> 0 </foo>', false],
+            ['<foo> true </foo>', true],
+            ['<foo> yes </foo>', true],
+            ['<foo> on </foo>', true],
+            ['<foo> 1 </foo>', true],
+            ['<foo>unrecognized</foo>', false, '', true],
+            ['<foo><bar>false</bar><baz>true</baz></foo>', false],
+            ['<foo><bar>false</bar><baz>true</baz></foo>', false, 'bar'],
+            ['<foo><bar>false</bar><baz>true</baz></foo>', true, 'baz'],
+            ['<foo><bar>false</bar><baz>true</baz></foo>', false, 'qux', true],
+        ];
+    }
+
+    /**
+     * @dataProvider provideBooleanValuesCases
+     */
+    public function testGetBooleanValues(string $xml, bool $expected, string $childName = '', bool $isDefaultFallback = false): void
+    {
+        $element = $this->parseXml($xml);
+        if ($childName !== '') {
+            $element = $element->{$childName};
+        }
+        $actual = self::$xml->getBool($element);
+        $this->assertSame($expected, $actual);
+        if ($isDefaultFallback) {
+            $actual = self::$xml->getBool($element, true);
+            $this->assertSame(true, $actual);
+        }
+    }
+
+    public static function provideBooleanAttributeCases(): array
+    {
+        return [
+            ['<foo />', 'bar', false, true],
+            ['<foo bar="" />', 'bar', false],
+            ['<foo bar="false" />', 'bar', false],
+            ['<foo bar="no" />', 'bar', false],
+            ['<foo bar="off" />', 'bar', false],
+            ['<foo bar="0" />', 'bar', false],
+            ['<foo bar="true" />', 'bar', true],
+            ['<foo bar="yes" />', 'bar', true],
+            ['<foo bar="on" />', 'bar', true],
+            ['<foo bar="1" />', 'bar', true],
+            ['<foo bar="" />', 'baz', false, true],
+            ['<foo bar="false" />', 'baz', false, true],
+            ['<foo bar="no" />', 'baz', false, true],
+            ['<foo bar="off" />', 'baz', false, true],
+            ['<foo bar="0" />', 'baz', false, true],
+            ['<foo bar="true" />', 'baz', false, true],
+            ['<foo bar="yes" />', 'baz', false, true],
+            ['<foo bar="on" />', 'baz', false, true],
+            ['<foo bar="1" />', 'baz', false, true],
+        ];
+    }
+
+    /**
+     * @dataProvider provideBooleanAttributeCases
+     */
+    public function testGetBooleanAttributes(string $xml, string $attributeName, bool $expected, bool $isDefaultFallback = false): void
+    {
+        $element = $this->parseXml($xml);
+        $actual = self::$xml->getBool($element[$attributeName]);
+        $this->assertSame($expected, $actual);
+        if ($isDefaultFallback) {
+            $actual = self::$xml->getBool($element[$attributeName], true);
+            $this->assertSame(true, $actual);
+        }
+    }
+
+    public static function proviteCreateElementData(): array
+    {
+        $lf = "\n";
+        $cr = "\r";
+        $crlf = "\r\n";
+
+        return [
+            ['', ''],
+            [null, ''],
+            [DateTimeImmutable::createFromFormat(\DateTimeInterface::ISO8601, '2005-08-15T15:52:01+0000'), '2005-08-15 15:52:01'],
+            [false, ''], // A better representation would be false (or at least 0), but we must preserve backward compatibility
+            [true, '1'], // A better representation would be true, but we must preserve backward compatibility
+            ['<', '<![CDATA[<]]>'],
+            ['&', '<![CDATA[&]]>'],
+            ['>', '<![CDATA[>]]>'],
+            ['A <u>string</u> that contains ]]>', '<![CDATA[A <u>string</u> that contains ]]]]><![CDATA[>]]>'],
+            ['<b>Test</b>!', '<![CDATA[<b>Test</b>!]]>'],
+            ['"Hello" he said ', '"Hello" he said '],
+            ["'Hello' she said ", "'Hello' she said "],
+            ["First & Second", "<![CDATA[First & Second]]>"],
+            ["First line{$lf}Second line", "First line{$lf}Second line"],
+            ["<b>First</b> line{$lf}Second line", "<![CDATA[<b>First</b> line{$lf}Second line]]>"],
+            // see https://www.w3.org/TR/2008/REC-xml-20081126/#sec-line-ends
+             ["First line{$crlf}Second line", "First line{$lf}Second line"],
+            ["First line{$crlf}Second line", "First line&#13;{$lf}Second line", Xml::FLAG_PRESERVE_CARRIAGE_RETURNS],
+            ["First line{$cr}Second line", "First line{$lf}Second line"],
+            ["First line{$cr}Second line", "First line&#13;Second line", Xml::FLAG_PRESERVE_CARRIAGE_RETURNS],
+            ["<b>First</b> line{$cr}Second line", "<![CDATA[<b>First</b> line{$lf}Second line]]>"],
+            ["<b>First</b> line{$crlf}Second line", "<![CDATA[<b>First</b> line{$lf}Second line]]>"],
+            ["<b>First</b> line{$crlf}Second line", "&lt;b&gt;First&lt;/b&gt; line&#13;{$lf}Second line", Xml::FLAG_PRESERVE_CARRIAGE_RETURNS],
+            ["<b>First</b> line{$cr}Second line", "<![CDATA[<b>First</b> line{$lf}Second line]]>"],
+            ["<b>First</b> line{$cr}Second line", "&lt;b&gt;First&lt;/b&gt; line&#13;Second line", Xml::FLAG_PRESERVE_CARRIAGE_RETURNS],
+        ];
+    }
+
+    /**
+     * @dataProvider proviteCreateElementData
+     */
+    public function testCreateElement($data, string $expectedXml, int $flags = 0): void
+    {
+        $parent = $this->parseXml('<parent />');
+        $child = self::$xml->createChildElement($parent, 'child', $data, $flags);
+        $this->assertSame((string) $child, (string) $parent->child);
+        $newParent = $this->parseXml($parent->asXML());
+        $newChild = $newParent->child;
+        $childOuterXML = $newChild->asXML();
+        $childInnerXML = str_ends_with($childOuterXML, '/>') ? '' : preg_replace('_^<child>(.*)</child>$_s', '\\1', $childOuterXML);
+        $this->assertSame($expectedXml, $childInnerXML);
+        $expectedValue = $data instanceof DateTimeInterface ? $data->format('Y-m-d H:i:s') : (string) $data;
+        if ($flags & Xml::FLAG_PRESERVE_CARRIAGE_RETURNS) {
+            $this->assertSame($expectedValue, (string) $newChild);
+        } else {
+            $this->assertSame(strtr($expectedValue, ["\r\n" => "\n", "\r" => "\n"]), (string) $newChild);
+        }
+    }
+
+    private function parseXml(string $xml): SimpleXMLElement
+    {
+        $element = simplexml_load_string($xml);
+        $this->assertInstanceOf(SimpleXMLElement::class, $element, "Failed to process XML: [$xml}");
+
+        return $element;
+    }
+}

--- a/tests/tests/Utility/Service/XmlTest.php
+++ b/tests/tests/Utility/Service/XmlTest.php
@@ -21,6 +21,14 @@ class XmlTest extends TestCase
     {
         self::$xml = app(Xml::class);
     }
+
+    public function testAlias(): void
+    {
+        $instanceFromAlias = app('helper/xml');
+        $instanceFromClassName = app(Xml::class);
+        $this->assertSame($instanceFromClassName, $instanceFromAlias);
+    }
+
     public static function provideBooleanValuesCases(): array
     {
         return [
@@ -124,24 +132,26 @@ class XmlTest extends TestCase
             ['<b>Test</b>!', '<![CDATA[<b>Test</b>!]]>'],
             ['"Hello" he said ', '"Hello" he said '],
             ["'Hello' she said ", "'Hello' she said "],
-            ["First & Second", "<![CDATA[First & Second]]>"],
+            ['First & Second', '<![CDATA[First & Second]]>'],
             ["First line{$lf}Second line", "First line{$lf}Second line"],
             ["<b>First</b> line{$lf}Second line", "<![CDATA[<b>First</b> line{$lf}Second line]]>"],
             // see https://www.w3.org/TR/2008/REC-xml-20081126/#sec-line-ends
-             ["First line{$crlf}Second line", "First line{$lf}Second line"],
+            ["First line{$crlf}Second line", "First line{$lf}Second line"],
             ["First line{$crlf}Second line", "First line&#13;{$lf}Second line", Xml::FLAG_PRESERVE_CARRIAGE_RETURNS],
             ["First line{$cr}Second line", "First line{$lf}Second line"],
-            ["First line{$cr}Second line", "First line&#13;Second line", Xml::FLAG_PRESERVE_CARRIAGE_RETURNS],
+            ["First line{$cr}Second line", 'First line&#13;Second line', Xml::FLAG_PRESERVE_CARRIAGE_RETURNS],
             ["<b>First</b> line{$cr}Second line", "<![CDATA[<b>First</b> line{$lf}Second line]]>"],
             ["<b>First</b> line{$crlf}Second line", "<![CDATA[<b>First</b> line{$lf}Second line]]>"],
             ["<b>First</b> line{$crlf}Second line", "&lt;b&gt;First&lt;/b&gt; line&#13;{$lf}Second line", Xml::FLAG_PRESERVE_CARRIAGE_RETURNS],
             ["<b>First</b> line{$cr}Second line", "<![CDATA[<b>First</b> line{$lf}Second line]]>"],
-            ["<b>First</b> line{$cr}Second line", "&lt;b&gt;First&lt;/b&gt; line&#13;Second line", Xml::FLAG_PRESERVE_CARRIAGE_RETURNS],
+            ["<b>First</b> line{$cr}Second line", '&lt;b&gt;First&lt;/b&gt; line&#13;Second line', Xml::FLAG_PRESERVE_CARRIAGE_RETURNS],
         ];
     }
 
     /**
      * @dataProvider proviteCreateElementData
+     *
+     * @param mixed $data
      */
     public function testCreateElement($data, string $expectedXml, int $flags = 0): void
     {
@@ -164,7 +174,7 @@ class XmlTest extends TestCase
     private function parseXml(string $xml): SimpleXMLElement
     {
         $element = simplexml_load_string($xml);
-        $this->assertInstanceOf(SimpleXMLElement::class, $element, "Failed to process XML: [$xml}");
+        $this->assertInstanceOf(SimpleXMLElement::class, $element, "Failed to process XML: {$xml}");
 
         return $element;
     }


### PR DESCRIPTION
This PR superseedes #11799 and #11803, with a few improvements:

1. the Xml service has been extended and improved
2. the Xml service is used when exporting data that could be better represented in CDATA sections
3. CDATA sections are created only when needed: I think it's much more readable
   ```xml
   <element>1</element>
   ```
   than
   ```xml
   <element><![CDATA[1]]></element>
   ```
   but this PR still uses CDATA for values containing `<`, `>`, or `&`, because IMHO it's more readable
   ```xml
   <element><![CDATA[<div><b>First line</b>
   & second line</div>]]></element>
   ```
   than
   ```xml
   <element>&lt;div&gt;&lt;b&gt;First line&lt;/b&gt;
   &amp; second line&lt;/div&gt;</element>
   ```
