### PR TITLE
Express form file handling

### DIFF
--- a/concrete/blocks/express_form/auto.js
+++ b/concrete/blocks/express_form/auto.js
@@ -147,13 +147,21 @@ $(function() {
             controlTemplate = _.template($('script[data-template=express-form-form-control]').html()),
             questionTemplate = _.template($('script[data-template=express-form-form-question]').html());
 
-        $tabOptions.on('change', 'input[name=notifyMeOnSubmission]', function() {
-            var $emailReplyToView = $('#ccm-block-express-form-options div[data-view=form-options-email-reply-to]');
+        $tabResults.find('input[name=notifyMeOnSubmission]').on('change', function() {
+            var $emailReplyToView = $('#ccm-block-express-form-results div[data-view=form-options-email-reply-to]');
             $('input[name=recipientEmail]').focus();
             if ($(this).is(':checked')) {
                 $emailReplyToView.show();
             } else {
                 $emailReplyToView.hide();
+            }
+        }).trigger('change');
+
+        $tabResults.find('input[name=storeFormSubmission]').on('change', function() {
+            var $notifyMeOnSubmission = $tabResults.find('input[name=notifyMeOnSubmission]')
+            var $recipientEmail = $tabResults.find('input[name=recipientEmail]')
+            if (!$(this).is(':checked')) {
+                $notifyMeOnSubmission.prop('checked', true).trigger('change');
             }
         }).trigger('change');
 
@@ -410,7 +418,7 @@ $(function() {
     ConcreteBlockForm.prototype.rescanEmailFields = function($emailReplyToView) {
         // Gather all the email controls
         var $tabEdit = $('#ccm-block-express-form-edit'),
-            $emailReplyToView = $('#ccm-block-express-form-options div[data-view=form-options-email-reply-to]'),
+            $emailReplyToView = $('#ccm-block-express-form-results div[data-view=form-options-email-reply-to]'),
             emailReplyToTemplate = _.template($('script[data-template=express-form-reply-to-email]').html()),
             $controls = $tabEdit.find('li[data-form-control-id]'),
             selected = $emailReplyToView.find('select[name=replyToEmailControlID]').val(),

--- a/concrete/blocks/express_form/controller.php
+++ b/concrete/blocks/express_form/controller.php
@@ -68,6 +68,11 @@ class Controller extends BlockController implements NotificationProviderInterfac
     public $notifyMeOnSubmission;
 
     /**
+     * @var bool|int|string|null
+     */
+    public $attachFilesToEmail;
+
+    /**
      * @var string|null
      */
     public $recipientEmail;
@@ -351,6 +356,7 @@ class Controller extends BlockController implements NotificationProviderInterfac
         $this->set('exFormID', null);
         $this->set('redirectCID', null);
         $this->set('notifyMeOnSubmission', false);
+        $this->set('attachFilesToEmail', false);
         $this->set('recipientEmail', '');
         $this->set('addFilesToSet', false);
         $this->set('replyToEmailControlID', null);
@@ -418,6 +424,7 @@ class Controller extends BlockController implements NotificationProviderInterfac
         // Make sure our data goes through correctly.
         $data['storeFormSubmission'] = isset($data['storeFormSubmission']) ?: 0;
         $data['notifyMeOnSubmission'] = isset($data['notifyMeOnSubmission']) ?: 0;
+        $data['attachFilesToEmail'] = isset($data['attachFilesToEmail']) ?: 0;
 
         // Now, let's handle saving the form entity ID against the form block db record
         $entity = false;
@@ -852,6 +859,7 @@ class Controller extends BlockController implements NotificationProviderInterfac
 
         $this->set('entities', Express::getEntities());
         $this->set('notifyMeOnSubmission', (bool) $this->notifyMeOnSubmission);
+        $this->set('attachFilesToEmail', $this->attachFilesToEmail);
     }
 
     public function action_get_type_form()

--- a/concrete/blocks/express_form/db.xml
+++ b/concrete/blocks/express_form/db.xml
@@ -36,6 +36,9 @@
     <field name="addFilesToFolder" type="integer">
       <default value="0"/>
     </field>
+    <field name="attachFilesToEmail" type="integer">
+      <default value="0"/>
+    </field>
   </table>
 
 </schema>

--- a/concrete/blocks/express_form/form.php
+++ b/concrete/blocks/express_form/form.php
@@ -155,9 +155,9 @@ $token = Core::make('token');
                     <?=$form->label('storeFormSubmission', t('Store submitted results of form.'), ['class'=>'form-check-label']); ?>
                 </div>
                 <?php if ($formSubmissionConfig === false) { ?>
-                    <div class="alert alert-warning"><?=t('<strong>Warning!</strong> Form submissions are not allowed to be stored in the database. You must set a valid email in the Options tab.'); ?>                </div>
+                    <div class="alert alert-warning"><?=t('<strong>Warning!</strong> Form submissions are not allowed to be stored in the database. You must set a valid email address.'); ?>                </div>
                 <?php } else { ?>
-                    <div class="alert alert-warning"><?=t('<strong>Warning!</strong> If not checked submitted data will be only sent by email. You must set a valid email in the Options tab.'); ?></div>
+                    <div class="alert alert-warning"><?=t('<strong>Warning!</strong> If not checked submitted data will be only sent by email. You must set a valid email address.'); ?></div>
                 <?php } ?>
             </div>
 
@@ -170,6 +170,44 @@ $token = Core::make('token');
                 <?php } ?>
             </div>
 
+        </fieldset>
+        
+        <fieldset>
+            <legend><?=t('Email'); ?></legend>
+            <div class="form-group">
+                <?=$form->label('recipientEmail', t('Send form submissions to email addresses')); ?>
+                <div class="input-group">
+                    <div class="input-group-text">
+                        <input type="checkbox" name="notifyMeOnSubmission" value="1" <?php if ($notifyMeOnSubmission == 1) { ?>checked<?php } ?>>
+                    </div>
+                    <?= $form->email('recipientEmail', $recipientEmail, ['autocomplete' => 'off', 'style' => 'z-index:2000;', 'multiple' => 'multiple']); ?>
+                </div>
+                <div class="help-block"><?=t('(Separate multiple emails with a comma)'); ?></div>
+            </div>
+            <div data-view="form-options-email-reply-to"></div>
+        </fieldset>
+
+        <fieldset>
+            <legend><?=t('Files'); ?></legend>
+            <div class="form-group">
+                <label class="control-label form-label" for="ccm-form-fileset"><?=t('Add uploaded files to a set?'); ?></label>
+                    <?php
+
+                    $fileSets = Concrete\Core\File\Set\Set::getMySets();
+                    $sets = [0 => t('None')];
+                    foreach ($fileSets as $fileSet) {
+                        $sets[$fileSet->getFileSetID()] = $fileSet->getFileSetDisplayName();
+                    }
+                    echo $form->select('addFilesToSet', $sets, $addFilesToSet);
+                    ?>
+            </div>
+            <div class="form-group">
+                <label class="control-label form-label"><?=t('Add uploaded files to folder'); ?></label>
+                <?php
+                $selector = new \Concrete\Core\Form\Service\Widget\FileFolderSelector();
+                echo $selector->selectFileFolder('addFilesToFolder', $addFilesToFolder);
+                ?>
+            </div>
         </fieldset>
 
     </div>
@@ -215,42 +253,6 @@ $token = Core::make('token');
                     }
                     ?>
                 </div>
-            </div>
-        </fieldset>
-        <fieldset>
-            <legend><?=t('Email'); ?></legend>
-            <div class="form-group">
-                <?=$form->label('recipientEmail', t('Send form submissions to email addresses')); ?>
-                <div class="input-group">
-                    <div class="input-group-text">
-                        <input type="checkbox" name="notifyMeOnSubmission" value="1" <?php if ($notifyMeOnSubmission == 1) { ?>checked<?php } ?>>
-                    </div>
-                    <?= $form->email('recipientEmail', $recipientEmail, ['autocomplete' => 'off', 'style' => 'z-index:2000;', 'multiple' => 'multiple']); ?>
-                </div>
-                <div class="help-block"><?=t('(Separate multiple emails with a comma)'); ?></div>
-            </div>
-            <div data-view="form-options-email-reply-to"></div>
-        </fieldset>
-        <fieldset>
-            <legend><?=t('Files'); ?></legend>
-            <div class="form-group">
-                <label class="control-label form-label" for="ccm-form-fileset"><?=t('Add uploaded files to a set?'); ?></label>
-                    <?php
-
-                    $fileSets = Concrete\Core\File\Set\Set::getMySets();
-                    $sets = [0 => t('None')];
-                    foreach ($fileSets as $fileSet) {
-                        $sets[$fileSet->getFileSetID()] = $fileSet->getFileSetDisplayName();
-                    }
-                    echo $form->select('addFilesToSet', $sets, $addFilesToSet);
-                    ?>
-            </div>
-            <div class="form-group">
-                <label class="control-label form-label"><?=t('Add uploaded files to folder'); ?></label>
-                <?php
-                $selector = new \Concrete\Core\Form\Service\Widget\FileFolderSelector();
-                echo $selector->selectFileFolder('addFilesToFolder', $addFilesToFolder);
-                ?>
             </div>
         </fieldset>
     </div>

--- a/concrete/blocks/express_form/form.php
+++ b/concrete/blocks/express_form/form.php
@@ -190,6 +190,13 @@ $token = Core::make('token');
         <fieldset>
             <legend><?=t('Files'); ?></legend>
             <div class="form-group">
+                <label class="control-label form-label"><?=t('Add uploaded files to folder'); ?></label>
+                <?php
+                $selector = new \Concrete\Core\Form\Service\Widget\FileFolderSelector();
+                echo $selector->selectFileFolder('addFilesToFolder', $addFilesToFolder);
+                ?>
+            </div>
+            <div class="form-group">
                 <label class="control-label form-label" for="ccm-form-fileset"><?=t('Add uploaded files to a set?'); ?></label>
                     <?php
 
@@ -202,11 +209,12 @@ $token = Core::make('token');
                     ?>
             </div>
             <div class="form-group">
-                <label class="control-label form-label"><?=t('Add uploaded files to folder'); ?></label>
-                <?php
-                $selector = new \Concrete\Core\Form\Service\Widget\FileFolderSelector();
-                echo $selector->selectFileFolder('addFilesToFolder', $addFilesToFolder);
-                ?>
+                <label class="control-label form-label"><?=t('E-Mail'); ?></label>
+                <div class="form-check">
+                    <?=$form->checkbox('attachFilesToEmail', 1, $attachFilesToEmail); ?>
+                    <?=$form->label('attachFilesToEmail', t('Send File as Email Attachment'), ['class'=>'form-check-label'] ); ?>
+                </div>
+                <div class="help-block"><?=t('This is not suitable for large files'); ?></div>
             </div>
         </fieldset>
 

--- a/concrete/src/Express/Entry/Notifier/Notification/FormBlockSubmissionEmailNotification.php
+++ b/concrete/src/Express/Entry/Notifier/Notification/FormBlockSubmissionEmailNotification.php
@@ -102,8 +102,7 @@ class FormBlockSubmissionEmailNotification extends AbstractFormBlockSubmissionNo
             $mh->addParameter('entity', $entry->getEntity());
             $mh->addParameter('formName', $this->getFormName($entry));
             $mh->addParameter("dataSaveEnabled", $this->blockController->storeFormSubmission);
-            if (!$this->blockController->storeFormSubmission) {
-                //if save submitted data is not active we send also files as attachments in email becuase it will be removed after entry remove
+            if (!$this->blockController->attachFilesToEmail) {
                 foreach ($this->getAttributeValues($entry) as $attributeValue) {
                     if ($attributeValue->getAttributeTypeObject()->getAttributeTypeHandle() == "image_file") {
                         $file = $attributeValue->getValue();


### PR DESCRIPTION
### Problems:
Files are not handled in a consistent way when form results are not saved.
- Files are uploaded but not moved to the selected folder.
- Antispam Service is not used when submitting results by email.

In the edit form options concerning form results are split up to the tabs "results" and "options".

Attaching larger files to E-Mail can cause problems.

### Changes:
- As files are uploaded in any case (this is good standard behavior in my opinion), they are handled in any case and are moved to the selected folder.
- If antispam triggers the file gets removed, submission fails.
- Options concerning the handling of form results (save, email, files) are grouped in the "results" tab.
- There is a separate option to attach files to the e-mail notification.