### PR TITLE
Allow using "secure" cookies automatically for HTTPS requests

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -1043,7 +1043,8 @@ return [
             'cookie_path' => false, // set a specific path here if you know it, otherwise it'll default to relative
             'cookie_lifetime' => 0,
             'cookie_domain' => false,
-            'cookie_secure' => false,
+            // true: enable the 'secure' flag; false: disable the secure flag; null: enable the 'secure' flag for https requests only
+            'cookie_secure' => null,
             'cookie_httponly' => true,
             'cookie_raw' => false,
             'cookie_samesite' => null,

--- a/concrete/controllers/single_page/dashboard/system/registration/session_options.php
+++ b/concrete/controllers/single_page/dashboard/system/registration/session_options.php
@@ -20,7 +20,8 @@ class SessionOptions extends DashboardSitePageController
             $validation->addRequiredToken("update_cookie_options");
 
             if ($validation->test()) {
-                $config->save("concrete.session.cookie.cookie_secure", $this->request->request->has("secure"));
+                $secure = $this->request->request->get('secure');
+                $config->save("concrete.session.cookie.cookie_secure", $secure === 'auto' ? null : (bool) $secure);
                 $config->save("concrete.session.cookie.cookie_httponly", $this->request->request->has("httponly"));
                 $config->save("concrete.session.cookie.cookie_raw", $this->request->request->has("raw"));
                 $config->save("concrete.session.cookie.cookie_domain", strlen($this->request->request->get("domain")) > 0 ? $this->request->request->get("domain") : false);
@@ -31,11 +32,11 @@ class SessionOptions extends DashboardSitePageController
                 $this->error = $validation->getError();
             }
         }
-
-        $this->set("secure", (bool)$config->get("concrete.session.cookie.cookie_secure"));
+        $this->set('secure', $config->get('concrete.session.cookie.cookie_secure'));
         $this->set("httponly", (bool)$config->get("concrete.session.cookie.cookie_httponly"));
         $this->set("raw", (bool)$config->get("concrete.session.cookie.cookie_raw"));
         $this->set("domain", (string)$config->get("concrete.session.cookie.cookie_domain"));
         $this->set("samesite", (string)$config->get("concrete.session.cookie.cookie_samesite"));
+        $this->set('currentRequestIsSecure', $this->request->isSecure());
     }
 }

--- a/concrete/controllers/single_page/dashboard/system/registration/session_options.php
+++ b/concrete/controllers/single_page/dashboard/system/registration/session_options.php
@@ -18,7 +18,6 @@ class SessionOptions extends DashboardSitePageController
         if ($this->request->getMethod() === "POST") {
             $validation->setData($this->request->request->all());
             $validation->addRequiredToken("update_cookie_options");
-
             if ($validation->test()) {
                 $secure = $this->request->request->get('secure');
                 $config->save("concrete.session.cookie.cookie_secure", $secure === 'auto' ? null : (bool) $secure);
@@ -26,11 +25,11 @@ class SessionOptions extends DashboardSitePageController
                 $config->save("concrete.session.cookie.cookie_raw", $this->request->request->has("raw"));
                 $config->save("concrete.session.cookie.cookie_domain", strlen($this->request->request->get("domain")) > 0 ? $this->request->request->get("domain") : false);
                 $config->save("concrete.session.cookie.cookie_samesite", strlen($this->request->request->get("samesite")) > 0 ? $this->request->request->get("samesite") : null);
+                $this->flash('success', t('The settings have been successfully updated.'));
 
-                $this->set("success", t("The settings has been successfully updated."));
-            } else {
-                $this->error = $validation->getError();
+                return $this->buildRedirect('/dashboard/system/registration/session_options');
             }
+            $this->error = $validation->getError();
         }
         $this->set('secure', $config->get('concrete.session.cookie.cookie_secure'));
         $this->set("httponly", (bool)$config->get("concrete.session.cookie.cookie_httponly"));

--- a/concrete/single_pages/dashboard/system/registration/session_options.php
+++ b/concrete/single_pages/dashboard/system/registration/session_options.php
@@ -6,11 +6,14 @@ use Concrete\Core\Form\Service\Form;
 use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\Validation\CSRF\Token;
 
-/** @var string $samesite */
-/** @var string $domain */
-/** @var bool $secure */
-/** @var bool $httponly */
-/** @var bool $raw */
+/**
+ * @var string $samesite
+ * @var string $domain
+ * @var bool|null $secure
+ * @var bool $httponly
+ * @var bool $raw
+ * @var bool $currentRequestIsSecure
+ */
 
 $app = Application::getFacadeApplication();
 /** @var Form $form */
