### PR TITLE
Set Recent Uploads to be first and default tab of file selector dialog

### DIFF
--- a/concrete/src/File/Component/Chooser/DefaultConfigurationFactory.php
+++ b/concrete/src/File/Component/Chooser/DefaultConfigurationFactory.php
@@ -45,8 +45,8 @@ class DefaultConfigurationFactory
 
         $sets = Set::getMySets();
         $searches = $this->entityManager->getRepository(SavedFileSearch::class)->findAll();
-        $configuration->addChooser(new FileManagerOption());
         $configuration->addChooser(new RecentUploadsOption());
+        $configuration->addChooser(new FileManagerOption());
         $configuration->addChooser(new SearchOption());
         if (count($sets) > 0) {
             $configuration->addChooser(new FileSetsOption());


### PR DESCRIPTION
After a lot of discussion with other Concrete users, and using the file selector dialog in V9 for quite some time, we've realised that there's one minor but annoying workflow usability issue with it that can be easily fixed.

The main issue is that the majority of the time when you are selecting a file, you are either:
- uploading a new file there and then
- or, selecting a file you've just recently uploaded, perhaps in a small batch in the file manager and you are now placing them on a page, selecting them for a product, for some thumbnails, etc, etc.

The 'File Manager' tab on the other hand, lists files and folders alphabetically, which isn't generally useful. It's good if you are digging down into a folder for something, or searching, but that is not anywhere as often as selecting a file you've just recently uploaded.

So it just doesn't make sense to have the File Manager option the default, when most of the time you just want to select a recent file.

The suggestion is to simply put the Recent Uploads tab as the first in the list, and therefore the default.
Changing from:
<img width="516" alt="Screenshot 2024-07-17 at 22 18 31" src="https://github.com/user-attachments/assets/1b3077fa-d4ae-4812-8fa8-c2449a1b14b6">
to
<img width="465" alt="Screenshot 2024-07-17 at 22 18 40" src="https://github.com/user-attachments/assets/c9b9d02b-e39d-4db8-b9a6-ee16d7a01af9">

