### PR TITLE
[v8] Fix exporting area layout column when area is null

### DIFF
--- a/concrete/src/Area/Layout/Column.php
+++ b/concrete/src/Area/Layout/Column.php
@@ -108,7 +108,9 @@ abstract class Column extends ConcreteObject implements ColumnInterface
         $column = $node->addChild('column');
         $this->exportDetails($column);
         $area = $this->getAreaObject();
-        $area->export($column, $area->getAreaCollectionObject());
+        if ($area) {
+            $area->export($column, $area->getAreaCollectionObject());
+        }
     }
 
     /**


### PR DESCRIPTION
While exporting a rather big website I have this error:

```
Call to a member function export() on null
```

let's fix it.