@@ -18,6 +21,20 @@ $form = $app->make(Form::class);
 /** @var Token $token */
 $token = $app->make(Token::class);
 
+if ($secure === null) {
+    $secureValue = 'auto';
+} else {
+    $secureValue = $secure ? '1' : '0';
+}
+if ($currentRequestIsSecure) {
+    $secureWarning = '';
+} else {
+    $secureWarning = implode('<br />', [
+        '<b class="text-danger">' . t('WARNING') . '</b>',
+        t('The website is currently served via HTTP and not via HTTPS.'),
+        t("If you enable this option you probably won't be able to log in again!"),
+    ]);
+}
 ?>
 
 <div class="alert alert-warning">
@@ -29,11 +46,6 @@ $token = $app->make(Token::class);
 
     <div class="form-group">
         <div class="form-check">
-            <?php echo $form->checkbox("secure", 1, $secure, ["class" => "form-check-input"]); ?>
-            <?php echo $form->label("secure", t("Enable %s", "<code>secure</code>"), ["class" => "form-check-label"]); ?>
-        </div>
-
-        <div class="form-check">
             <?php echo $form->checkbox("httponly", 1, $httponly, ["class" => "form-check-input"]); ?>
             <?php echo $form->label("httponly", t("Enable %s", "<code>httponly</code>"), ["class" => "form-check-label"]); ?>
         </div>
@@ -41,6 +53,29 @@ $token = $app->make(Token::class);
         <div class="form-check">
             <?php echo $form->checkbox("raw", 1, $raw, ["class" => "form-check-input"]); ?>
             <?php echo $form->label("raw", t("Enable %s", "<code>raw</code>"), ["class" => "form-check-label"]); ?>
+        </div>
+    </div>
+
+    <div class="form-group">
+        <?= $form->label('', t('Enable %s', '<code>secure</code>')) ?>
+        <div class="form-check">
+            <?= $form->radio('secure', '0', $secureValue, ['id' => 'secure-never']) ?>
+            <?= $form->label('secure-never', t('never'), ['class' => 'form-check-label']) ?>
+        </div>
+        <div class="form-check">
+            <?= $form->radio('secure', '1', $secureValue, ['id' => 'secure-always']) ?>
+            <?= $form->label('secure-always', t('always'), ['class' => 'form-check-label']) ?>
+            <?php
+            if ($secureWarning !== '') {
+                ?>
+                <i class="fas fa-exclamation-triangle text-danger launch-tooltip" title="<?= h($secureWarning) ?>" data-bs-html="true"></i>
+                <?php
+            }
+            ?>
+        </div>
+        <div class="form-check">
+            <?= $form->radio('secure', 'auto', $secureValue, ['id' => 'secure-auto']) ?>
+            <?= $form->label('secure-auto', t('only for secure (HTTPS) requests'), ['class' => 'form-check-label']) ?>
         </div>
     </div>
 

--- a/concrete/src/Cookie/CookieJar.php
+++ b/concrete/src/Cookie/CookieJar.php
@@ -128,12 +128,12 @@ class CookieJar
      * @param int $expire
      * @param string $path
      * @param null|string $domain
-     * @param bool $secure
+     * @param bool|null $secure
      * @param bool $httpOnly
      *
      * @return \Symfony\Component\HttpFoundation\Cookie
      */
-    public function set($name, $value = null, $expire = 0, $path = '/', $domain = null, $secure = false, $httpOnly = true)
+    public function set($name, $value = null, $expire = 0, $path = '/', $domain = null, $secure = null, $httpOnly = true)
     {
         return $this->responseCookies->addCookie($name, $value, $expire, $path, $domain, $secure, $httpOnly);
     }

--- a/concrete/src/Cookie/CookieServiceProvider.php
+++ b/concrete/src/Cookie/CookieServiceProvider.php
@@ -3,12 +3,16 @@
 namespace Concrete\Core\Cookie;
 
 use Concrete\Core\Foundation\Service\Provider as ServiceProvider;
