### PR TITLE
Fix error on "Waiting for Me" page if an unapproved page is deleted

### DIFF
--- a/concrete/src/Page/Collection/Version/Version.php
+++ b/concrete/src/Page/Collection/Version/Version.php
@@ -8,7 +8,9 @@ use Concrete\Core\Entity\Attribute\Value\PageValue;
 use Concrete\Core\Foundation\ConcreteObject;
 use Block;
 use Concrete\Core\Localization\Service\Date;
+use Concrete\Core\Page\Collection\Collection;
 use Concrete\Core\Page\Page;
+use Concrete\Core\Utility\Service\Validation\Numbers;
 use Doctrine\DBAL\Query\QueryBuilder;
 use PageType;
 use Permissions;
@@ -236,74 +238,81 @@ class Version extends ConcreteObject implements PermissionObjectInterface, Attri
      * Get a Version instance given the Collection and a version identifier.
      *
      * @param \Concrete\Core\Page\Collection\Collection $c the collection for which you want the version
-     * @param int|string $cvID the specific version ID (or 'ACTIVE', 'SCHEDULED', 'RECENT')
+     * @param int|string $cvID the specific version ID (or 'ACTIVE', 'SCHEDULED', 'RECENT', 'RECENT_UNAPPROVED')
      *
      * @return static
      */
     public static function get($c, $cvID)
     {
-        $app = Facade::getFacadeApplication();
-
-        /** @var RequestCache $cache */
-        $cache = $app->make('cache/request');
-        $key = '/Page/Collection/' . $c->getCollectionID() . '/Version/' . $cvID;
-        if ($cache->isEnabled()) {
-            $item = $cache->getItem($key);
-            if ($item->isHit()) {
-                return $item->get();
-            }
-        }
-
-        $db = $app->make('database')->connection();
-        $now = $app->make('date')->getOverridableNow();
-
-        $cID = false;
-        if ($c instanceof \Concrete\Core\Page\Page) {
-            $cID = $c->getCollectionPointerID();
-        }
-        if (!$cID) {
-            $cID = $c->getCollectionID();
-        }
-        $v = array($cID);
-
-        $q = "select * from CollectionVersions where cID = ?";
-
-        switch ($cvID) {
-            case 'ACTIVE':
-                $q .= ' and cvIsApproved = 1 and (cvPublishDate is null or cvPublishDate <= ?) and (cvPublishEndDate is null or cvPublishEndDate >= ?) order by cvPublishDate desc limit 1';
-                $v[] = $now;
-                $v[] = $now;
-                break;
-            case 'SCHEDULED':
-                $q .= ' and cvIsApproved = 1 and (cvPublishDate is not null and cvPublishDate > ?) order by cvPublishDate limit 1';
-                $v[] = $now;
-                break;
-            case 'RECENT':
-                $q .= ' order by cvID desc limit 1';
-                break;
-            case 'RECENT_UNAPPROVED':
-                $q .= 'and (cvIsApproved = 0 or cvIsApproved IS NULL) order by cvID desc limit 1';
-                break;
-            default:
-                $v[] = $cvID;
-                $q .= ' and cvID = ?';
-                break;
-        }
-
-        $row = $db->fetchAssoc($q, $v);
         $cv = new static();
 
-        if ($row !== false) {
-            $cv->setPropertiesFromArray($row);
+        $app = Facade::getFacadeApplication();
+        /** @var Numbers $numbers */
+        $numbers = $app->make(Numbers::class);
+
+        if ($c instanceof Collection && !$c->isError() && ($numbers->integer($cvID) || in_array($cvID, ['ACTIVE', 'SCHEDULED', 'RECENT', 'RECENT_UNAPPROVED']))) {
+            /** @var RequestCache $cache */
+            $cache = $app->make('cache/request');
+            $key = '/Page/Collection/' . $c->getCollectionID() . '/Version/' . $cvID;
+            if ($cache->isEnabled()) {
+                $item = $cache->getItem($key);
+                if ($item->isHit()) {
+                    return $item->get();
+                }
+            }
+
+            $db = $app->make('database')->connection();
+            $now = $app->make('date')->getOverridableNow();
+
+            $cID = false;
+            if ($c instanceof \Concrete\Core\Page\Page) {
+                $cID = $c->getCollectionPointerID();
+            }
+            if (!$cID) {
+                $cID = $c->getCollectionID();
+            }
+            $v = [$cID];
+
+            $q = 'select * from CollectionVersions where cID = ?';
+
+            switch ($cvID) {
+                case 'ACTIVE':
+                    $q .= ' and cvIsApproved = 1 and (cvPublishDate is null or cvPublishDate <= ?) and (cvPublishEndDate is null or cvPublishEndDate >= ?) order by cvPublishDate desc limit 1';
+                    $v[] = $now;
+                    $v[] = $now;
+                    break;
+                case 'SCHEDULED':
+                    $q .= ' and cvIsApproved = 1 and (cvPublishDate is not null and cvPublishDate > ?) order by cvPublishDate limit 1';
+                    $v[] = $now;
+                    break;
+                case 'RECENT':
+                    $q .= ' order by cvID desc limit 1';
+                    break;
+                case 'RECENT_UNAPPROVED':
+                    $q .= 'and (cvIsApproved = 0 or cvIsApproved IS NULL) order by cvID desc limit 1';
+                    break;
+                default:
+                    $v[] = $cvID;
+                    $q .= ' and cvID = ?';
+                    break;
+            }
+
+            $row = $db->fetchAssoc($q, $v);
+
+            if ($row !== false) {
+                $cv->setPropertiesFromArray($row);
+            } else {
+                $cv->loadError(VERSION_NOT_FOUND);
+            }
+
+            $cv->cID = $c->getCollectionID();
+
+            if (isset($item) && $item->isMiss()) {
+                $item->set($cv);
+                $cache->save($item);
+            }
         } else {
             $cv->loadError(VERSION_NOT_FOUND);
-        }
-
-        $cv->cID = $c->getCollectionID();
-
-        if (isset($item) && $item->isMiss()) {
-            $item->set($cv);
-            $cache->save($item);
         }
 
         return $cv;

--- a/concrete/src/Page/Collection/Version/Version.php
+++ b/concrete/src/Page/Collection/Version/Version.php
@@ -11,6 +11,7 @@ use Concrete\Core\Localization\Service\Date;
 use Concrete\Core\Page\Collection\Collection;
 use Concrete\Core\Page\Page;
 use Concrete\Core\Utility\Service\Validation\Numbers;
+use Concrete\Core\Workflow\Command\DeletePageVersionRequestsCommand;
 use Doctrine\DBAL\Query\QueryBuilder;
 use PageType;
 use Permissions;
@@ -1000,6 +1001,10 @@ class Version extends ConcreteObject implements PermissionObjectInterface, Attri
         $q = "delete from CollectionVersions where cID = '{$cID}' and cvID='{$cvID}'";
         $db->executeQuery($q);
         $this->refreshCache();
+
+        // Delete uncompleted workflow requests for this version
+        $deletePageVersionRequestsCommand = new DeletePageVersionRequestsCommand($cID, $cvID);
+        $app->executeCommand($deletePageVersionRequestsCommand);
 
         $ev = new Event($c);
         $ev->setUser($u);

--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -45,6 +45,7 @@ use Concrete\Core\Summary\Category\CategoryMemberInterface;
 use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\Support\Facade\Facade;
 use Concrete\Core\User\User;
+use Concrete\Core\Workflow\Command\DeletePageRequestsCommand;
 use Config;
 use Core;
 use Database;
@@ -3009,6 +3010,10 @@ EOT
             $this->getCollectionName(),
             $this->getCollectionPath()
         ));
