### PR TITLE
Disable MarketPlace intelligent search in concrete5 v8

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -8,7 +8,7 @@ return [
      */
     'version' => '8.5.18',
     'version_installed' => '8.5.18',
-    'version_db' => '20220319043123', // the key of the latest database migration
+    'version_db' => '20240809105200', // the key of the latest database migration
 
     /*
      * Installation status
@@ -556,10 +556,11 @@ return [
 
         /*
          * Enable intelligent search integration
+         * Disabled since we switched to the new marketplace
          *
          * @var bool concrete.marketplace.intelligent_search
          */
-        'intelligent_search' => true,
+        'intelligent_search' => false,
 
         /*
          * Log requests

--- a/concrete/src/Updater/Migrations/Migrations/Version20240809105200.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20240809105200.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Site\Service;
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
+use Concrete\Core\Config\Repository\Repository;
+
+class Version20240809105200 extends AbstractMigration implements RepeatableMigrationInterface
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Updater\Migrations\AbstractMigration::upgradeDatabase()
+     */
+    public function upgradeDatabase()
+    {
+        $config = $this->app->make(Repository::class);
+        if (!$config->get('concrete.marketplace.intelligent_search')) {
+            $this->output(t('Marketplace Intelligent Search is disabled'));
+        } elseif ($config->get('concrete.urls.concrete5_secure') !== 'https://marketplace.concretecms.com') {
+            $this->output(t('Marketplace Intelligent Search not disabled since the %s configuration has been customized', 'concrete.urls.concrete5_secure'));
+        } elseif ($config->get('concrete.urls.paths.marketplace.remote_item_list') !== '/marketplace/') {
+            $this->output(t('Marketplace Intelligent Search not disabled since the %s configuration has been customized', 'concrete.urls.paths.marketplace.remote_item_list'));
+        } else {
+            $config->save('concrete.marketplace.intelligent_search', false);
+            $this->output(t('Marketplace Intelligent Search has been disabled'));
+        }
+    }
+}


### PR DESCRIPTION
When we enter some text in the intelligent search box, the core is kind enough to also provide results from the concrete marketplace.

But on v8 we can't use this feature anymore, since the new marketplace requires v9.

Indeed, every time we enter some text in the search box, concrete5 performs a request like

```
https://marketplace.concretecms.com/marketplace/addons/-/get_remote_list?is_compatible=1&keywords=...
```

which now results in a redirect response:

```
HTTP/1.1 302 Moved Temporarily
Location: https://market.concretecms.com
```

so, concrete5 tries to fetch the json from `https://market.concretecms.com`, which of course provides the HTML of the new marketplace.

What about disabling this feature?