### PR TITLE
[v8] Fix Number::formatSize() for sizes bigger than GB

### DIFF
--- a/concrete/src/Utility/Service/Number.php
+++ b/concrete/src/Utility/Service/Number.php
@@ -160,6 +160,7 @@ class Number
         if ($forceUnit === 'GB' || (abs($size) < 1024 && (!strlen($forceUnit)))) {
             return t(/*i18n %s is a number, GB means Gigabyte */'%s GB', $this->format($size, 2));
         }
+        $size /= 1024;
 
         return t(/*i18n %s is a number, TB means Terabyte */'%s TB', $this->format($size, 2));
     }

--- a/tests/tests/Utility/Service/NumberTest.php
+++ b/tests/tests/Utility/Service/NumberTest.php
@@ -68,4 +68,28 @@ class NumberTest extends PHPUnit_Framework_Testcase
         $numberService = new Number();
         $this->assertSame($expected, $numberService->trim($test));
     }
+
+    public static function formatSizeDataProvider()
+    {
+        return [
+            ['0 bytes', 0],
+            ['1 byte', 1],
+            ['1.00 KB', 1 * 1024],
+            ['1.00 MB', 1 * 1024 * 1024],
+            ['1.00 GB', 1 * 1024 * 1024 * 1024],
+            ['1.00 TB', 1 * 1024 * 1024 * 1024 * 1024],
+        ];
+    }
+
+    /**
+     * @dataProvider formatSizeDataProvider
+     *
+     * @param string $test
+     * @param int|float|string $expected
+     */
+    public function testFormatSize($expected, $size, $forceUnit = '')
+    {
+        $numberService = new Number();
+        $this->assertSame($expected, $numberService->formatSize($size, $forceUnit));
+    }
 }


### PR DESCRIPTION
Same as #11884 but for v8