### PR TITLE
Fix: Remove orphaned blocks button deletes valid blocks

### DIFF
--- a/concrete/controllers/panel/add.php
+++ b/concrete/controllers/panel/add.php
@@ -5,6 +5,7 @@ namespace Concrete\Controller\Panel;
 use Concrete\Controller\Backend\UserInterface\Page as BackendInterfacePageController;
 use Concrete\Core\Application\EditResponse;
 use Concrete\Core\Application\Service\Urls;
+use Concrete\Core\Area\Area;
 use Concrete\Core\Block\Block;
 use Concrete\Core\Block\BlockType\BlockType;
 use Concrete\Core\Block\BlockType\BlockTypeList;
@@ -270,13 +271,14 @@ class Add extends BackendInterfacePageController
                             if (!$orphanedBlockFound) {
                                 $errorList->add(t("The given block is not orphaned."));
                             } else {
-                                $block = Block::getByID($blockId);
-
+                                $arID = $request->request->get('arId');
+                                $areaHandle = Area::getAreaHandleFromID($arID);
+                                $block = Block::getByID($blockId, $this->page, $areaHandle);
                                 if (!$block instanceof Block) {
                                     //$errorList->add(t("Error while removing orphaned block."));
                                 } else {
                                     // returns false because the area no longer exists in the theme.
-                                    $block->deleteBlock(true);
+                                    $block->deleteBlock();
                                 }
                             }
                         }
@@ -313,15 +315,16 @@ class Add extends BackendInterfacePageController
         if (count($arrOrphanedBlocks) === 0) {
             $errorList->add(t("There are no blocks to remove."));
         } else {
-            foreach ($this->getOrphanedBlockIds($usedAreas) as $arrOrphanedBlock) {
+            foreach ($arrOrphanedBlocks as $arrOrphanedBlock) {
                 $bID = (int)$arrOrphanedBlock["bID"];
-                $block = Block::getByID($bID);
+                $arHandle = $arrOrphanedBlock["arHandle"];
+                $block = Block::getByID($bID, $this->page, $arHandle);
 
                 if (!$block instanceof Block) {
                     $errorList->add(t("Error while removing orphaned block."));
                 } else {
                     // returns false because the area no longer exists in the theme.
-                    $block->deleteBlock(true);
+                    $block->deleteBlock();
                 }
             }
         }


### PR DESCRIPTION
As I said in the [comment](https://github.com/concretecms/concretecms/issues/12329#issuecomment-2496493421), the problem is we don't pass cID and arHandle when getting Block instances to remove. This PR fixes it.

Related issue: #12390 