### PR TITLE
Show scheduled times of automated tasks in system timezone

### DIFF
--- a/concrete/src/Entity/Command/ScheduledTask.php
+++ b/concrete/src/Entity/Command/ScheduledTask.php
@@ -145,11 +145,9 @@ class ScheduledTask implements \JsonSerializable
     #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
-        $timezone = date_default_timezone_get();
-        $dateScheduledString = (new \DateTime('@' . $this->getDateScheduled()))
-            ->setTimezone(new \DateTimeZone($timezone))
-            ->format('F d, Y g:i a');
-
+        /** @var \Concrete\Core\Localization\Service\Date $date */
+        $date = app('helper/date');
+        $dateScheduledString = $date->formatPrettyDateTime($this->getDateScheduled());
         $cronExpression = $this->getCronExpressionObject();
 
         $data = [
@@ -159,7 +157,7 @@ class ScheduledTask implements \JsonSerializable
             'dateScheduled' => $this->getDateScheduled(),
             'dateScheduledString' => $dateScheduledString,
             'cronExpression' => $this->getCronExpression(),
-            'nextRunDate' => $cronExpression->getNextRunDate()->format('Y-m-d H:i:s'),
+            'nextRunDate' => $date->formatPrettyDateTime($cronExpression->getNextRunDate()),
             'user' => $this->getUser(),
         ];
         return $data;


### PR DESCRIPTION
If your server timezone is UTC, your system timezone is JST, and cron expression is `0 0 * * *`
Concrete says the next run is "2025-01-08 00:00:00" but it's confusing
After merging this PR, it'll show "Tomorrow at 9:00 AM" it's more friendly to admin users