### PR TITLE
Fixed dropdowns on top_navigation_bar block when using vanilla bootstrap

### DIFF
--- a/concrete/blocks/top_navigation_bar/view.php
+++ b/concrete/blocks/top_navigation_bar/view.php
@@ -77,7 +77,7 @@ $c = Page::getCurrentPage();
                              */
                             if (count($item->getChildren()) > 0) { ?>
                                 <li class="nav-item dropdown">
-                                    <a class="nav-link<?= $item->isActiveParent() ? " nav-path-selected" : ""; ?> dropdown-toggle<?= $item->isActive() ? " active" : ""; ?>" data-concrete-toggle="dropdown" target="<?=$controller->getPageItemNavTarget($item)?>" href="<?= $item->getUrl() ?>">
+                                    <a class="nav-link<?= $item->isActiveParent() ? " nav-path-selected" : ""; ?> dropdown-toggle<?= $item->isActive() ? " active" : ""; ?>" data-bs-toggle="dropdown" target="<?=$controller->getPageItemNavTarget($item)?>" href="<?= $item->getUrl() ?>">
                                         <?=h($item->getName())?>
                                     </a>
                                     <ul class="dropdown-menu">


### PR DESCRIPTION
Dropdowns in the top_navigation_bar do not currently work when using a vanilla or custom build of bootstrap because they're relying on data-concrete-toggle instead of data-bs-toggle.

This pull request fixes this issue while still working with Concrete's version of Bootstrap.
