### PR TITLE
Add storage/overwrite attributes to config/option elements

### DIFF
--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportConfigValuesRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportConfigValuesRoutine.php
@@ -30,22 +30,22 @@ class ImportConfigValuesRoutine extends AbstractRoutine
             return;
         }
         $this->repositoryInstances = [];
-        foreach ($sx->config->children() as $key) {
-            $package = isset($key['package']) ? static::getPackageObject($key['package']) : null;
-            $node = (string) $key->getName();
-            if ($node !== 'option') {
-                // legacy
-                $key = $node;
+        foreach ($sx->config->children() as $element) {
+            $package = isset($element['package']) ? static::getPackageObject($element['package']) : null;
+            $elementName = $element->getName();
+            if ($elementName === 'option') {
+                $key = (string) $element['name'];
             } else {
-                $key = (string) $key['name'];
+                // legacy
+                $key = $elementName;
             }
-            $value = (string) $key;
+            $value = (string) $element;
             if ($value === 'false') {
                 $value = false;
             }
-            $rawOverwrite = isset($key['overwrite']) ? (string) $key['overwrite'] : '';
+            $rawOverwrite = isset($element['overwrite']) ? (string) $element['overwrite'] : '';
             $overwrite = $rawOverwrite === '' ? true : filter_var($rawOverwrite, FILTER_VALIDATE_BOOLEAN);
-            $repository = $this->getRepository(isset($key['storage']) ? (string) $key['storage'] : '', $package);
+            $repository = $this->getRepository(isset($element['storage']) ? (string) $element['storage'] : '', $package);
             if ($overwrite || !$repository->has($key)) {
                 $repository->set($key, $value);
                 $repository->save($key, $value);
@@ -63,6 +63,7 @@ class ImportConfigValuesRoutine extends AbstractRoutine
                 break;
             default:
                 $storage = 'file';
+                break;
         }
         $key = $storage . ($package ? "@{$package->getPackageHandle()}" : '');
         if (isset($this->repositoryInstances[$key])) {

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportConfigValuesRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportConfigValuesRoutine.php
@@ -1,42 +1,78 @@
 <?php
+
 namespace Concrete\Core\Backup\ContentImporter\Importer\Routine;
 
-use Concrete\Core\Attribute\Type;
-use Concrete\Core\Block\BlockType\BlockType;
-use Concrete\Core\Permission\Category;
-use Concrete\Core\Validation\BannedWord\BannedWord;
+use Concrete\Core\Entity\Package;
+use SimpleXMLElement;
 
 class ImportConfigValuesRoutine extends AbstractRoutine
 {
+    private $repositoryInstances;
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\Importer\Routine\RoutineInterface::getHandle()
+     */
     public function getHandle()
     {
         return 'config_values';
     }
 
-    public function import(\SimpleXMLElement $sx)
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\Importer\Routine\RoutineInterface::import()
+     */
+    public function import(SimpleXMLElement $sx)
     {
-        if (isset($sx->config)) {
-            foreach ($sx->config->children() as $key) {
-                $pkg = static::getPackageObject($key['package']);
-                $node = (string) $key->getName();
-                if ($node != 'option') {
-                    // legacy
-                    $option = $node;
-                } else {
-                    $option = (string) $key['name'];
-                }
-
-                $value = (string) $key;
-                if ($value === 'false') {
-                    $value = false;
-                }
-                if (is_object($pkg)) {
-                    \Config::save($pkg->getPackageHandle() . '::' . $option, $value);
-                } else {
-                    \Config::save($option, $value);
-                }
+        if (!isset($sx->config)) {
+            return;
+        }
+        $this->repositoryInstances = [];
+        foreach ($sx->config->children() as $key) {
+            $package = isset($key['package']) ? static::getPackageObject($key['package']) : null;
+            $node = (string) $key->getName();
+            if ($node !== 'option') {
+                // legacy
+                $key = $node;
+            } else {
+                $key = (string) $key['name'];
             }
+            $value = (string) $key;
+            if ($value === 'false') {
+                $value = false;
+            }
+            $repository = $this->getRepository(isset($key['storage']) ? (string) $key['storage'] : '', $package);
+            $repository->set($key, $value);
+            $repository->save($key, $value);
         }
     }
 
+    /**
+     * @return \Concrete\Core\Config\Repository\Repository|\Concrete\Core\Config\Repository\Liaison
+     */
+    private function getRepository(string $storage, ?Package $package)
+    {
+        switch ($storage) {
+            case 'database':
+                break;
+            default:
+                $storage = 'file';
+        }
+        $key = $storage . ($package ? "@{$package->getPackageHandle()}" : '');
+        if (isset($this->repositoryInstances[$key])) {
+            return $this->repositoryInstances[$key];
+        }
+        switch ($storage) {
+            case 'database':
+                $repository = $package ? $package->getController()->getDatabaseConfig() : app('config/database');
+                break;
+            case 'file':
+                $repository = $package ? $package->getController()->getFileConfig() : app('config');
+        }
+        $this->repositoryInstances[$key] = $repository;
+
+        return $repository;
+    }
 }

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportConfigValuesRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportConfigValuesRoutine.php
@@ -43,9 +43,13 @@ class ImportConfigValuesRoutine extends AbstractRoutine
             if ($value === 'false') {
                 $value = false;
             }
+            $rawOverwrite = isset($key['overwrite']) ? (string) $key['overwrite'] : '';
+            $overwrite = $rawOverwrite === '' ? true : filter_var($rawOverwrite, FILTER_VALIDATE_BOOLEAN);
             $repository = $this->getRepository(isset($key['storage']) ? (string) $key['storage'] : '', $package);
-            $repository->set($key, $value);
-            $repository->save($key, $value);
+            if ($overwrite || !$repository->has($key)) {
+                $repository->set($key, $value);
+                $repository->save($key, $value);
+            }
         }
     }
 


### PR DESCRIPTION
In CIF files we can import options with elements like these:

```xml
<concrete5-cif version="1.0">
    <config>
        <option name="option_name" package="package_handle">
            option value
        </option>
    </config>
</concrete5-cif>
```

I'd be handy to being able to specify which configuration repository should be used (file or database).
What about this new syntax?

```xml
<concrete5-cif version="1.0">
    <config>
        <option name="option_1" package="package_handle">
            Default behavior: store in a file (keep current behavior)
        </option>
        <option name="option_2" package="package_handle" storage="file">
            Store in a file (as the current behavior)
        </option>
        <option name="option_3" package="package_handle" storage="database">
            Store in the database (new feature!)
        </option>
    </config>
</concrete5-cif>
```
