### PR TITLE
Fix clicking on "sort by" labels while adding/editing a board

### DIFF
--- a/concrete/single_pages/dashboard/boards/add.php
+++ b/concrete/single_pages/dashboard/boards/add.php
@@ -26,15 +26,15 @@ $buttonText = t("Add");
             </label>
 
             <div class="form-check">
-                <?= $form->radio('sortBy', 'relevant_date_desc', true) ?>
-                <label class="form-check-label" for="sortBy2">
+                <?= $form->radio('sortBy', 'relevant_date_desc', true, ['id' => 'sort-by-date-desc']) ?>
+                <label class="form-check-label" for="sort-by-date-desc">
                     <?= t('Descending Date.') . ' ' . t('(Only items from the past)') ?>
                 </label>
             </div>
 
             <div class="form-check">
-                <?= $form->radio('sortBy', 'relevant_date_asc') ?>
-                <label class="form-check-label" for="sortBy1">
+                <?= $form->radio('sortBy', 'relevant_date_asc', ['id' => 'sort-by-date-asc']) ?>
+                <label class="form-check-label" for="sort-by-date-asc">
                     <?= t('Ascending Date.') . ' ' . t('(Only items from the future)') ?>
                 </label>
             </div>

--- a/concrete/single_pages/dashboard/boards/edit.php
+++ b/concrete/single_pages/dashboard/boards/edit.php
@@ -34,15 +34,15 @@ $buttonText = t("Add");
                     </label>
 
                     <div class="form-check">
-                        <?= $form->radio('sortBy', 'relevant_date_desc', $sortBy) ?>
-                        <label class="form-check-label" for="sortBy2">
+                        <?= $form->radio('sortBy', 'relevant_date_desc', $sortBy, ['id' => 'sort-by-date-desc']) ?>
+                        <label class="form-check-label" for="sort-by-date-desc">
                             <?= t('Descending Date.') . ' ' . t('(Only items from the past)') ?>
                         </label>
                     </div>
 
                     <div class="form-check">
-                        <?= $form->radio('sortBy', 'relevant_date_asc', $sortBy) ?>
-                        <label class="form-check-label" for="sortBy1">
+                        <?= $form->radio('sortBy', 'relevant_date_asc', $sortBy, ['id' => 'sort-by-date-asc']) ?>
+                        <label class="form-check-label" for="sort-by-date-asc">
                             <?= t('Ascending Date.') . ' ' . t('(Only items from the future)') ?>
                         </label>
                     </div>


### PR DESCRIPTION
Let's fix this funny bug:


https://github.com/user-attachments/assets/6654f7c6-6353-4399-9ae2-bf20322e0a8b

