### PR TITLE
Saving attribute throws error when no set selected

### DIFF
--- a/concrete/src/Page/Controller/DashboardAttributesPageController.php
+++ b/concrete/src/Page/Controller/DashboardAttributesPageController.php
@@ -196,6 +196,7 @@ abstract class DashboardAttributesPageController extends DashboardPageController
         $request = $this->request;
         $entity = $this->getCategoryObject();
         $category = $entity->getAttributeKeyCategory();
+        $set = null;
         if ($category->getSetManager()->allowAttributeSets()) {
             if ($request->request->has('asID')) {
                 $set = Set::getByID($request->request->get('asID'));


### PR DESCRIPTION
This takes place when saving an attribute settings from the dashboard. I noticed it when saving user attributes.

When the 'asID' parameter is not available in the request, the variable $set is not set at all and an error is thrown on line 209.

This fix simply initializes the $set variable with a default value of null
