### PR TITLE
Replace 'getHomePageID' with 'getSiteHomePageID' to retrieve the correct site's home page ID instead of the default one

### DIFF
--- a/concrete/src/Http/ResponseFactory.php
+++ b/concrete/src/Http/ResponseFactory.php
@@ -381,7 +381,7 @@ class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInter
 
         // let's test to see if this is, in fact, the home page,
         // and we're routing arguments onto it (which is screwing up the path.)
-        $home = Page::getByID(Page::getHomePageID());
+        $home = Page::getByID($this->app['site']->getSite()->getSiteHomePageID());
         $request->setCurrentPage($home);
         $homeController = $home->getPageController();
         $homeController->setupRequestActionAndParameters($request);


### PR DESCRIPTION
fixes #12029 