### PR TITLE
Allow overriding ErrorHandler, add exception listeners

### DIFF
--- a/concrete/src/Error/Provider/ErrorHandlingServiceProvider.php
+++ b/concrete/src/Error/Provider/ErrorHandlingServiceProvider.php
@@ -1,8 +1,8 @@
 <?php
 namespace Concrete\Core\Error\Provider;
 
-use Concrete\Core\Foundation\Service\Provider;
 use Concrete\Core\Error\Handling\ErrorHandler;
+use Concrete\Core\Foundation\Service\Provider;
 use Concrete\Core\Logging\Channels;
 use Concrete\Core\Logging\LoggerFactory;
 
@@ -10,8 +10,13 @@ class ErrorHandlingServiceProvider extends Provider
 {
     public function register()
     {
-        $logger = $this->app->make(LoggerFactory::class)->createLogger(Channels::CHANNEL_EXCEPTIONS);
-        $handler = $this->app->make(ErrorHandler::class, ['logger' => $logger]);
+        if ($this->app->bound(ErrorHandler::class)) {
+            $handler = $this->app->make(ErrorHandler::class);
+        } else {
+            $logger = $this->app->make(LoggerFactory::class)->createLogger(Channels::CHANNEL_EXCEPTIONS);
+            $handler = $this->app->make(ErrorHandler::class, ['logger' => $logger]);
+            $this->app->instance(ErrorHandler::class, $handler);
+        }
         $handler = ErrorHandler::register($handler);
         $handler->setExceptionHandler([$handler, 'renderConcreteException']);
     }


### PR DESCRIPTION
Before #12349 we could listen for exceptions by running

```php
$app->make('Whoops\Run')->pushHandler($custom);
```

What about supporting a similar function with the new error handling system introduced in #12349?

With this PR it'll be possible to have something like this:

```php
$app->make('Concrete\Core\Error\Handling\ErrorHandler')->addExceptionListener($custom);
```
