### PR TITLE
Performance Improvement: Make gallery block record cacheable

### DIFF
--- a/concrete/blocks/gallery/controller.php
+++ b/concrete/blocks/gallery/controller.php
@@ -26,7 +26,7 @@ class Controller extends BlockController implements FileTrackableInterface, Uses
     protected $btInterfaceHeight = '820';
     protected $btExportTables = ['btGallery', 'btGalleryEntries', 'btGalleryEntryDisplayChoices'];
     protected $btExportFileColumns = ['fID'];
-    protected $btCacheBlockRecord = false;
+    protected $btCacheBlockRecord = true;
     protected $btCacheBlockOutput = true;
     protected $btCacheBlockOutputForRegisteredUsers = false;
     protected $btCacheBlockOutputOnPost = true;


### PR DESCRIPTION
Why we can't cache records of gallery blocks? For debugging? I think it's cacheable.

https://github.com/concretecms/concretecms/commit/e28413add8cbd8e1e221935e8a92b832559a64ae

In my local environment, this is the last duplicated SQL query. Yey!

![Screenshot 2025-01-26 at 16 29 10](https://github.com/user-attachments/assets/5a8b8160-cc83-45c4-968b-e14a4b97002b)
