### PR TITLE
Improve installation speed

### DIFF
--- a/concrete/src/Attribute/TypeFactory.php
+++ b/concrete/src/Attribute/TypeFactory.php
@@ -172,7 +172,7 @@ class TypeFactory
         $r = $this->environment->getRecord(DIRNAME_ATTRIBUTES . '/' . $type->getAttributeTypeHandle() . '/' . FILENAME_ATTRIBUTE_DB, $type->getPackageHandle());
         if ($r->exists()) {
             // db.xml legacy approach
-            \Concrete\Core\Package\Package::installDB($r->file);
+            \Concrete\Core\Package\Package::installDB($r->file, false);
         }
 
         if (is_dir(DIR_APPLICATION . '/' . DIRNAME_CLASSES . '/' .

--- a/concrete/src/Attribute/TypeFactory.php
+++ b/concrete/src/Attribute/TypeFactory.php
@@ -3,7 +3,9 @@
 namespace Concrete\Core\Attribute;
 
 use Concrete\Core\Attribute\Category\CategoryService;
+use Concrete\Core\Backup\ContentImporter;
 use Concrete\Core\Database\DatabaseStructureManager;
+use Concrete\Core\Database\Schema\Schema;
 use Concrete\Core\Entity\Attribute\Type as AttributeType;
 use Concrete\Core\Entity\Package;
 use Concrete\Core\Foundation\Environment;
@@ -165,14 +167,16 @@ class TypeFactory
     }
 
     /**
-     * @param \Concrete\Core\Entity\Attribute\Type $type
+     * @param AttributeType $type
+     * @return void
+     * @throws \Doctrine\DBAL\ConnectionException
      */
     protected function installDatabase(AttributeType $type)
     {
         $r = $this->environment->getRecord(DIRNAME_ATTRIBUTES . '/' . $type->getAttributeTypeHandle() . '/' . FILENAME_ATTRIBUTE_DB, $type->getPackageHandle());
         if ($r->exists()) {
             // db.xml legacy approach
-            \Concrete\Core\Package\Package::installDB($r->file, false);
+            \Concrete\Core\Package\Package::installDB($r->file, ContentImporter::IMPORT_MODE_INSTALL);
         }
 
         if (is_dir(DIR_APPLICATION . '/' . DIRNAME_CLASSES . '/' .

--- a/concrete/src/Authentication/AuthenticationType.php
+++ b/concrete/src/Authentication/AuthenticationType.php
@@ -162,7 +162,7 @@ class AuthenticationType extends ConcreteObject
         $est = self::getByHandle($atHandle);
         $r = $est->mapAuthenticationTypeFilePath(FILENAME_AUTHENTICATION_DB);
         if ($r->exists()) {
-            Package::installDB($r->file);
+            Package::installDB($r->file, false);
         }
 
         return $est;

--- a/concrete/src/Authentication/AuthenticationType.php
+++ b/concrete/src/Authentication/AuthenticationType.php
@@ -2,6 +2,8 @@
 namespace Concrete\Core\Authentication;
 
 use Concrete\Authentication\Concrete\Controller;
+use Concrete\Core\Backup\ContentImporter;
+use Concrete\Core\Database\Schema\Schema;
 use Concrete\Core\Foundation\ConcreteObject;
 use Concrete\Core\Package\PackageList;
 use Core;
@@ -162,7 +164,7 @@ class AuthenticationType extends ConcreteObject
         $est = self::getByHandle($atHandle);
         $r = $est->mapAuthenticationTypeFilePath(FILENAME_AUTHENTICATION_DB);
         if ($r->exists()) {
-            Package::installDB($r->file, false);
+            Package::installDB($r->file, ContentImporter::IMPORT_MODE_INSTALL);
         }
 
         return $est;

--- a/concrete/src/Backup/ContentImporter.php
+++ b/concrete/src/Backup/ContentImporter.php
@@ -2,6 +2,7 @@
 namespace Concrete\Core\Backup;
 
 use Concrete\Core\Backup\ContentImporter\Importer\Routine\SpecifiableHomePageRoutineInterface;
+use Concrete\Core\Backup\ContentImporter\Importer\Routine\SpecifiableImportModeRoutineInterface;
 use Concrete\Core\Database\Connection\Connection;
 use Concrete\Core\File\File;
 use Concrete\Core\File\Importer;
@@ -65,6 +66,9 @@ class ContentImporter
             if (isset($this->home) && $routine instanceof SpecifiableHomePageRoutineInterface) {
                 $home = \Page::getByID($this->home->getCollectionID()); // we always need the most recent version.
                 $routine->setHomePage($home);
+            }
+            if ($routine instanceof SpecifiableImportModeRoutineInterface) {
+                $routine->setImportMode($this->importMode);
             }
             $routine->import($element);
             if (isset($this->home) && $routine instanceof SpecifiableHomePageRoutineInterface) {

--- a/concrete/src/Backup/ContentImporter.php
+++ b/concrete/src/Backup/ContentImporter.php
@@ -12,9 +12,29 @@ use Core;
 class ContentImporter
 {
 
+    public const IMPORT_MODE_INSTALL = 'install';
+    public const IMPORT_MODE_UPGRADE = 'upgrade';
+
     protected static $mcBlockIDs = array();
     protected static $ptComposerOutputControlIDs = array();
     protected $home;
+    protected $importMode = self::IMPORT_MODE_INSTALL;
+
+    /**
+     * @param string $importMode - a constant mapping to self::IMPORT_MODE_INSTALL or self::IMPORT_MODE_UPGRADE
+     * If upgrade is specified, any routines will work off existing database schema if applicable (note: not all
+     * CIF elements always support upgrade context.). If INSTALL is specified, we use empty database schemas for
+     * improved performance. For backward compatibility, UPGRADE is the default.
+     */
+    public function __construct(string $importMode = self::IMPORT_MODE_UPGRADE)
+    {
+        $this->importMode = $importMode;
+    }
+
+    public function setImportMode(string $importMode): void
+    {
+        $this->importMode = $importMode;
+    }
 
     public function importContentFile($file)
     {

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportBlockTypesRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportBlockTypesRoutine.php
@@ -1,6 +1,7 @@
 <?php
 namespace Concrete\Core\Backup\ContentImporter\Importer\Routine;
 
+use Concrete\Core\Backup\ContentImporter;
 use Concrete\Core\Block\BlockType\BlockType;
 use Concrete\Core\Permission\Category;
 
@@ -21,14 +22,18 @@ class ImportBlockTypesRoutine extends AbstractRoutine implements SpecifiableImpo
 
     public function import(\SimpleXMLElement $sx)
     {
+        $importMode = $this->importMode;
+        if (!$importMode) {
+            $importMode = ContentImporter::IMPORT_MODE_UPGRADE; // fallback for backward compatibility
+        }
         if (isset($sx->blocktypes)) {
             foreach ($sx->blocktypes->blocktype as $bt) {
                 if (!is_object(BlockType::getByHandle((string) $bt['handle']))) {
                     $pkg = static::getPackageObject($bt['package']);
                     if (is_object($pkg)) {
-                        BlockType::installBlockTypeFromPackage((string) $bt['handle'], $pkg, $this->importMode ?? null);
+                        BlockType::installBlockTypeFromPackage((string) $bt['handle'], $pkg, $importMode);
                     } else {
-                        BlockType::installBlockType((string) $bt['handle'], null, $this->importMode ?? null);
+                        BlockType::installBlockType((string) $bt['handle'], null, $importMode);
                     }
                 }
             }

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportBlockTypesRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportBlockTypesRoutine.php
@@ -4,11 +4,19 @@ namespace Concrete\Core\Backup\ContentImporter\Importer\Routine;
 use Concrete\Core\Block\BlockType\BlockType;
 use Concrete\Core\Permission\Category;
 
-class ImportBlockTypesRoutine extends AbstractRoutine
+class ImportBlockTypesRoutine extends AbstractRoutine implements SpecifiableImportModeRoutineInterface
 {
+
+    protected $importMode = null;
+
     public function getHandle()
     {
         return 'block_types';
+    }
+
+    public function setImportMode(string $importMode): void
+    {
+        $this->importMode = $importMode;
     }
 
     public function import(\SimpleXMLElement $sx)
@@ -18,9 +26,9 @@ class ImportBlockTypesRoutine extends AbstractRoutine
                 if (!is_object(BlockType::getByHandle((string) $bt['handle']))) {
                     $pkg = static::getPackageObject($bt['package']);
                     if (is_object($pkg)) {
-                        BlockType::installBlockTypeFromPackage((string) $bt['handle'], $pkg);
+                        BlockType::installBlockTypeFromPackage((string) $bt['handle'], $pkg, $this->importMode ?? null);
                     } else {
-                        BlockType::installBlockType((string) $bt['handle']);
+                        BlockType::installBlockType((string) $bt['handle'], null, $this->importMode ?? null);
                     }
                 }
             }

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/SpecifiableImportModeRoutineInterface.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/SpecifiableImportModeRoutineInterface.php
@@ -1,0 +1,17 @@
+<?php
+namespace Concrete\Core\Backup\ContentImporter\Importer\Routine;
+
+use Concrete\Core\Backup\ContentImporter;
+
+interface SpecifiableImportModeRoutineInterface
+{
+
+    /**
+     * Either ContentImporter::IMPORT_MODE_INSTALL or ContentImporter::IMPORT_MODE_UPGRADE
+
+     * @param string $importMode
+     * @return mixed
+     */
+    function setImportMode(string $importMode): void;
+
+}

--- a/concrete/src/Block/BlockController.php
+++ b/concrete/src/Block/BlockController.php
@@ -143,7 +143,7 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
 
             return $r;
         }
-        $ret = Package::installDB($path . '/' . FILENAME_BLOCK_DB);
+        $ret = Package::installDB($path . '/' . FILENAME_BLOCK_DB, false);
 
         return $ret;
     }

--- a/concrete/src/Block/BlockController.php
+++ b/concrete/src/Block/BlockController.php
@@ -132,7 +132,7 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
      *
      * @return mixed boolean or object having ->result (boolean) and ->message (string) properties
      */
-    public function install($path)
+    public function install($path, string $importMode = ContentImporter::IMPORT_MODE_UPGRADE)
     {
         // passed path is the path to this block (try saying that ten times fast)
         // create the necessary table
@@ -143,7 +143,7 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
 
             return $r;
         }
-        $ret = Package::installDB($path . '/' . FILENAME_BLOCK_DB, false);
+        $ret = Package::installDB($path . '/' . FILENAME_BLOCK_DB, $importMode);
 
         return $ret;
     }

--- a/concrete/src/Block/BlockType/BlockType.php
+++ b/concrete/src/Block/BlockType/BlockType.php
@@ -2,6 +2,7 @@
 
 namespace Concrete\Core\Block\BlockType;
 
+use Concrete\Core\Backup\ContentImporter;
 use Concrete\Core\Cache\Level\RequestCache;
 use Concrete\Core\Database\Connection\Connection;
 use Concrete\Core\Entity\Block\BlockType\BlockType as BlockTypeEntity;
@@ -82,7 +83,7 @@ class BlockType
      *
      * @return \Concrete\Core\Entity\Block\BlockType\BlockType
      */
-    public static function installBlockType($btHandle, $pkg = false)
+    public static function installBlockType($btHandle, $pkg = false, string $importMode = ContentImporter::IMPORT_MODE_UPGRADE)
     {
         $app = Application::getFacadeApplication();
         $em = $app->make(EntityManagerInterface::class);
@@ -97,7 +98,7 @@ class BlockType
         $path = dirname($locator->getRecord(DIRNAME_BLOCKS . '/' . $btHandle . '/' . FILENAME_BLOCK_DB)->getFile());
 
         //Attempt to run the subclass methods (install schema from db.xml, etc.)
-        $bta->install($path);
+        $bta->install($path, $importMode);
 
         // Prevent the database records being stored in wrong language
         $loc = $app->make(Localization::class);
@@ -188,8 +189,8 @@ class BlockType
      *
      * @return \Concrete\Core\Entity\Block\BlockType\BlockType
      */
-    public static function installBlockTypeFromPackage($btHandle, $pkg)
+    public static function installBlockTypeFromPackage($btHandle, $pkg, string $importMode = ContentImporter::IMPORT_MODE_UPGRADE)
     {
-        return static::installBlockType($btHandle, $pkg);
+        return static::installBlockType($btHandle, $pkg, $importMode);
     }
 }

--- a/concrete/src/Console/Command/InstallCommand.php
+++ b/concrete/src/Console/Command/InstallCommand.php
@@ -85,7 +85,7 @@ class InstallCommand extends Command
             ->addOption('force-attach', null, InputOption::VALUE_NONE, 'Always attach')
             ->addOption('interactive', 'i', InputOption::VALUE_NONE, 'Install using interactive (wizard) mode')
             ->addOption('disable-marketplace-connect', null, InputOption::VALUE_NONE, 'Do not automatically connect site to marketplace')
-            ->addOption('disable-installation-completion', null, InputOption::VALUE_NONE, 'Do not write the final configuration files necessary to complete installation')
+            ->addOption('defer-installation', null, InputOption::VALUE_NONE, 'Defer installation to a later point; do not write the final configuration files necessary to complete installation')
             ->addOption('ignore-warnings', null, InputOption::VALUE_NONE, 'Ignore warnings')
             ->setHelp(<<<EOT
 Returns codes:
@@ -753,7 +753,7 @@ EOT
             ->setUserPasswordHash($hasher->hashPassword($options['admin-password']))
             ->setServerTimeZoneId($options['timezone'])
             ->setIsConnectToMarketplaceEnabled($options['disable-marketplace-connect'] ? false : true)
-            ->setWriteConfigFileOnInstallationCompletion($options['disable-installation-completion'] ? false : true);
+            ->setDeferInstallation($options['defer-installation'] ? true : false);
         ;
 
         return $installer;

--- a/concrete/src/Console/Command/InstallCommand.php
+++ b/concrete/src/Console/Command/InstallCommand.php
@@ -156,6 +156,9 @@ EOT
                     $attach_mode = true;
                 }
             }
+            $db = app('database');
+            $db->executeQuery('set foreign_key_checks = 0');
+
             $routines = $spl->getInstallRoutines();
             foreach ($routines as $r) {
                 if ($attach_mode && !$r instanceof AttachModeCompatibleRoutineInterface) {

--- a/concrete/src/Console/Command/InstallCommand.php
+++ b/concrete/src/Console/Command/InstallCommand.php
@@ -85,6 +85,7 @@ class InstallCommand extends Command
             ->addOption('force-attach', null, InputOption::VALUE_NONE, 'Always attach')
             ->addOption('interactive', 'i', InputOption::VALUE_NONE, 'Install using interactive (wizard) mode')
             ->addOption('disable-marketplace-connect', null, InputOption::VALUE_NONE, 'Do not automatically connect site to marketplace')
+            ->addOption('disable-installation-completion', null, InputOption::VALUE_NONE, 'Do not write the final configuration files necessary to complete installation')
             ->addOption('ignore-warnings', null, InputOption::VALUE_NONE, 'Ignore warnings')
             ->setHelp(<<<EOT
 Returns codes:
@@ -751,7 +752,8 @@ EOT
             ->setUserEmail($options['admin-email'])
             ->setUserPasswordHash($hasher->hashPassword($options['admin-password']))
             ->setServerTimeZoneId($options['timezone'])
-            ->setIsConnectToMarketplaceEnabled($options['disable-marketplace-connect'] ? false : true);
+            ->setIsConnectToMarketplaceEnabled($options['disable-marketplace-connect'] ? false : true)
+            ->setWriteConfigFileOnInstallationCompletion($options['disable-installation-completion'] ? false : true);
         ;
 
         return $installer;

--- a/concrete/src/Console/Command/ResetCommand.php
+++ b/concrete/src/Console/Command/ResetCommand.php
@@ -48,20 +48,14 @@ EOT
                 throw new Exception("Operation aborted.");
             }
         }
+        $cn = Database::get();
+        $cn->executeQuery('set foreign_key_checks = 0');
         if (Database::getDefaultConnection()) {
             $output->write("Listing tables... ");
-            $cn = Database::get();
             /* @var $cn \Concrete\Core\Database\Connection\Connection */
             $sm = $cn->getSchemaManager();
             $tables = $sm->listTables();
             $output->writeln('<info>done.</info>');
-            foreach ($tables as $table) {
-                foreach ($table->getForeignKeys() as $foreignKey) {
-                    $output->write("Dropping foreign key {$table->getName()}.{$foreignKey->getName()}... ");
-                    $sm->dropForeignKey($foreignKey, $table);
-                    $output->writeln('<info>done.</info>');
-                }
-            }
             foreach ($tables as $table) {
                 $output->write("Dropping table {$table->getName()}... ");
                 $sm->dropTable($table);

--- a/concrete/src/Database/Schema/Parser/DoctrineXml05.php
+++ b/concrete/src/Database/Schema/Parser/DoctrineXml05.php
@@ -24,7 +24,7 @@ class DoctrineXml05 extends XmlParser
         return \DoctrineXml\Parser::fromDocument(
             $this->rawXML->asXML(),
             $db->getDatabasePlatform(),
-            true,
+            false,
             false,
             $filter,
             $this->getDatabaseVersion($db),

--- a/concrete/src/Install/InstallerOptions.php
+++ b/concrete/src/Install/InstallerOptions.php
@@ -33,7 +33,7 @@ class InstallerOptions
     /**
      * @var bool
      */
-    protected $writeConfigFileOnInstallationCompletion = true;
+    protected $deferInstallation = false;
 
     /**
      * Whether the user has accepted the privacy policy from the front-end installation
@@ -116,14 +116,14 @@ class InstallerOptions
         return $this->isConnectToMarketplaceEnabled;
     }
 
-    public function writeConfigFileOnInstallationCompletion(): bool
+    public function deferInstallation(): bool
     {
-        return $this->writeConfigFileOnInstallationCompletion;
+        return $this->deferInstallation;
     }
 
-    public function setWriteConfigFileOnInstallationCompletion(bool $writeConfigFileOnInstallationCompletion): self
+    public function setDeferInstallation(bool $deferInstallation): self
     {
-        $this->writeConfigFileOnInstallationCompletion = $writeConfigFileOnInstallationCompletion;
+        $this->deferInstallation = $deferInstallation;
         return $this;
     }
 

--- a/concrete/src/Install/InstallerOptions.php
+++ b/concrete/src/Install/InstallerOptions.php
@@ -31,6 +31,11 @@ class InstallerOptions
     protected $isConnectToMarketplaceEnabled = true;
 
     /**
+     * @var bool
+     */
+    protected $writeConfigFileOnInstallationCompletion = true;
+
+    /**
      * Whether the user has accepted the privacy policy from the front-end installation
      *
      * @var bool
@@ -111,12 +116,24 @@ class InstallerOptions
         return $this->isConnectToMarketplaceEnabled;
     }
 
+    public function writeConfigFileOnInstallationCompletion(): bool
+    {
+        return $this->writeConfigFileOnInstallationCompletion;
+    }
+
+    public function setWriteConfigFileOnInstallationCompletion(bool $writeConfigFileOnInstallationCompletion): self
+    {
+        $this->writeConfigFileOnInstallationCompletion = $writeConfigFileOnInstallationCompletion;
+        return $this;
+    }
+
     /**
      * @param bool $isConnectToMarketplaceEnabled
      */
-    public function setIsConnectToMarketplaceEnabled(bool $isConnectToMarketplaceEnabled): void
+    public function setIsConnectToMarketplaceEnabled(bool $isConnectToMarketplaceEnabled): self
     {
         $this->isConnectToMarketplaceEnabled = $isConnectToMarketplaceEnabled;
+        return $this;
     }
 
     /**

--- a/concrete/src/Package/Package.php
+++ b/concrete/src/Package/Package.php
@@ -962,7 +962,11 @@ abstract class Package implements LocalizablePackageInterface
     public function installDatabase()
     {
         $this->installEntitiesDatabase();
-        static::installDB($this->getPackagePath() . '/' . FILENAME_PACKAGE_DB, false);
+        // Note: this could and should use ContentImporter::IMPORT_MODE_INSTALL instead of IMPORT_MODE_UPGRADE, in order to get better
+        // performance, but I'm concerned there are packages out there using `installDatabase` on upgrade routines.
+        // If so, making this change would break those. So let's sacrifice performance for backward compatibility
+        // here.
+        static::installDB($this->getPackagePath() . '/' . FILENAME_PACKAGE_DB, ContentImporter::IMPORT_MODE_UPGRADE);
     }
 
     public function installEntitiesDatabase()
@@ -982,20 +986,26 @@ abstract class Package implements LocalizablePackageInterface
      * Installs a package database from an XML file.
      *
      * @param string $xmlFile Path to the database XML file
-     * @param bool $useExistingDatabaseSchema Whether to load the existing schema from the database or use an empty schema. Empty schema is faster.
-     *
-     * @throws \Doctrine\DBAL\ConnectionException
-     *
+     * @param string $importMode - If set to ContentImporter::IMPORT_MODE_UPGRADE, the schema will be checked against
+     * the current schema, supporting upgrades at a performance penalty. If set to ContentImporter::IMPORT_MODE_INSTALL
+     * the schema will be compared against an empty schema, which is a much faster operation and should be used when
+     * you know the installation is taking place against an empty database. ContentImporter::IMPORT_MODE_UPGRADE
+     * preserves backward compatibility as this was the way things always used to be handled.
      * @return bool|\stdClass Returns false if the XML file could not be found
+     *@throws \Doctrine\DBAL\ConnectionException
+     *
      */
-    public static function installDB($xmlFile, bool $useExistingDatabaseSchema = true)
+    public static function installDB($xmlFile, string $importMode = ContentImporter::IMPORT_MODE_UPGRADE)
     {
         if (!file_exists($xmlFile)) {
             return false;
         }
+        if (!in_array($importMode, [ContentImporter::IMPORT_MODE_UPGRADE, ContentImporter::IMPORT_MODE_INSTALL])) {
+            throw new \RuntimeException(t('Invalid import mode specified: %s', $importMode));
+        }
         $db = app(Connection::class);
         $parser = Schema::getSchemaParser(simplexml_load_file($xmlFile));
-        if ($useExistingDatabaseSchema) {
+        if ($importMode === ContentImporter::IMPORT_MODE_UPGRADE) {
             $parser->setIgnoreExistingTables(false);
         } else {
             // Since we're using an empty schema, we have to use the ignore existing tables option otherwise
@@ -1005,7 +1015,7 @@ abstract class Package implements LocalizablePackageInterface
         }
         $toSchema = $parser->parse($db);
 
-        if ($useExistingDatabaseSchema) {
+        if ($importMode === ContentImporter::IMPORT_MODE_UPGRADE) {
             $fromSchema = $db->getSchemaManager()->createSchema();
         } else {
             $fromSchema = new \Doctrine\DBAL\Schema\Schema();
@@ -1082,7 +1092,7 @@ abstract class Package implements LocalizablePackageInterface
             $this->destroyProxyClasses($em);
             $this->installEntitiesDatabase();
         }
-        static::installDB($this->getPackagePath() . '/' . FILENAME_PACKAGE_DB);
+        static::installDB($this->getPackagePath() . '/' . FILENAME_PACKAGE_DB, ContentImporter::IMPORT_MODE_UPGRADE);
     }
 
     /**

--- a/concrete/src/Package/StartingPointPackage.php
+++ b/concrete/src/Package/StartingPointPackage.php
@@ -465,7 +465,7 @@ class StartingPointPackage extends Package
             $dbm->destroyProxyClasses();
             $dbm->generateProxyClasses();
 
-            Package::installDB($installDirectory . '/db.xml');
+            Package::installDB($installDirectory . '/db.xml', false);
 
             $dbm->installDatabase();
             $this->indexAdditionalDatabaseFields();

--- a/concrete/src/Package/StartingPointPackage.php
+++ b/concrete/src/Package/StartingPointPackage.php
@@ -612,8 +612,10 @@ class StartingPointPackage extends Package
 
         $renderer = new Renderer($database);
 
-        file_put_contents(DIR_CONFIG_SITE . '/database.php', $renderer->render());
-        @chmod(DIR_CONFIG_SITE . '/database.php', $config->get('concrete.filesystem.permissions.file'));
+        if ($this->installerOptions->writeConfigFileOnInstallationCompletion()) {
+            file_put_contents(DIR_CONFIG_SITE . '/database.php', $renderer->render());
+            @chmod(DIR_CONFIG_SITE . '/database.php', $config->get('concrete.filesystem.permissions.file'));
+        }
 
         // Connect to the marketplace if possible.
         if ($this->installerOptions->isConnectToMarketplaceEnabled()) {
@@ -631,6 +633,8 @@ class StartingPointPackage extends Package
         }
 
         $siteConfig = \Site::getDefault()->getConfigRepository();
+        $siteConfig->save('name', $this->installerOptions->getSiteName());
+
         if (isset($installConfiguration['canonical-url']) && $installConfiguration['canonical-url']) {
             $siteConfig->save('seo.canonical_url', $installConfiguration['canonical-url']);
         }
@@ -679,7 +683,6 @@ class StartingPointPackage extends Package
     {
         \Core::make('site/type')->installDefault();
         $site = \Site::installDefault($this->installerOptions->getSiteLocaleId());
-        $site->getConfigRepository()->save('name', $this->installerOptions->getSiteName());
 
         $uiLocaleId = $this->installerOptions->getUiLocaleId();
         if ($uiLocaleId && $uiLocaleId !== Localization::BASE_LOCALE) {

--- a/concrete/src/Package/StartingPointPackage.php
+++ b/concrete/src/Package/StartingPointPackage.php
@@ -10,6 +10,7 @@ use Concrete\Core\Backup\ContentImporter;
 use Concrete\Core\Config\Renderer;
 use Concrete\Core\Config\Repository\Repository;
 use Concrete\Core\Database\DatabaseStructureManager;
+use Concrete\Core\Database\Schema\Schema;
 use Concrete\Core\Entity\OAuth\Scope;
 use Concrete\Core\File\Filesystem;
 use Concrete\Core\File\Service\File;
@@ -243,7 +244,7 @@ class StartingPointPackage extends Package
 
     protected function install_attributes()
     {
-        $ci = new ContentImporter();
+        $ci = new ContentImporter(ContentImporter::IMPORT_MODE_INSTALL);
         $ci->importContentFile(DIR_BASE_CORE . '/config/install/base/attributes.xml');
 
         $topicType = \Concrete\Core\Tree\TreeType::add('topic');
@@ -252,25 +253,25 @@ class StartingPointPackage extends Package
 
     protected function install_dashboard()
     {
-        $ci = new ContentImporter();
+        $ci = new ContentImporter(ContentImporter::IMPORT_MODE_INSTALL);
         $ci->importContentFile(DIR_BASE_CORE . '/config/install/base/single_pages/dashboard.xml');
     }
 
     protected function install_boards()
     {
-        $ci = new ContentImporter();
+        $ci = new ContentImporter(ContentImporter::IMPORT_MODE_INSTALL);
         $ci->importContentFile(DIR_BASE_CORE . '/config/install/base/boards.xml');
     }
 
     protected function install_page_types()
     {
-        $ci = new ContentImporter();
+        $ci = new ContentImporter(ContentImporter::IMPORT_MODE_INSTALL);
         $ci->importContentFile(DIR_BASE_CORE . '/config/install/base/page_types.xml');
     }
 
     protected function install_required_single_pages()
     {
-        $ci = new ContentImporter();
+        $ci = new ContentImporter(ContentImporter::IMPORT_MODE_INSTALL);
         $ci->importContentFile(DIR_BASE_CORE . '/config/install/base/single_pages/global.xml');
         $ci->importContentFile(DIR_BASE_CORE . '/config/install/base/single_pages/root.xml');
     }
@@ -280,7 +281,7 @@ class StartingPointPackage extends Package
      */
     protected function install_blocktypes()
     {
-        $ci = new ContentImporter();
+        $ci = new ContentImporter(ContentImporter::IMPORT_MODE_INSTALL);
         $ci->importContentFile(DIR_BASE_CORE . '/config/install/base/blocktypes_basic.xml');
         $ci->importContentFile(DIR_BASE_CORE . '/config/install/base/blocktypes_navigation.xml');
         $ci->importContentFile(DIR_BASE_CORE . '/config/install/base/blocktypes_form.xml');
@@ -294,61 +295,61 @@ class StartingPointPackage extends Package
 
     protected function install_blocktypes_basic()
     {
-        $ci = new ContentImporter();
+        $ci = new ContentImporter(ContentImporter::IMPORT_MODE_INSTALL);
         $ci->importContentFile(DIR_BASE_CORE . '/config/install/base/blocktypes_basic.xml');
     }
 
     protected function install_blocktypes_navigation()
     {
-        $ci = new ContentImporter();
+        $ci = new ContentImporter(ContentImporter::IMPORT_MODE_INSTALL);
         $ci->importContentFile(DIR_BASE_CORE . '/config/install/base/blocktypes_navigation.xml');
     }
 
     protected function install_blocktypes_form()
     {
-        $ci = new ContentImporter();
+        $ci = new ContentImporter(ContentImporter::IMPORT_MODE_INSTALL);
         $ci->importContentFile(DIR_BASE_CORE . '/config/install/base/blocktypes_form.xml');
     }
 
     protected function install_blocktypes_express()
     {
-        $ci = new ContentImporter();
+        $ci = new ContentImporter(ContentImporter::IMPORT_MODE_INSTALL);
         $ci->importContentFile(DIR_BASE_CORE . '/config/install/base/blocktypes_express.xml');
     }
 
     protected function install_blocktypes_social()
     {
-        $ci = new ContentImporter();
+        $ci = new ContentImporter(ContentImporter::IMPORT_MODE_INSTALL);
         $ci->importContentFile(DIR_BASE_CORE . '/config/install/base/blocktypes_social.xml');
     }
 
     protected function install_blocktypes_calendar()
     {
-        $ci = new ContentImporter();
+        $ci = new ContentImporter(ContentImporter::IMPORT_MODE_INSTALL);
         $ci->importContentFile(DIR_BASE_CORE . '/config/install/base/blocktypes_calendar.xml');
     }
 
     protected function install_blocktypes_multimedia()
     {
-        $ci = new ContentImporter();
+        $ci = new ContentImporter(ContentImporter::IMPORT_MODE_INSTALL);
         $ci->importContentFile(DIR_BASE_CORE . '/config/install/base/blocktypes_multimedia.xml');
     }
 
     protected function install_blocktypes_core_desktop()
     {
-        $ci = new ContentImporter();
+        $ci = new ContentImporter(ContentImporter::IMPORT_MODE_INSTALL);
         $ci->importContentFile(DIR_BASE_CORE . '/config/install/base/blocktypes_core_desktop.xml');
     }
 
     protected function install_blocktypes_other()
     {
-        $ci = new ContentImporter();
+        $ci = new ContentImporter(ContentImporter::IMPORT_MODE_INSTALL);
         $ci->importContentFile(DIR_BASE_CORE . '/config/install/base/blocktypes_other.xml');
     }
 
     protected function install_themes()
     {
-        $ci = new ContentImporter();
+        $ci = new ContentImporter(ContentImporter::IMPORT_MODE_INSTALL);
         $ci->importContentFile(DIR_BASE_CORE . '/config/install/base/summary.xml');
         $ci->importContentFile(DIR_BASE_CORE . '/config/install/base/themes.xml');
         // this remains for backward compatibility but no core themes use it.
@@ -359,13 +360,13 @@ class StartingPointPackage extends Package
 
     protected function install_tasks()
     {
-        $ci = new ContentImporter();
+        $ci = new ContentImporter(ContentImporter::IMPORT_MODE_INSTALL);
         $ci->importContentFile(DIR_BASE_CORE . '/config/install/base/tasks.xml');
     }
 
     protected function install_config()
     {
-        $ci = new ContentImporter();
+        $ci = new ContentImporter(ContentImporter::IMPORT_MODE_INSTALL);
         $ci->importContentFile(DIR_BASE_CORE . '/config/install/base/config.xml');
     }
 
@@ -404,18 +405,18 @@ class StartingPointPackage extends Package
     protected function import_files()
     {
         if (is_dir($this->getPackagePath() . '/files')) {
-            $ch = new ContentImporter();
+            $ci = new ContentImporter(ContentImporter::IMPORT_MODE_INSTALL);
             $computeThumbnails = true;
             if ($this->contentProvidesFileThumbnails()) {
                 $computeThumbnails = false;
             }
-            $ch->importFiles($this->getPackagePath() . '/files', $computeThumbnails);
+            $ci->importFiles($this->getPackagePath() . '/files', $computeThumbnails);
         }
     }
 
     protected function install_content()
     {
-        $ci = new ContentImporter();
+        $ci = new ContentImporter(ContentImporter::IMPORT_MODE_INSTALL);
         $ci->importContentFile($this->getPackagePath() . '/content.xml');
     }
 
@@ -465,7 +466,7 @@ class StartingPointPackage extends Package
             $dbm->destroyProxyClasses();
             $dbm->generateProxyClasses();
 
-            Package::installDB($installDirectory . '/db.xml', false);
+            Package::installDB($installDirectory . '/db.xml', ContentImporter::IMPORT_MODE_INSTALL);
 
             $dbm->installDatabase();
             $this->indexAdditionalDatabaseFields();
@@ -543,7 +544,7 @@ class StartingPointPackage extends Package
 
         // Install conversation default email
         \Conversation::setDefaultSubscribedUsers([$superuser]);
-        $ci = new ContentImporter();
+        $ci = new ContentImporter(ContentImporter::IMPORT_MODE_INSTALL);
         $ci->importContentFile(DIR_BASE_CORE . '/config/install/base/conversation.xml');
 
         $folderManager = new FolderManager();
@@ -687,7 +688,7 @@ class StartingPointPackage extends Package
 
     protected function install_permissions()
     {
-        $ci = new ContentImporter();
+        $ci = new ContentImporter(ContentImporter::IMPORT_MODE_INSTALL);
         $ci->importContentFile(DIR_BASE_CORE . '/config/install/base/permissions.xml');
     }
 

--- a/tests/tests/Package/DbXmlTest.php
+++ b/tests/tests/Package/DbXmlTest.php
@@ -2,6 +2,8 @@
 
 namespace Concrete\Tests\Package;
 
+use Concrete\Core\Backup\ContentImporter;
+use Concrete\Core\Database\Schema\Schema;
 use Database;
 use Package;
 use Concrete\Tests\TestCase;
@@ -27,7 +29,7 @@ class DbXmlTest extends TestCase
         $this->assertFalse($schema->hasTable('TestPackageTable'));
 
         // Create the table initially.
-        Package::installDB(DIR_TESTS . '/assets/Package/db-1.xml');
+        Package::installDB(DIR_TESTS . '/assets/Package/db-1.xml', ContentImporter::IMPORT_MODE_INSTALL);
 
         // Make sure the table was properly created and it contains the column
         // we are about to remove does NOT contain the column we are about to


### PR DESCRIPTION
This PR attempts to improve installation speed by disabling syntax checking of Doctrine XML files, disabling foreign key checks on reset and install, and not parsing the entire installed database schema every single time we try to install block type XML. 

In order to test improvements I restarted my local machine, installed concrete, uninstalled it, and then installed it again, taking note of the time. This generally resulted in the fastest performance available. Sometimes install speeds are slower than this locally, but I wanted to try and get them to be as fast as possible so I could accurately gauge the improvements here.

In regular 9.3.x, under optimal local install conditions, I could install Concrete with the Atomik Full starting point in 58 seconds. 

<img width="362" alt="Screen Shot 2024-08-03 at 10 47 05 AM" src="https://github.com/user-attachments/assets/f15cea07-fff5-43cd-9f78-dc4109308e0e">

With these improvements, installation time dropped to 38s. 

<img width="557" alt="Screen Shot 2024-08-03 at 10 47 14 AM" src="https://github.com/user-attachments/assets/91980cae-8168-4d2f-b631-943da52c3c23">



