### PR TITLE
Fixes issue with advanced log configuration

### DIFF
--- a/concrete/src/Logging/Configuration/AdvancedConfiguration.php
+++ b/concrete/src/Logging/Configuration/AdvancedConfiguration.php
@@ -26,10 +26,10 @@ class AdvancedConfiguration implements ConfigurationInterface
     {
         if (isset($config['loggers']) && is_array($config['loggers'])
             && array_key_exists(Channels::META_CHANNEL_ALL, $config['loggers'])) {
-    
+
             $allConfig = $config['loggers'][Channels::META_CHANNEL_ALL];
             $channels = array_merge(Channels::getCoreChannels(), [Channels::CHANNEL_APPLICATION]);
-            foreach($channels as $channel) {
+            foreach(array_diff($channels, array_keys($config['loggers'])) as $channel) {
                 $config['loggers'][$channel] = $allConfig;
             }
             unset($config['loggers'][Channels::META_CHANNEL_ALL]);


### PR DESCRIPTION
If you use advanced log configuration to set your own logger for `Channels::META_CHANNEL_ALL`, this logger gets applied to all core channels. Therefore you cannot set this at the same time as customising a specific core channel.

Found this by attempting to follow [this](https://documentation.concretecms.org/9-x/developers/security/logging#heading-7) guide.

This fix removes any core channels overridden in `application/concrete/config` from the loop.
