### PR TITLE
Fix #10974 . Add showing exist path modal

### DIFF
--- a/concrete/controllers/panel/detail/page/location.php
+++ b/concrete/controllers/panel/detail/page/location.php
@@ -149,4 +149,27 @@ class Location extends BackendInterfacePageController
             $r->outputJSON();
         }
     }
+
+    public function check()
+    {
+        $checkResponse = new PageEditResponse();
+        if ($this->validateAction()) {
+            $req = Request::getInstance();
+
+            $pathArray = $req->request->get('path');
+            $paths = [];
+
+            if (is_array($pathArray)) {
+                foreach ($pathArray as $path) {
+                    if ($path) {
+                        if ($this->page->isCanonicalPathOnAnotherPageExist($path)) {
+                            $paths[] = $path;
+                        }
+                    }
+                }
+            }
+            $checkResponse->setAdditionalDataAttribute('paths', $paths);
+            $checkResponse->outputJSON();
+        }
+    }
 }

--- a/concrete/controllers/panel/detail/page/location.php
+++ b/concrete/controllers/panel/detail/page/location.php
@@ -113,7 +113,7 @@ class Location extends BackendInterfacePageController
 
             // now we do additional page URLs
             $req = Request::getInstance();
-          
+
             $canonical = $req->request->get('canonical');
             $pathArray = $req->request->get('path');
 
@@ -121,7 +121,7 @@ class Location extends BackendInterfacePageController
             if($pathArray){
              $oc->clearPagePaths();
             }
-            
+
             if (isset($canonical) && $this->page->getCollectionID() == Page::getHomePageID()) {
                 throw new Exception('You cannot change the canonical path of the home page.');
             }
@@ -162,7 +162,7 @@ class Location extends BackendInterfacePageController
             if (is_array($pathArray)) {
                 foreach ($pathArray as $path) {
                     if ($path) {
-                        if ($this->page->isCanonicalPathOnAnotherPageExist($path)) {
+                        if ($this->isCanonicalPathOnAnotherPageExist($this->page->getCollectionID(), $path)) {
                             $paths[] = $path;
                         }
                     }
@@ -172,4 +172,18 @@ class Location extends BackendInterfacePageController
             $checkResponse->outputJSON();
         }
     }
+
+    protected function isCanonicalPathOnAnotherPageExist(int $cID, string $path)
+    {
+        $em = \ORM::entityManager();
+        return $em->getRepository('\Concrete\Core\Entity\Page\PagePath')
+            ->createQueryBuilder('pp')
+            ->where('pp.cID != :cID')
+            ->andWhere('pp.cPath = :cPath')
+            ->setParameter('cID', $cID)
+            ->setParameter('cPath', $path)
+            ->getQuery()
+            ->getResult();
+    }
+
 }

--- a/concrete/routes/panels/details.php
+++ b/concrete/routes/panels/details.php
@@ -25,6 +25,7 @@ $router->all('/ccm/system/panels/details/page/composer/publish', '\Concrete\Cont
 $router->all('/ccm/system/panels/details/page/composer/save_and_exit', '\Concrete\Controller\Panel\Detail\Page\Composer::saveAndExit');
 $router->all('/ccm/system/panels/details/page/location', '\Concrete\Controller\Panel\Detail\Page\Location::view');
 $router->all('/ccm/system/panels/details/page/location/submit', '\Concrete\Controller\Panel\Detail\Page\Location::submit');
+$router->all('/ccm/system/panels/details/page/location/check', '\Concrete\Controller\Panel\Detail\Page\Location::check');
 $router->all('/ccm/system/panels/details/page/permissions', '\Concrete\Controller\Panel\Detail\Page\Permissions::view');
 $router->all('/ccm/system/panels/details/page/permissions/save_simple', '\Concrete\Controller\Panel\Detail\Page\Permissions::save_simple');
 $router->all('/ccm/system/panels/details/page/preview', '\Concrete\Controller\Panel\Page\Design::preview');

--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -4035,6 +4035,19 @@ EOT
         Section::registerPage($this);
     }
 
