### PR TITLE
Check syntax of CIF files

### DIFF
--- a/.github/workflows/cif-syntax.yml
+++ b/.github/workflows/cif-syntax.yml
@@ -1,0 +1,29 @@
+name: Check CIFs Syntax
+
+on:
+  pull_request:
+  push:
+    tags-ignore:
+      - "**"
+
+jobs:
+  check-cif-syntax:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: temurin
+          java-package: jre
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      -
+        name: Download concrete-cif
+        run: curl -Lf -o /tmp/concrete-cif.jar https://github.com/concretecms/concrete-cif/releases/latest/download/concrete-cif.jar
+      -
+        name: Check
+        run: java -jar /tmp/concrete-cif.jar ./concrete

--- a/.github/workflows/cif-syntax.yml
+++ b/.github/workflows/cif-syntax.yml
@@ -12,13 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       -
-        name: Setup Java
-        uses: actions/setup-java@v3
-        with:
-          java-version: '17'
-          distribution: temurin
-          java-package: jre
-      -
         name: Checkout
         uses: actions/checkout@v4
       -


### PR DESCRIPTION
What about checking the syntax of CIF files?

PS: concrete-cif recognizes all the block types, and checks their fields.
So:

1. When we add a new field to a block type, we also have to update the XSD of concrete-cif (otherwise tests won't pass: XSD will say that a field is not recognized)
2. When we add a new block type to the core, we should also update the XSD of concrete-cif (tests will still pass, but we won't check the data of the new block since [we'll ignore the XML of the new block](https://github.com/concretecms/concrete-cif/blob/1.0.3/src/main/resources/concrete-cif-1.0.xsd#L2489-L2498)).

The same also occurs for anything else (attribute categories, attribute types, ...)