### PR TITLE
Fix "Decrement on bool" in page statistics

### DIFF
--- a/concrete/src/Page/Statistics.php
+++ b/concrete/src/Page/Statistics.php
@@ -64,7 +64,7 @@ class Statistics
     {
         $db = Loader::db();
         $cParentID = $db->GetOne("select cParentID from Pages where cID = ?", array($cID));
-        $cChildren = $db->GetOne("select cChildren from Pages where cID = ?", array($cParentID));
+        $cChildren = (int) $db->GetOne("select cChildren from Pages where cID = ?", array($cParentID));
         --$cChildren;
         if ($cChildren < 0) {
             $cChildren = 0;


### PR DESCRIPTION
This fixes the following issue:

Decrement on type bool has no effect, this will change in the next major version of PHP
