### PR TITLE
Add bulk cache setting options for pages

### DIFF
--- a/concrete/controllers/dialog/page/bulk/cache.php
+++ b/concrete/controllers/dialog/page/bulk/cache.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Concrete\Controller\Dialog\Page\Bulk;
+
+use Concrete\Controller\Backend\UserInterface as BackendInterfaceController;
+use Concrete\Core\Command\Batch\Batch;
+use Concrete\Core\Page\Command\DeletePageCommand;
+use Page;
+use Permissions;
+
+class Cache extends BackendInterfaceController
+{
+    protected $viewPath = '/dialogs/page/bulk/cache';
+    protected $pages;
+    protected $canEdit = false;
+
+    protected function canAccess()
+    {
+        $this->populatePages();
+
+        return $this->canEdit;
+    }
+
+    protected function populatePages()
+    {
+        if (!isset($this->pages)) {
+            if (is_array($_REQUEST['item'])) {
+                foreach ($_REQUEST['item'] as $cID) {
+                    $c = Page::getByID($cID);
+                    if (is_object($c) && !$c->isError()) {
+                        $this->pages[] = $c;
+                    }
+                }
+            }
+        }
+
+        if (count($this->pages) > 0) {
+            $this->canEdit = true;
+            foreach ($this->pages as $c) {
+                $cp = new Permissions($c);
+                if (!$cp->canEditPageSpeedSettings()) {
+                    $this->canEdit = false;
+                }
+            }
+        } else {
+            $this->canEdit = false;
+        }
+
+        return $this->canEdit;
+    }
+
+    public function view()
+    {
+        $config = $this->app->make('config');
+        $this->populatePages();
+        $fullPageCaching = -3;
+        $cCacheFullPageContentOverrideLifetime = -2;
+        $cCacheFullPageContentOverrideLifetimeCustomValue = -1;
+        foreach ($this->pages as $c) {
+            $cp = new Permissions($c);
+            if ($cp->canEditPageSpeedSettings()) {
+                if ($c->getCollectionFullPageCaching() != $fullPageCaching && $fullPageCaching != -3) {
+                    $fullPageCaching = -2;
+                } else {
+                    $fullPageCaching = $c->getCollectionFullPageCaching();
+                }
+                if ($c->getCollectionFullPageCachingLifetime(
+                    ) != $cCacheFullPageContentOverrideLifetime && $cCacheFullPageContentOverrideLifetime != -2) {
+                    $cCacheFullPageContentOverrideLifetime = -1;
+                } else {
+                    $cCacheFullPageContentOverrideLifetime = $c->getCollectionFullPageCachingLifetime();
+                }
+                if ($c->getCollectionFullPageCachingLifetimeCustomValue(
+                    ) != $cCacheFullPageContentOverrideLifetimeCustomValue && $cCacheFullPageContentOverrideLifetimeCustomValue != -1) {
+                    $cCacheFullPageContentOverrideLifetimeCustomValue = 0;
+                } else {
+                    $cCacheFullPageContentOverrideLifetimeCustomValue = $c->getCollectionFullPageCachingLifetimeCustomValue();
+                }
+            }
+        }
+		switch($config->get('concrete.cache.pages')) {
+			case 'blocks':
+				$globalSetting = t('cache page if all blocks support it.');
+				$enableCache = 1;
+				break;
+			case 'all':
+				$globalSetting = t('enable full page cache.');
+				$enableCache = 1;
+				break;
+            default: // false
+				$globalSetting = t('disable full page cache.');
+				$enableCache = 0;
+				break;
+		}
+		switch($this->app->make('config')->get('concrete.cache.full_page_lifetime')) {
+			case 'custom':
+				$custom = $this->app->make('date')->describeInterval($config->get('concrete.cache.full_page_lifetime_value') * 60);
+				$globalSettingLifetime = t('%s minutes', $custom);
+				break;
+			case 'forever':
+				$globalSettingLifetime = t('Until manually cleared');
+				break;
+            default: // "default"
+				$globalSettingLifetime = $this->app->make('date')->describeInterval($config->get('concrete.cache.lifetime'));
+				break;
+		}
+        $this->set('pages', $this->pages);
+        $this->set('fullPageCaching', $fullPageCaching);
+        $this->set('cCacheFullPageContentOverrideLifetime', $cCacheFullPageContentOverrideLifetime);
+        $this->set('cCacheFullPageContentOverrideLifetimeCustomValue', $cCacheFullPageContentOverrideLifetimeCustomValue);
+        $this->set('globalSetting', $globalSetting);
+        $this->set('enableCache', $enableCache);
+        $this->set('globalSettingLifetime', $globalSettingLifetime);
+    }
+
+    public function submit()
+    {
+        if ($this->canAccess()) {
+            $u = new \User();
+            $uID = $u->getUserID();
+            $pages = $this->pages;
+            $batch = Batch::create(t('Delete Pages'), function () use ($uID, $pages) {
+                foreach ($pages as $page) {
+                    yield new DeletePageCommand($page->getCollectionID(), $uID);
+                }
+            });
+            return $this->dispatchBatch($batch);
+        }
+    }
+
+
+}

