### PR TITLE
Fix undefined array key in workflow 

### DIFF
--- a/concrete/src/Workflow/Progress/BasicData.php
+++ b/concrete/src/Workflow/Progress/BasicData.php
@@ -9,7 +9,7 @@ class BasicData
     {
         $db = Loader::db();
         $r = $db->GetRow('select * from BasicWorkflowProgressData where wpID = ?', array($wp->getWorkflowProgressID()));
-        if (is_array($r) && $r['wpID']) {
+        if (!empty($r) && $r['wpID']) {
             $this->uIDStarted = $r['uIDStarted'];
             $this->uIDCompleted = $r['uIDCompleted'];
             $this->wpDateCompleted = $r['wpDateCompleted'];


### PR DESCRIPTION
`GetRow` function always returns array even if object has not been found. So we need to check if it's empty instead. Otherwise it will always throw an exception "undefined array key".
