### PR TITLE
Fix wrong template display name variable

### DIFF
--- a/concrete/src/Entity/Page/Template.php
+++ b/concrete/src/Entity/Page/Template.php
@@ -128,7 +128,7 @@ class Template implements \JsonSerializable
             'pTemplateID' => $this->getPageTemplateID(),
             'pTemplateHandle' => $this->getPageTemplateHandle(),
             'pTemplateName' => $this->getPageTemplateName(),
-            'pTemplateDisplayName' => $this->getPageTemplateDisplayName(),
+            'pTemplateDisplayName' => $this->getPageTemplateDisplayName('text'),
             'pTemplateIconImage' => $this->getPageTemplateIconImage(),
         ];
     }

--- a/concrete/views/panels/page/design.php
+++ b/concrete/views/panels/page/design.php
@@ -47,7 +47,7 @@ if ($skin) {
                     <input type="radio" class="form-check-input" name="pTemplateID" :id="template.pTemplateID" :value="template.pTemplateID" v-model="selectedTemplateID" />
                     <label class="form-check-label" :for="template.pTemplateID">
                         <span v-html="template.pTemplateIconImage"></span>
-                        {{template.pTemplateDisplayName}}
+                        {{template.pTemplateName}}
                     </label>
                 </div>
 

--- a/concrete/views/panels/page/design.php
+++ b/concrete/views/panels/page/design.php
@@ -47,7 +47,7 @@ if ($skin) {
                     <input type="radio" class="form-check-input" name="pTemplateID" :id="template.pTemplateID" :value="template.pTemplateID" v-model="selectedTemplateID" />
                     <label class="form-check-label" :for="template.pTemplateID">
                         <span v-html="template.pTemplateIconImage"></span>
-                        {{template.pTemplateName}}
+                        <span v-html="template.pTemplateDisplayName"></span> 
                     </label>
                 </div>
 

--- a/concrete/views/panels/page/design.php
+++ b/concrete/views/panels/page/design.php
@@ -47,7 +47,7 @@ if ($skin) {
                     <input type="radio" class="form-check-input" name="pTemplateID" :id="template.pTemplateID" :value="template.pTemplateID" v-model="selectedTemplateID" />
                     <label class="form-check-label" :for="template.pTemplateID">
                         <span v-html="template.pTemplateIconImage"></span>
-                        <span v-html="template.pTemplateDisplayName"></span> 
+                        {{template.pTemplateDisplayName}}
                     </label>
                 </div>
 


### PR DESCRIPTION
When the Template has special character, it displays it in the html format.

For example, I have a template named "Page d'actualité" and currently, it is displayed as "Page d\&#039;actualité".

Changing {{template.pTemplateDisplayName}} by  {{template.pTemplateName}} solves the issue.
