### PR TITLE
[v8] Safer storage of API keys on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __MACOSX
 .*swp
 .*swo
 *.iml
+.rnd
 
 # ignore composer files
 composer.phar

--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -1202,7 +1202,7 @@ return [
          */
         'enabled' => false,
 
-        /**
+        /*
          * Which grant types do we allow to connect to the API.
          *
          * @var array
@@ -1212,6 +1212,18 @@ return [
             'authorization_code' => true,
             'password_credentials' => false,
             'refresh_token' => true,
+        ],
+
+        'key' => [
+            'bits' => 2048,
+            // If empty we'll use the system temporary directory
+            'save_path' => '',
+            'ownership' => [
+                // Try to take the ownership of the key files stored in the save_path directory?
+                'set' => true,
+                // Abort the operation if taking the ownership fails?
+                'force' => false,
+            ],
         ],
     ],
 

--- a/concrete/src/Api/ApiServiceProvider.php
+++ b/concrete/src/Api/ApiServiceProvider.php
@@ -206,7 +206,7 @@ class ApiServiceProvider extends ServiceProvider
                 if (touch($keyPath)) {
                     $output = [];
                     $rc = -1;
-                    exec('icacls.exe ' . escapeshellarg(str_replace('/', DIRECTORY_SEPARATOR, $keyPath)) . ' /q /inheritancelevel:r /grant ' . escapeshellarg($_ENV['USERNAME']) . ':rw 2>&1', $output, $rc);
+                    exec('icacls.exe ' . escapeshellarg(str_replace('/', DIRECTORY_SEPARATOR, $keyPath)) . ' /q /inheritancelevel:r /grant ' . escapeshellarg($_ENV['USERNAME']) . ':F 2>&1', $output, $rc);
                     if ($rc === 0 && file_put_contents($keyPath, $key)) {
                         return new CryptKey('file://' . $keyPath, null, false);
                     }

--- a/concrete/src/Api/CryptKeyFactory.php
+++ b/concrete/src/Api/CryptKeyFactory.php
@@ -9,6 +9,9 @@ use League\OAuth2\Server\CryptKey;
 use phpseclib\Crypt\RSA;
 use RuntimeException;
 
+/**
+ * @deprecated since ConcreteCMS v9 key handling is much easier since keys aren't stored to file, so we don't need this class
+ */
 class CryptKeyFactory
 {
     /**

--- a/concrete/src/Api/CryptKeyFactory.php
+++ b/concrete/src/Api/CryptKeyFactory.php
@@ -1,0 +1,232 @@
+<?php
+
+namespace Concrete\Core\Api;
+
+use Concrete\Core\Application\Application;
+use Concrete\Core\Config\Repository\Repository;
+use Concrete\Core\Foundation\Environment\FunctionInspector;
+use League\OAuth2\Server\CryptKey;
+use phpseclib\Crypt\RSA;
+use RuntimeException;
+
+class CryptKeyFactory
+{
+    /**
+     * @var \Concrete\Core\Config\Repository\Repository
+     */
+    private $config;
+
+    /**
+     * @var \Concrete\Core\Foundation\Environment\FunctionInspector
+     */
+    private $functionInspector;
+
+    /**
+     * @var \Concrete\Core\Application\Application
+     */
+    private $app;
+
+    /**
+     * @var string[]|null
+     */
+    private $keyPair;
+
+    /**
+     * @var string|null
+     */
+    private $keysDirectory;
+
+    /**
+     * @var \League\OAuth2\Server\CryptKey[]
+     */
+    private $cryptKeys = [];
+
+    /**
+     * @param \Concrete\Core\Application\Application $app used to create \phpseclib\Crypt\RSA and the DB configuration repository instances
+     */
+    public function __construct(Repository $config, FunctionInspector $functionInspector, Application $app)
+    {
+        $this->config = $config;
+        $this->functionInspector = $functionInspector;
+        $this->app = $app;
+    }
+
+    /**
+     * @param string $handle ApiServiceProvider::KEY_PRIVATE | ApiServiceProvider::KEY_PUBLIC
+     *
+     * @throws \RuntimeException
+     *
+     * @return \League\OAuth2\Server\CryptKey
+     */
+    public function getCryptKey($handle)
+    {
+        if (!isset($this->cryptKeys[$handle])) {
+            $this->cryptKeys[$handle] = $this->buildCryptKey($handle);
+        }
+
+        return $this->cryptKeys[$handle];
+    }
+
+    /**
+     * @param string $handle ApiServiceProvider::KEY_PRIVATE | ApiServiceProvider::KEY_PUBLIC
+     *
+     * @throws \RuntimeException
+     *
+     * @return \League\OAuth2\Server\CryptKey
+     */
+    private function buildCryptKey($handle)
+    {
+        $file = $this->getKeyFile($handle);
+
+        return new CryptKey(
+            // $keyPath
+            $file,
+            // $passPhrase
+            null,
+            // $keyPermissionsCheck
+            false // we already manage key file ownership
+        );
+    }
+
+    /**
+     * @param string $handle ApiServiceProvider::KEY_PRIVATE | ApiServiceProvider::KEY_PUBLIC
+     *
+     * @throws \RuntimeException
+     *
+     * @return string
+     */
+    private function getKeyFile($handle)
+    {
+        $key = $this->getKey($handle);
+        $file = $this->getKeysDirectory() . '/ccm-' . $handle . '-' . sha1($key) . '.key';
+        if (!is_file($file)) {
+            $this->buildKeyFile($key, $file);
+        }
+        
+        return $file;
+    }
+
+    /**
+     * @param string $handle ApiServiceProvider::KEY_PRIVATE | ApiServiceProvider::KEY_PUBLIC
+     *
+     * @throws \RuntimeException
+     *
+     * @return string
+     */
+    private function getKey($handle)
+    {
+        if ($this->keyPair === null) {
+            $dbConfig = $this->app->make('config/database');
+
+            // See if we already have a keypair
+            $keyPair = $dbConfig->get('api.keypair');
+            if (!$keyPair) {
+                // Generate a new keypair
+                $bits = (int) $this->config->get('concrete.api.key.bits');
+                $rsa = $this->app->make(RSA::class);
+                $keyPair = $rsa->createKey($bits > 0 ? $bits : 2048);
+                foreach ($keyPair as &$item) {
+                    $item = str_replace("\r\n", "\n", $item);
+                }
+                // Save the keypair
+                $dbConfig->set('api.keypair', $keyPair);
+                $dbConfig->save('api.keypair', $keyPair);
+            }
+            $this->keyPair = $keyPair;
+        }
+        if (!isset($this->keyPair[$handle])) {
+            throw new RuntimeException(t('Invalid API key handle: %s', $handle));
+        }
+
+        return $this->keyPair[$handle];
+    }
+
+    /**
+     * @throws \RuntimeException
+     *
+     * @return string
+     */
+    private function getKeysDirectory()
+    {
+        if ($this->keysDirectory === null) {
+            $dir = $this->config->get('concrete.api.key.save_path');
+            if (!$dir) {
+                $dir = sys_get_temp_dir();
+            }
+            if (!is_dir($dir)) {
+                @mkdir($dir, $this->config->get('concrete.filesystem.permissions.directory'), true);
+            }
+            $dir = is_dir($dir) ? realpath($dir) : false;
+            if (!$dir) {
+                throw new RuntimeException(t('Failed to create the directory where the API key files should be stored.'));
+            }
+            $this->keysDirectory = rtrim(str_replace(DIRECTORY_SEPARATOR, '/', $dir), '/');
+        }
+
+        return $this->keysDirectory;
+    }
+
+    /**
+     * @param string $key
+     * @param string $file
+     *
+     * @throws \RuntimeException
+     */
+    private function buildKeyFile($key, $file)
+    {
+        if (file_put_contents($file, $key) === false) {
+            throw new RuntimeException(t('Unable to save an API key file.'));
+        }
+        if ($this->config->get('concrete.api.key.ownership.set')) {
+            try {
+                if (DIRECTORY_SEPARATOR === '\\') {
+                    $this->takeOwnershipWindows($file);
+                } else {
+                    $this->takeOwnershipPosix($file);
+                }
+            } catch (RuntimeException $x) {
+                if ($this->config->get('concrete.api.key.ownership.force')) {
+                    unlink($file);
+                    throw $x;
+                }
+            }
+        }
+    }
+
+    /**
+     * @param string $file
+     *
+     * @throws \RuntimeException
+     */
+    private function takeOwnershipPosix($file)
+    {
+        if (chmod($file, 0600) === false) {
+            throw new RuntimeException(t('Unable to set the permissions of an API key file: %s'), t('the function %s failed', 'chmod()'));
+        }
+    }
+
+    /**
+     * @param string $file
+     *
+     * @throws \RuntimeException
+     */
+    private function takeOwnershipWindows($file)
+    {
+        if (!$this->functionInspector->functionAvailable('exec')) {
+            throw new RuntimeException(t('Unable to set the permissions of an API key file: %s'), t('the function %s is not available', 'exec()'));
+        }
+        $currentUser = get_current_user();
+        if (empty($currentUser)) {
+            if (empty($_ENV['USERNAME'])) {
+                throw new RuntimeException(t('Unable to set the permissions of an API key file: %s'), t('unable to determine the current user'));
+            }
+            $currentUser = $_ENV['USERNAME'];
+        }
+        $output = [];
+        $rc = -1;
+        exec('icacls.exe ' . escapeshellarg(str_replace('/', DIRECTORY_SEPARATOR, $file)) . ' /q /inheritancelevel:r /grant ' . escapeshellarg($currentUser) . ':F 2>&1', $output, $rc);
+        if ($rc !== 0) {
+            throw new RuntimeException(t('Unable to set the permissions of an API key file: %s', t('the command %s failed', 'icacls') . "\n" . trim(implode("\n", $output))));
+        }
+    }
+}

--- a/tests/tests/Api/CryptKeyFactoryTest.php
+++ b/tests/tests/Api/CryptKeyFactoryTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Concrete\Tests\Api;
+
+use Concrete\Core\Api\ApiServiceProvider;
+use Concrete\Core\Api\CryptKeyFactory;
+use Concrete\Core\Application\Application;
+use Concrete\Core\Config\Repository\Repository;
+use Illuminate\Filesystem\Filesystem;
+use League\OAuth2\Server\CryptKey;
+use Mockery as M;
+use phpseclib\Crypt\RSA;
+use PHPUnit_Framework_TestCase;
+use RuntimeException;
+
+class CryptKeyFactoryTest extends PHPUnit_Framework_TestCase
+{
+    use M\Adapter\Phpunit\MockeryPHPUnitIntegration;
+
+    private static $tempDir;
+    public static function setUpBeforeClass()
+    {
+        self::$tempDir = str_replace(DIRECTORY_SEPARATOR, '/', __DIR__) . '/temp';
+        self::clearTemp();
+    }
+
+    public static function tearDownAfterClass()
+    {
+        self::clearTemp();
+    }
+
+    public function testGetCryptKey()
+    {
+        $realConfig = app(Repository::class);
+        $keyBits = $realConfig->get('concrete.api.key.bits');
+        $this->assertInternalType('int', $keyBits);
+        $this->assertGreaterThan(0, $keyBits);
+        $rsaKeyRaw = (new RSA())->createKey($keyBits);
+        $rsaKey = [];
+        foreach ($rsaKeyRaw as $k => $v) {
+            $rsaKey[$k] = is_string($k) ? str_replace("\r\n", "\n", $v) : $v;
+        }
+
+        $configMock = M::mock(Repository::class);
+        $dbConfigMock = M::mock(Repository::class);
+        $appMock = M::mock(Application::class);
+        $rsaMock = M::mock(RSA::class);
+
+        $configMock->shouldReceive('get')->withArgs(['concrete.api.key.bits'])->times(1)->andReturn($keyBits);
+        $configMock->shouldReceive('get')->withArgs(['concrete.api.key.save_path'])->times(1)->andReturn(self::$tempDir);
+        $configMock->shouldReceive('get')->withArgs(['concrete.filesystem.permissions.directory'])->times(1)->andReturn($realConfig->get('concrete.filesystem.permissions.directory'));
+        $configMock->shouldReceive('get')->withArgs(['concrete.api.key.ownership.set'])->times(2)->andReturn(true);
+        $configMock->shouldReceive('get')->withArgs(['concrete.api.key.ownership.force'])->andReturn(true);
+
+        $dbConfigMock->shouldReceive('get')->withArgs(['api.keypair'])->times(1)->andReturn(null);
+        $dbConfigMock->shouldReceive('set')->withArgs(['api.keypair', $rsaKey])->times(1)->andReturn(null);
+        $dbConfigMock->shouldReceive('save')->withArgs(['api.keypair', $rsaKey])->times(1)->andReturn(null);
+
+        $appMock->shouldReceive('make')->withArgs(['config/database'])->times(1)->andReturn($dbConfigMock);
+        $rsaMock->shouldReceive('createKey')->withArgs([$keyBits])->andReturn($rsaKeyRaw);
+        $appMock->shouldReceive('make')->withArgs([RSA::class])->times(1)->andReturn($rsaMock);
+
+        $instance = app(CryptKeyFactory::class, ['config' => $configMock, 'app' => $appMock]);
+        $error = null;
+        try {
+            $instance->getCryptKey('invalid');
+        } catch (RuntimeException $error) {
+        }
+        $this->assertInstanceOf(RuntimeException::class, $error);
+        $publicKey = $instance->getCryptKey(ApiServiceProvider::KEY_PUBLIC);
+        $this->assertInstanceOf(CryptKey::class, $publicKey);
+        $this->checkCryptKey($publicKey, $rsaKey[ApiServiceProvider::KEY_PUBLIC]);
+        $privateKey = $instance->getCryptKey(ApiServiceProvider::KEY_PRIVATE);
+        $this->assertInstanceOf(CryptKey::class, $privateKey);
+        $this->checkCryptKey($privateKey, $rsaKey[ApiServiceProvider::KEY_PRIVATE]);
+
+        $publicKey2 = $instance->getCryptKey(ApiServiceProvider::KEY_PUBLIC);
+        $this->assertSame($publicKey, $publicKey2);
+        $privateKey2 = $instance->getCryptKey(ApiServiceProvider::KEY_PRIVATE);
+        $this->assertSame($privateKey, $privateKey2);
+    }
+
+    private static function clearTemp()
+    {
+        $fs = new Filesystem();
+        if ($fs->isDirectory(self::$tempDir)) {
+            $fs->deleteDirectory(self::$tempDir, false);
+        }
+        if ($fs->exists(self::$tempDir)) {
+            throw new RuntimeException('Failed to delete directory ' . self::$tempDir);
+        }
+    }
+
+    private function checkCryptKey(CryptKey $cryptKey, $expectedContent)
+    {
+        $this->assertStringStartsWith('file://' . self::$tempDir . '/', $cryptKey->getKeyPath());
+        $path = substr($cryptKey->getKeyPath(), strlen('file://'));
+        $this->assertFileExists($path);
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $this->checkFileOwnerskipWindows($path);
+        } else {
+            $this->checkFileOwnerskipPosix($path);
+        }
+        $this->assertSame($expectedContent, file_get_contents($path));
+    }
+
+    private function checkFileOwnerskipWindows($path)
+    {
+        $path = str_replace('//', '\\', $path);
+        $output = [];
+        $rc = -1;
+        exec('icacls.exe ' . escapeshellarg($path) . ' /q 2>&1', $output, $rc);
+        $this->assertSame(0, $rc, implode("\n", $output));
+        /*
+         * Sample output:
+         * filename owner:(permissions)
+         *
+         * Successfully processed 1 files; Failed processing 0 files
+         */
+        $this->assertStringStartsWith($path, str_replace('//', '\\', $output[0]));
+        $perms = ltrim(substr($output[0], strlen($path)));
+        $currentUser = get_current_user();
+        if (empty($currentUser)) {
+            $currentUser = empty($_ENV['USERNAME']) ? '' : $_ENV['USERNAME'];
+        }
+        if ($currentUser !== '') {
+            $this->assertStringEndsWith($currentUser . ':(F)', $perms);
+        } else {
+            $this->assertStringEndsWith(':(F)', $perms);
+        }
+    }
+
+    private function checkFileOwnerskipPosix($path)
+    {
+        $this->assertSame(0600, fileperms($path) & 0700);
+    }
+}


### PR DESCRIPTION
In concrete5 v8 we are using a rather old league/oauth2-server version, and we can't upgrade to a newer one.

In this old version, API keys on Windows are stored in an unsafe way, and the package may complain about unsafe versions.

What about storing the keys in a more protected way by using [icacls.exe](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/icacls)?