### PR TITLE
Fix issue managing express entries when cache is disabled

### DIFF
--- a/concrete/src/Cache/Cache.php
+++ b/concrete/src/Cache/Cache.php
@@ -230,9 +230,14 @@ abstract class Cache implements FlushableInterface
         $app->make('cache')->disable();
 
         // See: https://github.com/concretecms/concretecms/issues/12422
-        $em = $app->make(EntityManagerInterface::class);
-        $ormMdCache = $app->make('Doctrine\Common\Cache\ArrayCache');
-        $em->getMetadataFactory()->setCache(new DoctrineAdapter($ormMdCache));
+        $db = $app->make('database');
+        if ($db->getDefaultConnection() !== null) {
+            // These would fail in case there is not a configured database
+            // connection, which is the case during installation.
+            $em = $app->make(EntityManagerInterface::class);
+            $ormMdCache = $app->make('Doctrine\Common\Cache\ArrayCache');
+            $em->getMetadataFactory()->setCache(new DoctrineAdapter($ormMdCache));
+        }
     }
 
     /**
@@ -246,8 +251,13 @@ abstract class Cache implements FlushableInterface
         $app->make('cache')->enable();
 
         // See: https://github.com/concretecms/concretecms/issues/12422
-        $em = $app->make(EntityManagerInterface::class);
-        $ormMdCache = $app->make('orm/cache');
-        $em->getMetadataFactory()->setCache(new DoctrineAdapter($ormMdCache));
+        $db = $app->make('database');
+        if ($db->getDefaultConnection() !== null) {
+            // These would fail in case there is not a configured database
+            // connection, which is the case during installation.
+            $em = $app->make(EntityManagerInterface::class);
+            $ormMdCache = $app->make('orm/cache');
+            $em->getMetadataFactory()->setCache(new DoctrineAdapter($ormMdCache));
+        }
     }
 }

--- a/concrete/src/Cache/Cache.php
+++ b/concrete/src/Cache/Cache.php
@@ -2,10 +2,12 @@
 namespace Concrete\Core\Cache;
 
 use Concrete\Core\Support\Facade\Application;
+use Doctrine\ORM\EntityManagerInterface;
 use Psr\Cache\CacheItemInterface;
 use Stash\Driver\BlackHole;
 use Stash\Driver\Composite;
 use Stash\Pool;
+use Symfony\Component\Cache\Adapter\DoctrineAdapter;
 
 /**
  * Base class for the three caching layers present in Concrete5:
@@ -226,6 +228,11 @@ abstract class Cache implements FlushableInterface
         $app->make('cache/request')->disable();
         $app->make('cache/expensive')->disable();
         $app->make('cache')->disable();
+
+        // See: https://github.com/concretecms/concretecms/issues/12422
+        $em = $app->make(EntityManagerInterface::class);
+        $ormMdCache = $app->make('Doctrine\Common\Cache\ArrayCache');
+        $em->getMetadataFactory()->setCache(new DoctrineAdapter($ormMdCache));
     }
 
     /**
@@ -237,5 +244,10 @@ abstract class Cache implements FlushableInterface
         $app->make('cache/request')->enable();
         $app->make('cache/expensive')->enable();
         $app->make('cache')->enable();
+
+        // See: https://github.com/concretecms/concretecms/issues/12422
+        $em = $app->make(EntityManagerInterface::class);
+        $ormMdCache = $app->make('orm/cache');
+        $em->getMetadataFactory()->setCache(new DoctrineAdapter($ormMdCache));
     }
 }

--- a/tests/tests/Cache/CacheTest.php
+++ b/tests/tests/Cache/CacheTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Concrete\Tests\Cache;
+
+use Concrete\Core\Cache\Cache;
+use Concrete\Core\Application\Application;
+use Concrete\Core\Support\Facade\Application as ApplicationFacade;
+use Concrete\Tests\TestCase;
+use Doctrine\ORM\EntityManagerInterface;
+
+class CacheTest extends TestCase
+{
+    /** @var array */
+    private $original;
+
+    /** @var \Concrete\Core\Cache\Level\RequestCache */
+    private $requestCache;
+
+    /** @var \Concrete\Core\Cache\Level\ExpensiveCache */
+    private $expensiveCache;
+
+    /** @var \Concrete\Core\Cache\Level\ObjectCache */
+    private $cache;
+
+    /** @var EntityManagerInterface */
+    private $em;
+
+    /**
+     * @before
+     */
+    public function beforeEach(): void
+    {
+        $app = ApplicationFacade::getFacadeApplication();
+        $this->original = [
+            'cache/request' => $app->make('cache/request'),
+            'cache/expensive' => $app->make('cache/expensive'),
+            'cache' => $app->make('cache'),
+            EntityManagerInterface::class => $app->make(EntityManagerInterface::class),
+        ];
+
+        $this->requestCache = $this->getMockBuilder('Concrete\Core\Cache\Level\RequestCache')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->expensiveCache = $this->getMockBuilder('Concrete\Core\Cache\Level\ExpensiveCache')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->cache = $this->getMockBuilder('Concrete\Core\Cache\Level\ObjectCache')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $this->em = $this->getMockBuilder('Doctrine\ORM\EntityManager')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $overrides = [
+            'cache/request' => $this->requestCache,
+            'cache/expensive' => $this->expensiveCache,
+            'cache' => $this->cache,
+            EntityManagerInterface::class => $this->em,
+        ];
+        foreach ($overrides as $key => $value) {
+            $app->bind($key, function () use ($value) {
+                return $value;
+            });
+        }
+    }
+
+    public function afterEach(): void
+    {
+        $app = ApplicationFacade::getFacadeApplication();
+        foreach ($this->original as $key => $value) {
+            $app->bind($key, function () use ($value) {
+                return $value;
+            });
+        }
+    }
+
+    public function testEnableAll(): void
+    {
+        $mdFactory = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadataFactory')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mdFactory->expects($this->once())->method('setCache')->with(
+            $this->isInstanceOf('Symfony\Component\Cache\Adapter\DoctrineAdapter')
+        );
+
+        $this->requestCache->expects($this->once())->method('enable');
+        $this->expensiveCache->expects($this->once())->method('enable');
+        $this->cache->expects($this->once())->method('enable');
+        $this->em->expects($this->once())->method('getMetadataFactory')->willReturn($mdFactory);
+
+        Cache::enableAll();
+    }
+
+    public function testEnableAllWithoutDbConnection(): void
+    {
+        $app = ApplicationFacade::getFacadeApplication();
+        $config = $app->make('config');
+        $conn = $config->get('database.default-connection');
+        $config->set('database.default-connection', null);
+
+        $this->requestCache->expects($this->once())->method('enable');
+        $this->expensiveCache->expects($this->once())->method('enable');
+        $this->cache->expects($this->once())->method('enable');
+        $this->em->expects($this->never())->method('getMetadataFactory');
+
+        Cache::enableAll();
+
+        $config->set('database.default-connection', $conn);
+    }
+
+    public function testDisableAll(): void
+    {
+        $mdFactory = $this->getMockBuilder('Doctrine\ORM\Mapping\ClassMetadataFactory')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $mdFactory->expects($this->once())->method('setCache')->with(
+            $this->isInstanceOf('Symfony\Component\Cache\Adapter\DoctrineAdapter')
+        );
+
+        $this->requestCache->expects($this->once())->method('disable');
+        $this->expensiveCache->expects($this->once())->method('disable');
+        $this->cache->expects($this->once())->method('disable');
+        $this->em->expects($this->once())->method('getMetadataFactory')->willReturn($mdFactory);
+
+        Cache::disableAll();
+    }
+
+    public function testDisableAllWithoutDbConnection(): void
+    {
+        $app = ApplicationFacade::getFacadeApplication();
+        $config = $app->make('config');
+        $conn = $config->get('database.default-connection');
+        $config->set('database.default-connection', null);
+
+        $this->requestCache->expects($this->once())->method('disable');
+        $this->expensiveCache->expects($this->once())->method('disable');
+        $this->cache->expects($this->once())->method('disable');
+        $this->em->expects($this->never())->method('getMetadataFactory');
+
+        Cache::disableAll();
+
+        $config->set('database.default-connection', $conn);
+    }
+}

