### PR TITLE
Fix wrong arguments passed from Page\AddBlock dialog controller to the view

### DIFF
--- a/concrete/controllers/dialog/page/add_block.php
+++ b/concrete/controllers/dialog/page/add_block.php
@@ -74,7 +74,7 @@ class AddBlock extends BackendInterfacePageController
                 $this->area->setCustomTemplate($btHandle, $template);
             }
         }
-        $bv->addScopeItems(array('a' => isset($this->a) ? $this->a : null, 'cp' => $this->permissions, 'ap' => $this->areaPermissions));
+        $bv->addScopeItems(array('a' => isset($this->areaToModify) ? $this->areaToModify : null, 'cp' => $this->permissions, 'ap' => $this->areaPermissions));
         $this->set('blockView', $bv);
         $this->set('blockType', $this->blockType);
         $this->set('btHandle', $this->blockType->getBlockTypeHandle());


### PR DESCRIPTION
Neither the controller nor its parent classes define `a`.
We should use `areaToModify`, right?