### PR TITLE
Feature concretecms#11242: add search field of cache settings

### DIFF
--- a/concrete/src/Page/PageList.php
+++ b/concrete/src/Page/PageList.php
@@ -693,6 +693,12 @@ class PageList extends DatabaseItemList implements PagerProviderInterface, Pagin
         $this->query->setParameter('containerID', $containerID);
     }
 
+    public function filterByCacheSettings($value)
+    {
+        $this->query->andWhere('p.cCacheFullPageContent = :cacheSettings');
+        $this->query->setParameter('cacheSettings', $value);
+    }
+
 
     /**
      * Sorts this list by display order.

--- a/concrete/src/Page/Search/Field/Field/CacheSettingField.php
+++ b/concrete/src/Page/Search/Field/Field/CacheSettingField.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Concrete\Core\Page\Search\Field\Field;
+
+use Concrete\Core\Search\Field\AbstractField;
+use Concrete\Core\Search\ItemList\ItemList;
+use Concrete\Core\Support\Facade\Application;
+
+class CacheSettingField extends AbstractField
+{
+    protected $requestVariables = [
+        'cacheSetting',
+    ];
+
+    public function getKey()
+    {
+        return 'cache_setting';
+    }
+
+    public function getDisplayName()
+    {
+        return t('Cache Setting');
+    }
+
+    /**
+     * @param ItemList $list
+     */
+    public function filterList(ItemList $list)
+    {
+        if (isset($this->data['cacheSetting'])) {
+            $list->filterByCacheSettings($this->getData('cacheSetting'));
+        }
+    }
+
+    public function renderSearchField()
+    {
+        $settingOptions = [
+            '1' => [
+                'value' => '-1',
+                'label' => t('Use global setting'),
+            ],
+            '2' => [
+                'value' => '0',
+                'label' => t('Do not cache'),
+            ],
+            '3' => [
+                'value' => '1',
+                'label' => t('Cache page'),
+            ],
+        ];
+        $app = Application::getFacadeApplication();
+
+        $form = $app->make('helper/form');
+        $html = '';
+        foreach ($settingOptions as $key => $value) {
+            $html .= '<div class="form-check">' . $form->radio('cacheSetting', $value['value'], $this->getData('cacheSetting')) . $form->label('cacheSetting' . $key, $value['label'], ['class' => 'form-check-label']) . '</div>';
+        }
+
+        return $html;
+    }
+}

--- a/concrete/src/Page/Search/Field/Manager.php
+++ b/concrete/src/Page/Search/Field/Manager.php
@@ -2,6 +2,7 @@
 namespace Concrete\Core\Page\Search\Field;
 
 use Concrete\Core\Attribute\Category\PageCategory;
+use Concrete\Core\Page\Search\Field\Field\CacheSettingField;
 use Concrete\Core\Page\Search\Field\Field\ContainsBlockTypeField;
 use Concrete\Core\Page\Search\Field\Field\ContainsContainerField;
 use Concrete\Core\Page\Search\Field\Field\DateAddedField;
@@ -48,7 +49,8 @@ class Manager extends FieldManager
             new DateLastModifiedField(),
             new DatePublicField(),
             new ContainsBlockTypeField(),
-            new ContainsContainerField()
+            new ContainsContainerField(),
+            new CacheSettingField(),
         ];
         $app = Facade::getFacadeApplication();
         $siteService = $app->make('site');


### PR DESCRIPTION
Add "Cache Setting" field for advanced search to "Dashboard -> Sitemap -> Page Search" with same option as in Composer