### PR TITLE
added a new protected property to fixed the error "Creation of dynamic property" in the PageView class

### DIFF
--- a/concrete/src/Page/View/PageView.php
+++ b/concrete/src/Page/View/PageView.php
@@ -28,6 +28,7 @@ class PageView extends View
     protected $cp;
     protected $pTemplateID;
     protected $customPreviewRequest;
+    protected $pTemplatePkgHandle;
 
     public function getScopeItems()
     {


### PR DESCRIPTION

- [ X] I read the __guidelines for contributing__ linked above. My pull request conforms to the coding style guidelines described within.
While working on a client project using PHP 8.3, I encountered an error due to recent changes in the handling of dynamic properties introduced in PHP 8.2. The solution was to add the missing protected property in the PageView class.

