### PR TITLE
Fix #11841 - Deleted Composer Control - block edit dialogue whoops.

### DIFF
--- a/concrete/blocks/core_page_type_composer_control_output/edit.php
+++ b/concrete/blocks/core_page_type_composer_control_output/edit.php
@@ -12,11 +12,16 @@ use Concrete\Core\Page\Type\Type as PageType;
 $ptComposerOutputControlID = $ptComposerOutputControlID ?? null;
 
 $c = Page::getCurrentPage();
-    // retrieve all block controls attached to this page template.
-    $pt = PageTemplate::getByID($c->getPageTemplateID());
-    $ptt = PageType::getByDefaultsPage($c);
+// retrieve all block controls attached to this page template.
+$pt = PageTemplate::getByID($c->getPageTemplateID());
+$ptt = PageType::getByDefaultsPage($c);
+
+// Allow for template or type subsequently deleted.
+if (is_object($pt) && is_object($ptt)) {
     $controls = PageTypeComposerOutputControl::getList($ptt, $pt);
-    $values = [];
+}
+$values = [];
+if (!empty($controls)) {
     foreach ($controls as $control) {
         $fls = PageTypeComposerFormLayoutSetControl::getByID($control->getPageTypeComposerFormLayoutSetControlID());
         if ($fls->getPageTypeComposerFormLayoutSetControlCustomLabel()) {
@@ -27,8 +32,10 @@ $c = Page::getCurrentPage();
         }
         $values[$control->getPageTypeComposerOutputControlID()] = $displayname;
     }
-?>
-<div class="form-group">
-	<label for="ptComposerOutputControlID" class="control-label form-label"><?=t('Control')?></label>
-	<?=$form->select('ptComposerOutputControlID', $values, $ptComposerOutputControlID ?? '')?>
-</div>
+    ?>
+    <div class="form-group">
+        <label for="ptComposerOutputControlID" class="control-label form-label"><?= t('Control') ?></label>
+        <?= $form->select('ptComposerOutputControlID', $values, $ptComposerOutputControlID ?? '') ?>
+    </div>
+    <?php
+}


### PR DESCRIPTION
See #11208 and 0e8975b
The affected composer control blocks will whoops on edit.

Don't try and load composer controls if there is no associated page template or type.
Don't bother to show the select option in the edit dialogue if there is nothing to select from.

