### PR TITLE
Overriding inherited function isValidControllerTask to add a check fo…

### DIFF
--- a/concrete/blocks/express_form/controller.php
+++ b/concrete/blocks/express_form/controller.php
@@ -981,4 +981,21 @@ class Controller extends BlockController implements NotificationProviderInterfac
         return $entityManager->getRepository(\Concrete\Core\Entity\Express\Form::class)
             ->findOneById($this->exFormID);
     }
+
+    /**
+     * @param string $method
+     * @param array $parameters
+     * @return bool
+     */
+    public function isValidControllerTask($method, $parameters = [])
+    {
+        $actions = ['action_form_success', 'action_submit'];
+        if (in_array($method, $actions)) {
+            if (isset($parameters[0]) && $this->bID != $parameters[0]) {
+                return false;
+            }
+        }
+
+        return parent::isValidControllerTask($method, $parameters);
+    }
 }


### PR DESCRIPTION
Overriding inherited function isValidControllerTask to add a check for $this->bID if the request if for an action that requires the bID of the controller instance to be the same as in the submitted form. If the bIDs are nor the same the function returns false to allow the next controller in the stack to handle the request. If the bIDs are the same the function is returning the result of the parent's isValidControllerTask function.

fixes #12254