### PR TITLE
Do not combine CAPTCHA JS because it fails to load in some cases

### DIFF
--- a/concrete/src/Captcha/RecaptchaV3Controller.php
+++ b/concrete/src/Captcha/RecaptchaV3Controller.php
@@ -104,7 +104,7 @@ class RecaptchaV3Controller extends AbstractController implements CaptchaInterfa
         $assetUrl = $config->get('captcha.recaptcha_v3.url.javascript_asset');
 
         $assetList->register('javascript', 'recaptcha_api', $assetUrl, ['local' => false]);
-        $assetList->register('javascript', 'recaptcha_render', 'js/captcha/recaptchav3.js', [], 'recaptcha_v3');
+        $assetList->register('javascript', 'recaptcha_render', 'js/captcha/recaptchav3.js', ['combine'=>false], 'recaptcha_v3');
 
         $assetList->registerGroup(
             'recaptcha_v3',


### PR DESCRIPTION
With "CSS and JavaScript Cache" enabled, depending on the page the user first views, the js/captcha/recaptchav3.js code isn't in the combined JS payload, and thus no ReCAPTCHA shows. Error shows in JS console: "reCAPTCHA couldn't find user-provided function: RecaptchaV3"