### PR TITLE
Strengthen tolerance of DefaultPackageProvider

### DIFF
--- a/concrete/src/Database/EntityManager/Provider/DefaultPackageProvider.php
+++ b/concrete/src/Database/EntityManager/Provider/DefaultPackageProvider.php
@@ -63,10 +63,13 @@ class DefaultPackageProvider extends AbstractPackageProvider
         }
 
         // Now if there are any autoloader entries, we automatically make those entity locations as well.
-        foreach($this->pkg->getPackageAutoloaderRegistries() as $path => $prefix) {
-            $drivers[] = new Driver(trim($prefix, '\\'),
-                new AnnotationDriver($reader, $this->pkg->getPackagePath() . '/' . $path)
-            );
+        $registries = $this->pkg->getPackageAutoloaderRegistries();
+        if(!empty($registries)) {
+            foreach($this->pkg->getPackageAutoloaderRegistries() as $path => $prefix) {
+                $drivers[] = new Driver(trim($prefix, '\\'),
+                    new AnnotationDriver($reader, $this->pkg->getPackagePath() . '/' . $path)
+                );
+            }
         }
 
         return $drivers;

--- a/concrete/src/Database/EntityManager/Provider/DefaultPackageProvider.php
+++ b/concrete/src/Database/EntityManager/Provider/DefaultPackageProvider.php
@@ -65,7 +65,7 @@ class DefaultPackageProvider extends AbstractPackageProvider
         // Now if there are any autoloader entries, we automatically make those entity locations as well.
         $registries = $this->pkg->getPackageAutoloaderRegistries();
         if(!empty($registries)) {
-            foreach($this->pkg->getPackageAutoloaderRegistries() as $path => $prefix) {
+            foreach($registries as $path => $prefix) {
                 $drivers[] = new Driver(trim($prefix, '\\'),
                     new AnnotationDriver($reader, $this->pkg->getPackagePath() . '/' . $path)
                 );


### PR DESCRIPTION
When packages are uninstalled, the foreach loop can sometimes whoops on empty registries.

This change allows the DefaultPackageProvider to be more tolerant of such issues.