### PR TITLE
Re-instate Dorset as an English County

### DIFF
--- a/concrete/src/Localization/Service/StatesProvincesList.php
+++ b/concrete/src/Localization/Service/StatesProvincesList.php
@@ -235,7 +235,7 @@ class StatesProvincesList
                     'CUMB' =>tc('English County', 'Cumbria'),
                     'DERBY' =>tc('English County', 'Derbyshire'),
                     'DEVON' =>tc('English County', 'Devon'),
-                    'DOR' =>tc('English County', 'Dorset'),
+                    'DORSET' =>tc('English County', 'Dorset'),
                     'EROY' =>tc('English County', 'East Riding of Yorkshire'),
                     'ESUS' =>tc('English County', 'East Sussex'),
                     'ESSEX' =>tc('English County', 'Essex'),

--- a/concrete/src/Localization/Service/StatesProvincesList.php
+++ b/concrete/src/Localization/Service/StatesProvincesList.php
@@ -235,6 +235,7 @@ class StatesProvincesList
                     'CUMB' =>tc('English County', 'Cumbria'),
                     'DERBY' =>tc('English County', 'Derbyshire'),
                     'DEVON' =>tc('English County', 'Devon'),
+                    'DOR' =>tc('English County', 'Dorset'),
                     'EROY' =>tc('English County', 'East Riding of Yorkshire'),
                     'ESUS' =>tc('English County', 'East Sussex'),
                     'ESSEX' =>tc('English County', 'Essex'),


### PR DESCRIPTION
When this was last updated, Dorset was accidentally deleted. This re-instates it.