+    public function isCanonicalPathOnAnotherPageExist(string $path)
+    {
+        $em = \ORM::entityManager();
+        return $em->getRepository('\Concrete\Core\Entity\Page\PagePath')
+            ->createQueryBuilder('pp')
+            ->where('pp.cID != :cID')
+            ->andWhere('pp.cPath = :cPath')
+            ->setParameter('cID', $this->getCollectionID())
+            ->setParameter('cPath', $path)
+            ->getQuery()
+            ->getResult();
+    }
+
     /**
      * Read the data from the database.
      *

--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -4035,19 +4035,6 @@ EOT
         Section::registerPage($this);
     }
 
-    public function isCanonicalPathOnAnotherPageExist(string $path)
-    {
-        $em = \ORM::entityManager();
-        return $em->getRepository('\Concrete\Core\Entity\Page\PagePath')
-            ->createQueryBuilder('pp')
-            ->where('pp.cID != :cID')
-            ->andWhere('pp.cPath = :cPath')
-            ->setParameter('cID', $this->getCollectionID())
-            ->setParameter('cPath', $path)
-            ->getQuery()
-            ->getResult();
-    }
-
     /**
      * Read the data from the database.
      *

--- a/concrete/views/panels/details/page/location.php
+++ b/concrete/views/panels/details/page/location.php
@@ -124,7 +124,7 @@ $(function() {
 
         $.ajax({
             type: 'POST',
-            url: '<?= $controller->action('check') ?>',
+            url: <?= json_encode((string) $controller->action('check')) ?>,
             data: formData,
             success: (xhr) => {
                 let response = JSON.parse(xhr);

--- a/concrete/views/panels/details/page/location.php
+++ b/concrete/views/panels/details/page/location.php
@@ -107,7 +107,7 @@ defined('C5_EXECUTE') or die("Access Denied.");
 </script>
 <div class="ccm-panel-detail-form-actions dialog-buttons">
     <button class="float-start btn btn-secondary" type="button" data-dialog-action="cancel" data-panel-detail-action="cancel"><?=t('Cancel')?></button>
-    <button class="float-end btn btn-success" type="button" data-dialog-action="submit" data-panel-detail-action="submit"><?=t('Save Changes')?></button>
+    <button class="float-end btn btn-success" type="button" data-dialog-action="submit"><?= t('Save Changes') ?></button>
 </div>
 
 <script type="text/javascript">
@@ -117,6 +117,32 @@ var renderPagePath = _.template(
 );
 
 $(function() {
+
+    $('button[data-dialog-action="submit"]').on('click', function(e) {
+        e.preventDefault();
+        let formData = $('form[data-dialog-form="location"]').serialize();
+
+        $.ajax({
+            type: 'POST',
+            url: '<?= $controller->action('check') ?>',
+            data: formData,
+            success: (xhr) => {
+                let response = JSON.parse(xhr);
+
+                if (response.paths && response.paths.length) {
+                    let pathsList = response.paths.map(path => `<li>${path}</li>`).join('');
+                    let errorMessage = `<?= t('Next paths already exist:') ?> <ul>${pathsList}</ul> <?= t('Do you want to continue?')?>`;
+
+                    ConcreteAlert.confirm(errorMessage, function () {
+                        $('form[data-dialog-form="location"]').submit();
+                    });
+                } else {
+                    $('form[data-dialog-form="location"]').submit();
+                }
+            }
+        });
+    });
+
 
 	$('form[data-panel-detail-form=location]').on('click', 'a[data-action=remove-page-path]', function(e) {
 		e.preventDefault();


### PR DESCRIPTION
Added a check in the request before initiating the save process. If the check returns an array of paths that already exist, a modal window is displayed to confirm the continuation of the saving process. Otherwise, the saving process continues as usual.

Fix #10974 

![image](https://github.com/concretecms/concretecms/assets/149998596/c8c33d56-ce6c-4255-9918-0845f0b1dc4b)


*Check these before submitting new pull requests*

- [x] I read the __guidelines for contributing__ linked above. My pull request conforms to the coding style guidelines described within.

If this condition is met, feel free to delete this whole message and to submit your pull request.

Thank you, your help is really appreciated!
