### PR TITLE
Fix PHP 8.4 warnings

### DIFF
--- a/.github/workflows/check-syntax.yml
+++ b/.github/workflows/check-syntax.yml
@@ -34,3 +34,4 @@ jobs:
           include: |
             bin/concrete
             bin/concrete5
+          fail-on-warnings: true

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/AbstractPageStructureRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/AbstractPageStructureRoutine.php
@@ -36,7 +36,7 @@ abstract class AbstractPageStructureRoutine extends AbstractRoutine
     /**
      * @param \SimpleXMLElement[] $elements
      */
-    protected function sortElementsByPath(array $elements, Closure $customComparer = null)
+    protected function sortElementsByPath(array $elements, ?Closure $customComparer = null)
     {
         $sortedElements = $elements;
         usort($sortedElements, static function (SimpleXMLElement $a, SimpleXMLElement $b) use (&$elements, $customComparer) {

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/ImportPageStructureRoutine.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/ImportPageStructureRoutine.php
@@ -100,7 +100,7 @@ class ImportPageStructureRoutine extends AbstractPageStructureRoutine implements
     /**
      * @return \Concrete\Core\Page\Page|string returns a string describing why we should import the page later on, or the created page otherwise
      */
-    private function getOrCreatePage(SimpleXMLElement $pageElement, array $localeInfo = null)
+    private function getOrCreatePage(SimpleXMLElement $pageElement, ?array $localeInfo = null)
     {
         $package = static::getPackageObject($pageElement['package']);
         $cName = isset($pageElement['name']) ? (string) $pageElement['name'] : '';

--- a/concrete/src/Backup/ContentImporter/Importer/Routine/StackTrait.php
+++ b/concrete/src/Backup/ContentImporter/Importer/Routine/StackTrait.php
@@ -118,7 +118,7 @@ trait StackTrait
      *
      * @return \Concrete\Core\Page\Stack\Folder\Folder
      */
-    protected function createFolder($name, $calculatedPath, Folder $parentFolder = null)
+    protected function createFolder($name, $calculatedPath, ?Folder $parentFolder = null)
     {
         $folder = $this->getFolderService()->add($name, $parentFolder);
         if ($this->existingFolders !== null) {
@@ -133,7 +133,7 @@ trait StackTrait
      *
      * @return int|null
      */
-    private function getStackIDByName($name, Folder $folder = null)
+    private function getStackIDByName($name, ?Folder $folder = null)
     {
         if ($folder !== null) {
             $parentPage = $folder->getPage();

--- a/concrete/src/Export/Item/Stack.php
+++ b/concrete/src/Export/Item/Stack.php
@@ -67,7 +67,7 @@ class Stack implements ItemInterface
      *
      * @return \SimpleXMLElement
      */
-    private function exportStack(SimpleXMLElement $xml, StackObject $stack, $path, SectionObject $section = null)
+    private function exportStack(SimpleXMLElement $xml, StackObject $stack, $path, ?SectionObject $section = null)
     {
         $db = app(Connection::class);
         $node = $xml->addChild('stack');


### PR DESCRIPTION
When I wrote #12299 I also created #12300 with almost the same code.
But for ConcreteCMS v9 we need some fixes because of PHP 8.4 warnings.

Those warnings are currently just displayed in the check-syntax.yml GitHub Action: first of all, let's make the Action fail in case of warnings.

I'll then update this PR with the required fixes.