### PR TITLE
Fixed bug in topic attribute export if no value was set

### DIFF
--- a/concrete/attributes/topics/controller.php
+++ b/concrete/attributes/topics/controller.php
@@ -120,8 +120,10 @@ class Controller extends AttributeTypeController implements
         $xml = $this->app->make(Xml::class);
         $avn = $akn->addChild('topics');
         $nodes = $this->attributeValue->getValue();
-        foreach ($nodes as $topic) {
-            $xml->createChildElement($avn, 'topic', $topic->getTreeNodeDisplayPath());
+        if (!empty($nodes)) {
+            foreach ($nodes as $topic) {
+                $xml->createChildElement($avn, 'topic', $topic->getTreeNodeDisplayPath());
+            }
         }
     }
 


### PR DESCRIPTION
Fixed a bug that prevented exporting pages with topic attributes if no value was set for the attribute.