### PR TITLE
Reload page when swapping a file

### DIFF
--- a/concrete/controllers/dialog/file/replace.php
+++ b/concrete/controllers/dialog/file/replace.php
@@ -24,6 +24,7 @@ class Replace extends Import
     {
         parent::setViewSets();
         $this->set('replacingFile', $this->getReplacingFile());
+        $this->set('reloadOnReplace', $this->getReloadOnReplace());
     }
 
     /**
@@ -98,5 +99,10 @@ class Replace extends Import
         $replacingFilePermissions = new Checker($replacingFile);
 
         return $replacingFilePermissions->canEditFileContents();
+    }
+
+    protected function getReloadOnReplace(): bool
+    {
+        return filter_var($this->request->query->get('reloadOnReplace'), FILTER_VALIDATE_BOOLEAN);
     }
 }

--- a/concrete/elements/dashboard/files/header.php
+++ b/concrete/elements/dashboard/files/header.php
@@ -28,7 +28,7 @@ $folder = $file->getFileFolderObject();
                    title="<?=t('Upload a new file to be used everywhere this current file is referenced.')?>"
                    dialog-title="<?= t('Swap') ?>"
                    dialog-width="80%" dialog-height="600"
-                   href="<?= URL::to('/ccm/system/dialogs/file/replace')?>?fID=<?=$file->getFileID()?>"
+                   href="<?= URL::to('/ccm/system/dialogs/file/replace')?>?fID=<?=$file->getFileID()?>&reloadOnReplace=true"
                 ><?=t('Swap')?></a></li>
 
             <li><a class="dropdown-item launch-tooltip"

--- a/concrete/views/dialogs/file/import.php
+++ b/concrete/views/dialogs/file/import.php
@@ -16,20 +16,23 @@ use Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface;
 use Concrete\Controller\Dialog\File\Import;
 use Concrete\Core\View\DialogView;
 
-/* @var Import $controller */
-/* @var DialogView $view */
-/* @var Token $token */
-/* @var Form $form */
-/* @var UserInterface $ui */
-/* @var ResolverManagerInterface $resolverManager */
-/* @var string $formID */
-/* @var FileFolder|null $currentFolder */
-/* @var Page|null $originalPage */
-/* @var StorageLocation $incomingStorageLocation */
-/* @var string $incomingPath */
-/* @var array $incomingContents */
-/* @var string|null $incomingContentsError */
-/* @var File|null $replacingFile */
+/**
+ * @var Import $controller
+ * @var DialogView $view
+ * @var Token $token
+ * @var Form $form
+ * @var UserInterface $ui
+ * @var ResolverManagerInterface $resolverManager
+ * @var string $formID
+ * @var FileFolder|null $currentFolder
+ * @var Page|null $originalPage
+ * @var StorageLocation $incomingStorageLocation
+ * @var string $incomingPath
+ * @var array $incomingContents
+ * @var string|null $incomingContentsError
+ * @var File|null $replacingFile
+ * @var bool|null $reloadOnReplace (may be not set)
+ */
 
 $app = Application::getFacadeApplication();
 /** @var Identifier $idHelper */
@@ -54,6 +57,7 @@ $dropZoneId = "ccm-drop-zone-" . $idHelper->getString();
                 if ($replacingFile ?? null) {
                     ?>
                     :replace-file-id="<?= $replacingFile->getFileID() ?>"
+                    :reload-on-replace="<?= ($reloadOnReplace ?? false) ? 'true' : 'false' ?>"
                     <?php
                 }
                 ?>


### PR DESCRIPTION
When we replace ("swap") a file in the `/dashboard/files/details/<file-id>` dashboard page, nothing happens: we should reload the page instead.

Before:

https://github.com/concretecms/concretecms/assets/928116/d1fe1814-0ce6-4c77-8763-03c0be7d26ab

After:

https://github.com/concretecms/concretecms/assets/928116/0ae7ea87-a105-4694-8eb4-475564f988f3


