### PR TITLE
Add Form Control popup - improvements

### DIFF
--- a/concrete/views/backend/page/type/composer/form/add_control.php
+++ b/concrete/views/backend/page/type/composer/form/add_control.php
@@ -36,6 +36,11 @@ defined('C5_EXECUTE') or die('Access Denied.');
                             <a href="#" data-control-type-id="<?= $type->getPageTypeComposerControlTypeID() ?>" data-control-identifier="<?= $control->getPageTypeComposerControlIdentifier() ?>">
                                 <?= $control->getPageTypeComposerControlIcon() ?>
                                 <?= $control->getPageTypeComposerControlDisplayName() ?>
+                                <?php if ($type->getPageTypeComposerControlTypeHandle() === 'collection_attribute') { ?>
+                                    <span class="text-muted small">
+                                        (<?= $control->getAttributeKeyObject()->getAttributeKeyHandle() ?>)
+                                    </span>
+                                <?php } ?>
                             </a>
                         </li>
                         <?php

--- a/concrete/views/backend/page/type/composer/form/add_control.php
+++ b/concrete/views/backend/page/type/composer/form/add_control.php
@@ -25,7 +25,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
         <?php
         foreach ($types as $index => $type) {
             ?>
-            <div class="tab-pane fade <?= $index == 0 ? 'active' : ''; ?> " id="<?= $type->getPageTypeComposerControlTypeHandle() ?>">
+            <div class="tab-pane fade <?= $index == 0 ? 'active show' : ''; ?> " id="<?= $type->getPageTypeComposerControlTypeHandle() ?>">
                 <input class="form-control ccm-input-text" type="text" name="attribute-search" placeholder="<?= t('Search attributes') ?>" />
                 <ul data-list="page-type-composer-control-type" class="item-select-list">
                     <?php


### PR DESCRIPTION
When adding custom attribute to Composer Form:

1. Fix blank screen on load.

![image](https://github.com/concretecms/concretecms/assets/33052836/fa1503c5-7d80-4fb5-8095-af92c0997456)

2. Display custom attribute handle next to name.

Attributes are not grouped by category in this list. 
So when using many attributes (especially with the same display name), it's hard to select proper attribute.
Displaying attribute handle helps a little with that.

![image](https://github.com/concretecms/concretecms/assets/33052836/af0eb22c-bf65-428b-8264-2075f94a19e1)
