### PR TITLE
CIF: add some missing attributes [v9]

### DIFF
--- a/concrete/config/install/packages/atomik_blank/content.xml
+++ b/concrete/config/install/packages/atomik_blank/content.xml
@@ -7,7 +7,7 @@
         <pagetemplate handle="full" name="Full" icon="full.png" package="" />
     </pagetemplates>
     <pagetypes>
-    <pagetype name="Page" handle="page" is-frequently-added="1" launch-in-composer="0">
+    <pagetype name="Page" handle="page" is-frequently-added="1" launch-in-composer="0" package="">
       <pagetemplates type="all" default="full"/>
       <target handle="all" package=""/>
       <composer>

--- a/concrete/config/install/packages/atomik_full/content.xml
+++ b/concrete/config/install/packages/atomik_full/content.xml
@@ -32,7 +32,7 @@
         <pagetemplate icon="two_column.png" name="Resource Detail" handle="resource_detail" package="" internal=""/>
     </pagetemplates>
     <pagetypes>
-        <pagetype name="Page" handle="page" is-frequently-added="1" launch-in-composer="0">
+        <pagetype name="Page" handle="page" is-frequently-added="1" launch-in-composer="0" package="">
             <pagetemplates type="all" default="full"/>
             <target handle="all" package=""/>
             <composer>
@@ -333,7 +333,7 @@
         <entity id="02e83926-0518-11ec-bb64-2d8e40952e25" handle="mailing_list" plural_handle="" name="Mailing List"
                 supports_custom_display_order="" include_in_public_list="" use_separate_site_result_buckets=""
                 description="" default_view_form="02e860ae-0518-11ec-bb64-2d8e40952e25"
-                default_edit_form="02e860ae-0518-11ec-bb64-2d8e40952e25" results-folder="/Forms">
+                default_edit_form="02e860ae-0518-11ec-bb64-2d8e40952e25" results-folder="/Forms" package="">
             <attributekeys>
                 <attributekey handle="email_address" name="Email Address" package="" searchable="1" indexed="1"
                               type="email" category=""/>
@@ -355,7 +355,7 @@
         </entity>
         <entity id="83ae65b1-79e8-4ded-bbca-e419bfd19bb6" handle="express_form_170" plural_handle="" name="Contact"
                 include_in_public_list="" description="" default_view_form="881b6bde-220f-4482-b8f9-ace40b5d169b"
-                default_edit_form="881b6bde-220f-4482-b8f9-ace40b5d169b" results-folder="/Forms">
+                default_edit_form="881b6bde-220f-4482-b8f9-ace40b5d169b" results-folder="/Forms" package="">
             <attributekeys>
                 <attributekey handle="contact_question_first_name" name="First Name" package="" searchable="1"
                               indexed="1" type="text" category="">

--- a/concrete/config/install/packages/elemental_full/content.xml
+++ b/concrete/config/install/packages/elemental_full/content.xml
@@ -67,7 +67,7 @@
         </attributekey>
     </attributekeys>
     <attributesets>
-        <attributeset handle="navigation" name="Navigation" category="collection">
+        <attributeset handle="navigation" name="Navigation" package="" category="collection">
             <attributekey handle="thumbnail"/>
             <attributekey handle="exclude_subpages_from_nav"/>
         </attributeset>
@@ -3087,7 +3087,7 @@
     <expressentities>
         <entity id="83ae65b1-79e8-4ded-bbca-e419bfd19bb6" handle="express_form_170" plural_handle="" name="Contact"
                 include_in_public_list="" description="" default_view_form="881b6bde-220f-4482-b8f9-ace40b5d169b"
-                default_edit_form="881b6bde-220f-4482-b8f9-ace40b5d169b" results-folder="/Forms">
+                default_edit_form="881b6bde-220f-4482-b8f9-ace40b5d169b" results-folder="/Forms" package="">
             <attributekeys>
                 <attributekey handle="contact_question_first_name" name="First Name" package="" searchable="1"
                               indexed="1" type="text" category="">
@@ -3156,7 +3156,7 @@
     </expressentities>
 
     <config>
-        <option name="concrete.calendar.topic_attribute">event_categories</option>
+        <option name="concrete.calendar.topic_attribute" package="">event_categories</option>
     </config>
 
 

--- a/concrete/config/install/upgrade/boards_containers.xml
+++ b/concrete/config/install/upgrade/boards_containers.xml
@@ -142,7 +142,7 @@
 
     <permissioncategories>
         <category handle="board" package=""/>
