### PR TITLE
Improve registration of multilingual services

### DIFF
--- a/concrete/src/Multilingual/MultilingualServiceProvider.php
+++ b/concrete/src/Multilingual/MultilingualServiceProvider.php
@@ -7,10 +7,11 @@ class MultilingualServiceProvider extends ServiceProvider
 {
     public function register()
     {
+        $this->app->bind('multilingual/interface/flag', Service\UserInterface\Flag::class);
+        $this->app->bind('multilingual/extractor', Service\Extractor::class);
+
         $singletons = array(
             'multilingual/interface/flag' => '\Concrete\Core\Multilingual\Service\UserInterface\Flag',
-            'multilingual/detector' => '\Concrete\Core\Multilingual\Service\Detector',
-            'multilingual/extractor' => '\Concrete\Core\Multilingual\Service\Extractor',
         );
 
         foreach ($singletons as $key => $value) {

--- a/concrete/src/Multilingual/MultilingualServiceProvider.php
+++ b/concrete/src/Multilingual/MultilingualServiceProvider.php
@@ -9,13 +9,11 @@ class MultilingualServiceProvider extends ServiceProvider
     {
         $this->app->bind('multilingual/interface/flag', Service\UserInterface\Flag::class);
         $this->app->bind('multilingual/extractor', Service\Extractor::class);
-
-        $singletons = array(
-            'multilingual/interface/flag' => '\Concrete\Core\Multilingual\Service\UserInterface\Flag',
-        );
-
-        foreach ($singletons as $key => $value) {
-            $this->app->singleton($key, $value);
+        foreach ([
+            'multilingual/detector' => Service\Detector::class,
+        ] as $alias => $class) {
+            $this->app->singleton($class);
+            $this->app->alias($class, $alias);
         }
     }
 }


### PR DESCRIPTION
`UserInterface\Flag` and `Service\Extractor` don't store any state in their own instance, so it's pretty useless to mark them as singletons (they eat memory for no reason).

We also have the `multilingual/detector` singleton, but `Detector` isn't: let's make the former an alias of the latter.