### PR TITLE
Improve StackList

### DIFF
--- a/concrete/src/Page/Stack/StackList.php
+++ b/concrete/src/Page/Stack/StackList.php
@@ -128,9 +128,11 @@ class StackList extends PageList
     }
 
     /**
-     * @param $queryRow
+     * {@inheritdoc}
      *
-     * @return \Stack
+     * @see \Concrete\Core\Page\PageList::getResult()
+     *
+     * @return \Concrete\Core\Page\Stack\Stack|\Concrete\Core\Page\Page|null
      */
     public function getResult($queryRow)
     {
@@ -138,5 +140,4 @@ class StackList extends PageList
 
         return $stack ?: parent::getResult($queryRow);
     }
-
 }


### PR DESCRIPTION
StackList can return 3 types of objects: global areas, stacks and pages representing stack folders.

At the moment we can only specify if we want global areas only (with `filterByGlobalAreas()`, or everything except global areas (with `excludeGlobalAreas()`).

This PR allows users to be more specific about what should be returned:

- with `setIncludeFolders()` you can specify if folders should be included or excluded from the result
- with `setIncludeGlobalAreas()` you can specify if global areas should be included or excluded from the result
- with `setIncludeStacks()` you can specify if stacks should be included or excluded from the result

Furthermore, currently we can ask StackList to retrieve the list of items under a specific folder (with `filterByFolder()`), but there's no way to ask StackList to retrieve the list in the "root" directory: this PR introduces the new `setRootItemsOnly()` method that allows it.