-        <category handle="board_admin" />
+        <category handle="board_admin" package=""/>
     </permissioncategories>
 
     <permissionkeys>
@@ -191,25 +191,25 @@
     </permissionkeys>
 
     <permissionaccessentitytypes>
-        <permissionaccessentitytype handle="group" package="">
+        <permissionaccessentitytype handle="group" name="Group" package="">
             <categories>
                 <category handle="board_admin" />
                 <category handle="board" />
             </categories>
         </permissionaccessentitytype>
-        <permissionaccessentitytype handle="user" package="">
+        <permissionaccessentitytype handle="user" name="User" package="">
             <categories>
                 <category handle="board_admin" />
                 <category handle="board" />
             </categories>
         </permissionaccessentitytype>
-        <permissionaccessentitytype handle="group_set" package="">
+        <permissionaccessentitytype handle="group_set" name="Group Set" package="">
             <categories>
                 <category handle="board_admin" />
                 <category handle="board" />
             </categories>
         </permissionaccessentitytype>
-        <permissionaccessentitytype handle="group_combination" package="">
+        <permissionaccessentitytype handle="group_combination" name="Group Combination" package="">
             <categories>
                 <category handle="board_admin" />
                 <category handle="board" />

--- a/concrete/config/install/upgrade/calendar.xml
+++ b/concrete/config/install/upgrade/calendar.xml
@@ -193,25 +193,25 @@
     </permissionkeys>
 
     <permissionaccessentitytypes>
-        <permissionaccessentitytype handle="group" package="">
+        <permissionaccessentitytype handle="group" name="Group" package="">
             <categories>
                 <category handle="calendar_admin" />
                 <category handle="calendar" />
             </categories>
         </permissionaccessentitytype>
-        <permissionaccessentitytype handle="user" package="">
+        <permissionaccessentitytype handle="user" name="User" package="">
             <categories>
                 <category handle="calendar_admin" />
                 <category handle="calendar" />
             </categories>
         </permissionaccessentitytype>
-        <permissionaccessentitytype handle="group_set" package="">
+        <permissionaccessentitytype handle="group_set" name="Group Set" package="">
             <categories>
                 <category handle="calendar_admin" />
                 <category handle="calendar" />
             </categories>
         </permissionaccessentitytype>
-        <permissionaccessentitytype handle="group_combination" package="">
+        <permissionaccessentitytype handle="group_combination" name="Group Combination" package="">
             <categories>
                 <category handle="calendar_admin" />
                 <category handle="calendar" />

--- a/concrete/config/install/upgrade/site_health.xml
+++ b/concrete/config/install/upgrade/site_health.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0"?>
 <concrete5-cif version="1.0">
     <tasks>
-        <task handle="production_status"/>
-        <task handle="page_cache_report"/>
-        <task handle="custom_javascript_report"/>
+        <task handle="production_status" package=""/>
+        <task handle="page_cache_report" package=""/>
+        <task handle="custom_javascript_report" package=""/>
     </tasks>
     <tasksets>
         <taskset handle="site_health" name="Site Health" package="">
@@ -42,7 +42,7 @@
     </blocktypes>
 
     <blocktypesets>
-        <blocktypeset handle="core_desktop">
+        <blocktypeset handle="core_desktop" name="Desktop" package="">
             <blocktype handle="desktop_latest_health_result"/>
         </blocktypeset>
     </blocktypesets>

--- a/concrete/themes/atomik/documentation/support/forms.xml
+++ b/concrete/themes/atomik/documentation/support/forms.xml
@@ -5,7 +5,7 @@
                 use_separate_site_result_buckets=""
                 description="This is sample content for the Atomik theme documentation. It may be removed without hurting the site. "
                 default_view_form="77c4ef3e-136c-11ec-9fc5-8aa7a7509c1c"
-                default_edit_form="77c4ef3e-136c-11ec-9fc5-8aa7a7509c1c" results-folder="/">
+                default_edit_form="77c4ef3e-136c-11ec-9fc5-8aa7a7509c1c" results-folder="/" package="">
             <attributekeys>
                 <attributekey handle="employee_first_name" name="First Name" package="" searchable="1" indexed="1"
                               type="text" category="">


### PR DESCRIPTION
Let's say for example that I create a package that installs a page type.
Its CIF should have a  `<pagetype />` element with a `package="my_package"` attribute.

If I forgot to add that attribute, I'd like that concrete-cif tells me about that.

So, what about making some attributes required?