### PR TITLE
Spam reporting, fix logging of non-scalar values in $args

### DIFF
--- a/concrete/src/Antispam/Service.php
+++ b/concrete/src/Antispam/Service.php
@@ -127,6 +127,9 @@ class Service
                 $logText .= t('Type: %s', Loader::helper('text')->unhandle($type));
                 $logText .= "\n";
                 foreach ($args as $key => $value) {
+                     if(!is_scalar($value)){
+                        $value = json_encode($value);
+                    }
                     $logText .= Loader::helper('text')->unhandle($key) . ': ' . $value . "\n";
                 }
 


### PR DESCRIPTION
The $args could contain non scalar values and consequently cause the generation of $logText to fail.

A simple catch-all solution is to json_encode any value that is not scalar.

As an aside, this file is full of Loader:: and also uses a mass of aliases. But that is a different issue, so I left them alone.