### PR TITLE
Fix 12158: Translation in Exclude from Navigation

### DIFF
--- a/concrete/attributes/boolean/form.php
+++ b/concrete/attributes/boolean/form.php
@@ -8,6 +8,6 @@
         <?php if ($checked) { ?> checked <?php } ?>
     >
     <label class="form-check-label" for="<?=$view->field('value')?>">
-        <?=t($controller->getCheckboxLabel())?>
+        <?=tc('AttributeKeyLabel', $controller->getCheckboxLabel())?>
     </label>
 </div>


### PR DESCRIPTION
This is a proposed fix for the bug [#12158](https://github.com/concretecms/concretecms/issues/12158). 1 file is modified:
`concrete/attributes/boolean/form.php` - Fixed the translation function in code from t() to tc() to add the context in translation, so the `AttributeKeyLabel` is parsed correctly.