### PR TITLE
Enhance `c5:package:pack` Command to Allow Flexible Output Path Without Requiring Zip File Name

### DIFF
--- a/concrete/src/Console/Command/PackPackageCommand.php
+++ b/concrete/src/Console/Command/PackPackageCommand.php
@@ -303,8 +303,16 @@ EOT
         }
         if ($this->input->getParameterOption(['--zip', '-z']) !== false) {
             $zipOption = (string) $this->input->getOption('zip');
-            if ($zipOption === '' || $zipOption === self::ZIPOUT_AUTO) {
-                $zipFilename = dirname($packageInfo->getPackageDirectory()) . '/' . $packageInfo->getHandle() . '-' . $packageInfo->getVersion() . '.zip';
+            if ($zipOption === '' || $zipOption === self::ZIPOUT_AUTO || substr($zipOption, -4) !== '.zip') {
+                // If the zip option is empty, set to auto, or doesn't end with '.zip', generate the zip filename
+                $baseDir = $zipOption !== '' && $zipOption !== self::ZIPOUT_AUTO ? rtrim($zipOption, '/') : dirname($packageInfo->getPackageDirectory());
+
+                // Create the directory if it doesn't exist
+                if (!is_dir($baseDir) && !mkdir($baseDir, 0777, true) && !is_dir($baseDir)) {
+                    throw new \RuntimeException("Unable to create the directory '{$baseDir}'");
+                }
+
+                $zipFilename = $baseDir . '/' . $packageInfo->getHandle() . '-' . $packageInfo->getVersion() . '.zip';
             } else {
                 $zipFilename = $zipOption;
             }


### PR DESCRIPTION
This PR enhances the `c5:package:pack` command by allowing the use of an output path without requiring the zip file name. 

Previously, specifying the output path also necessitated defining the zip file name. With this update, the output path alone can be used, simplifying the command.

### Examples:

1. **Basic Usage**
   - Command: `./concrete/bin/concrete c5:package:pack my_package ~/Desktop`
   - Output: `~/Desktop/my_package-x.x.x.zip`

2. **With Directory Creation**
   - Command: `./concrete/bin/concrete c5:package:pack my_package ~/Desktop/new_dir`
   - Output: `~/Desktop/new_dir/my_package-x.x.x.zip` (Creates `new_dir` if it doesn't exist)

3. **Specifying the Zip File Name**
   - Command: `./concrete/bin/concrete c5:package:pack my_package ~/Desktop/new_dir/my_package.zip`
   - Output: `~/Desktop/new_dir/my_package.zip`

This enhancement provides more flexibility and convenience when using the `c5:package:pack` command.