### PR TITLE
Feature 12216: Checkbox for enabling Hreflang created

### DIFF
--- a/concrete/attributes/boolean/form.php
+++ b/concrete/attributes/boolean/form.php
@@ -8,6 +8,6 @@
         <?php if ($checked) { ?> checked <?php } ?>
     >
     <label class="form-check-label" for="<?=$view->field('value')?>">
-        <?=t($controller->getCheckboxLabel())?>
+        <?=tc('AttributeKeyLabel', $controller->getCheckboxLabel())?>
     </label>
 </div>

--- a/concrete/controllers/single_page/dashboard/system/multilingual/setup.php
+++ b/concrete/controllers/single_page/dashboard/system/multilingual/setup.php
@@ -47,6 +47,7 @@ class Setup extends DashboardSitePageController
         $this->set('redirectHomeToDefaultLocale', $siteConfig->get('multilingual.redirect_home_to_default_locale'));
         $this->set('useBrowserDetectedLocale', $siteConfig->get('multilingual.use_browser_detected_locale'));
         $this->set('alwaysTrackUserLocale', $siteConfig->get('multilingual.always_track_user_locale'));
+        $this->set('setAlternateHreflang', $siteConfig->get('multilingual.set_alternate_hreflang'));
         $mlPage = Page::getByPath('/dashboard/system/basics/multilingual');
         if ($mlPage && !$mlPage->isError()) {
             $cp = new Checker($mlPage);
@@ -157,6 +158,10 @@ class Setup extends DashboardSitePageController
                 }
                 $siteConfig->save('multilingual.default_source_locale', $defaultSourceLocale);
                 $siteConfig->save('multilingual.always_track_user_locale', $this->post('alwaysTrackUserLocale') ? true : false);
+                #new code
+                $setAlternateHreflang = $this->post('set_alternate_hreflang') ? true : false;
+                $siteConfig->save('multilingual.set_alternate_hreflang', $setAlternateHreflang);
+                #end new code
                 $this->flash('success', t('Default Section settings updated.'));
                 $this->redirect('/dashboard/system/multilingual/setup', 'view');
             } else {

--- a/concrete/single_pages/dashboard/system/multilingual/setup.php
+++ b/concrete/single_pages/dashboard/system/multilingual/setup.php
@@ -139,6 +139,14 @@ foreach ($locales as $locale) {
                 <span><?= t('Always track user locale.') ?> <i class="launch-tooltip control-label fas fa-question-circle" title="<?= h(t('Tracking user locales requires the creation of session cookies. Disable this option to avoid tracking user locale in case the session cookie is not yet set.')) ?>"></i></span>
             </label>
         </div>
+        <!-- new code -->
+        <div class="form-check">
+            <?= $form->checkbox('set_alternate_hreflang', 1, $setAlternateHreflang) ?>
+            <label>
+                <span><?= t('Help search engines show the correct language version with Hreflang tags') ?></span>
+            </label>
+        </div>
+        <!-- end new code -->
     </div>
     <script>
         $(document).ready(function() {


### PR DESCRIPTION
This is a proposed new feature for the issue [#12216](https://github.com/concretecms/concretecms/issues/12216). 2 files are modified:

`concrete/controllers/single_page/dashboard/system/multilingual/setup.php` - Added a new `set` and `get` for the new variable `set_alternate_hreflang` and added the save function to the checkbox.

`concrete/single_pages/dashboard/system/multilingual/setup.php` - Created a new checkbox in the group of already existing checkboxes to accommodate the new functionality.