### PR TITLE
Add missing properties to Page\AddBlock dialog controller

### DIFF
--- a/concrete/controllers/dialog/page/add_block.php
+++ b/concrete/controllers/dialog/page/add_block.php
@@ -23,14 +23,48 @@ class AddBlock extends BackendInterfacePageController
     /**
      * @deprecated What's deprecated is the "public" part.
      *
+     * @var \Concrete\Core\Entity\Block\BlockType\BlockType|null
+     */
+    public $blockType;
+    
+    /**
+     * @deprecated What's deprecated is the "public" part.
+     *
      * @var \Concrete\Core\Area\Area
      */
     public $area;
 
+    /**
+     * @deprecated What's deprecated is the "public" part.
+     *
+     * @var \Concrete\Core\Page\Page
+     */
+    public $pageToModify;
+
+    /**
+     * @deprecated What's deprecated is the "public" part.
+     *
+     * @var \Concrete\Core\Area\Area
+     */
+    public $areaToModify;
+
+    /**
+     * @deprecated What's deprecated is the "public" part.
+     *
+     * @var \Concrete\Core\Permission\Checker
+     */
+    public $areaPermissions;
+
+    /**
+     * @deprecated What's deprecated is the "public" part.
+     *
+     * @var \Concrete\Core\Block\BlockController
+     */
+    public $blockTypeController;
+
     public function on_start()
     {
         parent::on_start();
-        $request = $this->request;
 
         if (!Loader::helper('validation/numbers')->integer($_REQUEST['btID'])) {
             throw new Exception(t('Access Denied'));
@@ -47,8 +81,7 @@ class AddBlock extends BackendInterfacePageController
         $this->areaPermissions = new Permissions($this->areaToModify);
         $cnt = $this->blockType->getController();
         if (!is_a($cnt, '\Concrete\Core\Block\BlockController')) {
-            throw new Exception(t(
-                                    'Unable to load the controller for this block type. Perhaps it has been moved or removed.'));
+            throw new Exception(t('Unable to load the controller for this block type. Perhaps it has been moved or removed.'));
         }
         $this->blockTypeController = $cnt;
         if (isset($_REQUEST['arCustomTemplates']) && is_array($_REQUEST['arCustomTemplates'])) {


### PR DESCRIPTION
In the Page\AddBlock dialog controller we assign values for properties that don't exist.

On PHP 8.2+ this leads to the following warning:

```
Creation of dynamic property Concrete\Controller\Dialog\Page\AddBlock::$blockType is deprecated
```

I solved this by defining the properties.

I created them as "public", because existing code may access those values.
But to signal that we shouldn't rely on these properties I marked them as deprecated.

Please remark that the core doesn't refer to these properties (at least, the regular expression `(?<!\$this)->(blockType|pageToModify|areaToModify|areaPermissions|blockTypeController)\b` doesn't match anything in the core)