### PR TITLE
Use correct site tree when adding an external link

### DIFF
--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -1190,7 +1190,7 @@ class Page extends Collection implements CategoryMemberInterface,
         $cInheritPermissionsFromCID = $this->getPermissionsCollectionID();
         $cInheritPermissionsFrom = 'PARENT';
 
-        $siteTreeID = \Core::make('site')->getSite()->getSiteTreeID();
+        $siteTreeID = $this->getSiteTreeID() ?: \Core::make('site')->getSite()->getSiteTreeID();
 
         $v = [$newCID, $siteTreeID, $cParentID, $uID, $cInheritPermissionsFrom, (int) $cInheritPermissionsFromCID, $cLink, $newWindow];
         $q = 'insert into Pages (cID, siteTreeID, cParentID, uID, cInheritPermissionsFrom, cInheritPermissionsFromCID, cPointerExternalLink, cPointerExternalLinkNewWindow) values (?, ?, ?, ?, ?, ?, ?, ?)';


### PR DESCRIPTION
When we create an external link, we always assign it to the site tree of the root home, but that's not correct when we add an external link under a secondary language, isn't it?