### PR TITLE
c5:package:install CLI command: pass install options to install method

### DIFF
--- a/concrete/src/Console/Command/InstallPackageCommand.php
+++ b/concrete/src/Console/Command/InstallPackageCommand.php
@@ -130,7 +130,7 @@ EOT
         $output->writeln('<info>passed.</info>');
 
         $output->write('Installing... ');
-        $r = $packageService->install($pkg, []);
+        $r = $packageService->install($pkg, $packageOptions);
         if ($r instanceof ErrorList) {
             throw new Exception(implode("\n", $r->getList()));
         }


### PR DESCRIPTION
We parse the command line options to build the data to be passed to the package installer, but we don't pass these options to the installer.

This bug exists since a2c527b64614d7b4dbeccb86688fae4b36b82279 (8 years ago!)