### PR TITLE
[Page List Block] Use class property btHandle instead of hardcoded block_type_handle

### DIFF
--- a/concrete/blocks/page_list/controller.php
+++ b/concrete/blocks/page_list/controller.php
@@ -248,7 +248,7 @@ class Controller extends BlockController implements UsesFeatureInterface
 
     public function action_preview_pane()
     {
-        $bt = BlockType::getByHandle('page_list');
+        $bt = BlockType::getByHandle($this->btHandle);
         $controller = $bt->getController();
 
         // @TODO - clean up this old code.
@@ -513,7 +513,7 @@ class Controller extends BlockController implements UsesFeatureInterface
         $this->set('uh', $uh);
         $this->set('includeDescription', true);
         $this->set('includeName', true);
-        $this->set('bt', BlockType::getByHandle('page_list'));
+        $this->set('bt', BlockType::getByHandle($this->btHandle));
         $this->set('featuredAttributeUnusableReason', $this->checkSearchablePageAttributeKey('is_featured'));
         $this->set('thumbnailAttribute', CollectionAttributeKey::getByHandle('thumbnail'));
         $this->set('titleFormat', 'h5');
@@ -568,7 +568,7 @@ class Controller extends BlockController implements UsesFeatureInterface
         }
         $uh = Core::make('helper/concrete/urls');
         $this->set('uh', $uh);
-        $this->set('bt', BlockType::getByHandle('page_list'));
+        $this->set('bt', BlockType::getByHandle($this->btHandle));
         $this->set('featuredAttributeUnusableReason', $this->checkSearchablePageAttributeKey('is_featured'));
         $this->set('thumbnailAttribute', CollectionAttributeKey::getByHandle('thumbnail'));
         $topicFilter = '';


### PR DESCRIPTION
We frequently extend the page_list block into a custom block. Since the block controller already has the `btHandle` property, let's utilize that to provide some flexibility.