### PR TITLE
Improve conversation captcha failure message

### DIFF
--- a/concrete/controllers/frontend/conversations/add_message.php
+++ b/concrete/controllers/frontend/conversations/add_message.php
@@ -286,7 +286,7 @@ class AddMessage extends FrontendController
         if (!$u->isRegistered()) {
             $captcha = $this->app->make('captcha');
             if (!$captcha->check()) {
-                $errors[] = t('Incorrect image validation code. Please check the image and re-enter the letters or numbers as necessary.');
+                $errors[] = t("The captcha didn't recognise you as a human. Please try again.");
             }
         }
     }


### PR DESCRIPTION
The existing conversation captcha failure message is very specific to the default captcha _'Incorrect image validation code. Please check the image and re-enter the letters or numbers as necessary._'

This change improves it by making the message more generic, so it is relevant to any captcha.

There is scope for better captcha error responses here. This is just a minimal fix.
