### PR TITLE
Update maxFilesize limit

### DIFF
--- a/concrete/src/File/Upload/Dropzone.php
+++ b/concrete/src/File/Upload/Dropzone.php
@@ -65,6 +65,7 @@ class Dropzone extends ClientSideUploader
             'timeout' => $this->getTimeout() * 1000,
             'chunking' => $this->isChunkingEnabled(),
             'parallelUploads' => $this->getParallelUploads(),
+            'maxFilesize' => 4096, // 4GiB
         ] + $this->getLocalizationOptions();
         if ($options['chunking']) {
             // You cannot set both: uploadMultiple and chunking


### PR DESCRIPTION
Set very high so this be determined by server and PHP settings Addresses https://forums.concretecms.org/t/concrete-9-unable-to-upload-files-larger-than-256mb/1578

Reference: https://docs.dropzone.dev/configuration/basics/configuration-options