### PR TITLE
[Performance Improvement] Avoid getting the same cID multiple times for the same stack

### DIFF
--- a/concrete/src/Page/Stack/Stack.php
+++ b/concrete/src/Page/Stack/Stack.php
@@ -116,7 +116,7 @@ class Stack extends Page
     {
         $c = Page::getCurrentPage();
         if (is_object($c) && (!$c->isError())) {
-            $identifier = sprintf('/stack/name/%s/%s/%s/%s', $stackName, $c->getCollectionID(), $cvID, $multilingualContentSource);
+            $identifier = sprintf('/stack/name/%s/%s/%s', $stackName, $c->getCollectionID(), $multilingualContentSource);
             $cache = Core::make('cache/request');
             $item = $cache->getItem($identifier);
             if (!$item->isMiss()) {

--- a/concrete/src/Page/Stack/Stack.php
+++ b/concrete/src/Page/Stack/Stack.php
@@ -7,6 +7,7 @@ use Concrete\Core\Page\Collection\Collection;
 use Concrete\Core\Page\Stack\Folder\Folder;
 use Concrete\Core\Permission\Checker;
 use Concrete\Core\Site\Tree\TreeInterface;
+use Concrete\Core\Support\Facade\Application;
 use Doctrine\DBAL\Connection;
 use GlobalArea;
 use Config;
@@ -57,11 +58,23 @@ class Stack extends Page
      */
     public static function getGlobalAreaStackFromName(Collection $collection, string $arHandle): ?Stack
     {
-        $db = app(Connection::class);
+        $app = Application::getFacadeApplication();
+        $db = $app->make(Connection::class);
         $checker = new Checker($collection);
-        $stackID = $db->executeQuery('select cID from Stacks where stName = ? and stType = ?', [
-            $arHandle, self::ST_TYPE_GLOBAL_AREA
-        ])->fetchOne();
+        
+        /** @var \Concrete\Core\Cache\Level\RequestCache $requestCache */
+        $requestCache = $app->make('cache/request');
+        $identifier = sprintf('/stack/global_area/%s/cID', $arHandle);
+        $item = $requestCache->getItem($identifier);
+        if ($item->isHit()) {
+            $stackID = $item->get();
+        } else {
+            $stackID = $db->executeQuery('select cID from Stacks where stName = ? and stType = ?', [
+                $arHandle, self::ST_TYPE_GLOBAL_AREA
+            ])->fetchOne();
+            $requestCache->save($item->set($stackID));
+        }
+
         if ($stackID) {
             if ($checker->canViewPageVersions()) {
                 $s = Stack::getByID($stackID, 'RECENT');


### PR DESCRIPTION
@aembler added the `$cvID` in the request cache key when getting the cID of the Stack from its name at 9f9d197036fc25434067ccbb4b34a9b2b93e0dd4
However, we don't need it because we get `cID` only; we never get `cvID` and store it in the request cache.
We can improve this request cache key, and it'll reduce the number of duplicate SQL queries.

Before fix:
<img width="1624" alt="Screenshot 2024-10-28 at 1 00 16" src="https://github.com/user-attachments/assets/98d0946b-dc01-48d9-95aa-92f6df3d2590">

After fix: 
<img width="1624" alt="Screenshot 2024-10-28 at 0 58 13" src="https://github.com/user-attachments/assets/a2d2f2d1-876f-445b-8258-eb816ce50663">
