### PR TITLE
[8.5] Fix getting all redis keys

### DIFF
--- a/concrete/src/Cache/Driver/RedisStashDriver.php
+++ b/concrete/src/Cache/Driver/RedisStashDriver.php
@@ -234,7 +234,7 @@ class RedisStashDriver extends AbstractDriver
             // If we have a prefix delete only the prefix keys
             if (!empty($this->prefix)) {
                 // This attaches the prefix to the keys
-                $keys = $this->redis->getKeys('*');
+                $keys = method_exists($this->redis, 'keys') ? $this->redis->keys('*') : $this->redis->getKeys('*');
                 // Remove the prefix
                 $this->redis->setOption(\Redis::OPT_PREFIX, null);
                 // Delete all keys

--- a/concrete/src/Session/SessionFactory.php
+++ b/concrete/src/Session/SessionFactory.php
@@ -294,7 +294,7 @@ class SessionFactory implements SessionFactoryInterface
         if (count($servers) == 1) {
             // If we only have one server in our array then we just reconnect to it
             $server = $servers[0];
-            $redis = $this->app->make(Redis::class);
+            $redis = $this->app->make(Redis::class, ['options' => []]);
 
             if (isset($server['socket']) && $server['socket']) {
                 $redis->connect($server['socket']);


### PR DESCRIPTION
When using Ondřej's PHP 7.4, the output of `php --ri redis` is:

- on Ubuntu 18.04: `Redis Version => 5.3.7`
- on Ubuntu 24.04: `Redis Version => 6.0.2`

And on Ubuntu 24.04 we have this error:

```
Error: Call to undefined method Redis::getKeys() in file concrete/src/Cache/Driver/RedisStashDriver.php on line 237
```

Let's fix this issue.