--- a/tests/tests/Cache/CacheTest.php
+++ b/tests/tests/Cache/CacheTest.php
@@ -64,6 +64,9 @@ class CacheTest extends TestCase
         }
     }
 
+    /**
+     * @after
+     */
     public function afterEach(): void
     {
         $app = ApplicationFacade::getFacadeApplication();

--- a/tests/tests/Express/EntryCacheTest.php
+++ b/tests/tests/Express/EntryCacheTest.php
@@ -100,7 +100,9 @@ class EntryCacheTest extends ConcreteDatabaseTestCase
         // Clear the loaded metadata for it to load again with the caching
         // layer. There is no other way doing this than through ReflectionClass.
         $reflectionClass = new \ReflectionClass('Doctrine\Persistence\Mapping\AbstractClassMetadataFactory');
-        $reflectionClass->getProperty('loadedMetadata')->setValue($mdf, []);
+        $prop = $reflectionClass->getProperty('loadedMetadata');
+        $prop->setAccessible(true); // needed for PHP 7
+        $prop->setValue($mdf, []);
     }
 
     public function tearDown(): void

--- a/tests/tests/Express/EntryCacheTest.php
+++ b/tests/tests/Express/EntryCacheTest.php
@@ -117,7 +117,7 @@ class EntryCacheTest extends ConcreteDatabaseTestCase
         Cache::disableAll();
     }
 
