### PR TITLE
Extend info provided by dashboard/blocks/types report

### DIFF
--- a/concrete/single_pages/dashboard/blocks/types/view.php
+++ b/concrete/single_pages/dashboard/blocks/types/view.php
@@ -21,6 +21,16 @@ if ($controller->getAction() == 'inspect') {
     <dl>
         <dt><?= t('Description') ?></dt>
         <dd><?= t($bt->getBlockTypeDescription()) ?></dd>
+        <dt><?= t('Block Type Handle') ?></dt>
+        <dd><?= $bt->getBlockTypeHandle() ?></dd>
+         <?php
+        if($bt->getPackageHandle()){
+            ?>
+            <dt><?= t('Package') ?></dt>
+            <dd><?= $bt->getPackageHandle() ?></dd>
+            <?php
+        }
+        ?>
         <dt><?= t('Usage Count') ?></dt>
         <dd><?= $num ?></dd>
         <dt><?= t('Usage Count on Active Pages') ?></dt>


### PR DESCRIPTION
Block type names can be wildly different from the handle, especially when translated, making it tricky to track down the source files.

Adding the handle and package to the report at dashboard/blocks/types makes it considerably easier to track down where a block's source code can be found.