### PR TITLE
Make it enable to include child topics on filter by topic attribute

### DIFF
--- a/concrete/attributes/topics/controller.php
+++ b/concrete/attributes/topics/controller.php
@@ -63,6 +63,7 @@ class Controller extends AttributeTypeController implements
 
         $expressions = [];
         $qb = $list->getQueryObject();
+        $expr = $qb->expr();
         foreach ($topics as $value) {
             if ($value instanceof TreeNode) {
                 $topic = $value;
@@ -73,11 +74,11 @@ class Controller extends AttributeTypeController implements
                     $topic instanceof \Concrete\Core\Tree\Node\Type\Topic ||
                     $topic instanceof Category)) {
                 $column = 'ak_' . $this->attributeKey->getAttributeKeyHandle();
-                $expressions[] = $qb->expr()->like($column, $qb->createNamedParameter('%||' . $topic->getTreeNodeDisplayPath() . '||%'));
+                $expressions[] = $expr->like($column, $qb->createNamedParameter('%||' . $topic->getTreeNodeDisplayPath() . '||%'));
+                $expressions[] = $expr->like($column, $qb->createNamedParameter('%||' . $topic->getTreeNodeDisplayPath() . '/%'));
             }
         }
 
-        $expr = $qb->expr();
         $qb->andWhere(call_user_func_array([$expr, 'orX'], $expressions));
     }
 


### PR DESCRIPTION
This PR fixes #11843 .

The reason this issue happens is the changes introduced in #11734 .
This PR makes sense, so I couldn't decide whether #11843 is a bug or an unexpected side effect, but I'd like to fix this issue for backward compatibility.