### PR TITLE
[v8] Additional fix for concretecms#10051

### DIFF
--- a/concrete/src/Page/Type/Composer/Control/CollectionAttributeControl.php
+++ b/concrete/src/Page/Type/Composer/Control/CollectionAttributeControl.php
@@ -121,6 +121,11 @@ class CollectionAttributeControl extends Control
 
     public function shouldPageTypeComposerControlStripEmptyValuesFromPage()
     {
+        $ak = $this->getAttributeKeyObject();
+        if (is_object($ak) && $ak->getAttributeTypeHandle() === 'boolean') {
+            return false;
+        }
+
         return true;
     }
 


### PR DESCRIPTION
**Striping boolean attribute values make it `false`.**

We are currently using a page list block that filters pages based on a boolean attribute with the value set to `true`. However, when someone edits a page, saves changes, or submits it for workflow approval, the page reappears in the list. This is because the attribute value gets deleted and becomes `null`.