### PR TITLE
Improve error message in LatestMigrationTest

### DIFF
--- a/tests/tests/Update/LatestMigrationTest.php
+++ b/tests/tests/Update/LatestMigrationTest.php
@@ -12,7 +12,14 @@ class LatestMigrationTest extends TestCase
     {
         $configuredDBVersion = $this->getConfiguredDBVersion();
         $latestMigrationID = $this->getLatestMigrationID();
-        $this->assertSame($configuredDBVersion, $latestMigrationID, "The last migration should be {$configuredDBVersion} instead of {$latestMigrationID}");
+        $this->assertSame(
+            $configuredDBVersion,
+            $latestMigrationID,
+            <<<EOT
+The ID of the latest migration is {$latestMigrationID}, and it doesn't match the value of the concrete.version_db configuration key ({$configuredDBVersion}).
+If you added a new migration, you should also update the value of version_db in the /concrete/config/concrete.php file
+EOT
+        );
     }
 
     protected function getConfiguredDBVersion(): string


### PR DESCRIPTION
When we add a new migration, we also have to update the value of the `concrete.version_db` configuration key.

We have a test that checks it, but its error message is rather cryptic.

[For example](https://github.com/concretecms/concretecms/actions/runs/10800282832/job/29957914401#step:10:62):

```
The last migration should be 20240711000000 instead of 20240910000000
```

What about improving that error message to something like the following:

```
The ID of the latest migration is 20240910000000, and it doesn't match the value of the concrete.version_db configuration key (20240711000000).
If you added a new migration, you should also update the value of version_db in the /concrete/config/concrete.php file
```
