### PR TITLE
CIF: Accept boolean-like values when importing booleans

### DIFF
--- a/concrete/attributes/address/controller.php
+++ b/concrete/attributes/address/controller.php
@@ -23,6 +23,7 @@ use Concrete\Core\Localization\Service\AddressFormat;
 use Concrete\Core\Localization\Service\CountryList;
 use Concrete\Core\Localization\Service\StatesProvincesList;
 use Concrete\Core\Support\Facade\Application;
+use Concrete\Core\Utility\Service\Xml;
 
 class Controller extends AttributeTypeController implements
     MulticolumnTextExportableAttributeInterface,
@@ -338,8 +339,8 @@ class Controller extends AttributeTypeController implements
     {
         $type = $this->getAttributeKeySettings();
         if (isset($akey->type)) {
-            
-            $type->setHasCustomCountries(!empty($akey->type['custom-countries']));
+            $xml = $this->app->make(Xml::class);
+            $type->setHasCustomCountries($xml->getBool($akey->type['custom-countries']));
             $type->setDefaultCountry((string) $akey->type['default-country']);
             if (isset($akey->type->countries)) {
                 $countries = [];
@@ -348,7 +349,7 @@ class Controller extends AttributeTypeController implements
                 }
                 $type->setCustomCountries($countries);
             }
-            $type->setGeolocateCountry(!empty($akey->type['geolocate-country']));
+            $type->setGeolocateCountry($xml->getBool($akey->type['geolocate-country']));
         }
 
         return $type;

--- a/concrete/attributes/boolean/controller.php
+++ b/concrete/attributes/boolean/controller.php
@@ -15,6 +15,7 @@ use Concrete\Core\Entity\Attribute\Value\Value\BooleanValue;
 use Concrete\Core\Error\ErrorList\ErrorList;
 use Concrete\Core\Search\ItemList\Database\AttributedItemList;
 use Concrete\Core\Utility\Service\Validation\Numbers;
+use Concrete\Core\Utility\Service\Xml;
 use Core;
 
 class Controller extends AttributeTypeController implements SimpleTextExportableAttributeInterface,
