### PR TITLE
Make thumbnails generated by Image Helper SEO-friendly

### DIFF
--- a/concrete/src/File/Image/BasicThumbnailer.php
+++ b/concrete/src/File/Image/BasicThumbnailer.php
@@ -308,6 +308,7 @@ class BasicThumbnailer implements ThumbnailerInterface, ApplicationAwareInterfac
         $version = null;
 
         $fh = $this->app->make('helper/file');
+        $th = $this->app->make('helper/text');
 
         $baseFilename = '';
         $extension = '';
@@ -317,6 +318,9 @@ class BasicThumbnailer implements ThumbnailerInterface, ApplicationAwareInterfac
                 $fID = $obj->getFileID();
                 $extension = $fh->getExtension($fr->getPath());
                 $baseFilename = md5(implode(':', [$fID, $maxWidth, $maxHeight, $crop, $fr->getTimestamp()]));
+                if ($obj->getTitle()) {
+                    $baseFilename = $th->sanitizeFileSystem(pathinfo($obj->getTitle(), PATHINFO_FILENAME)) . '-' . $baseFilename;
+                }
             } catch (Exception $e) {
                 $result = new \stdClass();
                 $result->src = '';


### PR DESCRIPTION
Currently, file name generated by Image helper is just a random hash string, for example:
`b84053bf3c244180e218f088ccf530e9.webp`

Lets grab Title from File object and change file name to more seo-friendly format:
`this-is-title-from-file-b84053bf3c244180e218f088ccf530e9.webp`

If you think, it's too disruptive (if you change File Title, new filename will be generated), I can add config items to enable/disable this behavior. But personally, I am always using this on my websites, since Titles are rarely changed after initial upload.

