### PR TITLE
Improve visibility of multilingual stacks menu

### DIFF
--- a/concrete/src/Navigation/Breadcrumb/Dashboard/DashboardStacksBreadcrumbFactory.php
+++ b/concrete/src/Navigation/Breadcrumb/Dashboard/DashboardStacksBreadcrumbFactory.php
@@ -63,23 +63,28 @@ class DashboardStacksBreadcrumbFactory implements ApplicationAwareInterface
             array_shift($stacks); // Remove the top "Stacks" page.
             $stacks[] = $stackOrFolder;
             foreach($stacks as $stack) {
-                $stackItem = new Item(
+                $breadcrumb->add(new Item(
                     $this->app->make('url')->to(
                         '/dashboard/blocks/stacks', 'view_details', $stack->getCollectionID()
                     ),
                     $stack->getCollectionName()
-                );
-                $breadcrumb->add($stackItem);
+                ));
             }
-            if ($stackOrFolder instanceof Stack) {
-                if ($locale !== '') {
-                    $stackItem = new Item(
+            if ($stackOrFolder instanceof Stack && !empty($sections)) {
+                if ($locale) {
+                    $section = $sections[$locale];
+                    $multilingualMenuItem = new Item(
                         '',
-                        $locale
+                        Flag::getSectionFlagIcon($section) . ' ' . h($section->getLanguageText()) . ' <span class="text-muted">(' . h($locale) . ')</span>',
                     );
-                    $breadcrumb->add($stackItem);
+                    
+                } else {
+                    $multilingualMenuItem = new Item(
+                        '',
+                        h(tc('Locale', 'Default Content'))
+                    );
                 }
-                // let's handle the breadcrumb dropdown for localized stacks
+                $breadcrumb->add($multilingualMenuItem);
                 if ($stackOrFolder->isNeutralStack()) {
                     $neutralStack = $stackOrFolder;
                 } else {
@@ -97,7 +102,7 @@ class DashboardStacksBreadcrumbFactory implements ApplicationAwareInterface
                 ];
 
                 foreach ($sections as $sectionLocale => $section) {
-                    /* @var Section $section */
+                    /** @var \Concrete\Core\Multilingual\Page\Section\Section $section */
                     $localizedStackName = Flag::getSectionFlagIcon($section) . ' ' . h($section->getLanguageText());
                     if ($neutralStack->getLocalizedStack($section) !== null) {
                         $localizedStackName = '<strong>' . $localizedStackName . '</strong>';
@@ -108,13 +113,13 @@ class DashboardStacksBreadcrumbFactory implements ApplicationAwareInterface
                             $neutralStack->getCollectionID() . rawurlencode('@' . $sectionLocale
                             )
                         ),
-                        $localizedStackName . ' <span class="text-muted">' . h($sectionLocale) . '</span>',
+                        $localizedStackName . ' <span class="text-muted">(' . h($sectionLocale) . ')</span>',
                         $locale === $sectionLocale
                     );
                 }
 
                 foreach($children as $child) {
-                    $stackItem->addChild($child);
+                    $multilingualMenuItem->addChild($child);
                 }
 
             }


### PR DESCRIPTION
Stacks and global areas can be customized for every language section.
As reported in #12356, this is an almost invisible feature.

With this PR, nothing changes in case of single-language websites:
![immagine](https://github.com/user-attachments/assets/276c5df9-f1a0-4d8a-82de-3de71b8b8043)

But with multilingual websites we now have an extra label `Default Content` which makes it clear that there may also be non-default contents:
![immagine](https://github.com/user-attachments/assets/8186f25a-3cdf-4a7b-9665-0c5d22f6a815)

Here's a sample session:

https://github.com/user-attachments/assets/5db85176-58dd-447e-8deb-f3c605fabb51


PS: Close #12356
