### PR TITLE
Performance improvement: Do not get style sets and global stacks repeatedly

### DIFF
--- a/concrete/config/app.php
+++ b/concrete/config/app.php
@@ -137,6 +137,8 @@ return [
         'core_summary' => '\Concrete\Core\Summary\ServiceProvider',
         'core_boards' => '\Concrete\Core\Board\ServiceProvider',
         'core_page' => \Concrete\Core\Page\PageServiceProvider::class,
+        'core_block' => \Concrete\Core\Block\BlockServiceProvider::class,
+        'core_area' => \Concrete\Core\Area\AreaServiceProvider::class,
 
         // Authentication
         'core_oauth' => '\Concrete\Core\Authentication\Type\OAuth\ServiceProvider',

--- a/concrete/src/Area/AreaServiceProvider.php
+++ b/concrete/src/Area/AreaServiceProvider.php
@@ -1,9 +1,10 @@
 <?php
-namespace Concrete\Core\Block;
+
+namespace Concrete\Core\Area;
 
 use Concrete\Core\Foundation\Service\Provider as ServiceProvider;
 
-class BlockServiceProvider extends ServiceProvider
+class AreaServiceProvider extends ServiceProvider
 {
     public function register()
     {

--- a/concrete/src/Area/CustomStyleRepository.php
+++ b/concrete/src/Area/CustomStyleRepository.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Concrete\Core\Area;
+
+use Concrete\Core\Area\CustomStyle as AreaCustomStyle;
+use Concrete\Core\Database\Connection\Connection;
+use Concrete\Core\Page\Collection\Collection;
+use Concrete\Core\Page\Collection\Version\Version;
+use Concrete\Core\Page\Stack\Stack;
+use Concrete\Core\Page\Theme\Theme;
+use Concrete\Core\StyleCustomizer\Inline\StyleSet;
+use Concrete\Core\Utility\Service\Text;
+
+class CustomStyleRepository
+{
+    protected $connection;
+    protected $text;
+    protected $styles = [];
+
+    function __construct(Connection $connection, Text $text)
+    {
+        $this->connection = $connection;
+        $this->text = $text;
+    }
+
+    /**
+     * @param \Concrete\Core\Page\Collection\Collection $collection
+     * @return array|AreaCustomStyle[]
+     */
+    public function getCollectionVersionAreaStyles(Collection $collection): array
+    {
+        $this->loadCollectionVersionAreaStyleRecords($collection->getCollectionID(), $collection->getVersionID());
+        $styles = [];
+        foreach ($this->styles[$collection->getCollectionID()] as $arHandle => $issID) {
+            $arHandle = $this->text->filterNonAlphaNum($arHandle);
+            $obj = StyleSet::getByID($issID);
+            if (is_object($obj)) {
+                $a = new Area($arHandle);
+                $obj = new AreaCustomStyle($obj, $a, $collection->getCollectionThemeObject());
+                $styles[] = $obj;
+            }
+        }
+
+        return $styles;
+    }
+
+    /**
+     * @param \Concrete\Core\Page\Collection\Version\Version $version
+     * @return array
+     */
+    public function getCollectionVersionAreaStyleIDs(Version $version): array
+    {
+        $this->loadCollectionVersionAreaStyleRecords($version->getCollectionID(), $version->getVersionID());
+
+        return $this->styles[$version->getCollectionID()] ?? [];
+    }
+
+    /**
+     * @param \Concrete\Core\Page\Stack\Stack $stack
+     * @param \Concrete\Core\Page\Theme\Theme $theme
+     * @return array|AreaCustomStyle[]
+     */
+    public function getStackAreaStyles(Stack $stack, Theme $theme): array
+    {
+        $this->loadCollectionVersionAreaStyleRecords($stack->getCollectionID(), $stack->getVersionID());
+        $styles = [];
+        foreach ($this->styles[$stack->getCollectionID()] as $arHandle => $issID) {
+            $arHandle = $this->text->filterNonAlphaNum($arHandle);
+            $obj = StyleSet::getByID($issID);
+            if (is_object($obj)) {
+                $a = new GlobalArea($arHandle);
+                $obj = new AreaCustomStyle($obj, $a, $theme);
+                $styles[] = $obj;
+            }
+        }
+
+        return $styles;
+    }
+
+    protected function loadCollectionVersionAreaStyleRecords(int $collectionID, int $versionID): void
+    {
+        if (!isset($this->styles[$collectionID])) {
+            $qb = $this->connection->createQueryBuilder();
+            $qb->select('arHandle', 'issID')
+                ->from('CollectionVersionAreaStyles')
+                ->where('cID = :cID')
+                ->andWhere('cvID = :cvID')
+                ->andWhere('issID > 0')
+                ->setParameter(':cID', $collectionID)
+                ->setParameter(':cvID', $versionID);
+            $r = $qb->execute()->fetchAllAssociative();
+            if (count($r) > 0) {
+                foreach ($r as $row) {
+                    $this->styles[$collectionID][$row['arHandle']] = $row['issID'];
+                }
+            } else {
+                $this->styles[$collectionID] = [];
+            }
+        }
+    }
+}

--- a/concrete/src/Block/Block.php
+++ b/concrete/src/Block/Block.php
@@ -943,33 +943,11 @@ EOT
      */
     public function getCustomStyleSetID()
     {
-        /** @var Connection $db */
-        $db = app(Connection::class);
         if (!isset($this->issID)) {
-            $co = $this->getBlockCollectionObject();
-
-            $arHandle = $this->getAreaHandle();
-            if ($arHandle && is_object($co)) {
-                $a = $this->getBlockAreaObject();
-                if ($a->isGlobalArea()) {
-                    // then we need to check against the global area name. We currently have the wrong area handle passed in
-                    $arHandle = STACKS_AREA_NAME;
-                }
-
-                $v = [
-                    $co->getCollectionID(),
-                    $co->getVersionID(),
-                    $arHandle,
-                    $this->getBlockID(),
-                ];
-
-                $this->issID = (int) $db->fetchOne(
-                    'select issID from CollectionVersionBlockStyles where cID = ? and cvID = ? and arHandle = ? and bID = ?',
-                    $v
-                );
-            } else {
-                $this->issID = 0;
-            }
+            /** @var \Concrete\Core\Block\CustomStyleRepository $customStyleRepository */
+            $customStyleRepository = app(CustomStyleRepository::class);
+            $issID = $customStyleRepository->getBlockStyleID($this);
+            $this->issID = $issID ?: 0;
         }
 
         return $this->issID;

--- a/concrete/src/Block/CustomStyleRepository.php
+++ b/concrete/src/Block/CustomStyleRepository.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Concrete\Core\Block;
+
+use Concrete\Core\Area\Area;
+use Concrete\Core\Area\GlobalArea;
+use Concrete\Core\Block\CustomStyle as BlockCustomStyle;
+use Concrete\Core\Database\Connection\Connection;
+use Concrete\Core\Page\Collection\Collection;
+use Concrete\Core\Page\Stack\Stack;
+use Concrete\Core\Page\Theme\Theme;
+use Concrete\Core\StyleCustomizer\Inline\StyleSet;
+use Concrete\Core\Utility\Service\Text;
+
+class CustomStyleRepository
+{
+    protected $connection;
+    protected $text;
+    protected $styles = [];
+
+    function __construct(Connection $connection, Text $text)
+    {
+        $this->connection = $connection;
+        $this->text = $text;
+    }
+
+    /**
+     * @param \Concrete\Core\Page\Collection\Collection $collection
+     * @return array|BlockCustomStyle[]
+     */
+    public function getCollectionVersionBlockStyles(Collection $collection): array
+    {
+        $this->loadCollectionVersionBlockStyleRecords($collection->getCollectionID(), $collection->getVersionID());
+        $styles = [];
+        foreach ($this->styles[$collection->getCollectionID()] as $arHandle => $blocks) {
+            foreach ($blocks as $bID => $issID) {
+                $arHandle = $this->text->filterNonAlphaNum($arHandle);
+                $obj = StyleSet::getByID($issID);
+                if (is_object($obj)) {
+                    $b = new Block();
+                    $b->bID = $bID;
+                    $a = new Area($arHandle);
+                    $b->setBlockAreaObject($a);
+                    $obj = new BlockCustomStyle($obj, $b, $collection->getCollectionThemeObject());
+                    $styles[] = $obj;
+                }
+            }
+        }
+
+        return $styles;
+    }
+
+    /**
+     * @param \Concrete\Core\Page\Stack\Stack $stack
+     * @param \Concrete\Core\Page\Theme\Theme $theme
+     * @return array|BlockCustomStyle[]
+     */
+    public function getStackBlockStyles(Stack $stack, Theme $theme): array
+    {
+        $this->loadCollectionVersionBlockStyleRecords($stack->getCollectionID(), $stack->getVersionID());
+        $styles = [];
+        foreach ($this->styles[$stack->getCollectionID()] as $blocks) {
+            foreach ($blocks as $bID => $issID) {
+                $obj = StyleSet::getByID($issID);
+                if (is_object($obj)) {
+                    $b = new Block();
+                    $b->bID = $bID;
+                    $a = new GlobalArea($stack->getStackName());
+                    $b->setBlockAreaObject($a);
+                    $obj = new BlockCustomStyle($obj, $b, $theme);
+                    $styles[] = $obj;
+                }
+            }
+        }
+
+        return $styles;
+    }
+
+    /**
+     * @param \Concrete\Core\Block\Block $block
+     * @return int|null
+     */
+    public function getBlockStyleID(Block $block): ?int
+    {
+        $collection = $block->getBlockCollectionObject();
+        $blockAreaHandle = $block->getAreaHandle();
+        if ($blockAreaHandle && is_object($collection)) {
+            $this->loadCollectionVersionBlockStyleRecords($collection->getCollectionID(), $collection->getVersionID());
+            $a = $block->getBlockAreaObject();
+            if ($a->isGlobalArea()) {
+                // then we need to check against the global area name. We currently have the wrong area handle passed in
+                $blockAreaHandle = STACKS_AREA_NAME;
+            }
+            foreach ($this->styles[$collection->getCollectionID()] as $arHandle => $blocks) {
+                if ($arHandle == $blockAreaHandle) {
+                    foreach ($blocks as $bID => $issID) {
+                        if ($bID == $block->getBlockID()) {
+                            return (int) $issID;
+                        }
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+
+    protected function loadCollectionVersionBlockStyleRecords(int $collectionID, int $versionID)
+    {
+        if (!isset($this->styles[$collectionID])) {
+            $qb = $this->connection->createQueryBuilder();
+            $qb->select('bID', 'arHandle', 'issID')
+                ->from('CollectionVersionBlockStyles')
+                ->where('cID = :cID')
+                ->andWhere('cvID = :cvID')
+                ->andWhere('issID > 0')
+                ->setParameter(':cID', $collectionID)
+                ->setParameter(':cvID', $versionID);
+            $r = $qb->execute()->fetchAllAssociative();
+            if (count($r) > 0) {
+                foreach ($r as $row) {
+                    $this->styles[$collectionID][$row['arHandle']][$row['bID']] = $row['issID'];
+                }
+            } else {
+                $this->styles[$collectionID] = [];
+            }
+        }
+    }
+}

--- a/concrete/src/Page/Collection/Version/Version.php
+++ b/concrete/src/Page/Collection/Version/Version.php
@@ -1,6 +1,7 @@
 <?php
 namespace Concrete\Core\Page\Collection\Version;
 
+use Concrete\Core\Area\CustomStyleRepository as AreaCustomStyleRepository;
 use Concrete\Core\Attribute\Key\CollectionKey;
 use Concrete\Core\Attribute\ObjectTrait;
 use Concrete\Core\Board\Command\RefreshRelevantBoardInstancesCommand;
@@ -553,15 +554,9 @@ class Version extends ConcreteObject implements PermissionObjectInterface, Attri
     {
         if (!isset($this->customAreaStyles)) {
             $app = Facade::getFacadeApplication();
-            $db = $app->make('database')->connection();
-            $r = $db->fetchAll('select issID, arHandle from CollectionVersionAreaStyles where cID = ? and cvID = ?', array(
-                $this->getCollectionID(),
-                $this->cvID,
-            ));
-            $this->customAreaStyles = array();
-            foreach ($r as $styles) {
-                $this->customAreaStyles[$styles['arHandle']] = $styles['issID'];
-            }
+            /** @var AreaCustomStyleRepository $customAreaStyleRepository */
+            $customAreaStyleRepository = $app->make(AreaCustomStyleRepository::class);
+            $this->customAreaStyles = $customAreaStyleRepository->getCollectionVersionAreaStyleIDs($this);
         }
 
         return $this->customAreaStyles;


### PR DESCRIPTION
Currently, we're trying to get custom style sets for every areas or blocks by running separate SQL queries.
It increases a number of queries when you have a long page that has a lot of areas and blocks.
Let's introduce shared repositories to reduce queries.

Before
![before](https://github.com/user-attachments/assets/ef6d8082-f89e-4888-a5a3-1179704981cb)
After - Reduced 15 statements
![after](https://github.com/user-attachments/assets/94eeab90-b921-4a9a-b559-4c01a178a7b3)

Also, we're getting global stacks twice at every request. Let's stop to do it we don't need to.

![Screenshot 2025-01-26 at 12 09 57](https://github.com/user-attachments/assets/a389d45e-26c7-44dd-94db-f18b0b19d1f7)