@@ -92,12 +93,10 @@ class Controller extends AttributeTypeController implements SimpleTextExportable
     {
         $type = $this->getAttributeKeySettings();
         if (isset($akey->type)) {
-            $checked = (string) $akey->type['checked'];
+            $xml = $this->app->make(Xml::class);
+            $type->setIsCheckedByDefault($xml->getBool($akey->type['checked']));
             $label = (string) $akey->type['checkbox-label'];
-            if ($checked != '') {
-                $type->setIsCheckedByDefault(true);
-            }
-            if ($label != '') {
+            if ($label !== '') {
                 $type->setCheckboxLabel($label);
             }
         }
@@ -136,8 +135,7 @@ class Controller extends AttributeTypeController implements SimpleTextExportable
     public function createAttributeValue($value)
     {
         $v = new BooleanValue();
-        $value = ($value == false || $value == '0') ? false : true;
-        $v->setValue($value);
+        $v->setValue(filter_var($value, FILTER_VALIDATE_BOOLEAN));
 
         return $v;
     }

--- a/concrete/attributes/date_time/controller.php
+++ b/concrete/attributes/date_time/controller.php
@@ -8,6 +8,7 @@ use Concrete\Core\Attribute\SimpleTextExportableAttributeInterface;
 use Concrete\Core\Entity\Attribute\Key\Settings\DateTimeSettings;
 use Concrete\Core\Entity\Attribute\Value\Value\DateTimeValue;
 use Concrete\Core\Error\ErrorList\ErrorList;
+use Concrete\Core\Utility\Service\Xml;
 use DateTime;
 use Exception;
 
@@ -103,7 +104,8 @@ class Controller extends AttributeTypeController implements SimpleTextExportable
     {
         $type = $this->getAttributeKeySettings();
         if (isset($akey->type)) {
-            $type->setUseNowIfEmpty($akey->type['use-now-if-empty']);
+            $xml = $this->app->make(Xml::class);
+            $type->setUseNowIfEmpty($xml->getBool($akey->type['use-now-if-empty']));
             $type->setMode($akey->type['mode']);
             $type->setTextCustomFormat(isset($akey->type['text-custom-format']) ? $akey->type['text-custom-format'] : '');
             $type->setTimeResolution($akey->type['time-resolution']);

--- a/concrete/attributes/select/controller.php
+++ b/concrete/attributes/select/controller.php
@@ -21,6 +21,7 @@ use Concrete\Core\Entity\Attribute\Value\Value\SelectValueUsedOption;
 use Concrete\Core\Error\ErrorList\ErrorList;
 use Concrete\Core\Error\UserMessageException;
 use Concrete\Core\Search\ItemList\Database\AttributedItemList;
+use Concrete\Core\Utility\Service\Xml;
 use Core;
 use Database;
 use Doctrine\Common\Collections\ArrayCollection;
@@ -172,17 +173,12 @@ class Controller extends AttributeTypeController implements
          */
         $type = $this->getAttributeKeySettings();
         if (isset($akey->type)) {
-            $akSelectAllowMultipleValues = $akey->type['allow-multiple-values'];
-            $akDisplayMultipleValuesOnSelect = $akey->type['display-multiple-values'];
-            $akSelectOptionDisplayOrder = $akey->type['display-order'];
-            $akSelectAllowOtherValues = $akey->type['allow-other-values'];
-            $akHideNoneOption = $akey->type['hide-none-option'];
-
-            $type->setAllowMultipleValues(((string) $akSelectAllowMultipleValues) == '1' ? true : false);
-            $type->setDisplayOrder($akSelectOptionDisplayOrder);
-            $type->setAllowOtherValues(((string) $akSelectAllowOtherValues) == '1' ? true : false);
-            $type->setDisplayMultipleValuesOnSelect(((string) $akDisplayMultipleValuesOnSelect) == '1' ? true : false);
-            $type->setHideNoneOption(((string) $akHideNoneOption) == '1' ? true : false);
+            $xml = $this->app->make(Xml::class);
+            $type->setAllowMultipleValues($xml->getBool($akey->type['allow-multiple-values']));
+            $type->setDisplayOrder($akey->type['display-order']);
+            $type->setAllowOtherValues($xml->getBool($akey->type['allow-other-values']));
+            $type->setDisplayMultipleValuesOnSelect($xml->getBool($akey->type['display-multiple-values']));
+            $type->setHideNoneOption($xml->getBool($akey->type['hide-none-option']));
 
             $list = new SelectValueOptionList();
             if (isset($akey->type->options)) {
@@ -190,7 +186,7 @@ class Controller extends AttributeTypeController implements
                 foreach ($akey->type->options->children() as $option) {
                     $opt = new SelectValueOption();
                     $opt->setSelectAttributeOptionValue((string) $option['value']);
-                    $opt->setIsEndUserAdded((bool) $option['is-end-user-added']);
+                    $opt->setIsEndUserAdded($xml->getBool($option['is-end-user-added']));
                     $opt->setOptionList($list);
                     $opt->setDisplayOrder($displayOrder);
                     $list->getOptions()->add($opt);

--- a/concrete/attributes/user_group/controller.php
+++ b/concrete/attributes/user_group/controller.php
@@ -23,6 +23,7 @@ use Concrete\Core\User\Group\Group;
 use Concrete\Core\User\Group\GroupList;
 use Concrete\Core\User\Group\GroupRepository;
 use Concrete\Core\User\User;
+use Concrete\Core\Utility\Service\Xml;
 use League\Fractal\Resource\Item;
 use League\Fractal\Resource\ResourceInterface;
 
@@ -331,9 +332,9 @@ class Controller extends AttributeTypeController implements
          * @var UserGroupSettings
          */
         if (isset($key->type)) {
+            $xml = $this->app->make(Xml::class);
             $akGroupSelectionMethod = (string) $key->type['group-selection-method'];
-            $akDisplayGroupsBeneathSpecificParent = (string) $key->type['display-groups-beneath-specific-parent'] == '1'
-                ? true : false;
+            $akDisplayGroupsBeneathSpecificParent = $xml->getBool($key->type['display-groups-beneath-specific-parent']);
             $settings->setGroupSelectionMethod($akGroupSelectionMethod);
             $settings->setDisplayGroupsBeneathSpecificParent($akDisplayGroupsBeneathSpecificParent);
             if ($akDisplayGroupsBeneathSpecificParent) {

--- a/concrete/src/Attribute/Category/UserCategory.php
+++ b/concrete/src/Attribute/Category/UserCategory.php
@@ -7,6 +7,7 @@ use Concrete\Core\Entity\Attribute\Key\UserKey;
 use Concrete\Core\Entity\Attribute\Type;
 use Concrete\Core\Entity\Package;
 use Concrete\Core\User\UserInfo;
+use Concrete\Core\Utility\Service\Xml;
 use Symfony\Component\HttpFoundation\Request;
 
 class UserCategory extends AbstractStandardCategory
@@ -175,12 +176,13 @@ class UserCategory extends AbstractStandardCategory
     public function import(Type $type, \SimpleXMLElement $element, ?Package $package = null)
     {
         $key = parent::import($type, $element, $package);
-        $key->setAttributeKeyDisplayedOnProfile((string) $element['profile-displayed'] == 1);
-        $key->setAttributeKeyEditableOnProfile((string) $element['profile-editable'] == 1);
-        $key->setAttributeKeyRequiredOnProfile((string) $element['profile-required'] == 1);
-        $key->setAttributeKeyEditableOnRegister((string) $element['register-editable'] == 1);
-        $key->setAttributeKeyRequiredOnRegister((string) $element['register-required'] == 1);
-        $key->setAttributeKeyDisplayedOnMemberList((string) $element['member-list-displayed'] == 1);
+        $xml = $this->application->make(Xml::class);
+        $key->setAttributeKeyDisplayedOnProfile($xml->getBool($element['profile-displayed']));
+        $key->setAttributeKeyEditableOnProfile($xml->getBool($element['profile-editable']));
+        $key->setAttributeKeyRequiredOnProfile($xml->getBool($element['profile-required']));
+        $key->setAttributeKeyEditableOnRegister($xml->getBool($element['register-editable']));
+        $key->setAttributeKeyRequiredOnRegister($xml->getBool($element['register-required']));
+        $key->setAttributeKeyDisplayedOnMemberList($xml->getBool($element['member-list-displayed']));
         // Save these settings to the database
         $this->entityManager->flush();
 

--- a/concrete/src/Attribute/Key/ImportLoader/StandardImportLoader.php
+++ b/concrete/src/Attribute/Key/ImportLoader/StandardImportLoader.php
@@ -2,22 +2,18 @@
 namespace Concrete\Core\Attribute\Key\ImportLoader;
 
 use Concrete\Core\Entity\Attribute\Key\Key;
+use Concrete\Core\Utility\Service\Xml;
 
 class StandardImportLoader implements ImportLoaderInterface
 {
     public function load(Key $key, \SimpleXMLElement $element)
     {
+        $xml = app(Xml::class);
         $key->setAttributeKeyName((string) $element['name']);
         $key->setAttributeKeyHandle((string) $element['handle']);
-        $indexed = (string) $element['indexed'];
-        $searchable = (string) $element['searchable'];
-        $internal = (string) $element['internal'];
-        if ($indexed === '1') {
-            $key->setIsAttributeKeyContentIndexed(true);
-        }
-        if ($internal === '1') {
-            $key->setIsAttributeKeyInternal(true);
-        }
+        $key->setIsAttributeKeyContentIndexed($xml->getBool($element['indexed']));
+        $key->setIsAttributeKeySearchable($xml->getBool($element['searchable']));
+        $key->setIsAttributeKeyInternal($xml->getBool($element['internal']));
 
         return $key;
     }

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportAttributeSetsRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportAttributeSetsRoutine.php
@@ -5,6 +5,7 @@ namespace Concrete\Core\Backup\ContentImporter\Importer\Routine;
 use Concrete\Core\Attribute\Category\CategoryService;
 use Concrete\Core\Attribute\SetFactory;
 use Concrete\Core\Support\Facade\Application;
+use Concrete\Core\Utility\Service\Xml;
 use SimpleXMLElement;
 
 class ImportAttributeSetsRoutine extends AbstractRoutine
@@ -28,6 +29,7 @@ class ImportAttributeSetsRoutine extends AbstractRoutine
     {
         if (isset($sx->attributesets)) {
             $app = Application::getFacadeApplication();
+            $xml = $app->make(Xml::class);
             $setFactory = $app->make(SetFactory::class);
             $categoryService = $app->make(CategoryService::class);
             foreach ($sx->attributesets->attributeset as $as) {
@@ -37,7 +39,7 @@ class ImportAttributeSetsRoutine extends AbstractRoutine
                 $manager = $controller->getSetManager();
                 if ($set === null) {
                     $pkg = static::getPackageObject($as['package']);
-                    $set = $manager->addSet((string) $as['handle'], (string) $as['name'], $pkg, $as['locked']);
+                    $set = $manager->addSet((string) $as['handle'], (string) $as['name'], $pkg, $xml->getBool($as['locked']));
                 }
                 foreach ($as->children() as $ask) {
                     $ak = $controller->getAttributeKeyByHandle((string) $ask['handle']);

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportBoardsRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportBoardsRoutine.php
@@ -7,9 +7,11 @@ use Concrete\Core\Entity\Board\Board;
 use Concrete\Core\Entity\Board\DataSource\Configuration\Configuration;
 use Concrete\Core\Entity\Board\DataSource\ConfiguredDataSource;
 use Concrete\Core\Entity\Board\DataSource\DataSource;
+use Concrete\Core\Entity\Board\SlotTemplate;
 use Concrete\Core\Entity\Board\Template;
+use Concrete\Core\Utility\Service\Xml;
 use Doctrine\ORM\EntityManager;
-use Concrete\Core\ENtity\Board\SlotTemplate;
+
 class ImportBoardsRoutine extends AbstractRoutine
 {
     public function getHandle()
@@ -19,9 +21,10 @@ class ImportBoardsRoutine extends AbstractRoutine
 
     public function import(\SimpleXMLElement $sx)
     {
-        $app = app();
-        $em = $app->make(EntityManager::class);
         if (isset($sx->boards)) {
+            $app = app();
+            $em = $app->make(EntityManager::class);
+            $xml = $app->make(Xml::class);
             foreach ($sx->boards->board as $b) {
                 $board = $em->getRepository(Board::class)->findOneByBoardName((string) $b['name']);
                 if (!$board) {
@@ -66,8 +69,7 @@ class ImportBoardsRoutine extends AbstractRoutine
                         }
                     }
 
-                    if (((string) $b['uses-custom-template-subset']) == '1') {
-
+                    if ($xml->getBool($b['uses-custom-template-subset'])) {
                         $templateIds = [];
                         foreach ($b->templates->template as $templateNode) {
                             $templateNodeEntity = $em->getRepository(SlotTemplate::class)->findOneByHandle((string) $templateNode['handle']);

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportConversationEditorsRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportConversationEditorsRoutine.php
@@ -3,6 +3,7 @@ namespace Concrete\Core\Backup\ContentImporter\Importer\Routine;
 
 use Concrete\Core\Conversation\Editor\Editor;
 use Concrete\Core\Permission\Category;
+use Concrete\Core\Utility\Service\Xml;
 
 class ImportConversationEditorsRoutine extends AbstractRoutine
 {
@@ -14,10 +15,11 @@ class ImportConversationEditorsRoutine extends AbstractRoutine
     public function import(\SimpleXMLElement $sx)
     {
         if (isset($sx->conversationeditors)) {
+            $xml = app(Xml::class);
             foreach ($sx->conversationeditors->editor as $th) {
                 $pkg = static::getPackageObject($th['package']);
                 $ce = Editor::add((string) $th['handle'], (string) $th['name'], $pkg);
-                if ($th['activated'] == '1') {
+                if ($xml->getBool($th['activated'])) {
                     $ce->activate();
                 }
             }

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportExpressAssociationsRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportExpressAssociationsRoutine.php
@@ -4,6 +4,7 @@ namespace Concrete\Core\Backup\ContentImporter\Importer\Routine;
 use Concrete\Core\Block\BlockType\BlockType;
 use Concrete\Core\Permission\Category;
 use Concrete\Core\Validation\BannedWord\BannedWord;
+use Concrete\Core\Utility\Service\Xml;
 use Doctrine\ORM\Id\UuidGenerator;
 
 class ImportExpressAssociationsRoutine extends AbstractRoutine
@@ -20,6 +21,7 @@ class ImportExpressAssociationsRoutine extends AbstractRoutine
         $em->getClassMetadata('Concrete\Core\Entity\Express\Association')->setIdGenerator(new \Doctrine\ORM\Id\AssignedGenerator());
 
         if (isset($sx->expressentities)) {
+            $xml = app(Xml::class);
             foreach ($sx->expressentities->entity as $entityNode) {
                 if (isset($entityNode->associations)) {
                     foreach($entityNode->associations->association as $associationNode) {
@@ -34,12 +36,8 @@ class ImportExpressAssociationsRoutine extends AbstractRoutine
                          */
                         $association->setTargetPropertyName((string) $associationNode['target-property-name']);
                         $association->setInversedByPropertyName((string) $associationNode['inversed-by-property-name']);
-                        if (((string) $associationNode['is-owned']) == '1') {
-                            $association->setIsOwnedByAssociation(true);
-                        }
-                        if (((string) $associationNode['is-owner']) == '1') {
-                            $association->setIsOwningAssociation(true);
-                        }
+                        $association->setIsOwnedByAssociation($xml->getBool($associationNode['is-owned']));
+                        $association->setIsOwningAssociation($xml->getBool($associationNode['is-owner']));
                         $em->persist($association);
                     }
                 }

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportExpressEntitiesRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportExpressEntitiesRoutine.php
@@ -7,6 +7,7 @@ use Concrete\Core\Entity\Express\Entity;
 use Concrete\Core\Permission\Category;
 use Concrete\Core\Support\Facade\Facade;
 use Concrete\Core\Tree\Type\ExpressEntryResults;
+use Concrete\Core\Utility\Service\Xml;
 use Concrete\Core\Validation\BannedWord\BannedWord;
 use Doctrine\ORM\Id\UuidGenerator;
 
@@ -24,6 +25,7 @@ class ImportExpressEntitiesRoutine extends AbstractRoutine
         $em->getClassMetadata('Concrete\Core\Entity\Express\Entity')->setIdGenerator(new \Doctrine\ORM\Id\AssignedGenerator());
 
         if (isset($sx->expressentities)) {
+            $xml = app(Xml::class);
             foreach ($sx->expressentities->entity as $entityNode) {
                 $entity = $em->find('Concrete\Core\Entity\Express\Entity', (string) $entityNode['id']);
                 if (!is_object($entity)) {
@@ -39,12 +41,9 @@ class ImportExpressEntitiesRoutine extends AbstractRoutine
                 $entity->setDescription((string) $entityNode['description']);
                 $entity->setName((string) $entityNode['name']);
                 $entity->setPackage(static::getPackageObject($entityNode['package']));
-                if (((string) $entityNode['include_in_public_list']) == '') {
-                    $entity->setIncludeInPublicList(false);
-                }
-                if (((string) $entityNode['use_separate_site_result_buckets']) === '1') {
-                    $entity->setUseSeparateSiteResultBuckets(true);
-                }
+                $entity->setSupportsCustomDisplayOrder($xml->getBool($entityNode['supports_custom_display_order']));
+                $entity->setIncludeInPublicList($xml->getBool($entityNode['include_in_public_list'], true));
+                $entity->setUseSeparateSiteResultBuckets($xml->getBool($entityNode['use_separate_site_result_buckets']));
                 $entity->setHandle((string) $entityNode['handle']);
                 $em->persist($entity);
 

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportGeolocatorsRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportGeolocatorsRoutine.php
@@ -4,6 +4,7 @@ namespace Concrete\Core\Backup\ContentImporter\Importer\Routine;
 use Concrete\Core\Entity\Geolocator;
 use Concrete\Core\Geolocator\GeolocatorService;
 use Concrete\Core\Support\Facade\Application;
+use Concrete\Core\Utility\Service\Xml;
 
 class ImportGeolocatorsRoutine extends AbstractRoutine
 {
@@ -28,6 +29,7 @@ class ImportGeolocatorsRoutine extends AbstractRoutine
             $app = Application::getFacadeApplication();
             $service = $app->make(GeolocatorService::class);
             $em = $service->getEntityManager();
+            $xml = $app->make(Xml::class);
             foreach ($sx->geolocators->geolocator as $xGeolocator) {
                 $handle = (string) $xGeolocator['handle'];
                 if ($service->getByHandle($handle) === null) {
@@ -43,7 +45,7 @@ class ImportGeolocatorsRoutine extends AbstractRoutine
                         }
                         $geolocator->setGeolocatorConfiguration($configuration);
                     }
-                    if (!empty($xGeolocator['active'])) {
+                    if ($xml->getBool($xGeolocator['active'])) {
                         $service->setCurrent($geolocator);
                     }
                     $em->persist($geolocator);

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportIpAccessControlCategoriesRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportIpAccessControlCategoriesRoutine.php
@@ -4,6 +4,7 @@ namespace Concrete\Core\Backup\ContentImporter\Importer\Routine;
 
 use Concrete\Core\Entity\Permission\IpAccessControlCategory;
 use Concrete\Core\Support\Facade\Application;
+use Concrete\Core\Utility\Service\Xml;
 use Doctrine\ORM\EntityManagerInterface;
 use SimpleXMLElement;
 
@@ -30,20 +31,20 @@ class ImportIpAccessControlCategoriesRoutine extends AbstractRoutine
             $app = Application::getFacadeApplication();
             $em = $app->make(EntityManagerInterface::class);
             $repo = $em->getRepository(IpAccessControlCategory::class);
+            $xml = $app->make(Xml::class);
             $categories = [];
             foreach ($sx->ipaccesscontrolcategories->ipaccesscontrolcategory as $xIpAccessControlCategory) {
                 $handle = (string) $xIpAccessControlCategory['handle'];
                 if ($handle !== '' && $repo->findOneBy(['handle' => $handle]) === null) {
-                    $enabled = (string) $xIpAccessControlCategory['enabled'];
                     $category = new IpAccessControlCategory();
                     $category
                         ->setHandle($handle)
                         ->setName($xIpAccessControlCategory['name'])
-                        ->setEnabled($enabled === '' ? true : $enabled)
+                        ->setEnabled($xml->getBool($xIpAccessControlCategory['enabled'], true))
                         ->setMaxEvents($xIpAccessControlCategory['max-events'])
                         ->setTimeWindow($xIpAccessControlCategory['time-window'])
                         ->setBanDuration($xIpAccessControlCategory['ban-duration'])
-                        ->setSiteSpecific($xIpAccessControlCategory['site-specific'])
+                        ->setSiteSpecific($xml->getBool($xIpAccessControlCategory['site-specific']))
                         ->setPackage(static::getPackageObject($xIpAccessControlCategory['package']))
                     ;
                     $logChannelHandle = (string) $xIpAccessControlCategory['log-channel-handle'];

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportPageFeedsRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportPageFeedsRoutine.php
@@ -2,6 +2,7 @@
 namespace Concrete\Core\Backup\ContentImporter\Importer\Routine;
 
 use Concrete\Core\Page\Feed;
+use Concrete\Core\Utility\Service\Xml;
 
 class ImportPageFeedsRoutine extends AbstractRoutine
 {
@@ -13,6 +14,7 @@ class ImportPageFeedsRoutine extends AbstractRoutine
     public function import(\SimpleXMLElement $sx)
     {
         if (isset($sx->pagefeeds)) {
+            $xml = app(Xml::class);
             foreach ($sx->pagefeeds->feed as $f) {
                 $feed = Feed::getByHandle((string) $f->handle);
                 $inspector = \Core::make('import/value_inspector');
@@ -27,15 +29,9 @@ class ImportPageFeedsRoutine extends AbstractRoutine
                 $feed->setTitle((string) $f->title);
                 $feed->setDescription((string) $f->description);
                 $feed->setHandle((string) $f->handle);
-                if ($f->descendents) {
-                    $feed->setIncludeAllDescendents(true);
-                }
-                if ($f->aliases) {
-                    $feed->setDisplayAliases(true);
-                }
-                if ($f->featured) {
-                    $feed->setDisplayFeaturedOnly(true);
-                }
+                $feed->setIncludeAllDescendents($xml->getBool($f->descendents));
+                $feed->setDisplayAliases($xml->getBool($f->aliases));
+                $feed->setDisplayFeaturedOnly($xml->getBool($f->featured));
                 if ($f->pagetype) {
                     $result = $inspector->inspect((string) $f->pagetype);
                     $pagetype = $result->getReplacedValue();

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportPageTemplatesRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportPageTemplatesRoutine.php
@@ -6,6 +6,7 @@ use Concrete\Core\Entity\Express\FieldSet;
 use Concrete\Core\Entity\Express\Form;
 use Concrete\Core\Page\Template;
 use Concrete\Core\Permission\Category;
+use Concrete\Core\Utility\Service\Xml;
 use Concrete\Core\Validation\BannedWord\BannedWord;
 
 class ImportPageTemplatesRoutine extends AbstractRoutine
@@ -18,6 +19,7 @@ class ImportPageTemplatesRoutine extends AbstractRoutine
     public function import(\SimpleXMLElement $sx)
     {
         if (isset($sx->pagetemplates)) {
+            $xml = app(Xml::class);
             foreach ($sx->pagetemplates->pagetemplate as $pt) {
                 $pkg = static::getPackageObject($pt['package']);
                 $ptt = Template::getByHandle($pt['handle']);
@@ -27,7 +29,7 @@ class ImportPageTemplatesRoutine extends AbstractRoutine
                         (string) $pt['name'],
                         (string) $pt['icon'],
                         $pkg,
-                        (string) $pt['internal']
+                        $xml->getBool($pt['internal'])
                     );
                 }
             }

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportSystemCaptchaLibrariesRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportSystemCaptchaLibrariesRoutine.php
@@ -5,6 +5,7 @@ use Concrete\Core\Attribute\Type;
 use Concrete\Core\Block\BlockType\BlockType;
 use Concrete\Core\Captcha\Library;
 use Concrete\Core\Permission\Category;
+use Concrete\Core\Utility\Service\Xml;
 use Concrete\Core\Validation\BannedWord\BannedWord;
 
 class ImportSystemCaptchaLibrariesRoutine extends AbstractRoutine
@@ -17,13 +18,14 @@ class ImportSystemCaptchaLibrariesRoutine extends AbstractRoutine
     public function import(\SimpleXMLElement $sx)
     {
         if (isset($sx->systemcaptcha)) {
+            $xml = app(Xml::class);
             foreach ($sx->systemcaptcha->library as $th) {
                 $pkg = static::getPackageObject($th['package']);
                 $scl = Library::getByHandle((string) $th['handle']);
                 if (!is_object($scl)) {
                     $scl = Library::add($th['handle'], $th['name'], $pkg);
                 }
-                if ($th['activated'] == '1') {
+                if ($xml->getBool($th['activated'])) {
                     $scl->activate();
                 }
             }

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportSystemContentEditorSnippetsRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportSystemContentEditorSnippetsRoutine.php
@@ -5,6 +5,7 @@ use Concrete\Core\Attribute\Type;
 use Concrete\Core\Block\BlockType\BlockType;
 use Concrete\Core\Editor\Snippet;
 use Concrete\Core\Permission\Category;
+use Concrete\Core\Utility\Service\Xml;
 use Concrete\Core\Validation\BannedWord\BannedWord;
 
 class ImportSystemContentEditorSnippetsRoutine extends AbstractRoutine
@@ -17,10 +18,11 @@ class ImportSystemContentEditorSnippetsRoutine extends AbstractRoutine
     public function import(\SimpleXMLElement $sx)
     {
         if (isset($sx->systemcontenteditorsnippets)) {
+            $xml = app(Xml::class);
             foreach ($sx->systemcontenteditorsnippets->snippet as $th) {
                 $pkg = static::getPackageObject($th['package']);
                 $scs = Snippet::add($th['handle'], $th['name'], $pkg);
-                if ($th['activated'] == '1') {
+                if ($xml->getBool($th['activated'])) {
                     $scs->activate();
                 }
             }

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportThemesRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportThemesRoutine.php
@@ -3,6 +3,7 @@ namespace Concrete\Core\Backup\ContentImporter\Importer\Routine;
 
 use Concrete\Core\Page\Theme\Theme;
 use Concrete\Core\Support\Facade\Facade;
+use Concrete\Core\Utility\Service\Xml;
 use Doctrine\ORM\EntityManager;
 
 class ImportThemesRoutine extends AbstractRoutine
@@ -15,6 +16,7 @@ class ImportThemesRoutine extends AbstractRoutine
     public function import(\SimpleXMLElement $sx)
     {
         if (isset($sx->themes)) {
+            $xml = app(Xml::class);
             foreach ($sx->themes->theme as $th) {
                 $pkg = static::getPackageObject($th['package']);
                 $pThemeHandle = (string) $th['handle'];
@@ -22,7 +24,7 @@ class ImportThemesRoutine extends AbstractRoutine
                 if (!is_object($pt)) {
                     $pt = Theme::add($pThemeHandle, $pkg);
                 }
-                if ($th['activated'] == '1') {
+                if ($xml->getBool($th['activated'])) {
                     $pt->applyToSite();
                 }
                 if (!empty($th['active-skin'])) {

--- a/concrete/src/Import/Item/Express/Control/AssociationControl.php
+++ b/concrete/src/Import/Item/Express/Control/AssociationControl.php
@@ -5,6 +5,7 @@ use Concrete\Core\Entity\Express\Entity;
 use Concrete\Core\Export\ExportableInterface;
 use Concrete\Core\Import\ImportableInterface;
 use Concrete\Core\Import\Item\Express\ItemInterface;
+use Concrete\Core\Utility\Service\Xml;
 use Doctrine\ORM\EntityManager;
 
 defined('C5_EXECUTE') or die("Access Denied.");
@@ -21,12 +22,11 @@ class AssociationControl implements ItemInterface
 
     public function import(\SimpleXMLElement $xml, Entity $entity)
     {
+        $xmlService = app(Xml::class);
         $control = new \Concrete\Core\Entity\Express\Control\AssociationControl();
         $control->setCustomLabel((string) $xml['custom-label']);
         $control->setAssociationEntityLabelMask((string) $xml['label-mask']);
-        if (((string) $xml['required']) == '1') {
-            $control->setIsRequired(true);
-        }
+        $control->setIsRequired($xmlService->getBool($xml['required']));
         $control->setId((string) $xml['id']);
         $association = $this->entityManager->find('Concrete\Core\Entity\Express\Association', (string) $xml['association']);
         $control->setAssociation($association);

--- a/concrete/src/Import/Item/Express/Control/AttributeKeyControl.php
+++ b/concrete/src/Import/Item/Express/Control/AttributeKeyControl.php
@@ -6,6 +6,7 @@ use Concrete\Core\Attribute\Category\ExpressCategory;
 use Concrete\Core\Entity\Attribute\Key\ExpressKey;
 use Concrete\Core\Entity\Express\Entity;
 use Concrete\Core\Import\Item\Express\ItemInterface;
+use Concrete\Core\Utility\Service\Xml;
 use Doctrine\ORM\EntityManager;
 
 defined('C5_EXECUTE') or die("Access Denied.");
@@ -29,12 +30,11 @@ class AttributeKeyControl implements ItemInterface
     public function import(\SimpleXMLElement $xml, Entity $entity)
     {
         if (isset($xml->attributekey)) {
+            $xmlService = app(Xml::class);
             $category = new ExpressCategory($entity, $this->application, $this->entityManager);
             $control = new \Concrete\Core\Entity\Express\Control\AttributeKeyControl();
             $control->setCustomLabel((string) $xml['custom-label']);
-            if (((string) $xml['required']) == '1') {
-                $control->setIsRequired(true);
-            }
+            $control->setIsRequired($xmlService->getBool($xml['required']));
             $control->setId((string) $xml['id']);
             $ak = $xml->attributekey;
             //$key = $category->getAttributeKeyByHandle((string) $ak['handle']);

--- a/concrete/src/Import/Item/Express/Control/EntityPropertyControl.php
+++ b/concrete/src/Import/Item/Express/Control/EntityPropertyControl.php
@@ -3,6 +3,7 @@ namespace Concrete\Core\Import\Item\Express\Control;
 
 use Concrete\Core\Entity\Express\Entity;
 use Concrete\Core\Import\Item\Express\ItemInterface;
+use Concrete\Core\Utility\Service\Xml;
 
 defined('C5_EXECUTE') or die("Access Denied.");
 
@@ -11,6 +12,7 @@ class EntityPropertyControl implements ItemInterface
 
     public function import(\SimpleXMLElement $xml, Entity $entity)
     {
+        $xmlService = app(Xml::class);
         switch((string) $xml['type-id']) {
             case 'text':
             default:
@@ -21,9 +23,7 @@ class EntityPropertyControl implements ItemInterface
         }
 
         $control->setCustomLabel((string) $xml['custom-label']);
-        if (((string) $xml['required']) == '1') {
-            $control->setIsRequired(true);
-        }
+        $control->setIsRequired($xmlService->getBool($xml['required']));
         $control->setId((string) $xml['id']);
         return $control;
     }

--- a/concrete/src/Page/Type/Type.php
+++ b/concrete/src/Page/Type/Type.php
@@ -35,6 +35,7 @@ use Concrete\Core\Page\Type\PublishTarget\Type\Type as PageTypePublishTargetType
 use Concrete\Core\Page\Type\Composer\FormLayoutSetControl as PageTypeComposerFormLayoutSetControl;
 use Concrete\Core\Page\Collection\Version\VersionList;
 use Concrete\Core\Page\Type\Composer\Control\CorePageProperty\CorePageProperty as CorePagePropertyPageTypeComposerControl;
+use Concrete\Core\Utility\Service\Xml;
 
 class Type extends ConcreteObject implements \Concrete\Core\Permission\ObjectInterface, AssignableObjectInterface
 {
@@ -393,6 +394,7 @@ class Type extends ConcreteObject implements \Concrete\Core\Permission\ObjectInt
 
     public static function import($node)
     {
+        $xml = app(Xml::class);
         $types = array();
         if ((string) $node->pagetemplates['type'] == 'custom' || (string) $node->pagetemplates['type'] == 'except') {
             if ((string) $node->pagetemplates['type'] == 'custom') {
@@ -437,20 +439,11 @@ class Type extends ConcreteObject implements \Concrete\Core\Permission\ObjectInt
             $data['allowedTemplates'] = $ptAllowedPageTemplates;
         }
 
-        $data['internal'] = 0;
-        if ($node['internal'] == '1') {
-            $data['internal'] = 1;
-        }
+        $data['internal'] = $xml->getBool($node['internal']) ? 1 : 0;
 
-        $data['ptLaunchInComposer'] = 0;
-        if ($node['launch-in-composer'] == '1') {
-            $data['ptLaunchInComposer'] = 1;
-        }
+        $data['ptLaunchInComposer'] = $xml->getBool($node['launch-in-composer']) ? 1 : 0;
 
-        $data['ptIsFrequentlyAdded'] = 0;
-        if ($node['is-frequently-added'] == '1') {
-            $data['ptIsFrequentlyAdded'] = 1;
-        }
+        $data['ptIsFrequentlyAdded'] = $xml->getBool($node['is-frequently-added']) ? 1 : 0;
 
         $data['templates'] = $types;
         $pkg = false;
@@ -473,16 +466,11 @@ class Type extends ConcreteObject implements \Concrete\Core\Permission\ObjectInt
                         $controltype = PageTypeComposerControlType::getByHandle((string) $controlnode['type']);
                         $control = $controltype->configureFromImportHandle((string) $controlnode['handle']);
                         $setcontrol = $control->addToPageTypeComposerFormLayoutSet($set, true);
-                        $required = (string) $controlnode['required'];
                         $customTemplate = (string) $controlnode['custom-template'];
                         $label = (string) $controlnode['custom-label'];
                         $description = (string) $controlnode['description'];
                         $outputControlID = (string) $controlnode['output-control-id'];
-                        if ($required == '1') {
-                            $setcontrol->updateFormLayoutSetControlRequired(true);
-                        } else {
-                            $setcontrol->updateFormLayoutSetControlRequired(false);
-                        }
+                        $setcontrol->updateFormLayoutSetControlRequired($xml->getBool($controlnode['required']));
                         if ($customTemplate) {
                             $setcontrol->updateFormLayoutSetControlCustomTemplate($customTemplate);
                         }

--- a/concrete/src/Permission/Key/Key.php
+++ b/concrete/src/Permission/Key/Key.php
@@ -14,6 +14,7 @@ use Gettext\Translations;
 use PDO;
 use SimpleXMLElement;
 use Concrete\Core\User\User;
+use Concrete\Core\Utility\Service\Xml;
 
 /**
  * @property bool|int|string $pkID
@@ -425,14 +426,15 @@ EOT
         } else {
             $pkg = null;
         }
+        $xml = app(Xml::class);
 
         return self::add(
             $pk['category'],
             $pk['handle'],
             $pk['name'],
             $pk['description'],
-            $pk['can-trigger-workflow'] ? 1 : 0,
-            $pk['has-custom-class'] ? 1 : 0,
+            $xml->getBool($pk['can-trigger-workflow']) ? 1 : 0,
+            $xml->getBool($pk['has-custom-class']) ? 1 : 0,
             $pkg
         );
     }

--- a/concrete/src/Tree/Type/Topic.php
+++ b/concrete/src/Tree/Type/Topic.php
@@ -8,6 +8,7 @@ use Group as UserGroup;
 use Concrete\Core\Permission\Access\Entity\GroupEntity as GroupPermissionAccessEntity;
 use Concrete\Core\Permission\Key\CategoryTreeNodeKey as CategoryTreeNodePermissionKey;
 use Concrete\Core\Permission\Access\Access as PermissionAccess;
+use Concrete\Core\Utility\Service\Xml;
 
 class Topic extends Tree
 {
@@ -90,27 +91,26 @@ class Topic extends Tree
 
     public static function importDetails(\SimpleXMLElement $sx)
     {
-        $isDefault = (string) $sx['default'];
-        if ($isDefault) {
+        $xml = app(Xml::class);
+        if ($xml->getBool($sx['default'])) {
             return static::getDefault();
-        } else {
-            $name = (string) $sx['name'];
-            $tree = static::getByName($name);
-            if (is_object($tree)) {
-                // We already have a tree. But we know we're going to have sub-nodes of this tree in the import, so let's keep the same
-                // tree so that pointers to attributes work, but let's clear it out.
-                $root = $tree->getRootTreeNodeObject();
-                $root->populateChildren();
-                $children = $root->getChildNodes();
-                foreach ($children as $child) {
-                    $child->delete();
-                }
-
-                return static::getByName($name);
-            } else {
-                return static::add($name);
-            }
         }
+        $name = (string) $sx['name'];
+        $tree = static::getByName($name);
+        if (is_object($tree)) {
+            // We already have a tree. But we know we're going to have sub-nodes of this tree in the import, so let's keep the same
+            // tree so that pointers to attributes work, but let's clear it out.
+            $root = $tree->getRootTreeNodeObject();
+            $root->populateChildren();
+            $children = $root->getChildNodes();
+            foreach ($children as $child) {
+                $child->delete();
+            }
+
+            return static::getByName($name);
+        }
+        
+        return static::add($name);
     }
 
     protected function loadDetails()

--- a/concrete/src/Utility/Service/Xml.php
+++ b/concrete/src/Utility/Service/Xml.php
@@ -14,10 +14,11 @@ class Xml
     /**
      * Extract a boolean from an element or an attribute value.
      *
-     * @param bool $default what should be returned if the element/attribute does not exist, or if it does not contain a boolean representation ('true', 'yes', 'on', '1', 'false', 'no', '0', '')
+     * @param bool|null $default what should be returned if the element/attribute does not exist, or if it does not contain a boolean representation ('true', 'yes', 'on', '1', 'false', 'no', '0', '')
      *
+     * @return bool|null returns NULL if and only if $default is null and the attribute/element doesn't exist (or it has an invalid value)
      */
-    public function getBool(?SimpleXMLElement $elementOrAttribute, bool $default = false): bool
+    public function getBool(?SimpleXMLElement $elementOrAttribute, ?bool $default = false): ?bool
     {
         /*
          * $element['nonExistingAttribute'] returns null


### PR DESCRIPTION
What about considering XML attributes like `name="false"` and elements like `<name>false</name>` as `false` when importing boolean attributes?

This PR also contains a couple of fixes:

1. when importing attribute keys, [we didn't save](https://github.com/concretecms/concretecms/blob/9.2.2/concrete/src/Attribute/Key/ImportLoader/StandardImportLoader.php#L13) the `searchable` value.
2. when importing express entities, [we didn't import](https://github.com/concretecms/concretecms/blob/9.2.2/concrete/src/Backup/ContentImporter/Importer/Routine/ImportExpressEntitiesRoutine.php#L37-L49) the `supports_custom_display_order` value.
