### PR TITLE
Feature #11763: Add total downloads count to FileList

### DIFF
--- a/concrete/src/File/FileList.php
+++ b/concrete/src/File/FileList.php
@@ -35,6 +35,7 @@ class FileList extends DatabaseItemList implements PagerProviderInterface, Pagin
         'f.fDateAdded',
         'fv.fvDateAdded',
         'fv.fvSize',
+        'totalDownloads',
     ];
 
     public function __construct(StickyRequest $req = null)

--- a/concrete/src/File/Search/ColumnSet/Available.php
+++ b/concrete/src/File/Search/ColumnSet/Available.php
@@ -1,6 +1,7 @@
 <?php
 namespace Concrete\Core\File\Search\ColumnSet;
 
+use Concrete\Core\File\Search\ColumnSet\Column\DownloadsColumn;
 use Concrete\Core\File\Search\ColumnSet\Column\FileIDColumn;
 use Concrete\Core\File\Search\ColumnSet\Column\FileVersionDateAddedColumn;
 use Concrete\Core\File\Search\ColumnSet\Column\FileVersionFilenameColumn;
@@ -69,6 +70,18 @@ class Available extends DefaultSet
         return $app->make('date')->formatDateTime($f->getDateAdded()->getTimestamp());
     }
 
+    public static function getDownloads($node)
+    {
+        if ($node->getTreeNodeTypeHandle() == 'file') {
+            $file = $node->getTreeNodeFileObject();
+            if (is_object($file)) {
+                return $file->getTotalDownloads();
+            }
+        }
+
+        return '';
+    }
+
     public function __construct()
     {
         parent::__construct();
@@ -77,5 +90,6 @@ class Available extends DefaultSet
         $this->addColumn(new FileIDColumn());
         $this->addColumn(new FileVersionFilenameColumn());
         $this->addColumn(new FileVersionDateAddedColumn());
+        $this->addColumn(new DownloadsColumn());
     }
 }

--- a/concrete/src/File/Search/ColumnSet/Column/DownloadsColumn.php
+++ b/concrete/src/File/Search/ColumnSet/Column/DownloadsColumn.php
@@ -1,0 +1,38 @@
+<?php
+namespace Concrete\Core\File\Search\ColumnSet\Column;
+
+use Concrete\Core\Database\Query\AndWhereNotExistsTrait;
+use Concrete\Core\Search\Column\Column;
+use Concrete\Core\Search\Column\PagerColumnInterface;
+use Concrete\Core\Search\ItemList\Pager\PagerProviderInterface;
+
+class DownloadsColumn extends Column implements PagerColumnInterface
+{
+
+    use AndWhereNotExistsTrait;
+
+    public function getColumnKey()
+    {
+        return 'totalDownloads';
+    }
+
+    public function getColumnName()
+    {
+        return t('Downloads');
+    }
+
+    public function getColumnCallback()
+    {
+        return ['\Concrete\Core\File\Search\ColumnSet\Available', 'getDownloads'];
+    }
+
+    public function filterListAtOffset(PagerProviderInterface $itemList, $mixed)
+    {
+        $query = $itemList->getQueryObject();
+        $sort = $this->getColumnSortDirection() == 'desc' ? '<' : '>';
+        $where = sprintf('totalDownloads %s :sortDownloads', $sort);
+        $query->setParameter('sortDownloads', $mixed->getTotalDownloads());
+        $this->andWhereNotExists($query, $where);
+    }
+
+}

--- a/concrete/src/File/Search/ColumnSet/DefaultSet.php
+++ b/concrete/src/File/Search/ColumnSet/DefaultSet.php
@@ -72,4 +72,16 @@ class DefaultSet extends ColumnSet
         $type = $this->getColumnByKey('name');
         $this->setDefaultSortColumn($type, 'asc');
     }
+
+    public static function getDownloads($node)
+    {
+        if ($node->getTreeNodeTypeHandle() == 'file') {
+            $file = $node->getTreeNodeFileObject();
+            if (is_object($file)) {
+                return $file->getTotalDownloads();
+            }
+        }
+
+        return '';
+    }
 }


### PR DESCRIPTION
This commit adds the total downloads count to the FileList and FolderItemList. It creates a DownloadsColumn class specifically for a new column in the file search menu to display total downloads. This update provides a clearer and more detailed display for the user.

*Check these before submitting new pull requests*

- [ ] I read the __guidelines for contributing__ linked above. My pull request conforms to the coding style guidelines described within.

If this condition is met, feel free to delete this whole message and to submit your pull request.

Thank you, your help is really appreciated!
