### PR TITLE
Add dashboard option to configure File Chooser default tab

### DIFF
--- a/concrete/config/install/base/single_pages/dashboard.xml
+++ b/concrete/config/install/base/single_pages/dashboard.xml
@@ -983,6 +983,14 @@
                 </attributekey>
             </attributes>
         </page>
+        <page name="File Chooser Options" path="/dashboard/system/files/file_chooser"
+              filename="/dashboard/system/files/file_chooser.php" pagetype="" description="" package="">
+            <attributes>
+                <attributekey handle="meta_keywords">
+                    <value>file, chooser</value>
+                </attributekey>
+            </attributes>
+        </page>
         <page name="File Manager Permissions" path="/dashboard/system/files/permissions"
               filename="/dashboard/system/files/permissions.php" pagetype="" description="" package="">
             <attributes>

--- a/concrete/controllers/single_page/dashboard/system/files/file_chooser.php
+++ b/concrete/controllers/single_page/dashboard/system/files/file_chooser.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Concrete\Controller\SinglePage\Dashboard\System\Files;
+
+use Concrete\Core\Http\ResponseFactoryInterface;
+use Concrete\Core\Page\Controller\DashboardPageController;
+use Symfony\Component\HttpFoundation\Response;
+
+class FileChooser extends DashboardPageController
+{
+    public function view(): void
+    {
+        $fileChooserDefaultTab = $this->app['config']->get('concrete.file_chooser.default_tab');
+
+        if (!$fileChooserDefaultTab) {
+            $fileChooserDefaultTab = 'file_manager';
+        }
+
+        $this->set('fileChooserDefaultTab', $fileChooserDefaultTab);
+    }
+
+    public function submit(): ?Response
+    {
+        if (!$this->token->validate('save_file_chooser_settings')) {
+            $this->error->add($this->token->getErrorMessage());
+        }
+
+        if (!$this->error->has()) {
+            $this->app['config']->save('concrete.file_chooser.default_tab',  $this->post('fileChooserDefaultTab'));
+
+            $this->flash('success', t('Settings saved successfully.'));
+
+            return $this->app->make(ResponseFactoryInterface::class)->redirect($this->action(''), 302);
+        }
+
+        return null;
+    }
+}

--- a/concrete/single_pages/dashboard/system/files/file_chooser.php
+++ b/concrete/single_pages/dashboard/system/files/file_chooser.php
@@ -1,0 +1,40 @@
+<?php
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+/**
+ * @var \Concrete\Core\View\View $view
+ * @var \Concrete\Core\Validation\CSRF\Token $token
+ * @var \Concrete\Core\Form\Service\Form $form
+ */
+
+?>
+<form method="post" action="<?= $view->action('submit') ?>">
+    <?= $token->output('save_file_chooser_settings') ?>
+    <div class="form-group">
+
+        <?php echo $form->label('fileChooserDefaultTab', t('Default Tab')) ?>
+        <div class="form-check">
+            <?= $form->radio('fileChooserDefaultTab', 'file_manager', $fileChooserDefaultTab === 'file_manager', ['required' => 'required', 'id'=>'file_manager_option']) ?>
+            <label for="file_manager_option">
+                <?= t('File Manager') ?>
+            </label>
+        </div>
+
+        <div class="form-check">
+            <?= $form->radio('fileChooserDefaultTab', 'recent_uploads', $fileChooserDefaultTab === 'recent_uploads', ['required' => 'required', 'id'=>'recent_uploads_option']) ?>
+            <label for="recent_uploads_option">
+                <?= t('Recent Uploads') ?>
+            </label>
+        </div>
+
+
+    </div>
+    <div class="ccm-dashboard-form-actions-wrapper">
+        <div class="ccm-dashboard-form-actions">
+            <div class="float-end">
+                <button type="submit" class="btn btn-primary"><?= t('Save') ?></button>
+            </div>
+        </div>
+    </div>
+</form>

--- a/concrete/src/File/Component/Chooser/DefaultConfigurationFactory.php
+++ b/concrete/src/File/Component/Chooser/DefaultConfigurationFactory.php
@@ -45,8 +45,19 @@ class DefaultConfigurationFactory
 
         $sets = Set::getMySets();
         $searches = $this->entityManager->getRepository(SavedFileSearch::class)->findAll();
-        $configuration->addChooser(new FileManagerOption());
-        $configuration->addChooser(new RecentUploadsOption());
+
+        $choosers = [new FileManagerOption(), new RecentUploadsOption()];
+
+        $fileChooserDefaultTab = app()['config']->get('concrete.file_chooser.default_tab');
+
+        if ($fileChooserDefaultTab == 'recent_uploads') {
+            $choosers = array_reverse($choosers);
+        }
+
+        foreach($choosers as $chooser) {
+            $configuration->addChooser($chooser);
+        }
+
         $configuration->addChooser(new SearchOption());
         if (count($sets) > 0) {
             $configuration->addChooser(new FileSetsOption());

--- a/concrete/src/Updater/Migrations/Migrations/Version20240910000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20240910000000.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Application\UserInterface\Dashboard\Navigation\NavigationCache;
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
+
+final class Version20240910000000 extends AbstractMigration implements RepeatableMigrationInterface
+{
+
+    public function upgradeDatabase()
+    {
+        $this->createSinglePage('/dashboard/system/files/file_chooser', 'File Chooser Options');
+
+        /** @var NavigationCache $navigationCache */
+        $navigationCache = $this->app->make(NavigationCache::class);
+        $navigationCache->clear();
+    }
+
+}


### PR DESCRIPTION
As per https://github.com/concretecms/concretecms/pull/12148#issuecomment-2263800871

This adds a new 'File Chooser Options' dashboard config page (as other pages didn't appear to suit this new option).
![Screenshot 2024-09-10 at 21 40 08](https://github.com/user-attachments/assets/81cb8aee-ee10-4c29-8d50-90dd13e19096)

This then allows the default tab to be swapped to Recent Uploads.
The existing default of 'File Manager' has not be changed, so this is just a new option.

<img width="465" alt="349692852-c9b9d02b-e39d-4db8-b9a6-ee16d7a01af9" src="https://github.com/user-attachments/assets/0b1c2ce7-9b70-4f65-8547-d218dc99054e">
