### PR TITLE
Check syntax with PHP 8.4

### DIFF
--- a/.github/workflows/check-syntax.yml
+++ b/.github/workflows/check-syntax.yml
@@ -6,8 +6,14 @@ on:
 
 jobs:
   check-syntax:
-    name: PHP
+    name: PHP ${{ matrix.php-version }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version:
+          # This list should include at least the value of Concrete\Core\Install\Preconditions\PhpVersion::MINIMUM_PHP_VERSION
+          - "7.3"
+          - "8.4"
     steps:
       -
         name: Checkout
@@ -16,14 +22,13 @@ jobs:
         name: Install PHP
         uses: shivammathur/setup-php@v2
         with:
-          # This should be the value of Concrete\Core\Install\Preconditions\PhpVersion::MINIMUM_PHP_VERSION
-          php-version: 7.3
+          php-version: ${{ matrix.php-version }}
           extensions: opcache
           coverage: none
           tools: none
       -
         name: Check syntax
-        uses: mlocati/check-php-syntax@main
+        uses: mlocati/check-php-syntax@v1
         with:
           directory: concrete
           include: |


### PR DESCRIPTION
We have a lot of deprecation warnings in PHP 8.4 (see the new check in the [Check Syntax](https://github.com/concretecms/concretecms/actions/workflows/check-syntax.yml) action).

I think https://github.com/concretecms/concretecms/pull/12023 should address them all.