### PR TITLE
Fix 12213: Express Entity and Topic Attribute Validation

### DIFF
--- a/concrete/attributes/express/controller.php
+++ b/concrete/attributes/express/controller.php
@@ -205,6 +205,21 @@ class Controller extends AttributeTypeController implements
         return ExpressSettings::class;
     }
 
+    public function validateKey($data = false)
+    {
+        if ($data == false) {
+            $data = $this->post();
+        }
+
+        $e = $this->app->make('error');
+
+        if (!isset($data['exEntityID'])) {
+            $e->add(t('You must specify a valid Express entity.'));
+        }
+
+        return $e;
+    }
+
     public function validateForm($p)
     {
         return $p['value'] != false;

--- a/concrete/attributes/express/type_form.php
+++ b/concrete/attributes/express/type_form.php
@@ -1,9 +1,20 @@
-<fieldset class="ccm-attribute ccm-attribute-date-time">
-<legend><?=t('Express Options')?></legend>
+<?php if(is_array($entities) && count($entities)) { ?>
+    <fieldset class="ccm-attribute ccm-attribute-date-time">
+    <legend><?=t('Express Options')?></legend>
 
-<div class="form-group">
-<?=$form->label('exEntityID', t('Entity'))?>
-<?=$form->select('exEntityID', $entities, $entityID)?>
-</div>
+    <div class="form-group">
+    <?=$form->label('exEntityID', t('Entity'))?>
+    <?=$form->select('exEntityID', $entities, $entityID)?>
+    </div>
 
-</fieldset>
+    </fieldset>
+<?php 
+} else { 
+    ?>
+
+    <div class="alert alert-danger"><?=t('You have not created any Express entities.
+You must create an entity on the <a href="%s">Express Page</a>
+before you can use this attribute type.', URL::to('/dashboard/express/entries'))?></div>
+
+<?php 
+} ?>

--- a/concrete/attributes/topics/controller.php
+++ b/concrete/attributes/topics/controller.php
@@ -344,7 +344,7 @@ class Controller extends AttributeTypeController implements
 
         $e = $this->app->make('error');
 
-        if (!$data['akTopicParentNodeID'] || !$data['akTopicTreeID']) {
+        if (!isset($data['akTopicParentNodeID']) || !isset($data['akTopicTreeID'])) {
             $e->add(t('You must specify a valid topic tree parent node ID and topic tree ID.'));
         }
 


### PR DESCRIPTION
This is a proposed fix for the bug #12213 I submitted yesterday. 3 Files are modified:

`concrete/attributes/express/controller.php` - Adds the "validateKey" method to check if an Express entity ID was passed by the form. If it's empty, a frontend error is added stating that the user must add a valid Express entity.  
  
`concrete/attribute/express/type_form.php` - Adds an 'if' block to check if the express entities variable is a (non-empty) array. If it isn't, it will show an error message stating that the user must add at least 1 express entity before they can use this attribute. This is similar to how the "Topics" attribute currently functions.  
  
`concrete/attributes/topics/controller/php` - Inside the "validateKey" method, wrap the array access in "isset()". On PHP 8+, attempting to access an array at an undefined key throws a **warning**.