### PR TITLE
Fix Page List Unknown column ‘ak_is_featured’

### DIFF
--- a/concrete/blocks/page_list/controller.php
+++ b/concrete/blocks/page_list/controller.php
@@ -396,9 +396,12 @@ class Controller extends BlockController implements UsesFeatureInterface
         }
 
         if ($this->displayFeaturedOnly == 1) {
-            $cak = CollectionAttributeKey::getByHandle('is_featured');
-            if (is_object($cak)) {
-                $this->list->filterByIsFeatured(1);
+            $ak = CollectionKey::getByHandle('is_featured');
+            if ($ak->isAttributeKeySearchable()) {
+                $cak = CollectionAttributeKey::getByHandle('is_featured');
+                if (is_object($cak)) {
+                    $this->list->filterByIsFeatured(1);
+                }
             }
         }
         if ($this->displayAliases) {

--- a/concrete/blocks/page_list/page_list_form.php
+++ b/concrete/blocks/page_list/page_list_form.php
@@ -291,10 +291,15 @@ echo $userInterface->tabs([
                     echo $form->label("featuredPagesOnly", t("Featured pages only."), ["class" => "form-check-label"]);
                     ?>
 
-                    <?php if (!is_object($featuredAttribute)) { ?>
+                    <?php if (!is_object($featuredAttribute) || !$featuredAttribute->isAttributeKeySearchable()) { ?>
                         <div class="help-block">
-                            <?php echo t(
-                                '(<strong>Note</strong>: You must create the "is_featured" page attribute first.)');
+                            <?php
+                            if (!is_object($featuredAttribute)) {
+                                echo t('(<strong>Note</strong>: You must create the "is_featured" page attribute first.)');
+                            }
+                            elseif (!$featuredAttribute->isAttributeKeySearchable()) {
+                                echo t('<strong>Filter Disabled</strong>: The "is_featured" page attribute is not available for advanced search.');
+                            }
                             ?>
                         </div>
                     <?php } ?>


### PR DESCRIPTION
Similar to the behavior of https://github.com/concretecms/concretecms/issues/12308
These modifications adds an edit interface note and avoids view error if the is_featured attribute is not "available for advanced search" at /dashboard/pages/attributes.

@aembler be it the way we want to do things, I'll have a fix for https://github.com/concretecms/concretecms/issues/12308 inbound as well.