### PR TITLE
Fix login with OAuth when there are attributes to be fulfilled

### DIFF
--- a/concrete/controllers/single_page/login.php
+++ b/concrete/controllers/single_page/login.php
@@ -196,7 +196,9 @@ class Login extends PageController implements LoggerAwareInterface
 
             $this->view();
 
-            return $this->getViewObject()->render();
+            $responseContent = $this->getViewObject()->render();
+
+            return $this->app->make(ResponseFactoryInterface::class)->create($responseContent);
         }
 
         $u->setLastAuthType($type);

--- a/concrete/controllers/single_page/login.php
+++ b/concrete/controllers/single_page/login.php
@@ -151,9 +151,6 @@ class Login extends PageController implements LoggerAwareInterface
         AuthenticationType $type,
         User $u
     ) {
-        if (!$type || !($type instanceof AuthenticationType)) {
-            return $this->view();
-        }
         $config = $this->app->make('config');
         if ($config->get('concrete.i18n.choose_language_login')) {
             $userLocale = $this->post('USER_LOCALE');

--- a/concrete/src/Authentication/Type/OAuth/OAuth1a/GenericOauth1aTypeController.php
+++ b/concrete/src/Authentication/Type/OAuth/OAuth1a/GenericOauth1aTypeController.php
@@ -23,7 +23,7 @@ abstract class GenericOauth1aTypeController extends GenericOauthTypeController
             // We should NOT allow you to complete the authentication flow and potentially rebind the
             // logged-in user here. Instead we halt the authentication flow.
             $this->showError(t('You are already logged in.'));
-            return false;
+            exit();
         }
         $token = \Request::getInstance()->get('oauth_token');
         $verifier = \Request::getInstance()->get('oauth_verifier');

--- a/concrete/src/Authentication/Type/OAuth/OAuth2/GenericOauth2TypeController.php
+++ b/concrete/src/Authentication/Type/OAuth/OAuth2/GenericOauth2TypeController.php
@@ -44,7 +44,7 @@ abstract class GenericOauth2TypeController extends GenericOauthTypeController
                 // We should NOT allow you to complete the authentication flow and potentially rebind the
                 // logged-in user here. Instead we halt the authentication flow.
                 $this->showError(t('You are already logged in.'));
-                return false;
+                exit();
             }
 
             $token = $service->requestAccessToken($code, $state);


### PR DESCRIPTION
I found the cause of https://github.com/concretecms/concretecms/issues/12146: it happened when there's a user attribute created with these options:

![required-attr](https://github.com/user-attachments/assets/c4bd094d-8302-4912-8aad-1e70ddb83e22)

Fix #12146