### PR TITLE
Display current stack locale in breadcrumb

### DIFF
--- a/concrete/src/Multilingual/Service/UserInterface/Flag.php
+++ b/concrete/src/Multilingual/Service/UserInterface/Flag.php
@@ -49,10 +49,19 @@ class Flag
         }
     }
 
+    /**
+     * @param \Concrete\Core\Page\Page|\Concrete\Core\Multilingual\Page\Section\Section $page
+     * @param bool $filePathOnly
+     *
+     * @return string|\HtmlObject\Image|null
+     */
     public static function getSectionFlagIcon($page, $filePathOnly = false)
     {
-        $db = Database::get();
-        $section = Section::getBySectionOfSite($page);
+        if ($page instanceof Section) {
+            $section = $page;
+        } else {
+            $section = Section::getBySectionOfSite($page);
+        }
         $icon = $section->getCountry();
         return self::getFlagIcon($icon, $filePathOnly);
     }

--- a/concrete/src/Navigation/Breadcrumb/Dashboard/DashboardStacksBreadcrumbFactory.php
+++ b/concrete/src/Navigation/Breadcrumb/Dashboard/DashboardStacksBreadcrumbFactory.php
@@ -72,6 +72,13 @@ class DashboardStacksBreadcrumbFactory implements ApplicationAwareInterface
                 $breadcrumb->add($stackItem);
             }
             if ($stackOrFolder instanceof Stack) {
+                if ($locale !== '') {
+                    $stackItem = new Item(
+                        '',
+                        $locale
+                    );
+                    $breadcrumb->add($stackItem);
+                }
                 // let's handle the breadcrumb dropdown for localized stacks
                 if ($stackOrFolder->isNeutralStack()) {
                     $neutralStack = $stackOrFolder;


### PR DESCRIPTION
Stacks and global areas can have a fallback version (the default) as well as language-specific versions.

If we edit a language-specific version we don't have a visual feedback in the breadcrump (so we don't know which language we are currently editing):

https://github.com/user-attachments/assets/12adbad8-d727-4712-93f7-f9c6bfdf686e

What about this new approach?

https://github.com/user-attachments/assets/b22352a1-f2a8-4912-a08c-78d5f3ddc9fc

