### PR TITLE
remove unused ids on twitter icons

### DIFF
--- a/concrete/src/Sharing/ShareThisPage/ServiceList.php
+++ b/concrete/src/Sharing/ShareThisPage/ServiceList.php
@@ -8,7 +8,7 @@ class ServiceList
     {
         return array(
             array('facebook', 'Facebook', 'fab fa-facebook'),
-            array('twitter', 'X',  null, '<svg id="icon-twitter-x" width="16" height="16" viewBox="0 0 300 300" version="1.1" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M178.57 127.15 290.27 0h-26.46l-97.03 110.38L89.34 0H0l117.13 166.93L0 300.25h26.46l102.4-116.59 81.8 116.59h89.34M36.01 19.54H76.66l187.13 262.13h-40.66"/></svg>'),
+            array('twitter', 'X',  null, '<svg width="16" height="16" viewBox="0 0 300 300" version="1.1" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M178.57 127.15 290.27 0h-26.46l-97.03 110.38L89.34 0H0l117.13 166.93L0 300.25h26.46l102.4-116.59 81.8 116.59h89.34M36.01 19.54H76.66l187.13 262.13h-40.66"/></svg>'),
             array('linkedin', 'LinkedIn', 'fab fa-linkedin'),
             array('reddit', 'Reddit', 'fab fa-reddit'),
             array('pinterest', 'Pinterest', 'fab fa-pinterest'),

--- a/concrete/src/Sharing/SocialNetwork/ServiceList.php
+++ b/concrete/src/Sharing/SocialNetwork/ServiceList.php
@@ -7,7 +7,7 @@ class ServiceList
     {
         $services = [
             ['facebook', 'Facebook', 'fab fa-facebook'],
-            ['twitter', 'X',  null, '<svg id="icon-twitter-x" width="16" height="16" viewBox="0 0 300 300" version="1.1" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M178.57 127.15 290.27 0h-26.46l-97.03 110.38L89.34 0H0l117.13 166.93L0 300.25h26.46l102.4-116.59 81.8 116.59h89.34M36.01 19.54H76.66l187.13 262.13h-40.66"/></svg>'],
+            ['twitter', 'X',  null, '<svg width="16" height="16" viewBox="0 0 300 300" version="1.1" xmlns="http://www.w3.org/2000/svg"><path fill="currentColor" d="M178.57 127.15 290.27 0h-26.46l-97.03 110.38L89.34 0H0l117.13 166.93L0 300.25h26.46l102.4-116.59 81.8 116.59h89.34M36.01 19.54H76.66l187.13 262.13h-40.66"/></svg>'],
             ['instagram', 'Instagram', 'fab fa-instagram'],
             ['tumblr', 'Tumblr', 'fab fa-tumblr-square'],
             ['github', 'Github', 'fab fa-github-square'],


### PR DESCRIPTION
The twitter icon in the social services uses has an id so when adding multiple times this icon, the W3C validator fails because of duplicate ids.
The id is unused ( there is no css nor JS related to it ) so I removed it