--- a/concrete/routes/dialogs/pages.php
+++ b/concrete/routes/dialogs/pages.php
@@ -36,6 +36,8 @@ $router->all('/bulk/delete/submit', 'Bulk\Delete::submit');
 $router->all('/bulk/permissions/get_all_access_entities', 'Bulk\Permissions::getAllAccessEntities');
 $router->all('/bulk/permissions', 'Bulk\Permissions::view');
 $router->all('/bulk/permissions/{task}', 'Bulk\Permissions::view');
+$router->all('/bulk/cache', 'Bulk\Cache::view');
+$router->all('/bulk/delete/cache', 'Bulk\Cache::submit');
 $router->all('/clipboard', 'Clipboard::view');
 $router->all('/delete', 'Delete::view');
 $router->all('/delete/submit', 'Delete::submit');

--- a/concrete/routes/dialogs/pages.php
+++ b/concrete/routes/dialogs/pages.php
@@ -37,7 +37,7 @@ $router->all('/bulk/permissions/get_all_access_entities', 'Bulk\Permissions::get
 $router->all('/bulk/permissions', 'Bulk\Permissions::view');
 $router->all('/bulk/permissions/{task}', 'Bulk\Permissions::view');
 $router->all('/bulk/cache', 'Bulk\Cache::view');
-$router->all('/bulk/delete/cache', 'Bulk\Cache::submit');
+$router->all('/bulk/cache/submit', 'Bulk\Cache::submit');
 $router->all('/clipboard', 'Clipboard::view');
 $router->all('/delete', 'Delete::view');
 $router->all('/delete/submit', 'Delete::submit');

--- a/concrete/src/Page/Search/Menu/MenuFactory.php
+++ b/concrete/src/Page/Search/Menu/MenuFactory.php
@@ -63,6 +63,19 @@ class MenuFactory
             )
         );
 
