### PR TITLE
Fix issue with invalid variable type

### DIFF
--- a/concrete/controllers/element/dashboard/marketplace/extend.php
+++ b/concrete/controllers/element/dashboard/marketplace/extend.php
@@ -62,7 +62,7 @@ class Extend extends ElementController
     public function view()
     {
         $connection = $this->packageRepository->getConnection();
-        if ($this->packageRepository->validate($connection)) {
+        if ($connection && $this->packageRepository->validate($connection)) {
             $this->set('browseThemesUrl', $this->getPurchaseConnectionUrl($connection, '/themes'));
             $this->set('browseAddonsUrl', $this->getPurchaseConnectionUrl($connection, '/addons'));
             $this->set('browseIntegrationsUrl', $this->getPurchaseConnectionUrl($connection, '/integrations'));

--- a/concrete/controllers/element/dashboard/marketplace/extend.php
+++ b/concrete/controllers/element/dashboard/marketplace/extend.php
@@ -9,6 +9,7 @@ use Concrete\Core\Marketplace\PackageRepositoryInterface;
 use Concrete\Core\Marketplace\PurchaseConnectionCoordinator;
 use Concrete\Core\Url\Resolver\PathUrlResolver;
 use Concrete\Core\Url\Resolver\UrlResolverInterface;
+use Concrete\Core\Marketplace\ConnectionInterface;
 
 defined('C5_EXECUTE') or die('Access Denied.');
 
@@ -62,7 +63,7 @@ class Extend extends ElementController
     public function view()
     {
         $connection = $this->packageRepository->getConnection();
-        if ($connection && $this->packageRepository->validate($connection)) {
+        if ($connection instanceof ConnectionInterface && $this->packageRepository->validate($connection)) {
             $this->set('browseThemesUrl', $this->getPurchaseConnectionUrl($connection, '/themes'));
             $this->set('browseAddonsUrl', $this->getPurchaseConnectionUrl($connection, '/addons'));
             $this->set('browseIntegrationsUrl', $this->getPurchaseConnectionUrl($connection, '/integrations'));


### PR DESCRIPTION
The function `Concrete\Core\Marketplace\PackageRepository::getConnection` returns `null` if there is no public or private key in the configuration. However, the `Concrete\Core\Marketplace\PackageRepository::validate()` method requires its first argument to be of type `Concrete\Core\Marketplace\ConnectionInterface`. As a result, if getConnection returns null, calling validate() will throw an error.