### PR TITLE
Sets the default filename when the file is going to be downloaded

### DIFF
--- a/concrete/blocks/document_library/controller.php
+++ b/concrete/blocks/document_library/controller.php
@@ -751,9 +751,9 @@ class Controller extends BlockController implements UsesFeatureInterface
                     $file->getFileID(), t('Details'));
             case 'title':
                 if ($this->downloadFileMethod == 'force') {
-                    return sprintf('<a href="%1$s" download="%2$s">%2$s</a>', $file->getForceDownloadURL(), $file->getTitle());
+                    return sprintf('<a href="%1$s" download="%2$s">%2$s</a>', $file->getForceDownloadURL(), h($file->getTitle()));
                 } else {
-                    return sprintf('<a href="%1$s" download="%2$s">%2$s</a>', $file->getDownloadURL(), $file->getTitle());
+                    return sprintf('<a href="%1$s" download="%2$s">%2$s</a>', $file->getDownloadURL(), h($file->getTitle()));
                 }
             case 'filename':
                 return $file->getFileName();

--- a/concrete/blocks/document_library/controller.php
+++ b/concrete/blocks/document_library/controller.php
@@ -751,9 +751,9 @@ class Controller extends BlockController implements UsesFeatureInterface
                     $file->getFileID(), t('Details'));
             case 'title':
                 if ($this->downloadFileMethod == 'force') {
-                    return sprintf('<a href="%s">%s</a>', $file->getForceDownloadURL(), $file->getTitle());
+                    return sprintf('<a href="%1$s" download="%2$s">%2$s</a>', $file->getForceDownloadURL(), $file->getTitle());
                 } else {
-                    return sprintf('<a href="%s">%s</a>', $file->getDownloadURL(), $file->getTitle());
+                    return sprintf('<a href="%1$s" download="%2$s">%2$s</a>', $file->getDownloadURL(), $file->getTitle());
                 }
             case 'filename':
                 return $file->getFileName();


### PR DESCRIPTION
This is an enhancement proposal.

Files are uploaded and these file names are converted to ASCII-only strings.
If the file names are originally Japanese, these filenames are often hard to read.

Adding a download attribute for &lt;a&gt; will specify the name for the download-target file. That is, if the download link is clicked, the browser will use the name as the file's default filename.

For the detailed specification, please see https://www.w3schools.com/tags/att_a_download.asp
&lt;a href="FILE_PATH_HERE" download="FILE_NAME_HERE"&gt;