### PR TITLE
[v9] Throw a specific exception on paths not found importing pages from CIF

### DIFF
--- a/concrete/src/Backup/ContentImporter/Exception/MissingPageAtPathException.php
+++ b/concrete/src/Backup/ContentImporter/Exception/MissingPageAtPathException.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Concrete\Core\Backup\ContentImporter\Exception;
+
+use Concrete\Core\Error\UserMessageException;
+
+/**
+ * Exception thrown when importing the page structure if the parent page does not exist (yet).
+ */
+class MissingPageAtPathException extends UserMessageException
+{
+    /**
+     * @var string[]
+     */
+    private $missingPagePaths = [];
+
+    /**
+     * @param string|string[] $missingPagePaths
+     * @param string $message
+     */
+    public function __construct($missingPagePaths, $message = '')
+    {
+        $this->missingPagePaths = is_array($missingPagePaths) ? $missingPagePaths : [$missingPagePaths];
+        if (!$message) {
+            if (count($this->missingPagePaths) === 1) {
+                $message = t('Missing the page with path %s', $this->missingPagePaths[0]);
+            } else {
+                $message = t('Missing the pages with the following paths:') . "\n- " . implode("\n- ", $this->missingPagePaths);
+            }
+        }
+        parent::__construct($message);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getMissingPagePaths()
+    {
+        return $this->missingPagePaths;
+    }
+
+    /**
+     * @return static
+     */
+    public function merge(MissingPageAtPathException $other)
+    {
+        return new static(array_merge($this->getMissingPagePaths(), $other->getMissingPagePaths()));
+    }
+}


### PR DESCRIPTION
When we import pages from CIF files, the core can throw an exception if a page doesn't exist at a specific path (think for example the case when we import a page with path `/foo/bar` but there isn't a page with path `/foo`).

What about throwing a specific exception in this case?

I'm studying a way to improve the Migration Tool, adding support for extended page imports, and this PR may be helpful.