### PR TITLE
Allow containers to be installed from subdirectories of elements/containers

### DIFF
--- a/concrete/src/Page/Container/Command/ContainerCommandValidator.php
+++ b/concrete/src/Page/Container/Command/ContainerCommandValidator.php
@@ -34,7 +34,10 @@ class ContainerCommandValidator implements ValidatorInterface
         if (empty($command->getContainer()->getContainerName())) {
             $this->errorList->add(t('You must give your container a valid name.'));
         }
-        $handle = $command->getContainer()->getContainerHandle();
+         /*
+          * By replacing '/' with '_' we allow a path/to/the_handle to validate.
+          */
+        $handle = str_replace('/','_', $command->getContainer()->getContainerHandle());
         if (!$this->stringValidator->handle($handle)) {
             $this->errorList->add(t('You must specify a valid handle for this container.'));
         }


### PR DESCRIPTION
The dashboard currently only allows containers to be installed from elements/containers.

By replacing '/' with '_' before validating the handle we allow a path/to/the_handle to validate and hence containers can now be installed from sub-directories using the dashboard page.