### PR TITLE
Remove dangling CollectionVersionBlocks

### DIFF
--- a/concrete/src/Page/Collection/Version/Version.php
+++ b/concrete/src/Page/Collection/Version/Version.php
@@ -988,6 +988,11 @@ class Version extends ConcreteObject implements PermissionObjectInterface, Attri
             $cvID,
         ));
 
+        $db->executeQuery('delete from CollectionVersionBlocks where cID = ? and cvID = ?', array(
+            $cID,
+            $cvID,
+        ));
+
         $q = "delete from CollectionVersions where cID = '{$cID}' and cvID='{$cvID}'";
         $db->executeQuery($q);
         $this->refreshCache();


### PR DESCRIPTION
It happens from time to time that there is a row in CollectionVersionBlocks referencing a bID to a block which no longer exists. These rows currently do not get deleted when you delete a version. This can "break" the page. 
Lets say the newest/live version is 3. Now you decide to approve version 2 and afterwards you delete version 3. Now there is still a row in CollectionVersionBlocks referring to version 3 because the block it referenced does no longer exist. This means you cannot create a new version anymore and instead you will get a "Integrity constraint violation: 1062 Duplicate entry" error. 
This is not a perfect solution because it does not address why there is a row referencing a block which no longer exists. But it will clean up "dangling" rows when you delete a version, making sure you do not brick the page.

*Check these before submitting new pull requests*

- [x] I read the __guidelines for contributing__ linked above. My pull request conforms to the coding style guidelines described within.

If this condition is met, feel free to delete this whole message and to submit your pull request.

Thank you, your help is really appreciated!
