### PR TITLE
Performance Improvement: Do not get home page twice

### DIFF
--- a/concrete/blocks/top_navigation_bar/controller.php
+++ b/concrete/blocks/top_navigation_bar/controller.php
@@ -101,6 +101,7 @@ class Controller extends BlockController implements UsesFeatureInterface, FileTr
     protected $btCacheBlockOutputForRegisteredUsers = true;
     protected $btCacheBlockOutputLifetime = 300;
     protected $btExportFileColumns = ['brandingLogo', 'brandingTransparentLogo'];
+    protected $home;
 
     /**
      * {@inheritdoc}
@@ -197,14 +198,18 @@ class Controller extends BlockController implements UsesFeatureInterface, FileTr
 
     protected function getHomePage(): Page
     {
-        $section = Section::getByLocale(\Localization::getInstance()->getLocale());
-        if ($section instanceof Section) {
-            $home = \Page::getByID($section->getSiteHomePageID());
-        } else {
-            $site = $this->app->make('site')->getSite();
-            $home = $site->getSiteHomePageObject();
+        if ($this->home === null) {
+            $section = Section::getByLocale(\Localization::getInstance()->getLocale());
+            if ($section instanceof Section) {
+                $home = \Page::getByID($section->getSiteHomePageID());
+            } else {
+                $site = $this->app->make('site')->getSite();
+                $home = $site->getSiteHomePageObject();
+            }
+            $this->home = $home;
         }
-        return $home;
+
+        return $this->home;
     }
 
     protected function getNavigation(): Navigation


### PR DESCRIPTION
Top Navigation Bar block controller is getting the home page twice. Let's avoid it