### PR TITLE
Fix mobile menu doesn't work since version 9

### DIFF
--- a/concrete/elements/page_controls_footer.php
+++ b/concrete/elements/page_controls_footer.php
@@ -54,7 +54,7 @@ if (isset($cp) && $cp->canViewToolbar() && (!$dh->inDashboard()) && !$view->isEd
     <div id="ccm-page-controls-wrapper" class="ccm-ui">
         <div id="ccm-toolbar" class="<?= $show_titles ? 'titles' : '' ?> <?= $large_font ? 'large-font' : '' ?>">
 						<?php
-              $mobileMenu = Element::get('dashboard/navigation/mobile');
+              $mobileMenu = Element::get('dashboard/navigation/mobile', ['section' => $c, 'currentPage' => $c]);
               $mobileMenu->render();
             ?> 
             <ul class="ccm-toolbar-item-list">


### PR DESCRIPTION
@ob7 implemented the mobile menu element but forgot to pass the current page, which is a required parameter.

https://github.com/concretecms/concretecms/commit/71eeed758fcd9aefb0937f3a3a39ab6d972ada44

I just add it.

This PR fixes #11253