### PR TITLE
Fix ExpressSearchIndexer to avoid creating an attribute index table for non-existing objects

### DIFF
--- a/concrete/src/Attribute/Category/SearchIndexer/ExpressSearchIndexer.php
+++ b/concrete/src/Attribute/Category/SearchIndexer/ExpressSearchIndexer.php
@@ -28,7 +28,7 @@ class ExpressSearchIndexer extends StandardSearchIndexer
         $isValid = parent::isValid($category);
 
         // Express category without a persisted entity are not valid for indexing
-        if ($isValid && $category instanceof ExpressCategory && $category->getExpressEntity()->getId() === null) {
+        if ($isValid && $category instanceof ExpressCategory && $category->getExpressEntity()->getHandle() === null) {
             $isValid = false;
         }
 

--- a/concrete/src/Attribute/Category/SearchIndexer/ExpressSearchIndexer.php
+++ b/concrete/src/Attribute/Category/SearchIndexer/ExpressSearchIndexer.php
@@ -2,6 +2,8 @@
 
 namespace Concrete\Core\Attribute\Category\SearchIndexer;
 
+use Concrete\Core\Attribute\Category\CategoryInterface;
+use Concrete\Core\Attribute\Category\ExpressCategory;
 use Concrete\Core\Entity\Express\Entity;
 
 class ExpressSearchIndexer extends StandardSearchIndexer
@@ -19,5 +21,17 @@ class ExpressSearchIndexer extends StandardSearchIndexer
         if ($this->connection->tableExists($previousTable)) {
             $this->connection->execute(sprintf('alter table %s rename %s', $previousTable, $newTable));
         }
+    }
+
+    protected function isValid(CategoryInterface $category)
+    {
+        $isValid = parent::isValid($category);
+
+        // Express category without a persisted entity are not valid for indexing
+        if ($isValid && $category instanceof ExpressCategory && $category->getExpressEntity()->getId() === null) {
+            $isValid = false;
+        }
+
+        return $isValid;
     }
 }


### PR DESCRIPTION
Fix #11727

If you want to fix this comment, I'll update this PR.
https://github.com/concretecms/concretecms/issues/11727#issuecomment-1952072573

I think we can keep `ExpressCategory` class as it is.
It's confusing but works without error if you merge this PR.