### PR TITLE
Use `null` so that redis starts from the beginning and doesn't try to resume a non-existant cursor

### DIFF
--- a/concrete/src/Config/Driver/Redis/RedisPaginatedTrait.php
+++ b/concrete/src/Config/Driver/Redis/RedisPaginatedTrait.php
@@ -16,7 +16,7 @@ trait RedisPaginatedTrait
      */
     protected function paginatedScan(Redis $redis, $pattern)
     {
-        $i = 0;
+        $i = null;
         do {
             $keys = $redis->scan($i, 'cfg=' . $pattern, 100);
 

--- a/tests/tests/Config/Driver/Redis/RedisPaginatedTraitTest.php
+++ b/tests/tests/Config/Driver/Redis/RedisPaginatedTraitTest.php
@@ -30,7 +30,7 @@ class RedisPaginatedTraitTest extends TestCase
 
 
         $redis = M::mock('Redis');
-        $expectedIterators = [0, 127, 135, 205];
+        $expectedIterators = [null, 127, 135, 205];
         $returnValues = [['cfg=foo', 'cfg=bar'], ['cfg=baz'], false];
 
         $redis->shouldReceive('scan')->times(3)->with(


### PR DESCRIPTION
This was originally changed in #9956 due to the contemporaneous version of the php redis extension removing `null`  support. They've since [added null back](https://github.com/phpredis/phpredis/pull/2069) and expect null to be passed initially.

See https://github.com/phpredis/phpredis/blob/faa4bc20868c76be4ecc4265015104a8adafccc4/redis.stub.php#L2971 for intended usage
