### PR TITLE
Update Service.php

### DIFF
--- a/concrete/src/Sharing/ShareThisPage/Service.php
+++ b/concrete/src/Sharing/ShareThisPage/Service.php
@@ -23,7 +23,12 @@ class Service extends SocialNetworkService
         if (!is_object($c)) {
             $req = Request::getInstance();
             $c = $req->getCurrentPage();
-            $url = urlencode($req->getUri());
+            if($c){
+            	$url = urlencode(URL::to($c));
+            }
+            else{
+            	$url = urlencode($req->getUri());
+            }
         } elseif (!$c->isError()) {
             $url = urlencode(URL::to($c));
         }


### PR DESCRIPTION
I found that when loading the "Share This Page" block via Javascript outside a typical Collection (such as a custom Route), the shared URL would only be the custom route (in my case an external JS file) rather than the current active page. If the Request's current page was set like this:

```
$request = Request::getInstance();
$page = Page::getByID($cID);
$request->setCurrentPage($page);
\Request::setInstance($request);
```

it would not be respected by the Share This Page block.

With this change, it overriding the Request current page works perfectly.