### PR TITLE
Support "json" attribute when importing config/option elements

### DIFF
--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportConfigValuesRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportConfigValuesRoutine.php
@@ -40,7 +40,10 @@ class ImportConfigValuesRoutine extends AbstractRoutine
                 $key = $elementName;
             }
             $value = (string) $element;
-            if ($value === 'false') {
+            $isJson = isset($element['json']) ? filter_var((string) $element['json'], FILTER_VALIDATE_BOOLEAN) : false;
+            if ($isJson) {
+                $value = json_decode($value, true, 512, JSON_THROW_ON_ERROR);
+            } elseif ($value === 'false') { // deprecated
                 $value = false;
             }
             $rawOverwrite = isset($element['overwrite']) ? (string) $element['overwrite'] : '';


### PR DESCRIPTION
Concrete can import configuration options from CIF files with a syntax like this:

```xml
<concrete5-cif version="1.0">
    <config>
        <option name="key">value</option>
    </config>
</concrete5-cif>
```

At the moment, the values of the options are always extracted as strings, with the special case of `'false'` which will be converted to a boolean `false`.
Why just this special case? What about adding support for importing numbers, booleans (including `true`) and arrays?
For example:

```xml
<concrete5-cif version="1.0">
    <config>
        <option name="boolean_value" json="true">true</option>
        <option name="integer_value" json="true">1</option>
        <option name="array_value" json="true">
            <![CDATA[{"key1":"value1","key2":true}]]>
        </option>
    </config>
</concrete5-cif>
```
