### PR TITLE
Fix 11735: Email notification checkbox now saves the state

### DIFF
--- a/concrete/blocks/express_form/controller.php
+++ b/concrete/blocks/express_form/controller.php
@@ -417,6 +417,7 @@ class Controller extends BlockController implements NotificationProviderInterfac
 
         // Make sure our data goes through correctly.
         $data['storeFormSubmission'] = isset($data['storeFormSubmission']) ?: 0;
+        $data['notifyMeOnSubmission'] = isset($data['notifyMeOnSubmission']) ?: 0;
 
         // Now, let's handle saving the form entity ID against the form block db record
         $entity = false;


### PR DESCRIPTION
This is a proposed fix for the bug [#11735](https://github.com/concretecms/concretecms/issues/11735). 1 file is modified:
`concrete/blocks/express_form/controller.php` - It was added a verification in the `save()` function with the already existing `storeFormSubmission` called `notifyMeOnSubmission`, that makes sure the state of the checkbox is saved correctly and goes through if the editor makes a change on the form.
