### PR TITLE
Empty date field in schedule automatically publishes page

### DIFF
--- a/concrete/elements/pages/schedule.php
+++ b/concrete/elements/pages/schedule.php
@@ -88,5 +88,7 @@ $(document).ready(function() {
             $('#version-scheduling .text-active, #version-scheduling .info-active').addClass('d-none');
         }
     });
+
+    $('#cvPublishDate_dt_pub').attr('required', '');
 });
 </script>


### PR DESCRIPTION
![Screenshot 2024-08-23 at 14 57 28](https://github.com/user-attachments/assets/ecbf28d0-c074-47a4-8db2-9baa13a3996d)

If a user selects checks the "From" box in the page publish scheduler but doesn't set the date field then the page will ignore the time input and publish immediately. We have had clients mistakenly assume by leaving the date field blank it will apply to the current day and then been surprised when their changes are instantly accessible to site visitors.

I understand the scheduling functionality is complicated therefore thought just making the date field required (albeit with JS) was the simplest solution to prevent this issue.

