### PR TITLE
Fix rendering content block images with custom width or height

### DIFF
--- a/concrete/src/Editor/LinkAbstractor.php
+++ b/concrete/src/Editor/LinkAbstractor.php
@@ -142,20 +142,34 @@ class LinkAbstractor extends ConcreteObject
                     $fo = \Concrete\Core\File\File::getByID($fID);
                 }
                 if ($fo !== null) {
-                    $usePictureTag = null;
                     $style = (string) $picture->style;
                     // move width px to width attribute and height px to height attribute
                     $widthPattern = '/(?:^width|[^-]width):\\s([0-9]+)px;?/i';
                     if (preg_match($widthPattern, $style, $matches)) {
                         $style = preg_replace($widthPattern, '', $style);
                         $picture->width = $matches[1];
-                        $usePictureTag = false;
                     }
                     $heightPattern = '/(?:^height|[^-]height):\\s([0-9]+)px;?/i';
                     if (preg_match($heightPattern, $style, $matches)) {
                         $style = preg_replace($heightPattern, '', $style);
                         $picture->height = $matches[1];
-                        $usePictureTag = false;
+                    }
+                    $usePictureTag = null;
+                    if ($usePictureTag === null) {
+                        $widthFromHtml = (string) $picture->width;
+                        if ($widthFromHtml === (string) (int) $widthFromHtml && is_numeric($widthFromAttributes = (string) $fo->getAttribute('width'))) {
+                            if ($widthFromHtml !== $widthFromAttributes) {
+                                $usePictureTag = false;
+                            }
+                        }
+                    }
+                    if ($usePictureTag === null) {
+                        $heightFromHtml = (string) $picture->height;
+                        if ($heightFromHtml === (string) (int) $heightFromHtml && is_numeric($heightFromAttributes = (string) $fo->getAttribute('height'))) {
+                            if ($heightFromHtml !== $heightFromAttributes) {
+                                $usePictureTag = false;
+                            }
+                        }
                     }
                     if ($style === '') {
                         unset($picture->style);


### PR DESCRIPTION
#12314 fixes rendering images with custom styles set in the form `style="widh: ...; height: ..."`.
But we often have images with the `width="..." height="..."` attributes: let's respect them too.

Fix #12414