### PR TITLE
Add a test case for file system cache fetch failure

### DIFF
--- a/tests/tests/Cache/Driver/FileSystemStashDriverTest.php
+++ b/tests/tests/Cache/Driver/FileSystemStashDriverTest.php
@@ -54,7 +54,7 @@ class FileSystemStashDriverTest extends ConcreteDatabaseTestCase
         $this->assertNull($driver->getData(['foobar']));
     }
 
-    private function storeTestData(DriverInterface $driver, mixed $data): void
+    private function storeTestData(DriverInterface $driver, string $data): void
     {
         $driver->storeData(['foobar'], $data, time() + 30);
     }

--- a/tests/tests/Cache/Driver/FileSystemStashDriverTest.php
+++ b/tests/tests/Cache/Driver/FileSystemStashDriverTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Concrete\Tests\Cache\Driver;
+
+use Concrete\Core\Support\Facade\Application;
+use Concrete\TestHelpers\Database\ConcreteDatabaseTestCase;
+use Stash\Interfaces\DriverInterface;
+use Stash\Driver\FileSystem\EncoderInterface;
+use Stash\Driver\FileSystem\NativeEncoder;
+use Mockery;
+
+/**
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class FileSystemStashDriverTest extends ConcreteDatabaseTestCase
+{
+    protected $tables = ['Logs'];
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $mock = Mockery::mock('overload:' . NativeEncoder::class, EncoderInterface::class);
+        $mock->shouldReceive('getExtension', 'serialize');
+        $mock->shouldReceive('deserialize')->andReturnUsing(function($path) {
+            // This emulates a situation where the cache file is being included
+            // after it was removed from the file system. This can happen if the
+            // file was removed after the `file_exists` check in this class.
+            include(__DIR__ . '/foobar.php');
+        });
+    }
+
+    public function tearDown(): void
+    {
+        Mockery::close();
+
+        parent::tearDown();
+    }
+
+    public function testExpensiveFilesystemCache(): void
+    {
+        $driver = $this->buildDriver('expensive');
+        $this->storeTestData($driver, 'Testing data');
+
+        $this->assertNull($driver->getData(['foobar']));
+    }
+
+    public function testOverridesFilesystemCache(): void
+    {
+        $driver = $this->buildDriver('overrides');
+        $this->storeTestData($driver, 'Testing data');
+
+        $this->assertNull($driver->getData(['foobar']));
+    }
+
+    private function storeTestData(DriverInterface $driver, mixed $data): void
+    {
+        $driver->storeData(['foobar'], $data, time() + 30);
+    }
+
+    private function buildDriver(string $level): DriverInterface
+    {
+        $app = Application::getFacadeApplication();
+        $config = $app['config']->get("concrete.cache.levels.{$level}.drivers.core_filesystem");
+
+        return new $config['class'](array_get($config, 'options'));
+    }
+}


### PR DESCRIPTION
I was trying to fix a bug related to certain cache fetch failures with the file system cache (#12427) which is why I wrote this test case.

After investigating the bug, I noticed the original issue in 9.3.x has been already fixed in 9.4.x through this commit: https://github.com/concretecms/concretecms/commit/a89860b3ee3ddc51b0b3de342beb18f5460a68ec

The original issue is further explained at #12427. This PR only adds a test case to ensure this would not happen again.