+        $menu->addItem(
+            new LinkItem(
+                "#",
+                t('Cache Settings'),
+                [
+                    'data-bulk-action-type' => 'dialog',
+                    'data-bulk-action-title' => t('Cache Settings'),
+                    'data-bulk-action-url' => Url::to('/ccm/system/dialogs/page/bulk/cache'),
+                    'data-bulk-action-dialog-width' => '500',
+                    'data-bulk-action-dialog-height' => '400'
+                ]
+            )
+        );
 
         if ($this->config->get('concrete.permissions.model') !== 'simple') {
             $menu->addItem(new DividerItem());

--- a/concrete/views/dialogs/page/bulk/cache.php
+++ b/concrete/views/dialogs/page/bulk/cache.php
@@ -1,0 +1,142 @@
+<?php
+
+defined('C5_EXECUTE') or die("Access Denied."); ?>
+<div class="ccm-ui">
+
+    <?php
+    if (count($pages) == 0) {
+        ?>
+        <?= t("You have not selected any pages.");
+        ?>
+        <?php
+    } else {
+        ?>
+
+        <form action="<?= $controller->action('submit') ?>" id="ccm-bulk-page-caching-form">
+
+            <div class="mb-3">
+                <label class="form-label"><?= t('Full Page Caching') ?></label>
+                <?php if ($fullPageCaching == '-2') { ?>
+                    <div class="form-check">
+                        <input type="radio" name="cCacheFullPageContent" id="cacheOption1" value="-2"
+                               class="form-check-input" <?= $fullPageCaching == -2 ? 'checked' : '' ?>>
+                        <label class="form-check-label" for="cacheOption1">
+                            <?= t('Multiple values') ?>
+                        </label>
+                    </div>
+                <?php } ?>
+                <div class="form-check">
+                    <input type="radio" name="cCacheFullPageContent" id="cacheOption2" value="-1"
+                           class="form-check-input" <?= $fullPageCaching == -1 ? 'checked' : '' ?>>
+                    <label class="form-check-label" for="cacheOption2">
+                        <?= t('Use global setting - %s', $globalSetting) ?>
+                    </label>
+                </div>
+                <div class="form-check">
+                    <input type="radio" name="cCacheFullPageContent" id="cacheOption3" value="0"
+                           class="form-check-input" <?= $fullPageCaching == 0 ? 'checked' : '' ?>>
+                    <label class="form-check-label" for="cacheOption3">
+                        <?= t('Do not cache this page.') ?>
+                    </label>
+                </div>
+                <div class="form-check">
+                    <input type="radio" name="cCacheFullPageContent" id="cacheOption4" value="1"
+                           class="form-check-input" <?= $fullPageCaching == 1 ? 'checked' : '' ?>>
+                    <label class="form-check-label" for="cacheOption4">
+                        <?= t('Cache this page.') ?>
+                    </label>
+                </div>
+            </div>
+
+            <div class="mb-3">
+                <label class="form-label"><?= t('Cache for how long?') ?></label>
+                <?php
+                $val = ($cCacheFullPageContentOverrideLifetimeCustomValue > 0 && $cCacheFullPageContentOverrideLifetime) ? $cCacheFullPageContentOverrideLifetimeCustomValue : ''; ?>
+
+                <?php if ($cCacheFullPageContentOverrideLifetime == '-1') { ?>
+                    <div class="form-check">
+                        <input type="radio" name="cCacheFullPageContentOverrideLifetime" id="lifetimeOption1"
+                               value="-1"
+                               class="form-check-input" <?= $cCacheFullPageContentOverrideLifetime == -1 ? 'checked' : '' ?>>
+                        <label class="form-check-label" for="lifetimeOption1">
+                            <?= t('Multiple values') ?>
+                        </label>
+                    </div>
+                <?php } ?>
+                <div class="form-check">
+                    <input type="radio" name="cCacheFullPageContentOverrideLifetime" id="lifetimeOption2"
+                           value="default"
+                           class="form-check-input" <?= $cCacheFullPageContentOverrideLifetime == 0 ? 'checked' : '' ?>>
+                    <label class="form-check-label" for="lifetimeOption2">
+                        <?= t('Use global setting - %s', $globalSettingLifetime) ?>
+                    </label>
+                </div>
+                <div class="form-check">
+                    <input type="radio" name="cCacheFullPageContentOverrideLifetime" id="lifetimeOption4"
+                           value="forever"
+                           class="form-check-input" <?= $cCacheFullPageContentOverrideLifetime == 'forever' ? 'checked' : '' ?>>
+                    <label class="form-check-label" for="lifetimeOption4">
+                        <?= t('Until manually cleared') ?>
+                    </label>
+                </div>
+                <div class="form-check">
+                    <input type="radio" name="cCacheFullPageContentOverrideLifetime" id="lifetimeOption5"
+                           value="custom"
+                           class="form-check-input" <?= $cCacheFullPageContentOverrideLifetime == 'custom' ? 'checked' : '' ?>>
+                    <label class="form-check-label" for="lifetimeOption5">
+                        <?= t('Custom') ?>
+                    </label>
+                    <div class="row row-cols-auto g-0 align-items-center">
+                        <div class="col-auto">
+                            <input type="text" name="cCacheFullPageContentLifetimeCustom"
+                                   id="customLifetime" value="<?= $val ?>" min="1" class="form-control"
+                                   style="width: 110px; display: inline-block;">
+                        </div>
+                        <div class="col-auto">
+                            <span class="ms-1"><?= t('minutes') ?></span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="dialog-buttons d-flex justify-content-end">
+                <button class="btn btn-secondary me-2" type="button" data-dialog-action="cancel"
+                        data-panel-detail-action="cancel"><?= t('Cancel') ?></button>
+                <button class="btn btn-success" type="button" data-dialog-action="submit"
+                        data-panel-detail-action="submit"><?= t('Save Changes') ?></button>
+            </div>
+        </form>
+
+        <?php
+    }
+    ?>
+</div>
+
+<script type="text/javascript">
+    $(function () {
+        $('#ccm-bulk-page-caching-form').on('change', 'input[name=cCacheFullPageContent]', function() {
+            let cCacheFullPageContent = $('input[name=cCacheFullPageContent]:checked').val()
+            if (cCacheFullPageContent === '1') {
+                $('input[name=cCacheFullPageContentOverrideLifetime]').prop('disabled', false);
+            } else {
+                $('input[name=cCacheFullPageContentOverrideLifetime]').prop('disabled', true);
+                if ($('input[name=cCacheFullPageContentOverrideLifetime][value="-2"]').length) {
+                    $('input[name=cCacheFullPageContentOverrideLifetime][value="-2"]').prop('checked', true);
+                } else {
+                    $('input[name=cCacheFullPageContentOverrideLifetime][value="default"]').prop('checked', true);
+                }
+            }
+            $('input[name=cCacheFullPageContentOverrideLifetime]:checked').trigger('change')
+        })
+        $('#ccm-bulk-page-caching-form').on('change', 'input[name=cCacheFullPageContentOverrideLifetime]', function() {
+            let cCacheFullPageContentOverrideLifetime = $('input[name=cCacheFullPageContentOverrideLifetime]:checked').val()
+            if (cCacheFullPageContentOverrideLifetime === 'custom') {
+                $('input[name=cCacheFullPageContentLifetimeCustom]').prop('disabled', false);
+            } else {
+                $('input[name=cCacheFullPageContentLifetimeCustom]').prop('disabled', true);
+                $('input[name=cCacheFullPageContentLifetimeCustom]').val('');
+            }
+        })
+        $('input[name=cCacheFullPageContent]:checked').trigger('change')
+    });
+</script>
+

--- a/concrete/views/dialogs/page/bulk/cache.php
+++ b/concrete/views/dialogs/page/bulk/cache.php
@@ -12,7 +12,15 @@ defined('C5_EXECUTE') or die("Access Denied."); ?>
     } else {
         ?>
 
-        <form action="<?= $controller->action('submit') ?>" id="ccm-bulk-page-caching-form">
+        <form action="<?= $controller->action('submit') ?>" data-dialog-form="bulk-page-caching" id="ccm-bulk-page-caching-form">
+
+            <?php foreach ($pages as $c) {
+                $cp = new Permissions($c);
+                if ($cp->canEditPageSpeedSettings()) { ?>
+                    <input type="hidden" name="item[]" value="<?=$c->getCollectionID()?>">
+            <?php }
+            }
+            ?>
 
             <div class="mb-3">
                 <label class="form-label"><?= t('Full Page Caching') ?></label>
@@ -101,7 +109,7 @@ defined('C5_EXECUTE') or die("Access Denied."); ?>
             <div class="dialog-buttons d-flex justify-content-end">
                 <button class="btn btn-secondary me-2" type="button" data-dialog-action="cancel"
                         data-panel-detail-action="cancel"><?= t('Cancel') ?></button>
-                <button class="btn btn-success" type="button" data-dialog-action="submit"
+                <button class="btn btn-success" type="button" id="save-bulk-cache-settings-button" data-dialog-action="submit"
                         data-panel-detail-action="submit"><?= t('Save Changes') ?></button>
             </div>
         </form>
@@ -117,13 +125,22 @@ defined('C5_EXECUTE') or die("Access Denied."); ?>
             let cCacheFullPageContent = $('input[name=cCacheFullPageContent]:checked').val()
             if (cCacheFullPageContent === '1') {
                 $('input[name=cCacheFullPageContentOverrideLifetime]').prop('disabled', false);
+                if ($('input[name=cCacheFullPageContentOverrideLifetime][value="-1"]').length) {
+                    $('input[name=cCacheFullPageContentOverrideLifetime][value="-1"]').prop('disabled', true);
+                    $('input[name=cCacheFullPageContentOverrideLifetime][value=default]').prop('checked', true);
+                }
             } else {
                 $('input[name=cCacheFullPageContentOverrideLifetime]').prop('disabled', true);
-                if ($('input[name=cCacheFullPageContentOverrideLifetime][value="-2"]').length) {
-                    $('input[name=cCacheFullPageContentOverrideLifetime][value="-2"]').prop('checked', true);
+                if ($('input[name=cCacheFullPageContentOverrideLifetime][value="-1"]').length) {
+                    $('input[name=cCacheFullPageContentOverrideLifetime][value="-1"]').prop('checked', true);
                 } else {
                     $('input[name=cCacheFullPageContentOverrideLifetime][value="default"]').prop('checked', true);
                 }
+            }
+            if (cCacheFullPageContent === '-2') {
+                $('#save-bulk-cache-settings-button').prop('disabled', true)
+            } else {
+                $('#save-bulk-cache-settings-button').prop('disabled', false)
             }
             $('input[name=cCacheFullPageContentOverrideLifetime]:checked').trigger('change')
         })


### PR DESCRIPTION
Closing out the oldest open feature request: adding the ability to bulk set page caching options, coming in 9.4.0.

<img width="1191" alt="Screen Shot 2024-12-09 at 10 29 47 AM" src="https://github.com/user-attachments/assets/8d0f1e13-ef15-4b9c-b88a-af8a039f6fba">

<img width="906" alt="Screen Shot 2024-12-09 at 10 30 01 AM" src="https://github.com/user-attachments/assets/ec3d9a77-6a35-4b3e-bcad-9136de19afb2">
