### PR TITLE
PHP 8 potentially undefined variable in view

### DIFF
--- a/concrete/single_pages/dashboard/pages/types/view.php
+++ b/concrete/single_pages/dashboard/pages/types/view.php
@@ -103,7 +103,7 @@
         } else {
             ?>
 		<p><?= t('You have not created any page types yet.'); ?></p>
-		<a href="<?= URL::to('/dashboard/pages/types/add', $siteTypeID); ?>" class="btn btn-primary"><?=t('Add Page Type'); ?></a>
+		<a href="<?= URL::to('/dashboard/pages/types/add', $siteTypeID ?? ''); ?>" class="btn btn-primary"><?=t('Add Page Type'); ?></a>
 	<?php
         } ?>
 


### PR DESCRIPTION
`$siteTypeID` is not always defined so will throw
> Whoops \ Exception \ ErrorException (E_WARNING)
> Undefined variable $siteTypeID

When visiting `/dashboard/pages/types` on a fresh install in some cases.

