### PR TITLE
Fix copy-paste error and clarify page listing permission requirements in API

### DIFF
--- a/concrete/src/Api/Controller/Pages.php
+++ b/concrete/src/Api/Controller/Pages.php
@@ -158,9 +158,9 @@ class Pages extends ApiController
         $list->getQueryObject()->andWhere('cPointerExternalLink is null');
 
         $list->setPermissionsChecker(
-            function ($file) {
-                $fp = new Checker($file);
-                return $fp->canViewPageInSitemap();
+            function ($page) {
+                $permissions = new Checker($page);
+                return $permissions->canViewPageInSitemap();
             }
         );
 
@@ -225,8 +225,8 @@ class Pages extends ApiController
 
         $list->setPermissionsChecker(
             function ($page) {
-                $fp = new Checker($page);
-                return $fp->canViewPageInSitemap();
+                $permissions = new Checker($page);
+                return $permissions->canViewPageInSitemap();
             }
         );
 


### PR DESCRIPTION
I've fixed a copy-paste issue here, but I’m wondering why the `listPages()` function requires the `canViewPageInSitemap` permission instead of `canViewPage`. 
As it stands, if I want to use the API to list pages that are already visible to guest users on a standard Concrete5 website, I need to grant both `canViewPageInSitemap` and `canViewPage` permissions. 
Would it make more sense for this to be controlled solely by `canViewPage`, or is there a specific reason for this design choice that I might be overlooking?