### PR TITLE
Fix unable to uncheck selected topic nodes

### DIFF
--- a/concrete/attributes/topics/search.php
+++ b/concrete/attributes/topics/search.php
@@ -4,6 +4,7 @@ if (is_object($tree)) {
     if (!is_array($selectedNode)) {
         $selectedNode = [$selectedNode];
     }
+    $selectedNode = array_map('intval', $selectedNode);
     $selectNodesByKey = json_encode($selectedNode);
     ?>
 


### PR DESCRIPTION
Fixes #12189
This issue is a side effect of https://github.com/concretecms/bedrock/pull/343 .
In that PR, I checked the selected node keys as integer values, so we have to force the type of keys to be integer on the PHP side, too.