### PR TITLE
Improve multilingual import/export [v9]

### DIFF
--- a/concrete/src/Area/Area.php
+++ b/concrete/src/Area/Area.php
@@ -878,18 +878,23 @@ class Area extends ConcreteObject implements \Concrete\Core\Permission\ObjectInt
      */
     public function export($p, $page)
     {
-        $area = $p->addChild('area');
-        $area->addAttribute('name', $this->getAreaHandle());
         $blocks = $page->getBlocks($this->getAreaHandle());
         $c = $this->getAreaCollectionObject();
         $style = $c->getAreaCustomStyle($this);
-        if (is_object($style)) {
+        if ($style === null && $blocks === []) {
+            return;
+        }
+        $area = $p->addChild('area');
+        $area->addAttribute('name', $this->getAreaHandle());
+        if ($style !== null) {
             $set = $style->getStyleSet();
             $set->export($area);
         }
-        $wrapper = $area->addChild('blocks');
-        foreach ($blocks as $bl) {
-            $bl->export($wrapper);
+        if ($blocks !== []) {
+            $wrapper = $area->addChild('blocks');
+            foreach ($blocks as $bl) {
+                $bl->export($wrapper);
+            }
         }
     }
 

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/AbstractPageStructureRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/AbstractPageStructureRoutine.php
@@ -1,6 +1,7 @@
 <?php
 namespace Concrete\Core\Backup\ContentImporter\Importer\Routine;
 
+use Closure;
 use SimpleXMLElement;
 
 abstract class AbstractPageStructureRoutine extends AbstractRoutine
@@ -32,10 +33,16 @@ abstract class AbstractPageStructureRoutine extends AbstractRoutine
     /**
      * @param \SimpleXMLElement[] $elements
      */
-    protected function sortElementsByPath(array $elements)
+    protected function sortElementsByPath(array $elements, Closure $customComparer = null)
     {
         $sortedElements = $elements;
-        usort($sortedElements, static function (SimpleXMLElement $a, SimpleXMLElement $b) use (&$elements) {
+        usort($sortedElements, static function (SimpleXMLElement $a, SimpleXMLElement $b) use (&$elements, $customComparer) {
+            if ($customComparer !== null) {
+                $cmp = $customComparer($a, $b);
+                if ($cmp) {
+                    return $cmp;
+                }
+            }
             $pathA = trim((string) $a['path'], '/');
             $pathB = trim((string) $b['path'], '/');
             $numA = $pathA === '' ? -1 : substr_count($pathA, '/');

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/AbstractPageStructureRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/AbstractPageStructureRoutine.php
@@ -2,10 +2,13 @@
 namespace Concrete\Core\Backup\ContentImporter\Importer\Routine;
 
 use Closure;
+use Concrete\Core\User\UserInfoRepository;
 use SimpleXMLElement;
 
 abstract class AbstractPageStructureRoutine extends AbstractRoutine
 {
+    private $resolvedUserNames = [];
+
     /**
      * @deprecated use sortElementsByPath()
      */
@@ -57,5 +60,24 @@ abstract class AbstractPageStructureRoutine extends AbstractRoutine
         });
 
         return array_values($sortedElements);
+    }
+
+    /**
+     * @param string|\SimpleXMLElement|null $userName
+     */
+    protected function resolveUserName($userName)
+    {
+        $userName = (string) $userName;
+        if ($userName === '') {
+            return USER_SUPER_ID;
+        }
+        if (isset($this->resolvedUserNames[$userName])) {
+            return $this->resolvedUserNames[$userName];
+        }
+        $userInfo = app(UserInfoRepository::class)->getByName($userName);
+        $userID = $userInfo === null ? USER_SUPER_ID : (int) $userInfo->getUserID();
+        $this->resolvedUserNames[$userName] = $userID;
+
+        return $userID;
     }
 }

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/AbstractPageStructureRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/AbstractPageStructureRoutine.php
@@ -1,14 +1,13 @@
 <?php
 namespace Concrete\Core\Backup\ContentImporter\Importer\Routine;
 
-use Concrete\Core\Block\Block;
-use Concrete\Core\Block\BlockType\BlockType;
-use Concrete\Core\Page\Page;
-use Concrete\Core\StyleCustomizer\Inline\StyleSet;
+use SimpleXMLElement;
 
 abstract class AbstractPageStructureRoutine extends AbstractRoutine
 {
-
+    /**
+     * @deprecated use sortElementsByPath()
+     */
     public static function setupPageNodeOrder($pageNodeA, $pageNodeB)
     {
         $pathA = (string) $pageNodeA['path'];
@@ -30,6 +29,26 @@ abstract class AbstractPageStructureRoutine extends AbstractRoutine
         }
     }
 
+    /**
+     * @param \SimpleXMLElement[] $elements
+     */
+    protected function sortElementsByPath(array $elements)
+    {
+        $sortedElements = $elements;
+        usort($sortedElements, static function (SimpleXMLElement $a, SimpleXMLElement $b) use (&$elements) {
+            $pathA = trim((string) $a['path'], '/');
+            $pathB = trim((string) $b['path'], '/');
+            $numA = $pathA === '' ? -1 : substr_count($pathA, '/');
+            $numB = $pathB === '' ? -1 : substr_count($pathB, '/');
+            if ($numA !== $numB) {
+                return $numA - $numB;
+            }
+            $indexA = array_search($a, $elements, true);
+            $indexB = array_search($b, $elements, true);
 
+            return $indexA - $indexB;
+        });
 
+        return array_values($sortedElements);
+    }
 }

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportPageContentRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportPageContentRoutine.php
@@ -92,6 +92,7 @@ class ImportPageContentRoutine extends AbstractPageContentRoutine implements Spe
 
     private function applyHrefLangMap(Page $sourcePage, array $map)
     {
+        app('multilingual/detector')->assumeEnabled();
         foreach ($map as $destinationLocaleID => $destinationPagePath) {
             $destinationPage = Page::getByPath($destinationPagePath);
             if (!$destinationPage || $destinationPage->isError() || $destinationPage->getCollectionID() == $sourcePage->getCollectionID()) {

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportPageContentRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportPageContentRoutine.php
@@ -33,12 +33,15 @@ class ImportPageContentRoutine extends AbstractPageContentRoutine implements Spe
         if (!isset($sx->pages) || !isset($sx->pages->page)) {
             return;
         }
-        $siteTree = $this->home ? $this->home->getSiteTreeObject() : null;
+        $defaultSiteTree = $this->home ? $this->home->getSiteTreeObject() : null;
         $pageAttributeCategory = app(PageCategory::class);
         foreach ($sx->pages->page as $pageElement) {
             $path = '/' . trim((string) $pageElement['path'], '/');
             if ($path !== '/') {
-                $page = Page::getByPath($path, 'RECENT', $siteTree);
+                $page = Page::getByPath($path, 'RECENT', $defaultSiteTree);
+                if ((!$page || $page->isError()) && $defaultSiteTree === null) {
+                    $page = Page::getByPath($path, 'RECENT');
+                }
             } else {
                 $page = $this->home ?: Page::getByID(Page::getHomePageID(), 'RECENT');
             }

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportPageStructureRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportPageStructureRoutine.php
@@ -260,17 +260,15 @@ class ImportPageStructureRoutine extends AbstractPageStructureRoutine implements
         if ($parent === null) {
             return t('Missing the page with path %s', $parentPagePath);
         }
-        $cID = $parent->addCollectionAliasExternal(
+        $page = $parent->addExternalLink(
             (string) $externalLinkElement['name'],
             (string) $externalLinkElement['destination'],
-            filter_var((string) $externalLinkElement['new-window'], FILTER_VALIDATE_BOOLEAN)
+            [
+                'newWindow' => filter_var((string) $externalLinkElement['new-window'], FILTER_VALIDATE_BOOLEAN),
+                'handle' => $cHandle,
+                'uID' => $this->resolveUserName($externalLinkElement['user']),
+            ]
         );
-        $page = Page::getByID($cID);
-        if ($page->getCollectionHandle() !== $cHandle) {
-            $page->update([
-                'cHandle' => $cHandle,
-            ]);
-        }
 
         return $page;
     }

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportPageStructureRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportPageStructureRoutine.php
@@ -328,6 +328,10 @@ class ImportPageStructureRoutine extends AbstractPageStructureRoutine implements
         if ($page && !$page->isError()) {
             return $page;
         }
+        $page = Page::getByPath($path, 'RECENT');
+        if ($page && !$page->isError()) {
+            return $page;
+        }
 
         return null;
     }

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportPageStructureRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportPageStructureRoutine.php
@@ -19,9 +19,9 @@ class ImportPageStructureRoutine extends AbstractPageStructureRoutine implements
     protected $home;
 
     /**
-     * @var \Concrete\Core\Entity\Site\Tree|null
+     * @var \Concrete\Core\Entity\Site\Site|null
      */
-    private $defaultSiteTree;
+    private $site;
 
     public function getHandle()
     {
@@ -56,7 +56,7 @@ class ImportPageStructureRoutine extends AbstractPageStructureRoutine implements
                 throw new UserMessageException(t('Unable to find the home page'));
             }
         }
-        $this->defaultSiteTree = $this->home->getSiteTreeObject();
+        $this->site = $this->home->getSite();
         $elements = $this->sortElementsByPath($elements);
         while ($elements !== []) {
             $delayed = [];
@@ -324,15 +324,9 @@ class ImportPageStructureRoutine extends AbstractPageStructureRoutine implements
         if ($path === '/') {
             return $this->home;
         }
-        $page = Page::getByPath($path, 'RECENT', $this->defaultSiteTree);
+        $page = Page::getByPath($path, 'RECENT', $this->site);
         if ($page && !$page->isError()) {
             return $page;
-        }
-        if ($this->defaultSiteTree !== null) {
-            $page = Page::getByPath($path, 'RECENT');
-            if ($page && !$page->isError()) {
-                return $page;
-            }
         }
 
         return null;

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportPageStructureRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportPageStructureRoutine.php
@@ -129,6 +129,7 @@ class ImportPageStructureRoutine extends AbstractPageStructureRoutine implements
                 if (!$pageTemplate) {
                     throw new UserMessageException(t('Missing page template when creating the home of a language'));
                 }
+                app('multilingual/detector')->assumeEnabled();
                 $service = app(Service::class);
                 $locale = $service->add($this->home->getSite(), $localeInfo['language'], $localeInfo['country']);
                 $page = $service->addHomePage($locale, $pageTemplate, $cName === '' ? 'Home' : $cName, $cHandle);

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportPageStructureRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportPageStructureRoutine.php
@@ -1,15 +1,26 @@
 <?php
 namespace Concrete\Core\Backup\ContentImporter\Importer\Routine;
 
+use Concrete\Core\Error\UserMessageException;
+use Concrete\Core\Localization\Locale\Service;
 use Concrete\Core\Page\Page;
 use Concrete\Core\Page\Template;
 use Concrete\Core\Page\Type\Type;
-use Concrete\Core\User\UserInfo;
+use Concrete\Core\User\UserInfoRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use SimpleXMLElement;
 
 class ImportPageStructureRoutine extends AbstractPageStructureRoutine implements SpecifiableHomePageRoutineInterface
 {
-
+    /**
+     * @var \Concrete\Core\Page\Page|null
+     */
     protected $home;
+
+    /**
+     * @var \Concrete\Core\Entity\Site\Tree|null
+     */
+    private $siteTree;
 
     public function getHandle()
     {
@@ -17,99 +28,169 @@ class ImportPageStructureRoutine extends AbstractPageStructureRoutine implements
     }
 
     /**
-     * Useful when we're calling this from another routine that imports a new home page.
-     * @param $c
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\Importer\Routine\SpecifiableHomePageRoutineInterface::setHomePage()
      */
     public function setHomePage($c)
     {
         $this->home = $c;
     }
 
-    public function import(\SimpleXMLElement $sx)
+    public function import(SimpleXMLElement $sx)
     {
-        if (isset($sx->pages)) {
-            $nodes = array();
-            $i = 0;
-            foreach ($sx->pages->page as $p) {
-                $p->originalPos = $i;
-                $nodes[] = $p;
-                ++$i;
+        if (!isset($sx->pages) || !isset($sx->pages->page)) {
+            return;
+        }
+
+        if ($this->home && !$this->home->isError()) {
+            $this->siteTree = $this->home->getSiteTreeObject();
+        } else {
+            $this->home = Page::getByID(Page::getHomePageID(), 'RECENT');
+            if (!$this->home || $this->home->isError()) {
+                throw new UserMessageException(t('Unable to find the home page'));
             }
-            usort($nodes, static function($nodeA, $nodeB): int {
-                return static::setupPageNodeOrder($nodeA, $nodeB);
-            });
-            if (isset($this->home)) {
-                $home = $this->home;
-                $siteTree = $this->home->getSiteTreeObject();
+            $this->siteTree = null;
+        }
+
+        $pageElements = [];
+        foreach ($sx->pages->page as $pageElement) {
+            $pageElements[] = $pageElement;
+        }
+        $pageElements = $this->sortElementsByPath($pageElements);
+        foreach ($pageElements as $pageElement) {
+            $localeInfo = $this->extractLocale($pageElement);
+            $this->getOrCreatePage($pageElement, $localeInfo);
+        }
+    }
+
+    /**
+     * @return \Concrete\Core\Page\Page
+     */
+    private function getOrCreatePage(SimpleXMLElement $pageElement, array $localeInfo = null)
+    {
+        $userName = (string) $pageElement['user'];
+        $userInfo = $userName === '' ? null : app(UserInfoRepository::class)->getByName($userName);
+        $package = static::getPackageObject($pageElement['package']);
+        $cName = isset($pageElement['name']) ? (string) $pageElement['name'] : '';
+        $cDescription = isset($pageElement['description']) ? (string) $pageElement['description'] : '';
+        $cDatePublic = (string) $pageElement['public-date'];
+        $pageTemplate = Template::getByHandle($pageElement['template']);
+        $pageTypeHandle = isset($pageElement['pagetype']) ? (string) $pageElement['pagetype'] : '';
+        $pageType = $pageTypeHandle === '' ? null : Type::getByHandle((string) $pageElement['pagetype']);
+
+        $pathSlugs = isset($pageElement['path']) ? preg_split('{/}', (string) $pageElement['path'], -1, PREG_SPLIT_NO_EMPTY) : [];
+        if ($pathSlugs === []) {
+            $page = $this->home;
+        } else {
+            $pagePath = '/' . implode('/', $pathSlugs);
+            $page = Page::getByPath($pagePath, 'RECENT', $this->siteTree);
+        }
+
+        if ($page && !$page->isError()) {
+            if ($localeInfo !== null) {
+                $this->updateExistingLocale($page, $localeInfo);
+            }
+            $page->update([
+                'cName' => $cName === '' ? null : $cName,
+                'cDescription' => $cDescription,
+                'cDatePublic' => $cDatePublic === '' ? null : $cDatePublic,
+                'ptID' => $pageType === null ? null : $pageType->getPageTypeID(),
+                'pTemplateID' => $pageTemplate === null ? null : $pageTemplate->getPageTemplateID(),
+                'uID' => $userInfo === null ? USER_SUPER_ID : $userInfo->getUserID(),
+                'pkgID' => $package === null ? null : $package->getPackageID(),
+            ]);
+        } else {
+            $slugs = $pathSlugs;
+            $cHandle = array_pop($slugs);
+            if ($slugs === []) {
+                $parent = $this->home;
             } else {
-                $home = Page::getByID(Page::getHomePageID(), 'RECENT');
-                $siteTree = null;
+                $parentPagePath = '/' . implode('/', $slugs);
+                $parent = Page::getByPath($parentPagePath, 'RECENT', $this->siteTree);
+                if (!$parent || $parent->isError()) {
+                    throw new UserMessageException(t('Missing the page with path %s', $parentPagePath));
+                }
             }
-
-            foreach ($nodes as $px) {
-                $pkg = static::getPackageObject($px['package']);
-                $data = array();
-                $user = (string) $px['user'];
-                if ($user != '') {
-                    $ui = UserInfo::getByUserName($user);
-                    if (is_object($ui)) {
-                        $data['uID'] = $ui->getUserID();
-                    } else {
-                        $data['uID'] = USER_SUPER_ID;
-                    }
+            if ($localeInfo === null || $this->localeAlreadyExists($localeInfo)) {
+                $page = $parent->add($pageType, [
+                    'uID' => $userInfo === null ? USER_SUPER_ID : $userInfo->getUserID(),
+                    'pkgID' => $package === null ? 0 : $package->getPackageID(),
+                    'cName' => $cName,
+                    'cHandle' => $cHandle,
+                    'cDescription' => $cDescription,
+                    'cDatePublic' => $cDatePublic === '' ? null : $cDatePublic,
+                ], $pageTemplate);
+            } else {
+                if (!$pageTemplate) {
+                    throw new UserMessageException(t('Missing page template when creating the home of a language'));
                 }
-                $cDatePublic = (string) $px['public-date'];
-                if ($cDatePublic) {
-                    $data['cDatePublic'] = $cDatePublic;
-                }
-
-                $data['pkgID'] = 0;
-                if (is_object($pkg)) {
-                    $data['pkgID'] = $pkg->getPackageID();
-                }
-                $args = array();
-                $ct = Type::getByHandle($px['pagetype']);
-                $template = Template::getByHandle($px['template']);
-                if ($px['path'] != '') {
-                    // not home page
-                    $page = Page::getByPath($px['path'], 'RECENT', $siteTree);
-                    if (!is_object($page) || ($page->isError())) {
-                        $lastSlash = strrpos((string) $px['path'], '/');
-                        $parentPath = substr((string) $px['path'], 0, $lastSlash);
-                        $data['cHandle'] = substr((string) $px['path'], $lastSlash + 1);
-                        if (!$parentPath) {
-                            $parent = $home;
-                        } else {
-                            $parent = Page::getByPath($parentPath, 'RECENT', $siteTree);
-                        }
-                        $page = $parent->add($ct, $data);
-                    }
-                } else {
-                    $page = $home;
-                }
-
-                $cName = (string) $px['name'];
-                if ($cName) {
-                    $args['cName'] = $cName;
-                }
-
-                $cDescription = (string) $px['description'];
-                if ($cDescription) {
-                    $args['cDescription'] = $cDescription;
-                }
-
-                if (is_object($ct)) {
-                    $args['ptID'] = $ct->getPageTypeID();
-                }
-
-                if ($template) {
-                    $args['pTemplateID'] = $template->getPageTemplateID();
-                }
-
-                if (count($args)) {
-                    $page->update($args);
-                }
+                $service = app(Service::class);
+                $locale = $service->add($this->home->getSite(), $localeInfo['language'], $localeInfo['country']);
+                $page = $service->addHomePage($locale, $pageTemplate, $cName === '' ? 'Home' : $cName, $cHandle);
+                $page->update([
+                    'cDescription' => $cDescription,
+                    'cDatePublic' => $cDatePublic === '' ? null : $cDatePublic,
+                    'ptID' => $pageType === null ? null : $pageType->getPageTypeID(),
+                    'uID' => $userInfo === null ? USER_SUPER_ID : $userInfo->getUserID(),
+                    'pkgID' => $package === null ? 0 : $package->getPackageID(),
+                ]);
             }
         }
+    }
+
+    private function extractLocale(SimpleXMLElement $pageElement)
+    {
+        if (!isset($pageElement->locale)) {
+            return null;
+        }
+        $localeElement = $pageElement->locale;
+        $language = isset($localeElement['language']) ? (string) $localeElement['language'] : '';
+        if ($language === '') {
+            return null;
+        }
+        $country =  isset($localeElement['country']) ? (string) $localeElement['country'] : '';
+        if ($country === '') {
+            return null;
+        }
+        return [
+            'language' => $language,
+            'country' => $country,
+        ];
+    }
+
+    private function updateExistingLocale(Page $page, array $localeInfo)
+    {
+        $pageTree = $page->getSiteTreeObject();
+        if (!$pageTree || $pageTree->getSiteHomePageID() != $page->getCollectionID()) {
+            return;
+        }
+        $editingLocale = $pageTree->getLocale();
+        if ($editingLocale->getLanguage() === $localeInfo['language'] && $editingLocale->getCountry() === $localeInfo['country']) {
+            return;
+        }
+        if ($this->localeAlreadyExists($localeInfo)) {
+            return;
+        }
+        $editingLocale->setLanguage($localeInfo['language']);
+        $editingLocale->setCountry($localeInfo['country']);
+        $service = app(Service::class);
+        $service->updatePluralSettings($editingLocale);
+        $em = app(EntityManagerInterface::class);
+        $em->flush();
+    }
+
+    /**
+     * @return bool
+     */
+    private function localeAlreadyExists(array $localeInfo)
+    {
+        foreach ($this->home->getSite()->getLocales() as $locale) {
+            if ($locale->getLanguage() === $localeInfo['language'] && $locale->getCountry() === $localeInfo['country']) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportStacksStructureRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportStacksStructureRoutine.php
@@ -1,6 +1,7 @@
 <?php
 namespace Concrete\Core\Backup\ContentImporter\Importer\Routine;
 
+use Concrete\Core\Page\Page;
 use Concrete\Core\Page\Stack\Stack;
 use SimpleXMLElement;
 
@@ -16,7 +17,7 @@ class ImportStacksStructureRoutine extends AbstractPageStructureRoutine implemen
     /**
      * @var \Concrete\Core\Entity\Site\Tree|null
      */
-    private $siteTree;
+    private $site;
 
     /**
      * {@inheritdoc}
@@ -43,7 +44,14 @@ class ImportStacksStructureRoutine extends AbstractPageStructureRoutine implemen
         if (!isset($sx->stacks)) {
             return;
         }
-        $this->siteTree = $this->home ? $this->home->getSiteTreeObject(): null;
+        if (!$this->home || $this->home->isError()) {
+            $this->home = Page::getByID(Page::getHomePageID(), 'RECENT');
+        }
+        if (!$this->home || $this->home->isError()) {
+            $this->site = null;
+        } else {
+            $this->site = $this->home->getSite();
+        }
         $nodes = [];
         foreach ($sx->stacks->children() as $child) {
             $nodes[] = $child;
@@ -70,9 +78,9 @@ class ImportStacksStructureRoutine extends AbstractPageStructureRoutine implemen
         }
         switch ($type) {
             case 'global_area':
-                $globalArea = Stack::getByName($name, 'RECENT', $this->siteTree);
+                $globalArea = Stack::getByName($name, 'RECENT', $this->site);
                 if (!$globalArea) {
-                    Stack::addGlobalArea($name, $this->siteTree);
+                    Stack::addGlobalArea($name);
                 }
                 break;
             case 'folder':

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportStacksStructureRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportStacksStructureRoutine.php
@@ -1,72 +1,100 @@
 <?php
 namespace Concrete\Core\Backup\ContentImporter\Importer\Routine;
 
-use Concrete\Core\Page\Stack\Folder\FolderService;
 use Concrete\Core\Page\Stack\Stack;
+use SimpleXMLElement;
 
 class ImportStacksStructureRoutine extends AbstractPageStructureRoutine implements SpecifiableHomePageRoutineInterface
 {
+    use StackTrait;
+
+    /**
+     * @var \Concrete\Core\Page\Page|null
+     */
+    protected $home;
+
+    /**
+     * @var \Concrete\Core\Entity\Site\Tree|null
+     */
+    private $siteTree;
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\Importer\Routine\RoutineInterface::getHandle()
+     */
     public function getHandle()
     {
         return 'stacks';
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\Importer\Routine\SpecifiableHomePageRoutineInterface::setHomePage()
+     */
     public function setHomePage($page)
     {
         $this->home = $page;
     }
 
-    public function import(\SimpleXMLElement $sx)
+    public function import(SimpleXMLElement $sx)
     {
         if (!isset($sx->stacks)) {
             return;
         }
-        $folderService = app(FolderService::class);
-        $siteTree = null;
-        if (isset($this->home)) {
-            $siteTree = $this->home->getSiteTreeObject();
-        }
+        $this->siteTree = $this->home ? $this->home->getSiteTreeObject(): null;
         $nodes = [];
         foreach ($sx->stacks->children() as $child) {
             $nodes[] = $child;
         }
         $nodes = $this->sortElementsByPath($nodes);
-        foreach ($nodes as $p) {
-            $name = (string) $p['name'];
-            if ($p->getName() == 'folder') {
-                $type = 'folder';
-            } else {
-                $type = (string) $p['type'];
+        for ($step = 1; $step <= 2; $step++) {
+            foreach ($nodes as $p) {
+                $this->importElement($p, $step);
             }
-            $pathSlugs = isset($p['path']) ? preg_split('{/}', (string) $p['path'], -1, PREG_SPLIT_NO_EMPTY) : [];
-            $path = $pathSlugs === [] ? '' : ('/' . implode('/', $pathSlugs));
-            if (count($pathSlugs) > 1) {
-                $parentPath = '/' . implode('/', array_slice($pathSlugs, 0, -1));
-                $parent = $folderService->getByPath($parentPath);
-            } else {
-                $parent = null;
-            }
-            switch ($type) {
-                case 'folder':
-                    $folder = $path === '' ? null : $folderService->getByPath($path);
-                    if (!$folder) {
-                        $folderService->add($name, $parent);
-                    }
-                    break;
-                case 'global_area':
-                    $globalArea = Stack::getByName($name, 'RECENT', $siteTree);
+        }
+    }
+
+    /**
+     * @param int $step 1: folders, 2: anything else
+     */
+    private function importElement(SimpleXMLElement $p, $step)
+    {
+        $name = (string) $p['name'];
+        $path = '/' . trim((string) $p['path'], '/');
+        if ($p->getName() == 'folder') {
+            $type = 'folder';
+        } else {
+            $type = (string) $p['type'];
+        }
+        switch ($type) {
+            case 'global_area':
+                if ($step === 2) {
+                    $globalArea = Stack::getByName($name, 'RECENT', $this->siteTree);
                     if (!$globalArea) {
-                        Stack::addGlobalArea($name, $siteTree);
+                        Stack::addGlobalArea($name, $this->siteTree);
                     }
-                    break;
-                default:
-                    // Stack
-                    $stack = $path === '' ? null : Stack::getByPath($path, 'RECENT', $siteTree);
-                    if (!$stack) {
+                }
+                break;
+            case 'folder':
+                if ($step === 1) {
+                    $parentFolder = $this->getOrCreateFolderByPath($path);
+                    $folderPath = rtrim($path, '/') . '/' . $name;
+                    if (!array_key_exists($folderPath, $this->getExistingFolders())) {
+                        $this->createFolder($name, $folderPath, $parentFolder);
+                    }
+                }
+                break;
+            default:
+                // Stack
+                if ($step === 2) {
+                    $parent = $this->getOrCreateFolderByPath($path);
+                    if ($this->getStackIDByName($name, $parent) === null) {
                         Stack::addStack($name, $parent);
                     }
-                    break;
-            }
+                }
+                break;
         }
     }
 }

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportStacksStructureRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportStacksStructureRoutine.php
@@ -1,10 +1,8 @@
 <?php
 namespace Concrete\Core\Backup\ContentImporter\Importer\Routine;
 
-use Concrete\Core\Page\Stack\Folder\Folder;
 use Concrete\Core\Page\Stack\Folder\FolderService;
 use Concrete\Core\Page\Stack\Stack;
-use Concrete\Core\Permission\Category;
 
 class ImportStacksStructureRoutine extends AbstractPageStructureRoutine implements SpecifiableHomePageRoutineInterface
 {
@@ -20,64 +18,55 @@ class ImportStacksStructureRoutine extends AbstractPageStructureRoutine implemen
 
     public function import(\SimpleXMLElement $sx)
     {
-        $folderService = new FolderService(\Core::make('app'), \Database::connection());
-
+        if (!isset($sx->stacks)) {
+            return;
+        }
+        $folderService = app(FolderService::class);
         $siteTree = null;
         if (isset($this->home)) {
             $siteTree = $this->home->getSiteTreeObject();
         }
-
-        if (isset($sx->stacks)) {
-
-            $nodes = array();
-            $i = 0;
-            foreach ($sx->stacks->children() as $p) {
-                $p->originalPos = $i;
-                $nodes[] = $p;
-                ++$i;
+        $nodes = [];
+        foreach ($sx->stacks->children() as $child) {
+            $nodes[] = $child;
+        }
+        $nodes = $this->sortElementsByPath($nodes);
+        foreach ($nodes as $p) {
+            $name = (string) $p['name'];
+            if ($p->getName() == 'folder') {
+                $type = 'folder';
+            } else {
+                $type = (string) $p['type'];
             }
-            usort($nodes, static function($nodeA, $nodeB): int {
-                return static::setupPageNodeOrder($nodeA, $nodeB);
-            });
-
-            foreach ($nodes as $p) {
-
+            $pathSlugs = isset($p['path']) ? preg_split('{/}', (string) $p['path'], -1, PREG_SPLIT_NO_EMPTY) : [];
+            $path = $pathSlugs === [] ? '' : ('/' . implode('/', $pathSlugs));
+            if (count($pathSlugs) > 1) {
+                $parentPath = '/' . implode('/', array_slice($pathSlugs, 0, -1));
+                $parent = $folderService->getByPath($parentPath);
+            } else {
                 $parent = null;
-                $path = (string) $p['path'];
-                if ($p->getName() == 'folder') {
-                    $type = 'folder';
-                } else {
-                    $type = (string) $p['type'];
-                }
-                $name = (string) $p['name'];
-                if ($path) {
-                    $lastSlash = strrpos($path, '/');
-                    $parentPath = substr($path, 0, $lastSlash);
-                    if ($parentPath) {
-                        $parent = $folderService->getByPath($parentPath);
-                    }
-                }
-
-                switch($type) {
-                    case 'folder':
-                        $folder = $folderService->getByPath($path);
-                        if (!is_object($folder)) {
-                            $folderService->add($name, $parent);
-                        }
-                        break;
-                    case 'global_area':
-                        $s = Stack::getByName($name, 'RECENT', $siteTree);
-                        if (!is_object($s)) {
-                            Stack::addGlobalArea($name, $siteTree);
-                        }
-                        break;
-                    default:
-                        //stack
-                        $s = Stack::getByPath($path, 'RECENT', $siteTree);
-                        if (!is_object($s)) {
-                            Stack::addStack($name, $parent);
-                        }
-                }
             }
-        }    }
+            switch ($type) {
+                case 'folder':
+                    $folder = $path === '' ? null : $folderService->getByPath($path);
+                    if (!$folder) {
+                        $folderService->add($name, $parent);
+                    }
+                    break;
+                case 'global_area':
+                    $globalArea = Stack::getByName($name, 'RECENT', $siteTree);
+                    if (!$globalArea) {
+                        Stack::addGlobalArea($name, $siteTree);
+                    }
+                    break;
+                default:
+                    // Stack
+                    $stack = $path === '' ? null : Stack::getByPath($path, 'RECENT', $siteTree);
+                    if (!$stack) {
+                        Stack::addStack($name, $parent);
+                    }
+                    break;
+            }
+        }
+    }
 }

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/StackTrait.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/StackTrait.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Concrete\Core\Backup\ContentImporter\Importer\Routine;
+
+use Concrete\Core\Page\Stack\Folder\FolderService;
+use Concrete\Core\Page\Page;
+use Concrete\Core\Page\Stack\Folder\Folder;
+use Concrete\Core\Page\Stack\Stack;
+use Concrete\Core\Database\Connection\Connection;
+
+trait StackTrait
+{
+    /**
+     * @var \Concrete\Core\Page\Stack\Folder\FolderService|null
+     */
+    private $folderService;
+
+    /**
+     * @var \Concrete\Core\Page\Page|null
+     */
+    private $foldersRootPage;
+
+    /**
+     * @var array|null
+     */
+    private $existingFolders;
+
+    protected function getFolderService()
+    {
+        if ($this->folderService === null) {
+            $this->folderService = app(FolderService::class);
+        }
+        return $this->folderService;
+    }
+
+    /**
+     * @return \Concrete\Core\Page\Page
+     */
+    protected function getFoldersRootPage()
+    {
+        if ($this->foldersRootPage === null) {
+            $this->foldersRootPage = Page::getByPath(STACKS_PAGE_PATH);
+        }
+
+        return $this->foldersRootPage;
+    }
+
+    /**
+     * @return \Concrete\Core\Page\Stack\Folder\Folder[] array keys are their path
+     */
+    protected function getExistingFolders()
+    {
+        if ($this->existingFolders === null) {
+            $this->existingFolders = [];
+            $walk = null;
+            $walk = function (Page $parentPage, $parentPagePath) use (&$walk) {
+                foreach ($parentPage->getCollectionChildrenArray(true) as $childID) {
+                    $childFolder = $this->getFolderService()->getByID($childID);
+                    if (!$childFolder) {
+                        continue;
+                    }
+                    $childFolderPage = $childFolder->getPage();
+                    $childPath = $parentPagePath . '/' . $childFolderPage->getCollectionName();
+                    $this->existingFolders[$childPath] = $childFolder;
+                    $walk($childFolderPage, $childPath);
+                }
+            };
+            $walk($this->getFoldersRootPage(), '');
+        }
+
+        return $this->existingFolders;
+    }
+
+    /**
+     * @param string $path
+     *
+     * @return \Concrete\Core\Page\Stack\Folder\Folder|null
+     */
+    protected function getOrCreateFolderByPath($path)
+    {
+        $path = '/' . trim($path, '/');
+        if ($path === '/') {
+            return null;
+        }
+        $existingFolders = $this->getExistingFolders();
+        $tryPath = $path;
+        $folder = null;
+        while (true) {
+            if (isset($existingFolders[$tryPath])) {
+                $folder = $existingFolders[$tryPath];
+                break;
+            }
+            $p = strrpos($tryPath, '/');
+            if ($p === 0) {
+                break;
+            }
+            $tryPath = substr($tryPath, $p - 1);
+        }
+        if ($folder === null) {
+            $existingPath = '';
+            $remainingPath = $path;
+        } else {
+            $existingPath = $tryPath;
+            $remainingPath = substr($path, strlen($tryPath));
+        }
+        $remainingChunks = preg_split('{/}', $remainingPath, -1, PREG_SPLIT_NO_EMPTY);
+        while ($remainingChunks !== []) {
+            $name = array_shift($remainingChunks);
+            $existingPath .= '/' . $name;
+            $folder = $this->createFolder($name, $existingPath, $folder);
+        }
+        return $folder;
+    }
+
+    /**
+     * @param string $name
+     * @param string $calculatedPath
+     *
+     * @return \Concrete\Core\Page\Stack\Folder\Folder
+     */
+    protected function createFolder($name, $calculatedPath, Folder $parentFolder = null)
+    {
+        $folder = $this->getFolderService()->add($name, $parentFolder);
+        if ($this->existingFolders !== null) {
+            $this->existingFolders[$calculatedPath] = $folder;
+        }
+
+        return $folder;
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return int|null
+     */
+    private function getStackIDByName($name, Folder $folder = null)
+    {
+        if ($folder !== null) {
+            $parentPage = $folder->getPage();
+        } else {
+            $parentPage = $this->getFoldersRootPage();
+        }
+        $cn = app(Connection::class);
+        $cID = $cn->fetchColumn(
+            'SELECT Stacks.cID FROM Stacks INNER JOIN Pages ON Stacks.cID = Pages.cID WHERE Stacks.stType <> :globalAreaType AND Stacks.stName = :name AND Pages.cParentID = :parentID',
+            [
+                'globalAreaType' => Stack::ST_TYPE_GLOBAL_AREA,
+                'name' => $name,
+                'parentID' => $parentPage->getCollectionID(),
+            ]
+        );
+        
+        return $cID ? (int) $cID : null;
+    }
+}

--- a/concrete/src/Export/Item/Stack.php
+++ b/concrete/src/Export/Item/Stack.php
@@ -1,36 +1,68 @@
 <?php
+
 namespace Concrete\Core\Export\Item;
 
-use Concrete\Core\Export\ExportableInterface;
+use Concrete\Core\Area\Area as AreaObject;
+use Concrete\Core\Database\Connection\Connection;
+use Concrete\Core\Multilingual\Page\Section\Section as SectionObject;
+use Concrete\Core\Page\Stack\Stack as StackObject;
+use SimpleXMLElement;
 
 defined('C5_EXECUTE') or die("Access Denied.");
 
 class Stack implements ItemInterface
 {
+    /**
+     * @param \Concrete\Core\Page\Stack\Stack $stack
+     *
+     * {@inheritDoc}
+     * @see \Concrete\Core\Export\Item\ItemInterface::export()
+     */
+    public function export($stack, SimpleXMLElement $xml)
+    {
+        if (!$stack->isNeutralStack()) {
+            return [];
+        }
+        $newNodes = [
+            $this->exportStack($stack, $xml)
+        ];
+        $sections = SectionObject::getList($stack->getSite());
+        foreach ($sections as $section) {
+            $localizedStack = $stack->getLocalizedStack($section);
+            if ($localizedStack !== null) {
+                $newNodes[] = $this->exportStack($localizedStack, $xml, $section);
+            }
+        }
+
+        return $newNodes;
+    }
 
     /**
-     * @param $stack \Concrete\Core\Page\Stack\Stack
-     * @param \SimpleXMLElement $xml
-     * @return mixed
+     * @return \SimpleXMLElement
      */
-    public function export($stack, \SimpleXMLElement $xml)
+    private function exportStack(StackObject $stack, SimpleXMLElement $xml, SectionObject $section = null)
     {
-        $db = \Database::connection();
+        $db = app(Connection::class);
         $node = $xml->addChild('stack');
-        $node->addAttribute('name', \Core::make('helper/text')->entities($stack->getCollectionName()));
-        if ($stack->getStackTypeExportText()) {
-            $node->addAttribute('type', $stack->getStackTypeExportText());
+        $node->addAttribute('name', $stack->getCollectionName());
+        $type = $stack->getStackTypeExportText();
+        if ($type) {
+            $node->addAttribute('type', $type);
         }
         $node->addAttribute('path', substr($stack->getCollectionPath(), strlen(STACKS_PAGE_PATH)));
+        if ($section !== null) {
+            $node->addAttribute('section', $section->getLocale());
+        }
 
-        // you shouldn't ever have a sub area in a stack but just in case.
-        $r = $db->Execute('select arHandle from Areas where cID = ? and arParentID = 0', array($stack->getCollectionID()));
-        while ($row = $r->fetch()) {
-            $ax = \Area::get($stack, $row['arHandle']);
-            $ax->export($node, $stack);
+        // We should have just a 'Main' area in stacks, but just in case.
+        $r = $db->executeQuery('select arHandle from Areas where cID = ? and arParentID = 0', [$stack->getCollectionID()]);
+        while (($row = $r->fetch()) !== false) {
+            $ax = AreaObject::get($stack, $row['arHandle']);
+            if ($ax) {
+                $ax->export($node, $stack);
+            }
         }
 
         return $node;
     }
-
 }

--- a/concrete/src/Export/Item/StackFolder.php
+++ b/concrete/src/Export/Item/StackFolder.php
@@ -1,26 +1,60 @@
 <?php
+
 namespace Concrete\Core\Export\Item;
 
-use Concrete\Core\Export\ExportableInterface;
+use Concrete\Core\Page\Stack\Folder\Folder as FolderObject;
+use Concrete\Core\Page\Stack\Folder\FolderService;
+use SimpleXMLElement;
 
 defined('C5_EXECUTE') or die("Access Denied.");
 
 class StackFolder implements ItemInterface
 {
-
     /**
-     * @param $folder \Concrete\Core\Page\Stack\Folder\Folder
-     * @param \SimpleXMLElement $xml
-     * @return mixed
+     * @param \Concrete\Core\Page\Stack\Folder\Folder $folder
+     *
+     * @return \SimpleXMLElement
      */
-    public function export($folder, \SimpleXMLElement $xml)
+    public function export($folder, SimpleXMLElement $xml)
     {
-        $page = $folder->getPage();
-        $node = $xml->addChild('folder');
-        $node->addAttribute('name', \Core::make('helper/text')->entities($page->getCollectionName()));
-        $node->addAttribute('path', substr($page->getCollectionPath(), strlen(STACKS_PAGE_PATH)));
-
-        return $node;
+        $folders = $this->expandFolders($folder);
+        $path = '';
+        foreach ($folders as $folder) {
+            $folderPage = $folder->getPage();
+            $name = $folderPage->getCollectionName();
+            $this->ensureFolder($xml, $name, $path ?: '/');
+            $path .= '/' . $name;
+        }
     }
 
+    /**
+     * @return \Concrete\Core\Page\Stack\Folder\Folder[]
+     */
+    private function expandFolders(FolderObject $folder)
+    {
+        $service = app(FolderService::class);
+        $result = [];
+        while ($folder) {
+            $result[] = $folder;
+            $parentID = $folder->getPage()->getCollectionParentID();
+            $folder = $parentID ? $service->getByID($parentID) : null;
+        }
+        return array_reverse($result);
+    }
+
+    /**
+     * @param string $name
+     * @param string $path
+     */
+    private function ensureFolder(SimpleXMLElement $parentElement, $name, $path)
+    {
+        foreach ($parentElement->folder as $existing) {
+            if ($name === (string) $existing['name'] && $path === (string) $existing['path']) {
+                return;
+            }
+        }
+        $el = $parentElement->addChild('folder');
+        $el->addAttribute('name', $name);
+        $el->addAttribute('path', $path);
+    }
 }

--- a/concrete/src/Localization/Locale/Service.php
+++ b/concrete/src/Localization/Locale/Service.php
@@ -99,6 +99,7 @@ class Service
         $locale = $this->updatePluralSettings($locale);
         $this->entityManager->persist($tree);
         $this->entityManager->persist($locale);
+        $site->getLocales()->add($locale);
         $this->entityManager->flush();
         
         $event = new \Symfony\Component\EventDispatcher\GenericEvent();

--- a/concrete/src/Multilingual/Service/Detector.php
+++ b/concrete/src/Multilingual/Service/Detector.php
@@ -393,6 +393,18 @@ class Detector implements ApplicationAwareInterface, SiteAggregateInterface
     }
 
     /**
+     * Assume that the site is multilingual enabled.
+     *
+     * @return $this
+     */
+    public function assumeEnabled()
+    {
+        $this->enabled = true;
+
+        return $this;
+    }
+
+    /**
      * Check if we can set a session value.
      *
      * @return bool

--- a/concrete/src/Page/Exporter.php
+++ b/concrete/src/Page/Exporter.php
@@ -27,6 +27,7 @@ class Exporter implements ItemInterface
         if ($locale !== null) {
             $this->exportLocaleRoot($p, $locale);
         }
+        $this->exportAdditionalPagePaths($p, $mixed);
         $hrefLangMap = $this->getHrefLangMap($mixed);
         if ($hrefLangMap !== []) {
             $this->exportHrefLangMap($p, $hrefLangMap);
@@ -99,6 +100,14 @@ class Exporter implements ItemInterface
         $country = (string) $locale->getCountry();
         if ($country !== '') {
             $localeElement->addAttribute('country', $country);
+        }
+    }
+
+    private function exportAdditionalPagePaths(SimpleXMLElement $parentElement, Page $page)
+    {
+        foreach ($page->getAdditionalPagePaths() as $additionalPath) {
+            $additionalPathElement = $parentElement->addChild('additional-path');
+            $additionalPathElement->addAttribute('path', $additionalPath->getPagePath());
         }
     }
 

--- a/concrete/src/Page/Exporter.php
+++ b/concrete/src/Page/Exporter.php
@@ -12,15 +12,33 @@ use SimpleXMLElement;
 
 class Exporter implements ItemInterface
 {
+    const TYPE_PAGE = 'page';
+    const TYPE_ALIAS = 'alias';
+    const TYPE_EXTERNALLINK = 'external-link';
+
     /**
      * @param \Concrete\Core\Page\Page $mixed
      */
     public function export($mixed, SimpleXMLElement $element)
     {
-        $isExternalLink = $mixed->isExternalLink();
-        $p = $element->addChild($isExternalLink ? 'external-link' : 'page');
+        if ($mixed->isExternalLink()) {
+            $type = self::TYPE_EXTERNALLINK;
+        } elseif ($mixed->isAliasPage()) {
+            $type = self::TYPE_ALIAS;
+            $aliasedPage = Page::getByID($mixed->getCollectionPointerID());
+        } else {
+            $type = self::TYPE_PAGE;
+        }
+        $p = $element->addChild($type);
         $p->addAttribute('name', $mixed->getCollectionName());
-        $p->addAttribute('path', $isExternalLink ? $mixed->generatePagePath() : $mixed->getCollectionPath());
+        switch ($type) {
+            case self::TYPE_EXTERNALLINK:
+                $p->addAttribute('path', $mixed->generatePagePath());
+                break;
+            default:
+                $p->addAttribute('path', $mixed->getCollectionPath());
+                break;
+        }
         $uiRepository = app(UserInfoRepository::class);
         $ui = null;
         $uID = $mixed->getCollectionUserID();
@@ -30,56 +48,65 @@ class Exporter implements ItemInterface
         if ($ui === null) {
             $ui = $uiRepository->getByID(USER_SUPER_ID);
         }
-        $p->addAttribute('user', $ui->getUserName());
-        $p->addAttribute('public-date', $mixed->getCollectionDatePublic());
-        if ($isExternalLink) {
-            $p->addAttribute('destination', $mixed->getCollectionPointerExternalLink());
-            $p->addAttribute('new-window', $mixed->openCollectionPointerExternalLinkInNewWindow() ? 'true' : 'false');
-        } else {
-            $p->addAttribute('filename', $mixed->getCollectionFilename());
-            $p->addAttribute('pagetype', $mixed->getPageTypeHandle());
-            $locale = $this->getLocaleForHome($mixed);
-            if ($locale !== null) {
-                $this->exportLocaleRoot($p, $locale);
-            }
-            $this->exportAdditionalPagePaths($p, $mixed);
-            $hrefLangMap = $this->getHrefLangMap($mixed);
-            if ($hrefLangMap !== []) {
-                $this->exportHrefLangMap($p, $hrefLangMap);
-            }
-            $templateID = $mixed->getPageTemplateID();
-            if ($templateID) {
-                $template = app(EntityManagerInterface::class)->find(\Concrete\Core\Entity\Page\Template::class, $templateID);
-                if ($template) {
-                    $p->addAttribute('template', $template->getPageTemplateHandle());
+        switch ($type) {
+            case self::TYPE_EXTERNALLINK:
+                $p->addAttribute('destination', $mixed->getCollectionPointerExternalLink());
+                $p->addAttribute('new-window', $mixed->openCollectionPointerExternalLinkInNewWindow() ? 'true' : 'false');
+                $p->addAttribute('user', $ui->getUserName());
+                $p->addAttribute('public-date', $mixed->getCollectionDatePublic());
+                break;
+            case self::TYPE_ALIAS:
+                $p->addAttribute('original-path', $aliasedPage->getCollectionPath());
+                $p->addAttribute('user', $ui->getUserName());
+                break;
+            case self::TYPE_PAGE:
+                $p->addAttribute('user', $ui->getUserName());
+                $p->addAttribute('public-date', $mixed->getCollectionDatePublic());
+                $p->addAttribute('filename', $mixed->getCollectionFilename());
+                $p->addAttribute('pagetype', $mixed->getPageTypeHandle());
+                $locale = $this->getLocaleForHome($mixed);
+                if ($locale !== null) {
+                    $this->exportLocaleRoot($p, $locale);
                 }
-            }
-            $p->addAttribute('description', $mixed->getCollectionDescription());
-            if ($mixed->getCollectionParentID() == 0) {
-                if ($mixed->getSiteTreeID() == 0) {
-                    $p->addAttribute('global', 'true');
-                } else {
-                    $p->addAttribute('root', 'true');
+                $this->exportAdditionalPagePaths($p, $mixed);
+                $hrefLangMap = $this->getHrefLangMap($mixed);
+                if ($hrefLangMap !== []) {
+                    $this->exportHrefLangMap($p, $hrefLangMap);
                 }
-            }
-            $attribs = $mixed->getSetCollectionAttributes();
-            if ($attribs !== []) {
-                $attributes = $p->addChild('attributes');
-                foreach ($attribs as $ak) {
-                    $av = $mixed->getAttributeValueObject($ak);
-                    $cnt = $ak->getController();
-                    $cnt->setAttributeValue($av);
-                    $akx = $attributes->addChild('attributekey');
-                    $akx->addAttribute('handle', $ak->getAttributeKeyHandle());
-                    $cnt->exportValue($akx);
+                $templateID = $mixed->getPageTemplateID();
+                if ($templateID) {
+                    $template = app(EntityManagerInterface::class)->find(\Concrete\Core\Entity\Page\Template::class, $templateID);
+                    if ($template) {
+                        $p->addAttribute('template', $template->getPageTemplateHandle());
+                    }
                 }
-            }
-    
-            $r = app(Connection::class)->executeQuery('select arHandle from Areas where cID = ? and arIsGlobal = 0 and arParentID = 0', [$mixed->getCollectionID()]);
-            while ($row = $r->FetchRow()) {
-                $ax = Area::get($mixed, $row['arHandle']);
-                $ax->export($p, $mixed);
-            }
+                $p->addAttribute('description', $mixed->getCollectionDescription());
+                if ($mixed->getCollectionParentID() == 0) {
+                    if ($mixed->getSiteTreeID() == 0) {
+                        $p->addAttribute('global', 'true');
+                    } else {
+                        $p->addAttribute('root', 'true');
+                    }
+                }
+                $attribs = $mixed->getSetCollectionAttributes();
+                if ($attribs !== []) {
+                    $attributes = $p->addChild('attributes');
+                    foreach ($attribs as $ak) {
+                        $av = $mixed->getAttributeValueObject($ak);
+                        $cnt = $ak->getController();
+                        $cnt->setAttributeValue($av);
+                        $akx = $attributes->addChild('attributekey');
+                        $akx->addAttribute('handle', $ak->getAttributeKeyHandle());
+                        $cnt->exportValue($akx);
+                    }
+                }
+        
+                $r = app(Connection::class)->executeQuery('select arHandle from Areas where cID = ? and arIsGlobal = 0 and arParentID = 0', [$mixed->getCollectionID()]);
+                while ($row = $r->FetchRow()) {
+                    $ax = Area::get($mixed, $row['arHandle']);
+                    $ax->export($p, $mixed);
+                }
+                break;
         }
         $p->addAttribute('package', $mixed->getPackageHandle());
     }

--- a/concrete/src/Page/Exporter.php
+++ b/concrete/src/Page/Exporter.php
@@ -2,37 +2,53 @@
 namespace Concrete\Core\Page;
 
 use Concrete\Core\Area\Area;
+use Concrete\Core\Database\Connection\Connection;
+use Concrete\Core\Entity\Site\Locale;
 use Concrete\Core\Export\Item\ItemInterface;
-use Concrete\Core\Support\Facade\Facade;
-use Concrete\Core\User\UserInfo;
+use Concrete\Core\Multilingual\Page\Section\Section;
+use Concrete\Core\User\UserInfoRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use SimpleXMLElement;
 
 class Exporter implements ItemInterface
 {
-
     /**
-     * @param Page $mixed
-     * @param \SimpleXMLElement $element
+     * @param \Concrete\Core\Page\Page $mixed
      */
-    public function export($mixed, \SimpleXMLElement $element)
+    public function export($mixed, SimpleXMLElement $element)
     {
-        $app = Facade::getFacadeApplication();
-        $pageNode = $element;
-        $p = $pageNode->addChild('page');
-        $p->addAttribute('name', $app->make('helper/text')->entities($mixed->getCollectionName()));
+        $p = $element->addChild('page');
+        $p->addAttribute('name', $mixed->getCollectionName());
         $p->addAttribute('path', $mixed->getCollectionPath());
         $p->addAttribute('public-date', $mixed->getCollectionDatePublic());
         $p->addAttribute('filename', $mixed->getCollectionFilename());
         $p->addAttribute('pagetype', $mixed->getPageTypeHandle());
-        $template = Template::getByID($mixed->getPageTemplateID());
-        if (is_object($template)) {
-            $p->addAttribute('template', $template->getPageTemplateHandle());
+        $locale = $this->getLocaleForHome($mixed);
+        if ($locale !== null) {
+            $this->exportLocaleRoot($p, $locale);
         }
-        $ui = UserInfo::getByID($mixed->getCollectionUserID());
-        if (!is_object($ui)) {
-            $ui = UserInfo::getByID(USER_SUPER_ID);
+        $hrefLangMap = $this->getHrefLangMap($mixed);
+        if ($hrefLangMap !== []) {
+            $this->exportHrefLangMap($p, $hrefLangMap);
+        }
+        $templateID = $mixed->getPageTemplateID();
+        if ($templateID) {
+            $template = app(EntityManagerInterface::class)->find(\Concrete\Core\Entity\Page\Template::class, $templateID);
+            if ($template) {
+                $p->addAttribute('template', $template->getPageTemplateHandle());
+            }
+        }
+        $uiRepository = app(UserInfoRepository::class);
+        $ui = null;
+        $uID = $mixed->getCollectionUserID();
+        if ($uID) {
+            $ui = $uiRepository->getByID($uID);
+        }
+        if ($ui === null) {
+            $ui = $uiRepository->getByID(USER_SUPER_ID);
         }
         $p->addAttribute('user', $ui->getUserName());
-        $p->addAttribute('description', $app->make('helper/text')->entities($mixed->getCollectionDescription()));
+        $p->addAttribute('description', $mixed->getCollectionDescription());
         $p->addAttribute('package', $mixed->getPackageHandle());
         if ($mixed->getCollectionParentID() == 0) {
             if ($mixed->getSiteTreeID() == 0) {
@@ -43,7 +59,7 @@ class Exporter implements ItemInterface
         }
 
         $attribs = $mixed->getSetCollectionAttributes();
-        if (count($attribs) > 0) {
+        if ($attribs !== []) {
             $attributes = $p->addChild('attributes');
             foreach ($attribs as $ak) {
                 $av = $mixed->getAttributeValueObject($ak);
@@ -55,12 +71,83 @@ class Exporter implements ItemInterface
             }
         }
 
-        $db = \Database::connection();
-        $r = $db->executeQuery('select arHandle from Areas where cID = ? and arIsGlobal = 0 and arParentID = 0', [$mixed->getCollectionID()]);
-        while ($row = $r->fetch()) {
+        $r = app(Connection::class)->executeQuery('select arHandle from Areas where cID = ? and arIsGlobal = 0 and arParentID = 0', [$mixed->getCollectionID()]);
+        while ($row = $r->FetchRow()) {
             $ax = Area::get($mixed, $row['arHandle']);
             $ax->export($p, $mixed);
         }
     }
 
+    /**
+     * @return \Concrete\Core\Entity\Site\Locale|null
+     */
+    private function getLocaleForHome(Page $page)
+    {
+        $siteTreeID = $page->getSiteTreeID();
+        if (!$siteTreeID) {
+            return null;
+        }
+        $section = Section::getByID($page->getCollectionID());
+
+        return $section ? $section->getLocaleObject() : null;
+    }
+
+    private function exportLocaleRoot(SimpleXMLElement $parentElement, Locale $locale)
+    {
+        $localeElement = $parentElement->addChild('locale');
+        $localeElement->addAttribute('language', $locale->getLanguage());
+        $country = (string) $locale->getCountry();
+        if ($country !== '') {
+            $localeElement->addAttribute('country', $country);
+        }
+    }
+
+    private function getHrefLangMap(Page $page)
+    {
+        $pageSection = Section::getBySectionOfSite($page);
+        if (!$pageSection) {
+            return [];
+        }
+        $site = $pageSection->getSite();
+        if (!$site) {
+            return [];
+        }
+        $map = [];
+        foreach (Section::getList($site) as $relatedSection) {
+            $relatedLocale = $relatedSection->getLocale();
+            if ($pageSection->getLocale() === $relatedLocale) {
+                continue;
+            }
+            $relatedPageID = $relatedSection->getTranslatedPageID($page);
+            if (!$relatedPageID) {
+                continue;
+            }
+            $relatedPage = Page::getByID($relatedPageID);
+            if (!$relatedPage || $relatedPage->isError()) {
+                continue;
+            }
+            $relatedPagePath = (string) $relatedPage->getCollectionPath();
+            if ($relatedPagePath === '' && Section::isMultilingualSection($relatedPageID)) {
+                $relatedPagePath = (string) $relatedSection->getCollectionPath();
+                if ($relatedPagePath === '') {
+                    $relatedPagePath = '/';
+                }
+            }
+            if ($relatedPagePath === '') {
+                continue;
+            }
+            $map[$relatedLocale] = $relatedPagePath;
+        }
+        return $map;
+    }
+
+    private function exportHrefLangMap(SimpleXMLElement $parentElement, array $map)
+    {
+        $hrefLangElement = $parentElement->addChild('hreflang');
+        foreach ($map as $locale => $path) {
+            $alternateElement = $hrefLangElement->addChild('alternate');
+            $alternateElement->addAttribute('locale', $locale);
+            $alternateElement->addAttribute('path', $path);
+        }
+    }
 }

--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -2423,6 +2423,7 @@ EOT
      *     @var int $ptID
      *     @var int $pTemplateID
      *     @var int $uID
+     *     @var int $pkgID
      *     @var string $cFilename
      *     @var int $cCacheFullPageContent -1: use the default settings; 0: no; 1: yes
      *     @var int $cCacheFullPageContentLifetimeCustom
@@ -2441,7 +2442,7 @@ EOT
         $cDescription = $this->getCollectionDescription();
         $cDatePublic = $this->getCollectionDatePublic();
         $uID = $this->getCollectionUserID();
-        $pkgID = $this->getPackageID();
+        $pkgID = empty($data['pkgID']) ? $this->getPackageID() : $data['pkgID'];
         $cFilename = $this->getCollectionFilename();
         $pTemplateID = $this->getPageTemplateID();
         $ptID = $this->getPageTypeID();

--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -1018,58 +1018,73 @@ class Page extends Collection implements CategoryMemberInterface,
 
 
     /**
-     * Make an alias to a page.
-     *
-     * @param \Concrete\Core\Page\Page $c The parent page that will contain the alias
-     *
-     * @return int The ID of the new collection
+     * @deprecated Use the createAlias() method
      */
     public function addCollectionAlias($c)
     {
+        return $this->createAlias($c)->getCollectionPointerOriginalID();
+    }
+
+    /**
+     * Make an alias to a page.
+     *
+     * @param \Concrete\Core\Page\Page $parentPage The page that will contain the alias
+     * @param array $options available keys:
+     * - name: the name of the alias  (default: the original page name)
+     * - handle: the handle of the alias to be created (default: the original page handle)
+     * - uID: the ID of the user that's creating the alias (default: the ID of the current user)
+     *
+     * @return \Concrete\Core\Page\Page
+     */
+    public function createAlias(Page $parentPage, array $options = [])
+    {
         $app = Application::getFacadeApplication();
-        $db = Database::connection();
-        $cParentID = $c->getCollectionID();
-
-        $u = $app->make(User::class);
-        $uID = $u->getUserID();
-
-        $handle = (string) $this->getCollectionHandle();
+        $db = $app->make(Connection::class);
+        $cParentID = $parentPage->getCollectionID();
+        $uID = empty($options['uID']) ? 0 : (int) $options['uID'];
+        if ($uID === 0) {
+            $u = $app->make(User::class);
+            $uID = $u->getUserID();
+        }
+        $handle = empty($options['handle']) ? '' : (string) $options['handle'];
         if ($handle === '') {
-            $handle = Core::make('helper/text')->handle($this->getCollectionName());
+            $handle = (string) $this->getCollectionHandle();
+            if ($handle === '') {
+                $handle = $app->make('helper/text')->handle($this->getCollectionName());
+            }
         }
-        $cDisplayOrder = $c->getNextSubPageDisplayOrder();
-
-        $_cParentID = $c->getCollectionID();
-        $q = 'select PagePaths.cPath from PagePaths where cID = ?';
-        $v = [$_cParentID];
-        if ($_cParentID != static::getHomePageID()) {
-            $q .= ' and ppIsCanonical = ?';
-            $v[] = 1;
-        }
-        $cPath = $db->fetchColumn($q, $v);
-
-        $data = [
+        $name = empty($options['name']) ? '' : (string) $options['name'];
+        $cDisplayOrder = $parentPage->getNextSubPageDisplayOrder();
+        $cPath = $db->fetchColumn(
+            'SELECT cPath FROM PagePaths WHERE cID = ? ORDER BY ppIsCanonical DESC',
+            [$cParentID]
+        );
+        $collection = $this->addCollection([
             'handle' => $handle,
-            'name' => '',
-        ];
-        $cobj = parent::addCollection($data);
-        $newCID = $cobj->getCollectionID();
-        $siteTreeID = $c->getSiteTreeID();
-
-        $v = [$newCID, $siteTreeID, $cParentID, $uID, $this->getCollectionID(), $cDisplayOrder];
-        $q = 'insert into Pages (cID, siteTreeID, cParentID, uID, cPointerID, cDisplayOrder) values (?, ?, ?, ?, ?, ?)';
-        $r = $db->prepare($q);
-
-        $r->execute($v);
-
+            'name' => $name,
+        ]);
+        $newCID = $collection->getCollectionID();
+        $siteTreeID = $parentPage->getSiteTreeID();
+        $db->insert('Pages', [
+            'cID' => $newCID,
+            'siteTreeID' => $siteTreeID,
+            'cParentID' => $cParentID,
+            'uID' => $uID,
+            'cPointerID' => $this->getCollectionID(),
+            'cDisplayOrder' => $cDisplayOrder,
+        ]);
+        $db->insert('PagePaths', [
+            'cID' => $newCID,
+            'cPath' => $cPath . '/' . $handle,
+            'ppIsCanonical' => 1,
+            'ppGeneratedFromURLSlugs' => 1,
+        ]);
         PageStatistics::incrementParents($newCID);
-
-        $q2 = 'insert into PagePaths (cID, cPath, ppIsCanonical, ppGeneratedFromURLSlugs) values (?, ?, ?, ?)';
-        $v2 = [$newCID, $cPath . '/' . $handle, 1, 1];
-        $db->executeQuery($q2, $v2);
-        $pe = new Event(\Page::getByID($newCID));
+        $newPage = Page::getByID($newCID);
+        $pe = new Event($newPage);
         Events::dispatch('on_page_alias_add', $pe);
-        return $newCID;
+
+        return $newPage;
     }
 
     /**

--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -1020,8 +1020,7 @@ class Page extends Collection implements CategoryMemberInterface,
     /**
      * Make an alias to a page.
      *
-     * @param \Concrete\Core\Page\Page $parentPage The parent page
-     * @param mixed $c
+     * @param \Concrete\Core\Page\Page $c The parent page that will contain the alias
      *
      * @return int The ID of the new collection
      */
@@ -1029,7 +1028,6 @@ class Page extends Collection implements CategoryMemberInterface,
     {
         $app = Application::getFacadeApplication();
         $db = Database::connection();
-        // the passed collection is the parent collection
         $cParentID = $c->getCollectionID();
 
         $u = $app->make(User::class);

--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -1401,7 +1401,7 @@ class Page extends Collection implements CategoryMemberInterface,
      */
     public function export($pageNode)
     {
-        $exporter = new Exporter();
+        $exporter = $this->getExporter();
         $exporter->export($this, $pageNode);
     }
 

--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -1165,57 +1165,64 @@ class Page extends Collection implements CategoryMemberInterface,
     }
 
     /**
-     * Add a new external link as a child of this page.
-     *
-     * @param string $cName
-     * @param string $cLink
-     * @param bool $newWindow
-     *
-     * @return int The ID of the new collection
+     * @deprecated Use addExternalLink()
      */
     public function addCollectionAliasExternal($cName, $cLink, $newWindow = 0)
     {
+        return $this->addExternalLink($cName, $cLink, ['newWindow' => $newWindow])->getCollectionID();
+    }
+
+    /**
+     * Add a new external link as a child of this page.
+     *
+     * @param string $name The name of the link
+     * @param string $link The target of the link
+     * @param array $options available keys:
+     * - newWindow: should the link be opened in a new window (default: false)
+     * - handle: the handle of the link to be created (default: derive it from $name)
+     * - uID: the ID of the user that's creating the external link (default: the ID of the current user)
+     *
+     * @return \Concrete\Core\Page\Page The newly created page
+     */
+    public function addExternalLink($name, $link, array $options = [])
+    {
         $app = Application::getFacadeApplication();
-        $db = Database::connection();
-        $dt = Core::make('helper/text');
-        $ds = Core::make('helper/security');
-        $u = $app->make(User::class);
+        $db = $app->make(Connection::class);
 
-        $cParentID = $this->getCollectionID();
-        $uID = $u->getUserID();
-
-        // make the handle out of the title
-        $cLink = $ds->sanitizeURL($cLink);
-        $handle = $dt->urlify($cName);
-        $data = [
-            'handle' => $handle,
-            'name' => $cName,
-        ];
-        $cobj = parent::addCollection($data);
-        $newCID = $cobj->getCollectionID();
-
-        if ($newWindow) {
-            $newWindow = 1;
-        } else {
-            $newWindow = 0;
+        $link = $app->make('helper/security')->sanitizeURL($link);
+        $newWindow = empty($options['newWindow']) ? 0 : 1;
+        $handle = empty($options['handle']) ? '' : (string) $options['handle'];
+        if ($handle === '') {
+            $handle = $app->make('helper/text')->urlify($name);
         }
+        $uID = empty($options['uID']) ? 0 : (int) $options['uID'];
+        if ($uID === 0) {
+            $uID = $app->make(User::class)->getUserID();
+        }
+        $cParentID = $this->getCollectionID();
+        $siteTreeID = $this->getSiteTreeID() ?: $app->make('site')->getSite()->getSiteTreeID();
+        $displayOrder = $this->getNextSubPageDisplayOrder();
 
-        $cInheritPermissionsFromCID = $this->getPermissionsCollectionID();
-        $cInheritPermissionsFrom = 'PARENT';
-
-        $siteTreeID = \Core::make('site')->getSite()->getSiteTreeID();
-
-        $v = [$newCID, $siteTreeID, $cParentID, $uID, $cInheritPermissionsFrom, (int) $cInheritPermissionsFromCID, $cLink, $newWindow];
-        $q = 'insert into Pages (cID, siteTreeID, cParentID, uID, cInheritPermissionsFrom, cInheritPermissionsFromCID, cPointerExternalLink, cPointerExternalLinkNewWindow) values (?, ?, ?, ?, ?, ?, ?, ?)';
-        $r = $db->prepare($q);
-
-        $r->execute($v);
-
+        $collection = $this->addCollection([
+            'handle' => $handle,
+            'name' => $name,
+        ]);
+        $newCID = $collection->getCollectionID();
+        $db->insert('Pages', [
+            'cID' => $newCID,
+            'siteTreeID' => $siteTreeID,
+            'cParentID' => $cParentID,
+            'uID' => $uID,
+            'cInheritPermissionsFrom' => 'PARENT',
+            'cInheritPermissionsFromCID' => (int) (int) $this->getPermissionsCollectionID(),
+            'cPointerExternalLink' => $link,
+            'cPointerExternalLinkNewWindow' => $newWindow,
+            'cDisplayOrder' => $displayOrder,
+        ]);
         PageStatistics::incrementParents($newCID);
+        $newPage = Page::getByID($newCID);
 
-        self::getByID($newCID)->movePageDisplayOrderToBottom();
-
-        return $newCID;
+        return $newPage;
     }
 
     /**

--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -2423,7 +2423,7 @@ EOT
      *     @var int $ptID
      *     @var int $pTemplateID
      *     @var int $uID
-     *     @var string $$cFilename
+     *     @var string $cFilename
      *     @var int $cCacheFullPageContent -1: use the default settings; 0: no; 1: yes
      *     @var int $cCacheFullPageContentLifetimeCustom
      *     @var string $cCacheFullPageContentOverrideLifetime

--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -449,7 +449,7 @@ class Page extends Collection implements CategoryMemberInterface,
     /**
      * {@inheritdoc}
      *
-     * @see \Concrete\Core\Summary\Template\Category\CategoryMemberInterface::getSummaryCategoryHandle()
+     * @see \Concrete\Core\Summary\Category\CategoryMemberInterface::getSummaryCategoryHandle()
      */
     public function getSummaryCategoryHandle() : string
     {


### PR DESCRIPTION
This PR does the following about exporting/importing CIF files:

### Add support for exporting and importing multilingual sections

In order to create a multilingua section, it's possible to have this syntax:
```xml
<page path="/fr" name="Other Locale Home" root="true">
    <locale language="fr" country="FR" />
</page>
```


### Add support for exporting and importing multilingual mappings

In order to map pages between languages, it's possible to have this syntax:
```xml
<page path="/example" name="English Sample Page">
    <hreflang>
        <alternate locale="fr_FR" path="/exemple" />
    </hreflang>
</page>
```

### Fix support for exporting/importing stack folders

At the moment, when we export stacks and their folders, we have something like this:

```xml
<stacks>
    <folder name="Root Folder" path="/123" />
    <folder name="Sub folder" path="/123/456" />
    <stack  name="Stack Name" path="/123/456/stack_handle" />
</stacks>
```

With this PR we now have:

```xml
<stacks>
    <folder name="Root Folder" path="/" />
    <folder name="Sub Folder" path="/Root Folder" />
    <stack  name="Stack Name" path="/Root Folder/Sub Folder" />
</stacks>
```


### Add support for exporting and importing localized versions of stacks

Before this PR, localized stacks wheren't exported at all.

With this PR we now have:

```xml
<stacks>
    <stack  name="Stack Name" path="/">
        <!-- ... -->
    </stack>
    <stack  name="Stack Name" path="/" section="fr_FR">
        <!-- ... -->
    </stack>
</stacks>
```



### Skip exporting empty areas

We now won't export empty areas anymore (I had a ton useless of `<area name="Area Name"><blocks /></area>` in my tests).

---

PS: close #12293 

PPS: if this PR will be merged, I'll update the [Migration Tool for ConcreteCMS v9](https://github.com/concretecms/migration_tool).
