### PR TITLE
add ccm_nocache to theme skin stylesheet

### DIFF
--- a/concrete/src/Entity/Page/Theme/CustomSkin.php
+++ b/concrete/src/Entity/Page/Theme/CustomSkin.php
@@ -257,10 +257,12 @@ class CustomSkin implements \JsonSerializable, SkinInterface
 
     public function getStylesheet(): Element
     {
+        $config = app('config');
+        $noCacheValue = "?ccm_nocache=" . sha1($noCacheValue = $config->get('concrete.version_installed') . '-' . $config->get('concrete.version_db') . "-" . $config->get('concrete.cache.last_cleared'));
         $stylesheet = REL_DIR_FILES_UPLOADED_STANDARD . '/' . DIRNAME_STYLE_CUSTOMIZER_PRESETS . '/' . $this->getIdentifier() . '.css';
         $element = new Element('link', null);
         $element->setIsSelfClosing(true);
-        $element->rel('stylesheet')->type('text/css')->href($stylesheet);
+        $element->rel('stylesheet')->type('text/css')->href($stylesheet . $noCacheValue);
         return $element;
     }
 

--- a/concrete/src/StyleCustomizer/Skin/PresetSkin.php
+++ b/concrete/src/StyleCustomizer/Skin/PresetSkin.php
@@ -70,12 +70,14 @@ class PresetSkin implements SkinInterface
 
     public function getStylesheet(): Element
     {
+        $config = app('config');
+        $noCacheValue = "?ccm_nocache=" . sha1($noCacheValue = $config->get('concrete.version_installed') . '-' . $config->get('concrete.version_db') . "-" . $config->get('concrete.cache.last_cleared'));
         $theme = $this->getTheme();
         $path = $theme->getSkinDirectoryRecord()->getUrl();
         $stylesheet = $path . '/' . $this->getIdentifier() . '.css';
         $element = new Element('link', null);
         $element->setIsSelfClosing(true);
-        $element->rel('stylesheet')->type('text/css')->href($stylesheet);
+        $element->rel('stylesheet')->type('text/css')->href($stylesheet . $noCacheValue);
         return $element;
     }
 


### PR DESCRIPTION
add in the ccm_nocache parameter to allow the site's skin to be refreshed when clearing the site's cache.

This uses the same logic as other assets to generate the parameter

closes #11845