-    public function testReadEntryProductionCacheEnabled()
+    public function testReadEntryProductionCacheEnabled(): void
     {
         Express::buildEntry('person')
             ->setPersonFirstName('Antti')
@@ -129,7 +129,7 @@ class EntryCacheTest extends ConcreteDatabaseTestCase
         $this->assertEquals('Hukkanen', $entry->getPersonLastName());
     }
 
-    public function testReadEntryProductionCacheDisabled()
+    public function testReadEntryProductionCacheDisabled(): void
     {
         // Ensure the temporary expensive cache is disabled
         Core::make('test/cache/expensive')->disable();

--- a/tests/tests/Express/EntryCacheTest.php
+++ b/tests/tests/Express/EntryCacheTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Concrete\Tests\Express;
+
+use Concrete\Core\Attribute\Key\Category;
+use Concrete\Core\Cache\Cache;
+use Concrete\Core\Cache\Adapter\DoctrineCacheDriver;
+use Concrete\Core\Express\Search\ColumnSet\DefaultSet;
+use Concrete\TestHelpers\Database\ConcreteDatabaseTestCase;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Cache\Adapter\DoctrineAdapter;
+use Core;
+use Express;
+
+class EntryCacheTest extends ConcreteDatabaseTestCase
+{
+    protected $pkg;
+
+    protected $tables = [
+        'Trees',
+        'TreeNodes',
+        'TreeGroupNodes',
+        'TreeTypes',
+        'TreeNodeTypes',
+        'TreeNodePermissionAssignments',
+        'PermissionAccessEntities',
+        'PermissionAccessEntityGroups',
+        'PermissionAccessEntityTypes',
+        'PermissionKeys',
+        'PermissionKeyCategories',
+        'Groups',
+    ];
+
+    protected $metadatas = [
+        'Concrete\Core\Entity\Express\Entity',
+        'Concrete\Core\Entity\Express\Entry',
+        'Concrete\Core\Entity\Express\Entry\Association',
+        'Concrete\Core\Entity\Express\Entry\AssociationEntry',
+        'Concrete\Core\Entity\Attribute\Category',
+        'Concrete\Core\Entity\Attribute\Value\ExpressValue',
+        'Concrete\Core\Entity\Attribute\Value\Value\Value',
+        'Concrete\Core\Entity\Attribute\Value\Value\TextValue',
+        'Concrete\Core\Entity\Attribute\Value\Value\ExpressValue',
+        'Concrete\Core\Entity\Attribute\Value\Value\AddressValue',
+        'Concrete\Core\Entity\Express\Association',
+        'Concrete\Core\Entity\Attribute\Type',
+        'Concrete\Core\Entity\Attribute\Key\ExpressKey',
+        'Concrete\Core\Entity\Attribute\Key\Key',
+        'Concrete\Core\Entity\Attribute\Key\Settings\TextSettings',
+        'Concrete\Core\Entity\Attribute\Key\Settings\AddressSettings',
+        'Concrete\Core\Entity\Attribute\Key\Settings\TextareaSettings',
+    ];
+
+    public function setUp(): void
+    {
+        $config = Core::make('config');
+        $config->set('concrete.cache.enabled', true);
+        $config->set('concrete.cache.doctrine_dev_mode', false);
+
+        parent::setUp();
+
+        $this->truncateTables();
+
+        \Concrete\Core\Tree\Node\NodeType::add('category');
+        \Concrete\Core\Tree\Node\NodeType::add('express_entry_category');
+        \Concrete\Core\Tree\TreeType::add('express_entry_results');
+        \Concrete\Core\Tree\Node\NodeType::add('express_entry_results');
+
+        $tree = \Concrete\Core\Tree\Type\ExpressEntryResults::add();
+
+        Category::add('express');
+
+        $factory = \Core::make('\Concrete\Core\Attribute\TypeFactory');
+        $factory->add('text', 'Text');
+
+        $person = Express::buildObject('person', 'people', 'Person');
+        $person->addAttribute('text', 'First Name', 'person_first_name');
+        $person->addAttribute('text', 'Last Name', 'person_last_name');
+        $entity = $person->save();
+
+        // Make sure the `result_column_set` column has a value
+        $entity->setResultColumnSet(new DefaultSet($entity->getAttributeKeyCategory()));
+        $em = Core::make(EntityManagerInterface::class);
+        $em->persist($entity);
+        $em->flush();
+
+        // This is the production cache setting that is normally applied. This
+        // would happen when `concrete.cache.doctrine_dev_mode` is not enabled
+        // (default).
+        Core::singleton('test/cache/expensive', function () {
+            $cache = new \Concrete\Core\Cache\Level\ExpensiveCache();
+            $cache->enable();
+            return $cache;
+        });
+        $ormMdCache = new DoctrineCacheDriver('test/cache/expensive');
+        $em = Core::make(EntityManagerInterface::class);
+        $mdf = $em->getMetadataFactory();
+        $mdf->setCache(new DoctrineAdapter($ormMdCache));
+
+        // Clear the loaded metadata for it to load again with the caching
+        // layer. There is no other way doing this than through ReflectionClass.
+        $reflectionClass = new \ReflectionClass('Doctrine\Persistence\Mapping\AbstractClassMetadataFactory');
+        $reflectionClass->getProperty('loadedMetadata')->setValue($mdf, []);
+    }
+
+    public function tearDown(): void
+    {
+        $config = Core::make('config');
+        $config->set('concrete.cache.enabled', false);
+        $config->set('concrete.cache.doctrine_dev_mode', true);
+
+        parent::tearDown();
+
+        // Reset to default
+        Cache::disableAll();
+    }
+
+    public function testReadEntryProductionCacheEnabled()
+    {
+        Express::buildEntry('person')
+            ->setPersonFirstName('Antti')
+            ->setPersonLastName('Hukkanen')
+            ->save();
+
+        $entry = Express::getEntry(1);
+        $this->assertEquals('Antti', $entry->getPersonFirstName());
+        $this->assertEquals('Hukkanen', $entry->getPersonLastName());
+    }
+
+    public function testReadEntryProductionCacheDisabled()
+    {
+        // Ensure the temporary expensive cache is disabled
+        Core::make('test/cache/expensive')->disable();
+
+        // It should be set to the ArrayCache when this is called. If not, the
+        // test below would fail. The test below also fails if the line below
+        // is commented out.
+        // See: https://github.com/concretecms/concretecms/issues/12422
+        Cache::disableAll();
+
+        Express::buildEntry('person')
+            ->setPersonFirstName('Antti')
+            ->setPersonLastName('Hukkanen')
+            ->save();
+
+        $entry = Express::getEntry(1);
+        $this->assertEquals('Antti', $entry->getPersonFirstName());
+        $this->assertEquals('Hukkanen', $entry->getPersonLastName());
+    }
+}


### PR DESCRIPTION
There is currently an issue with managing the express entries when production cache is disabled. This can cause queued page reindex commands to fail in case they deal with express entries because all caches are disabled in this situation as defined here:

https://github.com/concretecms/concretecms/blob/fe8c803d502dd9f3d02fd3fa0c726287082255a2/concrete/src/Messenger/MessengerEventSubscriber.php#L34

The issue is explained in more detail at #12422.

The added test case tests this situation and you can verify this issue by running that case without the added fix.

Fixes #12422