### PR TITLE
[Performance Improvement] Avoid getting express attribute key category from database multiple times

### DIFF
--- a/concrete/src/Attribute/Category/ExpressCategory.php
+++ b/concrete/src/Attribute/Category/ExpressCategory.php
@@ -34,9 +34,17 @@ class ExpressCategory extends AbstractStandardCategory
     {
         $this->expressEntity = $entity;
         parent::__construct($application, $entityManager);
-        $this->setCategoryEntity(
-            $entityManager->getRepository(Category::class)->findOneBy(['akCategoryHandle' => 'express'])
-        );
+        $cache = $application->make('cache/request');
+        $identifier = '/attribute/category/express';
+        $item = $cache->getItem($identifier);
+        if ($item->isHit()) {
+            $this->setCategoryEntity($item->get());
+        } else {
+            $expressCategory = $entityManager->getRepository(Category::class)->findOneBy(['akCategoryHandle' => 'express']);
+            $this->setCategoryEntity($expressCategory);
+            $item->set($expressCategory);
+            $cache->save($item);
+        }
     }
 
     /**


### PR DESCRIPTION
Before fix:
<img width="1624" alt="Screenshot 2024-10-28 at 2 08 58" src="https://github.com/user-attachments/assets/f07a4f4a-44db-4c2f-8c6b-88c0fd873653">

After fix:
<img width="1624" alt="Screenshot 2024-10-28 at 2 48 45" src="https://github.com/user-attachments/assets/6bb734b2-4720-4cb0-b528-fce6e2338c08">
