### PR TITLE
Fix memory allocation issue with thumbnail generation and Imagick

### DIFF
--- a/concrete/src/File/Command/GenerateThumbnailCommandHandler.php
+++ b/concrete/src/File/Command/GenerateThumbnailCommandHandler.php
@@ -53,6 +53,8 @@ class GenerateThumbnailCommandHandler
                                         $fileVersion->generateThumbnail($thumbnailTypeVersion);
                                     }
                                 }
+
+                                $fileVersion->releaseImagineImage();
                             }
                         }
                     }


### PR DESCRIPTION
This fixes an issue with the Imagick resources being left allocated during the thumbnail generation with a lot of files in the system.

The error output is the following from Imagine's Imagick driver:
```
  cache resources exhausted `' @ error/cache.c/OpenPixelCache/4119  
```

Replication instructions:
1. Add thousands of images in the system (in the exact case there were 8000+ images)
2. Make sure in your `/etc/ImageMagick-6/policy.xml` you have set the following config (this was the default on the system where this happened):
  * `<policy domain="resource" name="disk" value="2GiB"/>`
3. Run the command `./concrete/bin/concrete5 task:generate-thumbnails`
4. See the error (or if not, keep adding images)

A workaround would be to raise the "disk" cache size for ImageMagick but the problem would reappear after a while when the file storage size continues to grow.