### PR TITLE
Let Page::getByPath() accept a Site instance [v9]

### DIFF
--- a/concrete/src/Entity/Site/Site.php
+++ b/concrete/src/Entity/Site/Site.php
@@ -285,6 +285,21 @@ class Site implements TreeInterface, ObjectInterface, PermissionObjectInterface,
     }
 
     /**
+     * Get the IDs of every tree of this site.
+     *
+     * @return int[]  The first one is the ID of default site tree
+     */
+    public function getSiteTreeIDs(): array
+    {
+        return array_map(
+            static function ($siteTree) {
+                return (int) $siteTree->getSiteTreeID();
+            },
+            $this->getSiteTreeObjects()
+        );
+    }
+
+    /**
      * Get the default locale (if set).
      *
      * @return \Concrete\Core\Entity\Site\Locale|null
@@ -314,6 +329,28 @@ class Site implements TreeInterface, ObjectInterface, PermissionObjectInterface,
         }
 
         return $locale === null ? null : $locale->getSiteTree();
+    }
+
+    /**
+     * Get the trees of every locale of this site.
+     *
+     * @return \Concrete\Core\Entity\Site\SiteTree[] The first one is the default site tree
+     */
+    public function getSiteTreeObjects(): array
+    {
+        $defaultSiteTree = $this->getSiteTreeObject();
+        if ($defaultSiteTree === null) {
+            return [];
+        }
+        $result = [$defaultSiteTree];
+        foreach ($this->getLocales() as $locale) {
+            $siteTree = $locale->getSiteTree();
+            if ($siteTree !== null && !in_array($siteTree, $result, true)) {
+                $result[] = $siteTree;
+            }
+        }
+
+        return $result;
     }
 
     /**

--- a/concrete/src/Entity/Site/Site.php
+++ b/concrete/src/Entity/Site/Site.php
@@ -76,7 +76,7 @@ class Site implements TreeInterface, ObjectInterface, PermissionObjectInterface,
     protected $siteHandle;
 
     /**
-     * The language sections of this site.
+     * The locale sections of this site.
      *
      * @ORM\OneToMany(targetEntity="Locale", cascade={"all"}, mappedBy="site")
      * @ORM\JoinColumn(name="siteLocaleID", referencedColumnName="siteLocaleID")
@@ -239,7 +239,7 @@ class Site implements TreeInterface, ObjectInterface, PermissionObjectInterface,
     }
 
     /**
-     * Get the language sections of this site.
+     * Get the locale sections of this site.
      *
      * @return \Concrete\Core\Entity\Site\Locale[]|\Doctrine\Common\Collections\ArrayCollection
      */
@@ -249,7 +249,7 @@ class Site implements TreeInterface, ObjectInterface, PermissionObjectInterface,
     }
 
     /**
-     * Set the language sections of this site.
+     * Set the locale sections of this site.
      *
      * @param \Concrete\Core\Entity\Site\Locale[]|\Doctrine\Common\Collections\ArrayCollection $locales
      */
@@ -289,7 +289,7 @@ class Site implements TreeInterface, ObjectInterface, PermissionObjectInterface,
      */
     public function getDefaultLocale()
     {
-        foreach ($this->locales as $locale) {
+        foreach ($this->getLocales() as $locale) {
             if ($locale->getIsDefault()) {
                 return $locale;
             }
@@ -313,7 +313,7 @@ class Site implements TreeInterface, ObjectInterface, PermissionObjectInterface,
     }
 
     /**
-     * Get the home page of the default language.
+     * Get the home page of the default locale.
      *
      * @param string|int $version 'ACTIVE', 'RECENT' or a specific page version ID
      *

--- a/concrete/src/Entity/Site/Site.php
+++ b/concrete/src/Entity/Site/Site.php
@@ -259,7 +259,7 @@ class Site implements TreeInterface, ObjectInterface, PermissionObjectInterface,
     }
 
     /**
-     * Get the ID of the home page.
+     * Get the ID of the home page of the default locale.
      *
      * @return int|null
      */
@@ -271,6 +271,8 @@ class Site implements TreeInterface, ObjectInterface, PermissionObjectInterface,
     }
 
     /**
+     * Get the ID of the tree of the default locale.
+     *
      * {@inheritdoc}
      *
      * @see \Concrete\Core\Site\Tree\TreeInterface::getSiteTreeID()
@@ -297,6 +299,8 @@ class Site implements TreeInterface, ObjectInterface, PermissionObjectInterface,
     }
 
     /**
+     * Get the tree of the default locale.
+     *
      * {@inheritdoc}
      *
      * @see \Concrete\Core\Site\Tree\TreeInterface::getSiteTreeObject()

--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -60,6 +60,7 @@ use Queue;
 use Request;
 use Session;
 use Concrete\Core\Events\EventDispatcher;
+use Doctrine\DBAL\ParameterType;
 use UserInfo;
 
 /**
@@ -309,7 +310,7 @@ class Page extends Collection implements CategoryMemberInterface,
      *
      * @param string $path the page path (example: /path/to/page)
      * @param string $version the page version ('RECENT' for the most recent version, 'ACTIVE' for the currently published version, 'SCHEDULED' for the currently scheduled version, or an integer to retrieve a specific version ID)
-     * @param \Concrete\Core\Site\Tree\TreeInterface|null $tree
+     * @param \Concrete\Core\Entity\Site\Site|\Concrete\Core\Site\Tree\TreeInterface|null $tree
      *
      * @return \Concrete\Core\Page\Page
      */
@@ -319,12 +320,32 @@ class Page extends Collection implements CategoryMemberInterface,
         $cache = \Core::make('cache/request');
 
         if ($tree) {
-            $item = $cache->getItem(sprintf('site/page/path/%s/%s', $tree->getSiteTreeID(), trim($path, '/')));
+            if ($tree instanceof Site) {
+                $treeIDs = $tree->getSiteTreeIDs();
+                sort($treeIDs, SORT_NUMERIC);
+            } else {
+                $treeIDs = [$tree->getSiteTreeID()];
+            }
+            $item = $cache->getItem(sprintf('site/page/path/%s/%s', implode('-', $treeIDs), trim($path, '/')));
             $cID = $item->get();
             if ($item->isMiss()) {
-                $db = Database::connection();
-                $cID = $db->fetchColumn('select Pages.cID from PagePaths inner join Pages on Pages.cID = PagePaths.cID where cPath = ? and siteTreeID = ?', [$path, $tree->getSiteTreeID()]);
-                $cache->save($item->set($cID));
+                if ($treeIDs === []) {
+                    $cID = 0;
+                } else {
+                    $db = Database::connection();
+                    $cID = $db->fetchOne(
+                        'SELECT Pages.cID FROM PagePaths INNER JOIN Pages ON Pages.cID = PagePaths.cID WHERE siteTreeID IN (?) AND cPath = ? LIMIT 1',
+                        [
+                            $treeIDs,
+                            $path,
+                        ],
+                        [
+                            $db::PARAM_INT_ARRAY,
+                            ParameterType::STRING,
+                        ]
+                    );
+                    $cache->save($item->set($cID));
+                }
             }
         } else {
             $item = $cache->getItem(sprintf('page/path/%s', trim($path, '/')));


### PR DESCRIPTION
A site is made by one or more trees (one tree for every locale).
What about:
1. adding an easy way to get all the trees of a site?
2. allowing Page::getByPath() to look for pages in all locales instead of the default one when passed a site instance?