+
+        // Delete uncompleted workflow requests for this page (need to run before the page is deleted)
+        $deletePageRequestsCommand = new DeletePageRequestsCommand($cID);
+        $app->executeCommand($deletePageRequestsCommand);
 
         parent::delete();
 

--- a/concrete/src/Workflow/Command/DeletePageRequestsCommand.php
+++ b/concrete/src/Workflow/Command/DeletePageRequestsCommand.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Concrete\Core\Workflow\Command;
+
+use Concrete\Core\Page\Command\PageCommand;
+
+class DeletePageRequestsCommand extends PageCommand
+{
+}

--- a/concrete/src/Workflow/Command/DeletePageRequestsCommandHandler.php
+++ b/concrete/src/Workflow/Command/DeletePageRequestsCommandHandler.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Concrete\Core\Workflow\Command;
+
+use Concrete\Core\Page\Page;
+use Concrete\Core\Workflow\BasicWorkflow;
+use Concrete\Core\Workflow\Progress\BasicData;
+use Concrete\Core\Workflow\Progress\PageProgress;
+
+class DeletePageRequestsCommandHandler
+{
+    public function __invoke(DeletePageRequestsCommand $command)
+    {
+        $c = Page::getByID($command->getPageID());
+        $progresses = PageProgress::getList($c);
+        /** @var PageProgress $progress */
+        foreach ($progresses as $progress) {
+            $workflow = $progress->getWorkflowObject();
+            if ($workflow instanceof BasicWorkflow) {
+                $progressData = new BasicData($progress);
+                $progressData->delete();
+            }
+            $progress->delete();
+        }
+    }
+}

--- a/concrete/src/Workflow/Command/DeletePageVersionRequestsCommand.php
+++ b/concrete/src/Workflow/Command/DeletePageVersionRequestsCommand.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Concrete\Core\Workflow\Command;
+
+use Concrete\Core\Page\Command\PageCommand;
+
+class DeletePageVersionRequestsCommand extends PageCommand
+{
+    protected int $versionID;
+
+    public function __construct(int $pageID, int $versionID)
+    {
+        parent::__construct($pageID);
+        $this->setVersionID($versionID);
+    }
+
+    public function getVersionID(): int
+    {
+        return $this->versionID;
+    }
+
+    public function setVersionID(int $versionID): self
+    {
+        $this->versionID = $versionID;
+
+        return $this;
+    }
+}

--- a/concrete/src/Workflow/Command/DeletePageVersionRequestsCommandHandler.php
+++ b/concrete/src/Workflow/Command/DeletePageVersionRequestsCommandHandler.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Concrete\Core\Workflow\Command;
+
+use Concrete\Core\Page\Page;
+use Concrete\Core\Workflow\BasicWorkflow;
+use Concrete\Core\Workflow\Progress\BasicData;
+use Concrete\Core\Workflow\Progress\PageProgress;
+use Concrete\Core\Workflow\Request\ApprovePageRequest;
+use Concrete\Core\Workflow\Request\UnapprovePageRequest;
+
+class DeletePageVersionRequestsCommandHandler
+{
+    public function __invoke(DeletePageVersionRequestsCommand $command)
+    {
+        $cID = $command->getPageID();
+        $cvID = $command->getVersionID();
+
+        $c = Page::getByID($cID);
+        $progresses = PageProgress::getList($c);
+        /** @var PageProgress $progress */
+        foreach ($progresses as $progress) {
+            $request = $progress->getWorkflowRequestObject();
+            if ($request instanceof ApprovePageRequest || $request instanceof UnapprovePageRequest) {
+                if ($request->getRequestedVersionID() == $cvID) {
+                    $workflow = $progress->getWorkflowObject();
+                    if ($workflow instanceof BasicWorkflow) {
+                        $progressData = new BasicData($progress);
+                        $progressData->delete();
+                    }
+                    $progress->delete();
+                }
+            }
+        }
+    }
+}

--- a/concrete/src/Workflow/Request/ApprovePageRequest.php
+++ b/concrete/src/Workflow/Request/ApprovePageRequest.php
@@ -1,15 +1,15 @@
 <?php
 namespace Concrete\Core\Workflow\Request;
 
+use Concrete\Core\Page\Collection\Version\Version as CollectionVersion;
+use Concrete\Core\Page\Page;
 use HtmlObject\Element;
 use Workflow;
 use Loader;
-use Page;
 use Concrete\Core\Workflow\Description as WorkflowDescription;
 use Permissions;
 use PermissionKey;
 use Concrete\Core\Workflow\Progress\Progress as WorkflowProgress;
-use CollectionVersion;
 use Events;
 use Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface;
 use Concrete\Core\Workflow\Progress\Action\Action as WorkflowProgressAction;
