### PR TITLE
Full Content Swap: delete all pages, actually

### DIFF
--- a/concrete/src/Package/ContentSwapper.php
+++ b/concrete/src/Package/ContentSwapper.php
@@ -52,6 +52,10 @@ class ContentSwapper implements ContentSwapperInterface
             \Core::make('cache/request')->disable();
 
             $pl = new PageList();
+            $pl->ignorePermissions();
+            $pl->includeAliases();
+            $pl->includeInactivePages();
+            $pl->setPageVersionToRetrieve(PageList::PAGE_VERSION_RECENT);
             $pages = $pl->getResults();
             foreach ($pages as $c) {
                 $c->delete();


### PR DESCRIPTION
When we install a package with "Full Content Swap", we delete all the pages (except the homepage) first.

But we have a few problems when we retrieve the pages to be deleted:

1. when installing via web, the currently logged in user is admin, so the permission checks are not performed. But when installing via CLI pages that are not visible by guests are not deleted. Let's avoid that by explicitly ignoring permissions
2. we don't delete page aliases: let's do that
3. we only delete pages that are currently published: we should delete all the pages, including inactive pages or pages that are scheduled to be published in the future.