### PR TITLE
Fix for some of the warnings in PHP 8

### DIFF
--- a/concrete/blocks/express_entry_list/controller.php
+++ b/concrete/blocks/express_entry_list/controller.php
@@ -134,6 +134,8 @@ class Controller extends BlockController implements UsesFeatureInterface
      */
     public $titleFormat;
 
+    public $entityManager;
+    
     protected $btInterfaceWidth = "640";
     protected $btInterfaceHeight = "400";
     protected $btTable = 'btExpressEntryList';

--- a/concrete/src/Application/Service/Dashboard.php
+++ b/concrete/src/Application/Service/Dashboard.php
@@ -85,7 +85,7 @@ class Dashboard
             }
         }
 
-        return $path === '/dashboard' || strpos($path, '/dashboard/') === 0;
+        return $path === '/dashboard' || strpos((string) $path, '/dashboard/') === 0;
     }
 
     /**


### PR DESCRIPTION
Although the $path is set to a string, `getCollectionPath()` sometimes returns `null`, which produces a warning:

strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated