### PR TITLE
Avoid a couple of exceptions

### DIFF
--- a/concrete/single_pages/login.php
+++ b/concrete/single_pages/login.php
@@ -5,6 +5,7 @@ use Concrete\Core\Attribute\Key\Key;
 defined('C5_EXECUTE') or die('Access denied.');
 
 $form = Loader::helper('form');
+$user = $user ?? app('user');
 
 if (isset($authType) && $authType) {
     $active = $authType;

--- a/concrete/src/File/Tracker/UsageTracker.php
+++ b/concrete/src/File/Tracker/UsageTracker.php
@@ -195,7 +195,7 @@ class UsageTracker implements TrackerInterface
                     $file = $file->getFileID();
                 } elseif (uuid_is_valid($file)) {
                     $fo = \Concrete\Core\File\File::getByUUID($file);
-                    $file = $fo->getFileID();
+                    $file = $fo ? $fo->getFileID() : null;
                 }
 
                 if ($file && $persist($collection, $trackable, (int) $file)) {


### PR DESCRIPTION
- Avoid call to a member function getFileID() on null
- Avoid undefined variable $user on the login page