### PR TITLE
Fix exporting page fields when page can't be found [v8]

### DIFF
--- a/concrete/src/Backup/ContentExporter.php
+++ b/concrete/src/Backup/ContentExporter.php
@@ -87,8 +87,9 @@ class ContentExporter
     {
         if ($cID > 0) {
             $c = Page::getByID($cID);
-
-            return '{ccm:export:page:' . $c->getCollectionPath() . '}';
+            if ($c && !$c->isError()) {
+                return '{ccm:export:page:' . $c->getCollectionPath() . '}';
+            }
         }
     }
 


### PR DESCRIPTION
Same as #12451 but for concrete5 v8