### PR TITLE
Fix Accordion controller.php to allow pretty URLs in description field

### DIFF
--- a/concrete/blocks/accordion/controller.php
+++ b/concrete/blocks/accordion/controller.php
@@ -320,6 +320,9 @@ class Controller extends BlockController implements UsesFeatureInterface
             $sortOrder = 0;
             foreach ($entries as $entry) {
                 // Add the entry row
+                if (isset($entry['description'])) {
+					$entry['description'] = LinkAbstractor::translateTo($entry['description']);
+				}
                 $db->executeStatement(
                     'INSERT INTO btAccordionEntries (bID, sortOrder, title, description) VALUES (?, ?, ?, ?)',
                     [(int) $this->bID, $sortOrder++, $entry['title'], $entry['description']]


### PR DESCRIPTION
Added LinkAbstractor translate when saving Description field to ensure that internal links are being saved with pretty URL formatting intact.