+use Concrete\Core\Http\Request;
 
 class CookieServiceProvider extends ServiceProvider
 {
     public function register()
     {
         $this->app->singleton(ResponseCookieJar::class);
+        $this->app->extend(ResponseCookieJar::class, function (ResponseCookieJar $jar): ResponseCookieJar {
+            return $jar->setSecureDefault($this->app->make(Request::class)->isSecure());
+        });
         $this->app->singleton(CookieJar::class);
         $this->app->alias(CookieJar::class, 'cookie');
     }

--- a/concrete/src/Cookie/ResponseCookieJar.php
+++ b/concrete/src/Cookie/ResponseCookieJar.php
@@ -8,14 +8,9 @@ use Symfony\Component\HttpFoundation\Cookie;
 class ResponseCookieJar
 {
     /**
-     * @var \Concrete\Core\Http\Request
+     * @var bool
      */
-    protected $request;
-
-    public function __construct(Request $request)
-    {
-        $this->request = $request;
-    }
+    private $secureDefault = false;
 
     /**
      * The list of new cookies to be added to the response.
@@ -32,6 +27,28 @@ class ResponseCookieJar
     protected $clearedCookies = [];
 
     /**
+     * Set the value of the "secure" flag when it is set to null.
+     *
+     * @return $this
+     */
+    public function setSecureDefault(bool $default): self
+    {
+        $this->secureDefault = $default;
+
+        return $this;
+    }
+
+    /**
+     * Get the value of the "secure" flag when it is set to null.
+     *
+     * @return $this
+     */
+    public function isSecureDefault(): bool
+    {
+        return $this->secureDefault;
+    }
+
+    /**
      * Adds a Cookie object to the cookie pantry.
      *
      * @param string $name The cookie name
@@ -39,16 +56,16 @@ class ResponseCookieJar
      * @param int $expire The number of seconds until the cookie expires
      * @param string $path The path for the cookie
      * @param null|string $domain The domain the cookie is available to
-     * @param bool|null $secure whether the cookie should only be transmitted over a HTTPS connection from the client. Use NULL to to set the secure flag if the current request uses HTTPS
+     * @param bool|null $secure whether the cookie should only be transmitted over a HTTPS connection from the client. Use NULL to to use the default value
      * @param bool $httpOnly Whether the cookie will be made accessible only through the HTTP protocol
      * @param bool $raw Whether the cookie value should be sent with no url encoding
      * @param string|null $sameSite Whether the cookie will be available for cross-site requests
      * @return \Symfony\Component\HttpFoundation\Cookie
      */
-    public function addCookie($name, $value = null, $expire = 0, $path = '/', $domain = null, $secure = false, $httpOnly = true, $raw = false, $sameSite = null)
+    public function addCookie($name, $value = null, $expire = 0, $path = '/', $domain = null, $secure = null, $httpOnly = true, $raw = false, $sameSite = null)
     {
         if ($secure === null) {
-            $secure = $this->request->isSecure();
+            $secure = $this->isSecureDefault();
         } else {
             $secure = (bool) $secure;
         }
@@ -67,6 +84,7 @@ class ResponseCookieJar
      */
     public function addCookieObject(Cookie $cookie)
     {
+        $cookie->setSecureDefault($this->isSecureDefault());
         $name = $cookie->getName();
         $isNew = true;
         foreach ($this->cookies as $index => $value) {

--- a/concrete/src/Cookie/ResponseCookieJar.php
+++ b/concrete/src/Cookie/ResponseCookieJar.php
@@ -2,10 +2,21 @@
 
 namespace Concrete\Core\Cookie;
 
+use Concrete\Core\Http\Request;
 use Symfony\Component\HttpFoundation\Cookie;
 
 class ResponseCookieJar
 {
+    /**
+     * @var \Concrete\Core\Http\Request
+     */
+    protected $request;
+
+    public function __construct(Request $request)
+    {
+        $this->request = $request;
+    }
+
     /**
      * The list of new cookies to be added to the response.
      *
@@ -28,7 +39,7 @@ class ResponseCookieJar
      * @param int $expire The number of seconds until the cookie expires
      * @param string $path The path for the cookie
      * @param null|string $domain The domain the cookie is available to
-     * @param bool $secure whether the cookie should only be transmitted over a HTTPS connection from the client
+     * @param bool|null $secure whether the cookie should only be transmitted over a HTTPS connection from the client. Use NULL to to set the secure flag if the current request uses HTTPS
      * @param bool $httpOnly Whether the cookie will be made accessible only through the HTTP protocol
      * @param bool $raw Whether the cookie value should be sent with no url encoding
      * @param string|null $sameSite Whether the cookie will be available for cross-site requests
@@ -36,6 +47,11 @@ class ResponseCookieJar
      */
     public function addCookie($name, $value = null, $expire = 0, $path = '/', $domain = null, $secure = false, $httpOnly = true, $raw = false, $sameSite = null)
     {
+        if ($secure === null) {
+            $secure = $this->request->isSecure();
+        } else {
+            $secure = (bool) $secure;
+        }
         $cookie = new Cookie($name, $value, $expire, $path, $domain, $secure, $httpOnly, $raw, $sameSite);
         $this->addCookieObject($cookie);
 

--- a/concrete/src/Cookie/ResponseCookieJar.php
+++ b/concrete/src/Cookie/ResponseCookieJar.php
@@ -40,8 +40,6 @@ class ResponseCookieJar
 
     /**
      * Get the value of the "secure" flag when it is set to null.
-     *
-     * @return $this
      */
     public function isSecureDefault(): bool
     {

--- a/concrete/src/Session/SessionFactory.php
+++ b/concrete/src/Session/SessionFactory.php
@@ -72,7 +72,7 @@ class SessionFactory implements SessionFactoryInterface
 
         /* @TODO Remove this call. We should be able to set this against the request somewhere much higher than this */
         /*       At the very least we should have an observer that can track the session status and set this */
-        $this->app->make(\Concrete\Core\Http\Request::class)->setSession($session);
+        $this->app->make(Request::class)->setSession($session);
 
         return $session;
     }
@@ -186,6 +186,9 @@ class SessionFactory implements SessionFactoryInterface
 
         if (array_get($options, 'cookie_path', false) === false) {
             $options['cookie_path'] = $app['app_relative_path'] . '/';
+        }
+        if (array_get($options, 'cookie_secure') === null) {
+            $options['cookie_secure'] = $this->app->make(Request::class)->isSecure();
         }
 
         $storage->setOptions($options);

--- a/tests/tests/Cookie/CookieTest.php
+++ b/tests/tests/Cookie/CookieTest.php
@@ -11,16 +11,19 @@ class CookieTest extends TestCase
 {
     public function testCookiesFromRequest()
     {
-        $jar = new CookieJar($this->getSampleRequest([]), new ResponseCookieJar());
+        $request = $this->getSampleRequest([]);
+        $jar = new CookieJar($request, new ResponseCookieJar($request));
         $this->assertFalse($jar->has('test'));
-        $jar = new CookieJar($this->getSampleRequest(['test' => 'RequestCookieValue']), new ResponseCookieJar());
+        $request = $this->getSampleRequest(['test' => 'RequestCookieValue']);
+        $jar = new CookieJar($request, new ResponseCookieJar($request));
         $this->assertTrue($jar->has('test'));
         $this->assertSame('RequestCookieValue', $jar->get('test'));
     }
 
     public function testOverridingCookies()
     {
-        $jar = new CookieJar($this->getSampleRequest(['test1' => 'RequestCookieValue1', 'test2' => 'RequestCookieValue2']), new ResponseCookieJar());
+        $request = $this->getSampleRequest(['test1' => 'RequestCookieValue1', 'test2' => 'RequestCookieValue2']);
+        $jar = new CookieJar($request, new ResponseCookieJar($request));
 
         $this->assertTrue($jar->has('test1'));
         $this->assertTrue($jar->has('test2'));

--- a/tests/tests/Update/NewMigrationsTest.php
+++ b/tests/tests/Update/NewMigrationsTest.php
@@ -22,7 +22,17 @@ class NewMigrationsTest extends TestCase
                 return $pullRequestMigrationID < $baseMigrationID;
             });
         }
-        $this->assertSame([], $invalidMigrationIDs, "There shouldn't be any migration with an ID lower than {$baseMigrationID}");
+        $this->assertSame(
+            [],
+            $invalidMigrationIDs,
+            <<<EOT
+There shouldn't be any migration with an ID lower than {$baseMigrationID}
+for commits between
+{$state->getBaseSha1()}
+and
+{$state->getMergeSha1()} 
+EOT
+        );
     }
 
     /**


### PR DESCRIPTION
By default we currently don't set the "secure" flag of session cookies.
We do that in order to let websites being served via HTTP (setting the "secure" flag for HTTP websites would prevent users from logging in).

What about changing the default behaviour, creating "secure" cookies automatically for websites served via HTTPS?

I've also updated the System & Settings > Login & Registration > Session Options dashboard page:

| Before | After |
|---|---|
| ![immagine](https://github.com/concretecms/concretecms/assets/928116/4ad06bf4-a36d-4d81-a985-33191c677e53) | ![immagine](https://github.com/concretecms/concretecms/assets/928116/202bf74b-5675-42dc-a599-badda8b272cd) |

If users visit the dashboard page via HTTP, I also added this tooltip:

![immagine](https://github.com/concretecms/concretecms/assets/928116/8035ea55-8bfa-4a5d-b218-a1c9287c11d2)




Ref: H1 2399192