### PR TITLE
Register switch_language path as all

### DIFF
--- a/concrete/routes/multilingual.php
+++ b/concrete/routes/multilingual.php
@@ -13,7 +13,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
  */
 
 $router
-    ->get('/switch_language/{currentPageID}/{targetSectionID}', 'SwitchLanguage::switchLanguage')
+    ->post('/switch_language/{currentPageID}/{targetSectionID}', 'SwitchLanguage::switchLanguage')
     ->setName('switch_language')
     ->setRequirements(['currentPageID' => '[0-9]+', 'targetSectionID' => '[0-9]+'])
 ;

--- a/concrete/routes/multilingual.php
+++ b/concrete/routes/multilingual.php
@@ -13,7 +13,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
  */
 
 $router
-    ->post('/switch_language/{currentPageID}/{targetSectionID}', 'SwitchLanguage::switchLanguage')
+    ->all('/switch_language/{currentPageID}/{targetSectionID}', 'SwitchLanguage::switchLanguage')
     ->setName('switch_language')
     ->setRequirements(['currentPageID' => '[0-9]+', 'targetSectionID' => '[0-9]+'])
 ;


### PR DESCRIPTION
The switch language block makes a POST request to the `/ccm/frontend/multilingual/switch_language` path, but the route is registered as GET. I have updated the route to POST. Please let me know if you would prefer to use `ALL` instead of `POST`.