### PR TITLE
Allow specifying package install options via CIF

### DIFF
--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportPackagesRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportPackagesRoutine.php
@@ -1,56 +1,110 @@
 <?php
+
 namespace Concrete\Core\Backup\ContentImporter\Importer\Routine;
 
-use Concrete\Core\Attribute\Type;
-use Concrete\Core\Block\BlockType\BlockType;
-use Concrete\Core\Package\Package;
-use Concrete\Core\Permission\Category;
-use Concrete\Core\Support\Facade\Facade;
-use Concrete\Core\Utility\Service\Xml;
-use Concrete\Core\Validation\BannedWord\BannedWord;
+use Concrete\Core\Package\BrokenPackage;
 use Concrete\Core\Package\PackageService;
+use Concrete\Core\Utility\Service\Xml;
 use Concrete\Core\Validation\CSRF\Token;
+use SimpleXMLElement;
 
+/**
+ * @example
+ * <?xml version="1.0"?>
+ * <concrete5-cif version="1.0">
+ *     <packages>
+ *         <package handle="my_package" />
+ *         <package handle="my_package" full-content-swap="true" />
+ *         <package handle="my_package" full-content-swap="true" content-swap-file="my-content.xml" />
+ *         <package handle="my_package">
+ *             <option name="scalar" value="value" />
+ *             <option name="array[]" value="value1" />
+ *             <option name="array[]" value="value2" />
+ *         </package>
+ *     </packages>
+ * </concrete5-cif>
+ */
 class ImportPackagesRoutine extends AbstractRoutine
 {
+    /**
+     * @var \Concrete\Core\Package\PackageService
+     */
+    protected $packageService;
+
+    /**
+     * @var \Concrete\Core\Utility\Service\Xml
+     */
+    protected $xml;
+
+    /**
+     * @var \Concrete\Core\Validation\CSRF\Token
+     */
+    protected $token;
+
+    public function __construct(PackageService $packageService, Xml $xml, Token $token)
+    {
+        $this->packageService = $packageService;
+        $this->xml = $xml;
+        $this->token = $token;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\Importer\Routine\RoutineInterface::getHandle()
+     */
     public function getHandle()
     {
         return 'packages';
     }
 
-    public function import(\SimpleXMLElement $sx)
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\Importer\Routine\RoutineInterface::import()
+     */
+    public function import(SimpleXMLElement $sx)
     {
-        if (isset($sx->packages)) {
-            $xml = app(Xml::class);
-            foreach ($sx->packages->package as $p) {
-                $pkg = Package::getByHandle((string) $p['handle']);
-                if (!$pkg) {
-                    $pkgClass = Package::getClass((string) $p['handle']);
-                    if ($pkgClass) {
-                        $app = Facade::getFacadeApplication();
-                        $service = $app->make(PackageService::class);
-                        /** @var Token $token */
-                        $token = $app->make(Token::class);
-
-                        $data = [];
-
-                        if ($xml->getBool($p['full-content-swap'])) {
-                            $data["pkgDoFullContentSwap"] = true;
-                            // set this token to perform a full content swap when installing starting point packages
-                            $data["ccm_token"] = $token->generate("install_options_selected");
-
-                            if (isset($p['content-swap-file'])) {
-                                $data["contentSwapFile"] = (string)$p['content-swap-file'];
-                            } else {
-                                $data["contentSwapFile"] = "content.xml";
-                            }
+        if (!isset($sx->packages)) {
+            return;
+        }
+        foreach ($sx->packages->package as $xPackage) {
+            $pkg = $this->packageService->getByHandle((string) $xPackage['handle']);
+            if ($pkg) {
+                continue;
+            }
+            $pkgClass = $this->packageService->getClass((string) $xPackage['handle']);
+            if (!$pkgClass || $pkgClass instanceof BrokenPackage) {
+                continue;
+            }
+            $data = [];
+            if ($this->xml->getBool($xPackage['full-content-swap'])) {
+                // set this token to perform a full content swap when installing starting point packages
+                $data['pkgDoFullContentSwap'] = true;
+                $data['ccm_token'] = $this->token->generate('install_options_selected');
+                if (isset($xPackage['content-swap-file'])) {
+                    $data['contentSwapFile'] = (string) $xPackage['content-swap-file'];
+                } else {
+                    $data['contentSwapFile'] = 'content.xml';
+                }
+            }
+            if (isset($xPackage->option)) {
+                foreach ($xPackage->option as $xOption) {
+                    $optionName = (string) $xOption['name'];
+                    $optionValue = (string) $xOption['value'];
+                    if (str_ends_with($optionName, '[]')) {
+                        $key = substr($optionName, 0, -2);
+                        if (is_array($data[$key] ?? null)) {
+                            $data[$key][] = $optionValue;
+                        } else {
+                            $data[$key] = [$optionValue];
                         }
-
-                        $service->install($pkgClass, $data);
+                    } else {
+                        $data[$optionName] = $optionValue;
                     }
                 }
             }
+            $this->packageService->install($pkgClass, $data);
         }
     }
-
 }

--- a/concrete/src/Package/Package.php
+++ b/concrete/src/Package/Package.php
@@ -607,9 +607,14 @@ abstract class Package implements LocalizablePackageInterface
      * Install the package info row and the database (doctrine entities and db.xml).
      * Packages installing additional content should override this method, call the parent method (`parent::install()`).
      *
+     * @param array $data The data received from:
+     * - the dashboard/install element of the package when installing via web
+     * - the options passed to the CLI command when installing via CLI
+     * - <option name="..." value="..." /> elements defined under the <package> element when installing via CIF
+     *
      * @return \Concrete\Core\Entity\Package
      */
-    public function install()
+    public function install(/** array $data */)
     {
         PackageList::refreshCache();
         $em = $this->app->make(EntityManagerInterface::class);

--- a/tests/tests/Backup/Import/ImportPackagesTest.php
+++ b/tests/tests/Backup/Import/ImportPackagesTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\Tests\Backup\Import;
+
+use Concrete\Core\Backup\ContentImporter\Importer\Routine\ImportPackagesRoutine;
+use Concrete\Core\Package\Package;
+use Concrete\Core\Package\PackageService;
+use Concrete\Core\Utility\Service\Xml;
+use Concrete\Core\Validation\CSRF\Token;
+use Concrete\Tests\TestCase;
+use Mockery as M;
+
+class ImportPackagesTest extends TestCase
+{
+    public static function provideTestCases(): array
+    {
+        return [
+            [
+                '<package handle="test_package" />',
+                [
+                ],
+            ],
+            [
+                '<package handle="test_package" full-content-swap="false" />',
+                [
+                ],
+            ],
+            [
+                '<package handle="test_package" full-content-swap="" />',
+                [
+                ],
+            ],
+            [
+                '<package handle="test_package" full-content-swap="0" />',
+                [
+                ],
+            ],
+            [
+                '<package handle="test_package" full-content-swap="no" />',
+                [
+                ],
+            ],
+            [
+                '<package handle="test_package" content-swap-file="my-content.xml" />',
+                [
+                ],
+            ],
+            [
+                '<package handle="test_package" full-content-swap="true" />',
+                [
+                    'pkgDoFullContentSwap' => true,
+                    'ccm_token' => 'GeneratedToken',
+                    'contentSwapFile' => 'content.xml',
+                ],
+            ],
+            [
+                '<package handle="test_package" full-content-swap="1" />',
+                [
+                    'pkgDoFullContentSwap' => true,
+                    'ccm_token' => 'GeneratedToken',
+                    'contentSwapFile' => 'content.xml',
+                ],
+            ],
+            [
+                '<package handle="test_package" full-content-swap="yes" content-swap-file="my-content.xml" />',
+                [
+                    'pkgDoFullContentSwap' => true,
+                    'ccm_token' => 'GeneratedToken',
+                    'contentSwapFile' => 'my-content.xml',
+                ],
+            ],
+            [
+                '<package handle="test_package">
+                    <option name="opt" />
+                </package>',
+                [
+                    'opt' => '',
+                ],
+            ],
+            [
+                '<package handle="test_package">
+                    <option name="opt" value="val" />
+                </package>',
+                [
+                    'opt' => 'val',
+                ],
+            ],
+            [
+                '<package handle="test_package">
+                    <option name="opt[]" value="val" />
+                </package>',
+                [
+                    'opt' => ['val'],
+                ],
+            ],
+            [
+                '<package handle="test_package">
+                    <option name="opt[]" value="val1" />
+                    <option name="opt[]" value="val2" />
+                </package>',
+                [
+                    'opt' => ['val1', 'val2'],
+                ],
+            ],
+            [
+                '<package handle="test_package" full-content-swap="true" content-swap-file="my-content.xml" >
+                    <option name="arr1[]" value="val1" />
+                    <option name="arr2[]" value="val21" />
+                    <option name="plain" value="value" />
+                    <option name="arr2[]" value="val22" />
+                </package>',
+                [
+                    'pkgDoFullContentSwap' => true,
+                    'ccm_token' => 'GeneratedToken',
+                    'contentSwapFile' => 'my-content.xml',
+                    'arr1' => ['val1'],
+                    'arr2' => ['val21', 'val22'],
+                    'plain' => 'value',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider provideTestCases
+     */
+    public function testReadingCIF(string $cifChunk, array $expectedInstallOptions): void
+    {
+        $packageControllerMock = M::mock(Package::class);
+
+        $tokenMock = M::mock(Token::class);
+        $tokenMock->shouldReceive('generate')->zeroOrMoreTimes()->with('install_options_selected')->andReturn('GeneratedToken');
+
+        $packageServiceMock = M::mock(PackageService::class);
+        $packageServiceMock->shouldReceive('getByHandle')->once()->with('test_package')->andReturn(null);
+        $packageServiceMock->shouldReceive('getClass')->once()->with('test_package')->andReturn($packageControllerMock);
+        $packageServiceMock->shouldReceive('install')->once()->with($packageControllerMock, $expectedInstallOptions);
+
+        $sx = simplexml_load_string('<?xml version="1.0"?><concrete5-cif version="1.0"><packages>' . $cifChunk . '</packages></concrete5-cif>');
+        $importer = new ImportPackagesRoutine($packageServiceMock, app(Xml::class), $tokenMock);
+        $importer->import($sx);
+    }
+}


### PR DESCRIPTION
We can currently define package install options in two ways:

- using the package `dashboard/install` element when installing via web
- specifying [additional options](https://github.com/concretecms/concretecms/blob/9.3.3/concrete/src/Console/Command/InstallPackageCommand.php#L39) in the `c5:package:install` command when installing via CLI (this currently doesn't work - fixed by #12190)

But there's no way to specify package install options when importing CIF files: what about allowing it?

PS: since this PR introduces new elements in the CIF files, we should also update the CIF XSD specifications - see https://github.com/concretecms/concrete-cif/pull/34 (I'll merge that PR if this PR gets merged).