### PR TITLE
Fix type of "length" ORM annotation in SearchResult Health entity

### DIFF
--- a/concrete/src/Entity/Health/Report/SearchResult.php
+++ b/concrete/src/Entity/Health/Report/SearchResult.php
@@ -22,7 +22,7 @@ class SearchResult extends Result
 
     /**
      *
-     * @ORM\Column(type="string", length="1")
+     * @ORM\Column(type="string", length=1)
      */
     protected $searchType;
 


### PR DESCRIPTION
The `length` annotation requires an integer value, not a string.