@@ -56,9 +56,9 @@ class ApprovePageRequest extends PageRequest
         $d = new WorkflowDescription();
         $c = Page::getByID($this->cID, 'RECENT');
         if ($c && !$c->isError()) {
-            $link = Loader::helper('navigation')->getLinkToCollection($c, true);
-            $v = $c->getVersionObject();
-            if (is_object($v)) {
+            $link = $c->getCollectionLink();
+            $v = CollectionVersion::get($c, $this->cvID);
+            if (is_object($v) && !$v->isError()) {
                 $comments = $c->getVersionObject()->getVersionComments();
 
                 if (!$this->isNewPageRequest()) {
@@ -77,6 +77,11 @@ class ApprovePageRequest extends PageRequest
                     $d->setInContextDescription(t("New Page %s submitted for approval.", $this->cvID));
                     $d->setShortStatus(t("New Page"));
                 }
+            } else {
+                $d->setEmailDescription(t('Deleted Version.'));
+                $d->setDescription(t('Deleted Version.'));
+                $d->setInContextDescription(t('Deleted Version.'));
+                $d->setShortStatus(t('Deleted Version.'));
             }
         } else {
             $d->setEmailDescription(t('Deleted Page.'));

--- a/concrete/src/Workflow/Request/ApprovePageRequest.php
+++ b/concrete/src/Workflow/Request/ApprovePageRequest.php
@@ -1,26 +1,31 @@
 <?php
+
 namespace Concrete\Core\Workflow\Request;
 
 use Concrete\Core\Page\Collection\Version\Version as CollectionVersion;
 use Concrete\Core\Page\Page;
-use HtmlObject\Element;
-use Workflow;
-use Concrete\Core\Workflow\Description as WorkflowDescription;
-use Permissions;
-use PermissionKey;
-use Concrete\Core\Workflow\Progress\Progress as WorkflowProgress;
-use Events;
+use Concrete\Core\Permission\Checker as Permissions;
+use Concrete\Core\Permission\Key\Key as PermissionKey;
+use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface;
+use Concrete\Core\Workflow\Description as WorkflowDescription;
 use Concrete\Core\Workflow\Progress\Action\Action as WorkflowProgressAction;
+use Concrete\Core\Workflow\Progress\Progress as WorkflowProgress;
 use Concrete\Core\Workflow\Progress\Response as WorkflowProgressResponse;
+use HtmlObject\Element;
 
 class ApprovePageRequest extends PageRequest
 {
     protected $wrStatusNum = 30;
+
     protected $cvID;
+
     private $isScheduled = false;
+
     private $cvPublishDate;
+
     private $cvPublishEndDate;
+
     private $keepOtherScheduling = false;
 
     public function __construct()
@@ -39,18 +44,6 @@ class ApprovePageRequest extends PageRequest
         return $this->cvID;
     }
 
-    protected function isNewPageRequest()
-    {
-        $active = Page::getByID($this->cID, 'ACTIVE');
-        if (is_object($active) && !$active->isError()) {
-            $version = $active->getVersionObject();
-            if (is_object($version) && $version->getVersionID()) {
-                return false;
-            }
-        }
-        return true;
-    }
-
     public function getWorkflowRequestDescriptionObject()
     {
         $d = new WorkflowDescription();
@@ -63,19 +56,31 @@ class ApprovePageRequest extends PageRequest
 
                 if (!$this->isNewPageRequest()) {
                     // new version of existing page
-                    $d->setEmailDescription(t("\"%s\" has pending changes and needs to be approved.\n\nVersion Comments: %s\n\nView the page here: %s.",
-                        $c->getCollectionName(), $comments, $link));
-                    $d->setDescription(t("Version %s of Page <a target=\"_blank\" href=\"%s\">%s</a> submitted for Approval.", $this->cvID, $link,
-                        $c->getCollectionName()));
-                    $d->setInContextDescription(t("Page Version %s Submitted for Approval.", $this->cvID));
-                    $d->setShortStatus(t("Pending Approval"));
+                    $d->setEmailDescription(t(
+                        "\"%s\" has pending changes and needs to be approved.\n\nVersion Comments: %s\n\nView the page here: %s.",
+                        $c->getCollectionName(),
+                        $comments,
+                        $link
+                    ));
+                    $d->setDescription(t(
+                        'Version %s of Page <a target="_blank" href="%s">%s</a> submitted for Approval.',
+                        $this->cvID,
+                        $link,
+                        $c->getCollectionName()
+                    ));
+                    $d->setInContextDescription(t('Page Version %s Submitted for Approval.', $this->cvID));
+                    $d->setShortStatus(t('Pending Approval'));
                 } else {
                     // Completely new page.
-                    $d->setEmailDescription(t("New page created: \"%s\". This page requires approval.\n\nAuthor Comments: %s\n\nView the page here: %s.",
-                        $c->getCollectionName(), $comments, $link));
-                    $d->setDescription(t("New Page: <a target=\"_blank\" href=\"%s\">%s</a>", $link, $c->getCollectionName()));
-                    $d->setInContextDescription(t("New Page %s submitted for approval.", $this->cvID));
-                    $d->setShortStatus(t("New Page"));
+                    $d->setEmailDescription(t(
+                        "New page created: \"%s\". This page requires approval.\n\nAuthor Comments: %s\n\nView the page here: %s.",
+                        $c->getCollectionName(),
+                        $comments,
+                        $link
+                    ));
+                    $d->setDescription(t('New Page: <a target="_blank" href="%s">%s</a>', $link, $c->getCollectionName()));
+                    $d->setInContextDescription(t('New Page %s submitted for approval.', $this->cvID));
+                    $d->setShortStatus(t('New Page'));
                 }
             } else {
                 $d->setEmailDescription(t('Deleted Page Version.'));
@@ -128,13 +133,13 @@ class ApprovePageRequest extends PageRequest
 
         $span = new Element('i');
         $span->addClass('fas fa-file');
+
         return $span;
     }
 
-
     public function getWorkflowRequestAdditionalActions(WorkflowProgress $wp)
     {
-        $buttons = array();
+        $buttons = [];
         $c = Page::getByID($this->cID, 'ACTIVE');
         $cp = new Permissions($c);
         if ($cp->canViewPageVersions()) {
@@ -160,7 +165,9 @@ class ApprovePageRequest extends PageRequest
         $ev = new \Concrete\Core\Page\Collection\Version\Event($c);
         $v = $c->getVersionObject();
         $ev->setCollectionVersionObject($v);
-        Events::dispatch('on_page_version_deny', $ev);
+
+        $app = Application::getFacadeApplication();
+        $app['director']->dispatch('on_page_version_deny', $ev);
 
         parent::cancel($wp);
     }
@@ -173,7 +180,9 @@ class ApprovePageRequest extends PageRequest
 
         $ev = new \Concrete\Core\Page\Collection\Version\Event($c);
         $ev->setCollectionVersionObject($v);
-        Events::dispatch('on_page_version_submit_approve', $ev);
+
+        $app = Application::getFacadeApplication();
+        $app['director']->dispatch('on_page_version_submit_approve', $ev);
 
         $wpr = new WorkflowProgressResponse();
         $wpr->setWorkflowProgressResponseURL(\URL::to($c));
@@ -192,6 +201,7 @@ class ApprovePageRequest extends PageRequest
     {
         $c = Page::getByID($this->getRequestedPageID());
         $v = CollectionVersion::get($c, $this->cvID);
+
         return $v->getVersionComments();
     }
 
@@ -229,4 +239,16 @@ class ApprovePageRequest extends PageRequest
         return $this->isScheduled;
     }
 
+    protected function isNewPageRequest()
+    {
+        $active = Page::getByID($this->cID, 'ACTIVE');
+        if (is_object($active) && !$active->isError()) {
+            $version = $active->getVersionObject();
+            if (is_object($version) && $version->getVersionID()) {
+                return false;
+            }
+        }
+
+        return true;
+    }
 }

--- a/concrete/src/Workflow/Request/ApprovePageRequest.php
+++ b/concrete/src/Workflow/Request/ApprovePageRequest.php
@@ -55,27 +55,34 @@ class ApprovePageRequest extends PageRequest
     {
         $d = new WorkflowDescription();
         $c = Page::getByID($this->cID, 'RECENT');
-        $link = Loader::helper('navigation')->getLinkToCollection($c, true);
-        $v = $c->getVersionObject();
-        if (is_object($v)) {
-            $comments = $c->getVersionObject()->getVersionComments();
+        if ($c && !$c->isError()) {
+            $link = Loader::helper('navigation')->getLinkToCollection($c, true);
+            $v = $c->getVersionObject();
+            if (is_object($v)) {
+                $comments = $c->getVersionObject()->getVersionComments();
 
-            if (!$this->isNewPageRequest()) {
-                // new version of existing page
-                $d->setEmailDescription(t("\"%s\" has pending changes and needs to be approved.\n\nVersion Comments: %s\n\nView the page here: %s.",
-                    $c->getCollectionName(), $comments, $link));
-                $d->setDescription(t("Version %s of Page <a target=\"_blank\" href=\"%s\">%s</a> submitted for Approval.", $this->cvID, $link,
-                    $c->getCollectionName()));
-                $d->setInContextDescription(t("Page Version %s Submitted for Approval.", $this->cvID));
-                $d->setShortStatus(t("Pending Approval"));
-            } else {
-                // Completely new page.
-                $d->setEmailDescription(t("New page created: \"%s\". This page requires approval.\n\nAuthor Comments: %s\n\nView the page here: %s.",
-                    $c->getCollectionName(), $comments, $link));
-                $d->setDescription(t("New Page: <a target=\"_blank\" href=\"%s\">%s</a>", $link, $c->getCollectionName()));
-                $d->setInContextDescription(t("New Page %s submitted for approval.", $this->cvID));
-                $d->setShortStatus(t("New Page"));
+                if (!$this->isNewPageRequest()) {
+                    // new version of existing page
+                    $d->setEmailDescription(t("\"%s\" has pending changes and needs to be approved.\n\nVersion Comments: %s\n\nView the page here: %s.",
+                        $c->getCollectionName(), $comments, $link));
+                    $d->setDescription(t("Version %s of Page <a target=\"_blank\" href=\"%s\">%s</a> submitted for Approval.", $this->cvID, $link,
+                        $c->getCollectionName()));
+                    $d->setInContextDescription(t("Page Version %s Submitted for Approval.", $this->cvID));
+                    $d->setShortStatus(t("Pending Approval"));
+                } else {
+                    // Completely new page.
+                    $d->setEmailDescription(t("New page created: \"%s\". This page requires approval.\n\nAuthor Comments: %s\n\nView the page here: %s.",
+                        $c->getCollectionName(), $comments, $link));
+                    $d->setDescription(t("New Page: <a target=\"_blank\" href=\"%s\">%s</a>", $link, $c->getCollectionName()));
+                    $d->setInContextDescription(t("New Page %s submitted for approval.", $this->cvID));
+                    $d->setShortStatus(t("New Page"));
+                }
             }
+        } else {
+            $d->setEmailDescription(t('Deleted Page.'));
+            $d->setDescription(t('Deleted Page.'));
+            $d->setInContextDescription(t('Deleted Page.'));
+            $d->setShortStatus(t('Deleted Page.'));
         }
 
         return $d;

--- a/concrete/src/Workflow/Request/ApprovePageRequest.php
+++ b/concrete/src/Workflow/Request/ApprovePageRequest.php
@@ -5,7 +5,6 @@ use Concrete\Core\Page\Collection\Version\Version as CollectionVersion;
 use Concrete\Core\Page\Page;
 use HtmlObject\Element;
 use Workflow;
-use Loader;
 use Concrete\Core\Workflow\Description as WorkflowDescription;
 use Permissions;
 use PermissionKey;
@@ -18,6 +17,7 @@ use Concrete\Core\Workflow\Progress\Response as WorkflowProgressResponse;
 class ApprovePageRequest extends PageRequest
 {
     protected $wrStatusNum = 30;
+    protected $cvID;
     private $isScheduled = false;
     private $cvPublishDate;
     private $cvPublishEndDate;
@@ -54,12 +54,12 @@ class ApprovePageRequest extends PageRequest
     public function getWorkflowRequestDescriptionObject()
     {
         $d = new WorkflowDescription();
-        $c = Page::getByID($this->cID, 'RECENT');
+        $c = Page::getByID($this->cID, $this->cvID);
         if ($c && !$c->isError()) {
             $link = $c->getCollectionLink();
-            $v = CollectionVersion::get($c, $this->cvID);
+            $v = $c->getVersionObject();
             if (is_object($v) && !$v->isError()) {
-                $comments = $c->getVersionObject()->getVersionComments();
+                $comments = $v->getVersionComments();
 
                 if (!$this->isNewPageRequest()) {
                     // new version of existing page
@@ -78,10 +78,10 @@ class ApprovePageRequest extends PageRequest
                     $d->setShortStatus(t("New Page"));
                 }
             } else {
-                $d->setEmailDescription(t('Deleted Version.'));
-                $d->setDescription(t('Deleted Version.'));
-                $d->setInContextDescription(t('Deleted Version.'));
-                $d->setShortStatus(t('Deleted Version.'));
+                $d->setEmailDescription(t('Deleted Page Version.'));
+                $d->setDescription(t('Deleted Page Version.'));
+                $d->setInContextDescription(t('Deleted Page Version.'));
+                $d->setShortStatus(t('Deleted Page Version.'));
             }
         } else {
             $d->setEmailDescription(t('Deleted Page.'));

--- a/concrete/src/Workflow/Request/ApproveStackRequest.php
+++ b/concrete/src/Workflow/Request/ApproveStackRequest.php
@@ -1,10 +1,11 @@
 <?php
+
 namespace Concrete\Core\Workflow\Request;
 
+use Concrete\Core\Page\Collection\Version\Version as CollectionVersion;
+use Concrete\Core\Page\Stack\Stack;
+use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\Workflow\Progress\Progress as WorkflowProgress;
-use CollectionVersion;
-use Events;
-use Stack;
 use Concrete\Core\Workflow\Progress\Response as WorkflowProgressResponse;
 
 class ApproveStackRequest extends ApprovePageRequest
@@ -17,12 +18,14 @@ class ApproveStackRequest extends ApprovePageRequest
         if ($s->getStackName() != $v->getVersionName()) {
             // The stack name has changed so we need to
             // update that for the stack object as well.
-            $s->update(array('stackName' => $v->getVersionName()));
+            $s->update(['stackName' => $v->getVersionName()]);
         }
 
         $ev = new \Concrete\Core\Page\Collection\Version\Event($s);
         $ev->setCollectionVersionObject($v);
-        Events::dispatch('on_page_version_submit_approve', $ev);
+
+        $app = Application::getFacadeApplication();
+        $app['director']->dispatch('on_page_version_submit_approve', $ev);
 
         $wpr = new WorkflowProgressResponse();
         $wpr->setWorkflowProgressResponseURL(\URL::to($s));

--- a/concrete/src/Workflow/Request/ChangePagePermissionsInheritanceRequest.php
+++ b/concrete/src/Workflow/Request/ChangePagePermissionsInheritanceRequest.php
@@ -1,15 +1,18 @@
 <?php
+
 namespace Concrete\Core\Workflow\Request;
 
 use Concrete\Core\Page\Page;
+use Concrete\Core\Permission\Key\Key as PermissionKey;
 use Concrete\Core\Workflow\Description as WorkflowDescription;
-use PermissionKey;
 use Concrete\Core\Workflow\Progress\Progress as WorkflowProgress;
 use Concrete\Core\Workflow\Progress\Response as WorkflowProgressResponse;
 
 class ChangePagePermissionsInheritanceRequest extends PageRequest
 {
     protected $wrStatusNum = 30;
+
+    protected $inheritance;
 
     public function __construct()
     {
@@ -33,10 +36,10 @@ class ChangePagePermissionsInheritanceRequest extends PageRequest
         $c = Page::getByID($this->cID, 'ACTIVE');
         if ($c && !$c->isError()) {
             $link = $c->getCollectionLink();
-            $d->setEmailDescription(t("\"%s\" has pending permission inheritance. View the page here: %s.", $c->getCollectionName(), $link));
-            $d->setInContextDescription(t("Page Submitted to Change Permission Inheritance to %s.", ucfirst(strtolower($this->inheritance))));
-            $d->setDescription(t("<a href=\"%s\">%s</a> submitted to change permission inheritance to %s.", $link, $c->getCollectionName(), ucfirst(strtolower($this->inheritance))));
-            $d->setShortStatus(t("Permission Inheritance Changes"));
+            $d->setEmailDescription(t('"%s" has pending permission inheritance. View the page here: %s.', $c->getCollectionName(), $link));
+            $d->setInContextDescription(t('Page Submitted to Change Permission Inheritance to %s.', ucfirst(strtolower($this->inheritance))));
+            $d->setDescription(t('<a href="%s">%s</a> submitted to change permission inheritance to %s.', $link, $c->getCollectionName(), ucfirst(strtolower($this->inheritance))));
+            $d->setShortStatus(t('Permission Inheritance Changes'));
         } else {
             $d->setEmailDescription(t('Deleted page.'));
             $d->setInContextDescription(t('Deleted page.'));

--- a/concrete/src/Workflow/Request/ChangePagePermissionsInheritanceRequest.php
+++ b/concrete/src/Workflow/Request/ChangePagePermissionsInheritanceRequest.php
@@ -1,8 +1,7 @@
 <?php
 namespace Concrete\Core\Workflow\Request;
 
-use Loader;
-use Page;
+use Concrete\Core\Page\Page;
 use Concrete\Core\Workflow\Description as WorkflowDescription;
 use PermissionKey;
 use Concrete\Core\Workflow\Progress\Progress as WorkflowProgress;
@@ -32,11 +31,18 @@ class ChangePagePermissionsInheritanceRequest extends PageRequest
     {
         $d = new WorkflowDescription();
         $c = Page::getByID($this->cID, 'ACTIVE');
-        $link = Loader::helper('navigation')->getLinkToCollection($c, true);
-        $d->setEmailDescription(t("\"%s\" has pending permission inheritance. View the page here: %s.", $c->getCollectionName(), $link));
-        $d->setInContextDescription(t("Page Submitted to Change Permission Inheritance to %s.", ucfirst(strtolower($this->inheritance))));
-        $d->setDescription(t("<a href=\"%s\">%s</a> submitted to change permission inheritance to %s.", $link, $c->getCollectionName(), ucfirst(strtolower($this->inheritance))));
-        $d->setShortStatus(t("Permission Inheritance Changes"));
+        if ($c && !$c->isError()) {
+            $link = $c->getCollectionLink();
+            $d->setEmailDescription(t("\"%s\" has pending permission inheritance. View the page here: %s.", $c->getCollectionName(), $link));
+            $d->setInContextDescription(t("Page Submitted to Change Permission Inheritance to %s.", ucfirst(strtolower($this->inheritance))));
+            $d->setDescription(t("<a href=\"%s\">%s</a> submitted to change permission inheritance to %s.", $link, $c->getCollectionName(), ucfirst(strtolower($this->inheritance))));
+            $d->setShortStatus(t("Permission Inheritance Changes"));
+        } else {
+            $d->setEmailDescription(t('Deleted page.'));
+            $d->setInContextDescription(t('Deleted page.'));
+            $d->setDescription(t('Deleted page.'));
+            $d->setShortStatus(t('Deleted page.'));
+        }
 
         return $d;
     }

--- a/concrete/src/Workflow/Request/ChangePagePermissionsRequest.php
+++ b/concrete/src/Workflow/Request/ChangePagePermissionsRequest.php
@@ -1,9 +1,8 @@
 <?php
 namespace Concrete\Core\Workflow\Request;
 
+use Concrete\Core\Page\Page;
 use Workflow;
-use Loader;
-use Page;
 use Concrete\Core\Workflow\Description as WorkflowDescription;
 use Permissions;
 use PermissionKey;
@@ -38,11 +37,18 @@ class ChangePagePermissionsRequest extends PageRequest
     {
         $d = new WorkflowDescription();
         $c = Page::getByID($this->cID, 'ACTIVE');
-        $link = Loader::helper('navigation')->getLinkToCollection($c, true);
-        $d->setEmailDescription(t("\"%s\" has pending permission changes. View the page here: %s.", $c->getCollectionName(), $link));
-        $d->setInContextDescription(t("Page Submitted for Permission Changes."));
-        $d->setDescription(t("<a href=\"%s\">%s</a> submitted for Permission Changes.", $link, $c->getCollectionName()));
-        $d->setShortStatus(t("Permission Changes"));
+        if ($c && !$c->isError()) {
+            $link = $c->getCollectionLink();
+            $d->setEmailDescription(t("\"%s\" has pending permission changes. View the page here: %s.", $c->getCollectionName(), $link));
+            $d->setInContextDescription(t("Page Submitted for Permission Changes."));
+            $d->setDescription(t("<a href=\"%s\">%s</a> submitted for Permission Changes.", $link, $c->getCollectionName()));
+            $d->setShortStatus(t("Permission Changes"));
+        } else {
+            $d->setEmailDescription(t('Deleted page.'));
+            $d->setInContextDescription(t('Deleted page.'));
+            $d->setDescription(t('Deleted page.'));
+            $d->setShortStatus(t('Deleted page.'));
+        }
 
         return $d;
     }

--- a/concrete/src/Workflow/Request/ChangePagePermissionsRequest.php
+++ b/concrete/src/Workflow/Request/ChangePagePermissionsRequest.php
@@ -1,21 +1,22 @@
 <?php
+
 namespace Concrete\Core\Workflow\Request;
 
 use Concrete\Core\Page\Page;
-use Workflow;
-use Concrete\Core\Workflow\Description as WorkflowDescription;
-use Permissions;
-use PermissionKey;
-use Concrete\Core\Workflow\Progress\Progress as WorkflowProgress;
 use Concrete\Core\Permission\Access\Access as PermissionAccess;
-use Concrete\Core\Workflow\Progress\Action\Action as WorkflowProgressAction;
-use Concrete\Core\Workflow\Progress\Response as WorkflowProgressResponse;
+use Concrete\Core\Permission\Key\Key as PermissionKey;
 use Concrete\Core\Permission\Set as PermissionSet;
 use Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface;
+use Concrete\Core\Workflow\Description as WorkflowDescription;
+use Concrete\Core\Workflow\Progress\Action\Action as WorkflowProgressAction;
+use Concrete\Core\Workflow\Progress\Progress as WorkflowProgress;
+use Concrete\Core\Workflow\Progress\Response as WorkflowProgressResponse;
 
 class ChangePagePermissionsRequest extends PageRequest
 {
     protected $wrStatusNum = 30;
+
+    protected $permissionSet;
 
     public function __construct()
     {
@@ -39,10 +40,10 @@ class ChangePagePermissionsRequest extends PageRequest
         $c = Page::getByID($this->cID, 'ACTIVE');
         if ($c && !$c->isError()) {
             $link = $c->getCollectionLink();
-            $d->setEmailDescription(t("\"%s\" has pending permission changes. View the page here: %s.", $c->getCollectionName(), $link));
-            $d->setInContextDescription(t("Page Submitted for Permission Changes."));
-            $d->setDescription(t("<a href=\"%s\">%s</a> submitted for Permission Changes.", $link, $c->getCollectionName()));
-            $d->setShortStatus(t("Permission Changes"));
+            $d->setEmailDescription(t('"%s" has pending permission changes. View the page here: %s.', $c->getCollectionName(), $link));
+            $d->setInContextDescription(t('Page Submitted for Permission Changes.'));
+            $d->setDescription(t('<a href="%s">%s</a> submitted for Permission Changes.', $link, $c->getCollectionName()));
+            $d->setShortStatus(t('Permission Changes'));
         } else {
             $d->setEmailDescription(t('Deleted page.'));
             $d->setInContextDescription(t('Deleted page.'));
@@ -75,7 +76,7 @@ class ChangePagePermissionsRequest extends PageRequest
 
     public function getWorkflowRequestAdditionalActions(WorkflowProgress $wp)
     {
-        $buttons = array();
+        $buttons = [];
         $w = $wp->getWorkflowObject();
         if ($w->canApproveWorkflowProgressObject($wp)) {
             $c = Page::getByID($this->cID, 'ACTIVE');

--- a/concrete/src/Workflow/Request/ChangeSubpageDefaultsInheritanceRequest.php
+++ b/concrete/src/Workflow/Request/ChangeSubpageDefaultsInheritanceRequest.php
@@ -1,8 +1,7 @@
 <?php
 namespace Concrete\Core\Workflow\Request;
 
-use Loader;
-use Page;
+use Concrete\Core\Page\Page;
 use Concrete\Core\Workflow\Description as WorkflowDescription;
 use Permissions;
 use PermissionKey;
@@ -33,15 +32,22 @@ class ChangeSubpageDefaultsInheritanceRequest extends PageRequest
     {
         $d = new WorkflowDescription();
         $c = Page::getByID($this->cID, 'ACTIVE');
-        $link = Loader::helper('navigation')->getLinkToCollection($c, true);
-        $d->setEmailDescription(t("\"%s\" has pending sub-page permission inhiterance changes. View the page here: %s.", $c->getCollectionName(), $link));
-        if ($this->inheritance == 0) {
-            $d->setInContextDescription(t("Sub-pages pending change to inherit permissions from page type."));
+        if ($c && !$c->isError()) {
+            $link = $c->getCollectionLink();
+            $d->setEmailDescription(t("\"%s\" has pending sub-page permission inhiterance changes. View the page here: %s.", $c->getCollectionName(), $link));
+            if ($this->inheritance == 0) {
+                $d->setInContextDescription(t("Sub-pages pending change to inherit permissions from page type."));
+            } else {
+                $d->setInContextDescription(t("Sub-pages pending change to inherit permissions from parent."));
+            }
+            $d->setDescription(t("<a href=\"%s\">%s</a> has pending sub-page permission inhiterance changes.", $link, $c->getCollectionName()));
+            $d->setShortStatus(t("Sub-Page Inheritance Changes"));
         } else {
-            $d->setInContextDescription(t("Sub-pages pending change to inherit permissions from parent."));
+            $d->setEmailDescription(t('Deleted page.'));
+            $d->setInContextDescription(t('Deleted page.'));
+            $d->setDescription(t('Deleted page.'));
+            $d->setShortStatus(t('Deleted page.'));
         }
-        $d->setDescription(t("<a href=\"%s\">%s</a> has pending sub-page permission inhiterance changes.", $link, $c->getCollectionName()));
-        $d->setShortStatus(t("Sub-Page Inheritance Changes"));
 
         return $d;
     }

--- a/concrete/src/Workflow/Request/ChangeSubpageDefaultsInheritanceRequest.php
+++ b/concrete/src/Workflow/Request/ChangeSubpageDefaultsInheritanceRequest.php
@@ -1,16 +1,18 @@
 <?php
+
 namespace Concrete\Core\Workflow\Request;
 
 use Concrete\Core\Page\Page;
+use Concrete\Core\Permission\Key\Key as PermissionKey;
 use Concrete\Core\Workflow\Description as WorkflowDescription;
-use Permissions;
-use PermissionKey;
 use Concrete\Core\Workflow\Progress\Progress as WorkflowProgress;
 use Concrete\Core\Workflow\Progress\Response as WorkflowProgressResponse;
 
 class ChangeSubpageDefaultsInheritanceRequest extends PageRequest
 {
     protected $wrStatusNum = 30;
+
+    protected $inheritance;
 
     public function __construct()
     {
@@ -34,14 +36,14 @@ class ChangeSubpageDefaultsInheritanceRequest extends PageRequest
         $c = Page::getByID($this->cID, 'ACTIVE');
         if ($c && !$c->isError()) {
             $link = $c->getCollectionLink();
-            $d->setEmailDescription(t("\"%s\" has pending sub-page permission inhiterance changes. View the page here: %s.", $c->getCollectionName(), $link));
+            $d->setEmailDescription(t('"%s" has pending sub-page permission inhiterance changes. View the page here: %s.', $c->getCollectionName(), $link));
             if ($this->inheritance == 0) {
-                $d->setInContextDescription(t("Sub-pages pending change to inherit permissions from page type."));
+                $d->setInContextDescription(t('Sub-pages pending change to inherit permissions from page type.'));
             } else {
-                $d->setInContextDescription(t("Sub-pages pending change to inherit permissions from parent."));
+                $d->setInContextDescription(t('Sub-pages pending change to inherit permissions from parent.'));
             }
-            $d->setDescription(t("<a href=\"%s\">%s</a> has pending sub-page permission inhiterance changes.", $link, $c->getCollectionName()));
-            $d->setShortStatus(t("Sub-Page Inheritance Changes"));
+            $d->setDescription(t('<a href="%s">%s</a> has pending sub-page permission inhiterance changes.', $link, $c->getCollectionName()));
+            $d->setShortStatus(t('Sub-Page Inheritance Changes'));
         } else {
             $d->setEmailDescription(t('Deleted page.'));
             $d->setInContextDescription(t('Deleted page.'));

--- a/concrete/src/Workflow/Request/DeletePageRequest.php
+++ b/concrete/src/Workflow/Request/DeletePageRequest.php
@@ -1,9 +1,9 @@
 <?php
 namespace Concrete\Core\Workflow\Request;
 
+use Concrete\Core\Page\Page;
 use Config;
 use Loader;
-use Page;
 use Stack;
 use Concrete\Core\Workflow\Description as WorkflowDescription;
 use PermissionKey;
@@ -25,15 +25,22 @@ class DeletePageRequest extends PageRequest
     {
         $d = new WorkflowDescription();
         $c = Page::getByID($this->cID, 'ACTIVE');
-        $item = t('page');
-        if ($c->getPageTypeHandle() == STACKS_PAGE_TYPE) {
-            $item = t('stack');
+        if ($c && !$c->isError()) {
+            $item = t('page');
+            if ($c->getPageTypeHandle() == STACKS_PAGE_TYPE) {
+                $item = t('stack');
+            }
+            $link = $c->getCollectionLink();
+            $d->setEmailDescription(t("\"%s\" has been marked for deletion. View the page here: %s.", $c->getCollectionName(), $link));
+            $d->setInContextDescription(t("This %s has been marked for deletion. ", $item));
+            $d->setDescription(t("<a href=\"%s\">%s</a> has been marked for deletion. ", $link, $c->getCollectionName()));
+            $d->setShortStatus(t("Pending Delete"));
+        } else {
+            $d->setEmailDescription(t('Deleted page.'));
+            $d->setInContextDescription(t('Deleted page.'));
+            $d->setDescription(t('Deleted page.'));
+            $d->setShortStatus(t('Deleted page.'));
         }
-        $link = Loader::helper('navigation')->getLinkToCollection($c, true);
-        $d->setEmailDescription(t("\"%s\" has been marked for deletion. View the page here: %s.", $c->getCollectionName(), $link));
-        $d->setInContextDescription(t("This %s has been marked for deletion. ", $item));
-        $d->setDescription(t("<a href=\"%s\">%s</a> has been marked for deletion. ", $link, $c->getCollectionName()));
-        $d->setShortStatus(t("Pending Delete"));
 
         return $d;
     }

--- a/concrete/src/Workflow/Request/DeletePageRequest.php
+++ b/concrete/src/Workflow/Request/DeletePageRequest.php
@@ -1,14 +1,13 @@
 <?php
+
 namespace Concrete\Core\Workflow\Request;
 
 use Concrete\Core\Page\Page;
-use Config;
-use Loader;
-use Stack;
+use Concrete\Core\Page\Stack\Stack;
+use Concrete\Core\Permission\Key\Key as PermissionKey;
+use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\Workflow\Description as WorkflowDescription;
-use PermissionKey;
 use Concrete\Core\Workflow\Progress\Progress as WorkflowProgress;
-use URL;
 use Concrete\Core\Workflow\Progress\Response as WorkflowProgressResponse;
 
 class DeletePageRequest extends PageRequest
@@ -31,10 +30,10 @@ class DeletePageRequest extends PageRequest
                 $item = t('stack');
             }
             $link = $c->getCollectionLink();
-            $d->setEmailDescription(t("\"%s\" has been marked for deletion. View the page here: %s.", $c->getCollectionName(), $link));
-            $d->setInContextDescription(t("This %s has been marked for deletion. ", $item));
-            $d->setDescription(t("<a href=\"%s\">%s</a> has been marked for deletion. ", $link, $c->getCollectionName()));
-            $d->setShortStatus(t("Pending Delete"));
+            $d->setEmailDescription(t('"%s" has been marked for deletion. View the page here: %s.', $c->getCollectionName(), $link));
+            $d->setInContextDescription(t('This %s has been marked for deletion. ', $item));
+            $d->setDescription(t('<a href="%s">%s</a> has been marked for deletion. ', $link, $c->getCollectionName()));
+            $d->setShortStatus(t('Pending Delete'));
         } else {
             $d->setEmailDescription(t('Deleted page.'));
             $d->setInContextDescription(t('Deleted page.'));
@@ -72,13 +71,14 @@ class DeletePageRequest extends PageRequest
             $c = Stack::getByID($this->getRequestedPageID());
             $c->delete();
             $wpr = new WorkflowProgressResponse();
-            $wpr->setWorkflowProgressResponseURL(URL::to(STACKS_LISTING_PAGE_PATH, 'stack_deleted'));
+            $wpr->setWorkflowProgressResponseURL(\URL::to(STACKS_LISTING_PAGE_PATH, 'stack_deleted'));
 
             return $wpr;
         }
 
         $cParentID = $c->getCollectionParentID();
-        if (Config::get('concrete.misc.enable_trash_can')) {
+        $app = Application::getFacadeApplication();
+        if ($app['config']->get('concrete.misc.enable_trash_can')) {
             $c->moveToTrash();
         } else {
             $c->delete();

--- a/concrete/src/Workflow/Request/MovePageRequest.php
+++ b/concrete/src/Workflow/Request/MovePageRequest.php
@@ -1,15 +1,17 @@
 <?php
+
 namespace Concrete\Core\Workflow\Request;
 
 use Concrete\Core\Page\Page;
+use Concrete\Core\Permission\Key\Key as PermissionKey;
 use Concrete\Core\Workflow\Description as WorkflowDescription;
-use PermissionKey;
 use Concrete\Core\Workflow\Progress\Progress as WorkflowProgress;
 use Concrete\Core\Workflow\Progress\Response as WorkflowProgressResponse;
 
 class MovePageRequest extends PageRequest
 {
     protected $targetCID;
+
     protected $wrStatusNum = 50;
 
     public function __construct()
@@ -41,10 +43,10 @@ class MovePageRequest extends PageRequest
         if ($c && $target && !$c->isError() && !$target->isError()) {
             $link = $c->getCollectionLink();
             $targetLink = $target->getCollectionLink();
-            $d->setEmailDescription(t("\"%s\" is pending a move to beneath \"%s\". Source Page: %s. Target Page: %s.", $c->getCollectionName(), $target->getCollectionName(), $link, $targetLink));
-            $d->setInContextDescription(t("This page is pending a move beneath <strong><a href=\"%s\">%s</a></strong>. ", $targetLink, $target->getCollectionName()));
-            $d->setDescription(t("<a href=\"%s\">%s</a> is pending a move beneath <strong><a href=\"%s\">%s</a></strong>. ", $link, $c->getCollectionName(), $targetLink, $target->getCollectionName()));
-            $d->setShortStatus(t("Pending Move"));
+            $d->setEmailDescription(t('"%s" is pending a move to beneath "%s". Source Page: %s. Target Page: %s.', $c->getCollectionName(), $target->getCollectionName(), $link, $targetLink));
+            $d->setInContextDescription(t('This page is pending a move beneath <strong><a href="%s">%s</a></strong>. ', $targetLink, $target->getCollectionName()));
+            $d->setDescription(t('<a href="%s">%s</a> is pending a move beneath <strong><a href="%s">%s</a></strong>. ', $link, $c->getCollectionName(), $targetLink, $target->getCollectionName()));
+            $d->setShortStatus(t('Pending Move'));
         } else {
             $d->setEmailDescription(t('Deleted page.'));
             $d->setInContextDescription(t('Deleted page.'));

--- a/concrete/src/Workflow/Request/MovePageRequest.php
+++ b/concrete/src/Workflow/Request/MovePageRequest.php
@@ -1,8 +1,7 @@
 <?php
 namespace Concrete\Core\Workflow\Request;
 
-use Loader;
-use Page;
+use Concrete\Core\Page\Page;
 use Concrete\Core\Workflow\Description as WorkflowDescription;
 use PermissionKey;
 use Concrete\Core\Workflow\Progress\Progress as WorkflowProgress;
@@ -39,12 +38,19 @@ class MovePageRequest extends PageRequest
         $d = new WorkflowDescription();
         $c = Page::getByID($this->cID, 'ACTIVE');
         $target = Page::getByID($this->targetCID, 'ACTIVE');
-        $link = Loader::helper('navigation')->getLinkToCollection($c, true);
-        $targetLink = Loader::helper('navigation')->getLinkToCollection($target, true);
-        $d->setEmailDescription(t("\"%s\" is pending a move to beneath \"%s\". Source Page: %s. Target Page: %s.", $c->getCollectionName(), $target->getCollectionName(), $link, $targetLink));
-        $d->setInContextDescription(t("This page is pending a move beneath <strong><a href=\"%s\">%s</a></strong>. ", $targetLink, $target->getCollectionName()));
-        $d->setDescription(t("<a href=\"%s\">%s</a> is pending a move beneath <strong><a href=\"%s\">%s</a></strong>. ", $link, $c->getCollectionName(), $targetLink, $target->getCollectionName()));
-        $d->setShortStatus(t("Pending Move"));
+        if ($c && $target && !$c->isError() && !$target->isError()) {
+            $link = $c->getCollectionLink();
+            $targetLink = $target->getCollectionLink();
+            $d->setEmailDescription(t("\"%s\" is pending a move to beneath \"%s\". Source Page: %s. Target Page: %s.", $c->getCollectionName(), $target->getCollectionName(), $link, $targetLink));
+            $d->setInContextDescription(t("This page is pending a move beneath <strong><a href=\"%s\">%s</a></strong>. ", $targetLink, $target->getCollectionName()));
+            $d->setDescription(t("<a href=\"%s\">%s</a> is pending a move beneath <strong><a href=\"%s\">%s</a></strong>. ", $link, $c->getCollectionName(), $targetLink, $target->getCollectionName()));
+            $d->setShortStatus(t("Pending Move"));
+        } else {
+            $d->setEmailDescription(t('Deleted page.'));
+            $d->setInContextDescription(t('Deleted page.'));
+            $d->setDescription(t('Deleted page.'));
+            $d->setShortStatus(t('Deleted page.'));
+        }
 
         return $d;
     }

--- a/concrete/src/Workflow/Request/PageRequest.php
+++ b/concrete/src/Workflow/Request/PageRequest.php
@@ -1,13 +1,14 @@
 <?php
+
 namespace Concrete\Core\Workflow\Request;
 
 use Concrete\Core\Page\Page;
-use Concrete\Core\Workflow\Workflow;
-use HtmlObject\Element;
-use PermissionKey;
+use Concrete\Core\Permission\Key\Key as PermissionKey;
+use Concrete\Core\Workflow\Progress\PageProgress as PageWorkflowProgress;
 use Concrete\Core\Workflow\Progress\Progress as WorkflowProgress;
 use Concrete\Core\Workflow\Progress\Response as WorkflowProgressResponse;
-use Concrete\Core\Workflow\Progress\PageProgress as PageWorkflowProgress;
+use Concrete\Core\Workflow\Workflow;
+use HtmlObject\Element;
 
 abstract class PageRequest extends Request
 {
@@ -70,8 +71,7 @@ abstract class PageRequest extends Request
     {
         $span = new Element('i');
         $span->addClass('fas fa-file-alt');
+
         return $span;
     }
-
-
 }

--- a/concrete/src/Workflow/Request/PageRequest.php
+++ b/concrete/src/Workflow/Request/PageRequest.php
@@ -1,9 +1,9 @@
 <?php
 namespace Concrete\Core\Workflow\Request;
 
+use Concrete\Core\Page\Page;
 use Concrete\Core\Workflow\Workflow;
 use HtmlObject\Element;
-use Page;
 use PermissionKey;
 use Concrete\Core\Workflow\Progress\Progress as WorkflowProgress;
 use Concrete\Core\Workflow\Progress\Response as WorkflowProgressResponse;
@@ -11,6 +11,8 @@ use Concrete\Core\Workflow\Progress\PageProgress as PageWorkflowProgress;
 
 abstract class PageRequest extends Request
 {
+    protected $cID;
+
     public function setRequestedPage($c)
     {
         $cID = ($c->getCollectionPointerOriginalID() > 0) ? $c->getCollectionPointerOriginalID() : $c->getCollectionID();

--- a/concrete/src/Workflow/Request/UnapprovePageRequest.php
+++ b/concrete/src/Workflow/Request/UnapprovePageRequest.php
@@ -1,21 +1,20 @@
 <?php
+
 namespace Concrete\Core\Workflow\Request;
 
+use Concrete\Core\Page\Collection\Version\Version as CollectionVersion;
 use Concrete\Core\Page\Page;
-use HtmlObject\Element;
-use Workflow;
+use Concrete\Core\Permission\Key\Key as PermissionKey;
+use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\Workflow\Description as WorkflowDescription;
-use Permissions;
-use PermissionKey;
 use Concrete\Core\Workflow\Progress\Progress as WorkflowProgress;
-use CollectionVersion;
-use Events;
-use Concrete\Core\Workflow\Progress\Action\Action as WorkflowProgressAction;
 use Concrete\Core\Workflow\Progress\Response as WorkflowProgressResponse;
+use HtmlObject\Element;
 
 class UnapprovePageRequest extends PageRequest
 {
     protected $wrStatusNum = 30;
+
     protected $cvID;
 
     public function __construct()
@@ -43,9 +42,9 @@ class UnapprovePageRequest extends PageRequest
             $v = $c->getVersionObject();
             if (is_object($v) && !$v->isError()) {
                 $d->setEmailDescription(t("Page unapproval requested for page: \"%s\".\n\nView the page here: %s.", $c->getCollectionName(), $link));
-                $d->setDescription(t("Page %s submitted for unapproval.", '<a target="_blank" href="' . $c->getCollectionLink() . '">' . $c->getCollectionName() . '</a>'));
-                $d->setInContextDescription(t("Page %s submitted for unapproval.", $c->getCollectionName()));
-                $d->setShortStatus(t("Page Version Unapproval"));
+                $d->setDescription(t('Page %s submitted for unapproval.', '<a target="_blank" href="' . $c->getCollectionLink() . '">' . $c->getCollectionName() . '</a>'));
+                $d->setInContextDescription(t('Page %s submitted for unapproval.', $c->getCollectionName()));
+                $d->setShortStatus(t('Page Version Unapproval'));
             } else {
                 $d->setEmailDescription(t('Deleted Page Version.'));
                 $d->setInContextDescription(t('Deleted Page Version.'));
@@ -93,6 +92,7 @@ class UnapprovePageRequest extends PageRequest
     {
         $span = new Element('i');
         $span->addClass('fas fa-thumbs-down');
+
         return $span;
     }
 
@@ -105,7 +105,9 @@ class UnapprovePageRequest extends PageRequest
 
             $ev = new \Concrete\Core\Page\Collection\Version\Event($c);
             $ev->setCollectionVersionObject($v);
-            Events::dispatch('on_page_version_submit_deny', $ev);
+
+            $app = Application::getFacadeApplication();
+            $app['director']->dispatch('on_page_version_submit_deny', $ev);
 
             $wpr = new WorkflowProgressResponse();
             $wpr->setWorkflowProgressResponseURL(\URL::to($c));
@@ -113,6 +115,4 @@ class UnapprovePageRequest extends PageRequest
             return $wpr;
         }
     }
-
-
 }

--- a/concrete/src/Workflow/Request/UnapprovePageRequest.php
+++ b/concrete/src/Workflow/Request/UnapprovePageRequest.php
@@ -1,10 +1,9 @@
 <?php
 namespace Concrete\Core\Workflow\Request;
 
+use Concrete\Core\Page\Page;
 use HtmlObject\Element;
 use Workflow;
-use Loader;
-use Page;
 use Concrete\Core\Workflow\Description as WorkflowDescription;
 use Permissions;
 use PermissionKey;
@@ -17,6 +16,7 @@ use Concrete\Core\Workflow\Progress\Response as WorkflowProgressResponse;
 class UnapprovePageRequest extends PageRequest
 {
     protected $wrStatusNum = 30;
+    protected $cvID;
 
     public function __construct()
     {
@@ -38,13 +38,25 @@ class UnapprovePageRequest extends PageRequest
     {
         $d = new WorkflowDescription();
         $c = Page::getByID($this->cID, $this->cvID);
-        $link = Loader::helper('navigation')->getLinkToCollection($c, true);
-        $v = $c->getVersionObject();
-        if (is_object($v)) {
-            $d->setEmailDescription(t("Page unapproval requested for page: \"%s\".\n\nView the page here: %s.", $c->getCollectionName(), $link));
-            $d->setDescription(t("Page %s submitted for unapproval.", '<a target="_blank" href="' . $c->getCollectionLink() . '">' . $c->getCollectionName() . '</a>'));
-            $d->setInContextDescription(t("Page %s submitted for unapproval.", $c->getCollectionName()));
-            $d->setShortStatus(t("Page Version Unapproval"));
+        if ($c && !$c->isError()) {
+            $link = $c->getCollectionLink();
+            $v = $c->getVersionObject();
+            if (is_object($v) && !$v->isError()) {
+                $d->setEmailDescription(t("Page unapproval requested for page: \"%s\".\n\nView the page here: %s.", $c->getCollectionName(), $link));
+                $d->setDescription(t("Page %s submitted for unapproval.", '<a target="_blank" href="' . $c->getCollectionLink() . '">' . $c->getCollectionName() . '</a>'));
+                $d->setInContextDescription(t("Page %s submitted for unapproval.", $c->getCollectionName()));
+                $d->setShortStatus(t("Page Version Unapproval"));
+            } else {
+                $d->setEmailDescription(t('Deleted Page Version.'));
+                $d->setInContextDescription(t('Deleted Page Version.'));
+                $d->setDescription(t('Deleted Page Version.'));
+                $d->setShortStatus(t('Deleted Page Version.'));
+            }
+        } else {
+            $d->setEmailDescription(t('Deleted page.'));
+            $d->setInContextDescription(t('Deleted page.'));
+            $d->setDescription(t('Deleted page.'));
+            $d->setShortStatus(t('Deleted page.'));
         }
 
         return $d;


### PR DESCRIPTION
Fixes #11818

* Refactor `Version::get` to avoid Stash error
* Show "Deleted page" as a description for workflow requests when the requested page has already been deleted
  ![Screenshot 2023-12-03 at 21 48 03](https://github.com/concretecms/concretecms/assets/514294/510ef440-4ba1-4f6c-b089-aa61bf0df5e7)
* Delete uncompleted Workflow Progress data when the page is deleted
* Refactor Page Request classes (part of #9126)