### PR TITLE
Extend php info provided to environment report

### DIFF
--- a/concrete/src/System/Info.php
+++ b/concrete/src/System/Info.php
@@ -249,12 +249,26 @@ class Info
             $phpSettings = [
                 "max_execution_time - $maxExecutionTime",
             ];
+
+            $doNotFilter = [
+                'allow_url_fopen',
+                'allow_url_include',
+                'short_open_tag',
+                'error_log',
+                'file_uploads',
+            ];
+            
             foreach ($phpinfo as $name => $section) {
                 foreach ($section as $key => $val) {
                     if (preg_match('/.*max_execution_time*/', $key)) {
                         continue;
                     }
-                    if (strpos($key, 'limit') === false && strpos($key, 'safe') === false && strpos($key, 'max') === false) {
+                    if (strpos($key, 'limit') === false &&
+                        strpos($key, 'safe') === false &&
+                        strpos($key, 'max') === false &&
+                        strpos($key, 'version') === false &&
+                        !in_array($key, $doNotFilter)
+                    ) {
                         continue;
                     }
                     if (is_array($val)) {


### PR DESCRIPTION
Adds a list of further phpinfo keys which are covered by the php section of the site environment report.

The list currently includes a few items found to be troublesome when moving or updating sites and info that could be of use to a developer diagnosing problems.

Allow anything to do with 'version' into the site environment report. (This may be a bit over-generous)
