### PR TITLE
Show entities development mode in Environment report

### DIFF
--- a/concrete/controllers/single_page/dashboard/system/environment/info.php
+++ b/concrete/controllers/single_page/dashboard/system/environment/info.php
@@ -43,6 +43,9 @@ class Info extends DashboardPageController
 # Concrete Cache Settings
 {$info->getCache()}
 
+# Database Entities Settings
+{$info->getEntities()}
+
 # Server Software
 {$info->getServerSoftware()}
 


### PR DESCRIPTION
Get the entities info from 
https://github.com/concretecms/concretecms/pull/11827

And insert it into the Environment report. I have added it just after the Cache report, which may be subject to other opinion on where it should be.

Its a separate pull because
a) I am not that good at GIT ;-)
b) The second part is more open to opinion/discussion
