### PR TITLE
Nginx rule: don't suggest $uri/ in try_files

### DIFF
--- a/concrete/src/Service/Configuration/HTTP/NginxGenerator.php
+++ b/concrete/src/Service/Configuration/HTTP/NginxGenerator.php
@@ -44,7 +44,7 @@ class NginxGenerator extends Generator implements GeneratorInterface
 
                 return <<<EOT
 location {$DIR_REL}/ {
-	try_files \$uri \$uri/ {$DIR_REL}/{$DISPATCHER_FILENAME}?\$query_string;
+	try_files \$uri \$uri/index.html \$uri/index.php {$DIR_REL}/{$DISPATCHER_FILENAME}?\$query_string;
 }
 EOT
                 ;


### PR DESCRIPTION
We are currently suggesting this nginx configuration in the /dashboard/system/seo/urls dashboard page:

```nginx
location / {
	try_files $uri $uri/ /index.php?$query_string;
}
```

That instructs nginx to serve:
1. the requested file at `$uri` if it's an existing file (the ` $url ` chunk)
2. the directory index at  `$uri` if it's an existing directory (the ` $url/ ` chunk)
3. otherwise use `/index.php` (the ` /index.php?$query_string ` chunk)

The second chunk isn't correct IMHO: I have these entries in my nginx error logs

```
2024/06/23 16:49:24 [error] 145180#145180: *1234567 directory index of
"/var/www/www.mysite.com/concrete/images/"
is forbidden, client: 1.2.3.4, server: www.mysite.com, request:
"GET /concrete/images/ HTTP/1.1", host: "www.mysite.com"
```

What about suggesting the following instead?

```nginx
location / {
	try_files $uri $uri/index.html $uri/index.php /index.php?$query_string;
}
```

## Comparision of a directory that doesn't contain an `index.html` file

With the old nginx configuration files, we have:

```
$ curl -Ii https://www.mysite.com/concrete/images
HTTP/1.1 301 Moved Permanently
Location: https://www.mysite.com/concrete/images/
…

$ curl -Ii https://www.mysite.com/concrete/images/
HTTP/1.1 403 Forbidden
…
```

With the nginx configuration suggested by this PR:

```
$ curl -Ii https://www.mysite.com/concrete/images
HTTP/1.1 404 Not Found
…

$ curl -Ii https://www.mysite.com/concrete/images/
HTTP/1.1 404 Not Found
…
```

## Comparision of a directory that contains an empty `index.html` file

With the old nginx configuration files, we have:

```
$ curl -Ii https://www.mysite.com/application
HTTP/1.1 301 Moved Permanently
Location: https://www.mysite.com/application/
…

$ curl -Ii https://www.mysite.com/application/
HTTP/1.1 200 OK
Content-Length: 0
…
```

With the nginx configuration suggested by this PR:

```
$ curl -Ii https://www.mysite.com/application
HTTP/1.1 200 OK
Content-Length: 0
…

$ curl -Ii https://www.mysite.com/application/
HTTP/1.1 200 OK
Content-Length: 0
…
```
