### PR TITLE
Refactoring RSS Displayer: Using array_slice to limit number of posts and removing redundant loop in the view file

### DIFF
--- a/concrete/blocks/rss_displayer/controller.php
+++ b/concrete/blocks/rss_displayer/controller.php
@@ -190,16 +190,7 @@ class Controller extends BlockController implements UsesFeatureInterface
 
         try {
             $channel = $fp->load($this->url, $this->rssFeedCacheLifetime);
-            $posts = $fp->getPosts($channel);
-
-            $i = 0;
-            foreach ($posts as $post) {
-                $posts[] = $post;
-                if (($i + 1) == intval($this->itemsToDisplay)) {
-                    break;
-                }
-                ++$i;
-            }
+            $posts = array_slice($fp->getPosts($channel), 0, intval($this->itemsToDisplay));
         } catch (\Exception $e) {
             $this->set('errorMsg', t('Unable to load RSS posts.'));
         }
@@ -251,14 +242,7 @@ class Controller extends BlockController implements UsesFeatureInterface
             // We manually set cache time to 2hrs here as getSearchableContent()
             // can probably cope with slightly older data
             $channel = $fp->load($this->url, 7200);
-            $i = 0;
-            foreach ($channel as $post) {
-                $posts[] = $post;
-                if (($i + 1) == intval($this->itemsToDisplay)) {
-                    break;
-                }
-                ++$i;
-            }
+            $posts = array_slice($fp->getPosts($channel), 0, intval($this->itemsToDisplay));
         } catch (\Exception $e) {
         }
 

--- a/concrete/blocks/rss_displayer/view.php
+++ b/concrete/blocks/rss_displayer/view.php
@@ -20,9 +20,6 @@ if (isset($errorMsg) && strlen($errorMsg) > 0) {
     echo $errorMsg;
 } else {
     foreach ($posts as $itemNumber => $item) {
-        if (intval($itemNumber) >= intval($rssObj->itemsToDisplay)) {
-            break;
-        }
         ?>
 		
 		<div class="ccm-block-rss-displayer-item">


### PR DESCRIPTION
This pull request refactors the RSS displayer by:
  
- Replacing the manual loop with array_slice to limit the number of posts the RSS displayer handles set by the itemsToDisplay property.
- Removing the redundant loop in the RSS displayer view file that checks itemNumber against itemsToDisplay. This loop is unnecessary since the array is already sliced in the controller.

These changes ensure consistency by relying on the controller to handle post limiting, simplify the view code, and improve readability.

fixes #12253