### PR TITLE
Let BlockController::import() return the created Block

### DIFF
--- a/concrete/src/Block/BlockController.php
+++ b/concrete/src/Block/BlockController.php
@@ -412,6 +412,13 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
         return $this->btTable;
     }
 
+    /**
+     * @param \Concrete\Core\Page\Page $page
+     * @param string $arHandle
+     * @param \SimpleXMLElement $blockNode
+     *
+     * @return \Concrete\Core\Block\Block
+     */
     public function import($page, $arHandle, \SimpleXMLElement $blockNode)
     {
         $xml = $this->app->make(Xml::class);
@@ -467,6 +474,8 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
             $blockController = $b->getController(); // We have to do this because we need it loaded with the right block object, data.
             $this->app->make(AggregateTracker::class)->track($blockController);
         }
+
+        return $b;
     }
 
     /**


### PR DESCRIPTION
This is required by the migration tool - see [here](https://github.com/concretecms/migration_tool/blob/4a1ebefce92aae4360e4e4504f836a669d23025f/src/PortlandLabs/Concrete5/MigrationTool/Publisher/Block/CIFPublisher.php#L17) and [here](https://github.com/concretecms/migration_tool/blob/4a1ebefce92aae4360e4e4504f836a669d23025f/src/PortlandLabs/Concrete5/MigrationTool/Publisher/Command/Handler/PublishPageContentCommandHandler.php#L60-L74)