### PR TITLE
SEOCanonical Class Add getIncludedQuerystringParameters()

### DIFF
--- a/concrete/src/Url/SeoCanonical.php
+++ b/concrete/src/Url/SeoCanonical.php
@@ -166,4 +166,13 @@ class SeoCanonical
     {
         $this->includedQuerystringParameters[] = $parameter;
     }
+
+    /**
+     * @since 9.2.X
+     * @return array
+     */
+    public function getIncludedQuerystringParameters()
+    {
+        return $this->includedQuerystringParameters;
+    }
 }


### PR DESCRIPTION
Use this method to return the list of included querystring keys for the current page.  In my case, this is facilitating the further refinement of core canonical url output.

Currently there is an associated bug which I'm able to work around in the mean time...
https://github.com/concretecms/concretecms/issues/12013