### PR TITLE
Fix invalid permission key to solve error on update files via API

### DIFF
--- a/concrete/src/Api/Controller/Files.php
+++ b/concrete/src/Api/Controller/Files.php
@@ -308,7 +308,7 @@ class Files extends ApiController
         }
 
         $checker = new Checker($file);
-        if (!$checker->canEditFile()) {
+        if (!$checker->canEditFileProperties()) {
             return $this->error(t('You do not have access to edit this file.', 401));
         }
 


### PR DESCRIPTION
When you try to update files via API, you'll get the following error:

```
Exception: Unable to get permission key for edit_file in file /path/to/concrete/src/Permission/Response/Response.php on line 107
```

This PR will fix it.