### PR TITLE
Fix #11327. Translate to abstract link before save

### DIFF
--- a/concrete/blocks/accordion/controller.php
+++ b/concrete/blocks/accordion/controller.php
@@ -322,7 +322,7 @@ class Controller extends BlockController implements UsesFeatureInterface
                 // Add the entry row
                 $db->executeStatement(
                     'INSERT INTO btAccordionEntries (bID, sortOrder, title, description) VALUES (?, ?, ?, ?)',
-                    [(int) $this->bID, $sortOrder++, $entry['title'], $entry['description']]
+                    [(int) $this->bID, $sortOrder++, $entry['title'], LinkAbstractor::translateTo($entry['description'])]
                 );
             }
         }


### PR DESCRIPTION
Wrap 'description' in LinkAbstractor::translateTo() before write to database.
Change` <img...>` to` <concrete-picture fID= ...>`
Fix  #11327

![image](https://github.com/concretecms/concretecms/assets/149998596/3cc8dbf6-7a73-49b2-865d-a424f661cc2d)

*Check these before submitting new pull requests*

- [x] I read the __guidelines for contributing__ linked above. My pull request conforms to the coding style guidelines described within.

If this condition is met, feel free to delete this whole message and to submit your pull request.

Thank you, your help is really appreciated!
