### PR TITLE
Better support for multiple redirect URIs

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -8,7 +8,7 @@ return [
      */
     'version' => '9.2.7',
     'version_installed' => '9.2.7',
-    'version_db' => '20240122172319', // the key of the latest database migration
+    'version_db' => '20240318000000', // the key of the latest database migration
 
     /*
      * Installation status

--- a/concrete/single_pages/dashboard/system/api/integrations/form.php
+++ b/concrete/single_pages/dashboard/system/api/integrations/form.php
@@ -35,7 +35,7 @@ if (isset($client) && $client->hasCustomScopes()) {
             <div class="mb-3">
                 <label class="form-label" for="redirect"><?php echo t('Redirect'); ?></label>
                 <div class="input-group">
-                    <input type="url" class="form-control" autocomplete="off"  v-model="redirect">
+                    <input pattern="https?:\/\/.+" class="form-control" autocomplete="off"  v-model="redirect">
                     <span class="input-group-text"><i class="fas fa-asterisk"></i></span>
                 </div>
             </div>

--- a/concrete/src/Entity/OAuth/Client.php
+++ b/concrete/src/Entity/OAuth/Client.php
@@ -41,8 +41,8 @@ class Client implements ClientEntityInterface, \JsonSerializable
     protected $name;
 
     /**
-     * @var string|string[]
-     * @ORM\Column(type="string")
+     * @var string
+     * @ORM\Column(type="text")
      */
     protected $redirectUri;
 

--- a/concrete/src/Updater/Migrations/Migrations/Version20240318000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20240318000000.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Entity\OAuth\Client;
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
+
+final class Version20240318000000 extends AbstractMigration implements RepeatableMigrationInterface
+{
+    public function upgradeDatabase(): void
+    {
+        $this->refreshEntities([
+            // Update varchar to text
+            Client::class,
+        ]);
+    }
+}


### PR DESCRIPTION
This PR does a few things to better support multiple redirect URIs:

1. Switch from `type='uri'` to a basic pattern that forces the string to start with `http://` or `https://`
2. Use `text` column type for redirects so that we can fit longer redirect uris than 255 chars
3. Update the form validation for save to validate the URIs individually rather than as a single string
4. Adds a migration to handle upgrade

The effect of those changes is I can have as many redirect URIs as I want.
