### PR TITLE
Performance Improvement: PageList

### DIFF
--- a/concrete/src/Page/PageList.php
+++ b/concrete/src/Page/PageList.php
@@ -188,7 +188,6 @@ class PageList extends DatabaseItemList implements PagerProviderInterface, Pagin
 
     public function finalizeQuery(\Doctrine\DBAL\Query\QueryBuilder $query)
     {
-        $expr = $query->expr();
         if ($this->includeAliases) {
             $query->from('Pages', 'p')
                 ->leftJoin('p', 'Pages', 'pa', 'p.cPointerID = pa.cID')
@@ -262,13 +261,13 @@ class PageList extends DatabaseItemList implements PagerProviderInterface, Pagin
             } else {
                 switch ($this->siteTree) {
                     case self::SITE_TREE_CURRENT:
-                        $c = \Page::getCurrentPage();
+                        $c = Page::getCurrentPage();
                         $tree = false;
                         if (is_object($c) && !$c->isError()) {
                             $tree = $c->getSiteTreeObject();
                         }
                         if (!is_object($tree)) {
-                            $site = \Core::make('site')->getSite();
+                            $site = $app->make('site')->getSite();
                             $tree = $site->getSiteTreeObject();
                         }
                         break;

--- a/concrete/src/Page/PageList.php
+++ b/concrete/src/Page/PageList.php
@@ -209,24 +209,41 @@ class PageList extends DatabaseItemList implements PagerProviderInterface, Pagin
                 ->andWhere('p.cIsTemplate = 0');
         }
 
+        $app = Application::getFacadeApplication();
         switch ($this->pageVersionToRetrieve) {
             case self::PAGE_VERSION_RECENT:
-                $query->andWhere('cv.cvID = (select max(cvID) from CollectionVersions where cID = cv.cID)');
+                $query->innerJoin(
+                    'p',
+                    '(select cID, max(cvID) as max_cvID from CollectionVersions group by cID)',
+                    'cv_max',
+                    'cv_max.cID = p.cID and cv_max.max_cvID = cv.cvID'
+                );
                 break;
             case self::PAGE_VERSION_RECENT_UNAPPROVED:
-                $query
-                    ->andWhere('cv.cvID = (select max(cvID) from CollectionVersions where cID = cv.cID)')
-                    ->andWhere($expr->eq('cvIsApproved', 0));
+                $query->innerJoin(
+                    'p',
+                    '(select cID, max(cvID) as max_cvID from CollectionVersions where cvIsApproved = 0 group by cID)',
+                    'cv_max',
+                    'cv_max.cID = p.cID and cv_max.max_cvID = cv.cvID'
+                );
                 break;
             case self::PAGE_VERSION_SCHEDULED:
-                $now = new \DateTime();
-                $query->andWhere('cv.cvID = (select cvID from CollectionVersions where cID = cv.cID and cvIsApproved = 1 and ((cvPublishDate > :cvPublishDate) and (cvPublishEndDate >= :cvPublishDate or cvPublishEndDate is null)) order by cvPublishDate desc limit 1)');
-                $query->setParameter('cvPublishDate', $now->format('Y-m-d H:i:s'));
+                $query->innerJoin(
+                    'p',
+                    '(select cID, max(cvPublishDate) as max_cvPublishDate from CollectionVersions where cvIsApproved = 1 and ((cvPublishDate > :cvPublishDate) and (cvPublishEndDate >= :cvPublishDate or cvPublishEndDate is null)) group by cID)',
+                    'cv_max',
+                    'cv_max.cID = p.cID and cv_max.max_cvPublishDate = cv.cvPublishDate'
+                );
+                $query->setParameter('cvPublishDate', $app->make('date')->getOverridableNow());
                 break;
             case self::PAGE_VERSION_ACTIVE:
             default:
-                $app = Application::getFacadeApplication();
-                $query->andWhere('cv.cvID = (select max(cvID) from CollectionVersions where cID = cv.cID and cvIsApproved = 1 and ((cvPublishDate <= :cvPublishDate or cvPublishDate is null) and (cvPublishEndDate >= :cvPublishDate or cvPublishEndDate is null)))');
+                $query->innerJoin(
+                  'p',
+                  '(select cID, max(cvID) as max_cvID from CollectionVersions where cvIsApproved = 1 and ((cvPublishDate <= :cvPublishDate or cvPublishDate is null) and (cvPublishEndDate >= :cvPublishDate or cvPublishEndDate is null)) group by cID)',
+                  'cv_max',
+                  'cv_max.cID = p.cID and cv_max.max_cvID = cv.cvID'
+                );
                 $query->setParameter('cvPublishDate', $app->make('date')->getOverridableNow());
                 break;
         }


### PR DESCRIPTION
## Reduce execution time to get pages in the PageList class

This is the original query, and it takes 630ms to get pages on the site I'm working on now.

```
SELECT p.cID, cv.cvDatePublic FROM Pages p
	LEFT JOIN PagePaths pp ON p.cID = pp.cID and pp.ppIsCanonical = true
	LEFT JOIN PageSearchIndex psi ON p.cID = psi.cID
	LEFT JOIN PageTypes pt ON p.ptID = pt.ptID
	INNER JOIN Collections c ON p.cID = c.cID
	INNER JOIN CollectionVersions cv ON p.cID = cv.cID
	LEFT JOIN CollectionSearchIndexAttributes csi ON c.cID = csi.cID
	WHERE (pt.ptHandle = 'press')
		AND (pp.cPath LIKE "/pressroom/%")
		AND (pp.ppIsCanonical = 1)
		AND (p.cPointerID < 1)
		AND (p.cIsTemplate = 0)
		AND (cv.cvID = (select max(cvID) from CollectionVersions where cID = cv.cID and cvIsApproved = 1 and ((cvPublishDate <= "2025-02-06 18:28:23" or cvPublishDate is null) and (cvPublishEndDate >= "2025-02-06 18:28:23" or cvPublishEndDate is null)))) AND (p.cIsActive = true)
		AND (p.siteTreeID = 1)
		AND (p.cIsSystemPage = 0)
	ORDER BY cv.cvDatePublic desc
	LIMIT 10;
```

Here is the result of the "EXPLAIN ANALYZE". It runs a subquery to get max collection IDs more than 28k times to get only 10 rows.

```
-> Limit: 10 row(s)  (actual time=632..632 rows=10 loops=1)
    -> Sort: cv.cvDatePublic DESC, limit input to 10 row(s) per chunk  (actual time=632..632 rows=10 loops=1)
        -> Stream results  (cost=9.75 rows=9.59) (actual time=1.8..631 rows=327 loops=1)
            -> Nested loop inner join  (cost=9.75 rows=9.59) (actual time=1.79..631 rows=327 loops=1)
                -> Nested loop left join  (cost=8.72 rows=0.137) (actual time=1.57..4.83 rows=327 loops=1)
                    -> Nested loop left join  (cost=8.65 rows=0.137) (actual time=1.49..4.05 rows=327 loops=1)
                        -> Nested loop inner join  (cost=8.6 rows=0.137) (actual time=1.37..3.47 rows=327 loops=1)
                            -> Nested loop inner join  (cost=8.56 rows=0.137) (actual time=1.27..2.9 rows=327 loops=1)
                                -> Filter: ((p.cIsSystemPage = 0) and (p.cIsActive = true) and (p.cIsTemplate = 0) and (p.cPointerID < 1))  (cost=8.31 rows=0.627) (actual time=0.815..1.44 rows=329 loops=1)
                                    -> Index lookup on p using siteTreeID (siteTreeID=1), with index condition: (p.ptID = '8')  (cost=8.31 rows=904) (actual time=0.806..1.35 rows=331 loops=1)
                                -> Filter: ((pp.ppIsCanonical = 1) and (pp.cPath like '/pressroom/%'))  (cost=0.311 rows=0.219) (actual time=0.00291..0.00328 rows=0.994 loops=329)
                                    -> Index lookup on pp using cID (cID=p.cID)  (cost=0.311 rows=1.11) (actual time=0.00253..0.00285 rows=1.01 loops=329)
                            -> Single-row covering index lookup on c using PRIMARY (cID=p.cID)  (cost=0.978 rows=1) (actual time=0.00162..0.00164 rows=1 loops=327)
                        -> Single-row covering index lookup on psi using PRIMARY (cID=p.cID)  (cost=0.978 rows=1) (actual time=0.00162..0.00164 rows=0.994 loops=327)
                    -> Single-row covering index lookup on csi using PRIMARY (cID=p.cID)  (cost=1.16 rows=1) (actual time=0.00226..0.00231 rows=0.994 loops=327)
                -> Filter: (cv.cvID = (select #2))  (cost=51.4 rows=69.8) (actual time=1.91..1.91 rows=1 loops=327)
                    -> Index lookup on cv using PRIMARY (cID=p.cID)  (cost=51.4 rows=69.8) (actual time=0.0454..0.0651 rows=87.2 loops=327)
                    -> Select #2 (subquery in condition; dependent)
                        -> Aggregate: max(collectionversions.cvID)  (cost=0.524 rows=1) (actual time=0.021..0.0211 rows=1 loops=28525)
                            -> Filter: ((collectionversions.cvIsApproved = 1) and ((collectionversions.cvPublishDate <= TIMESTAMP'2025-02-06 18:28:23') or (collectionversions.cvPublishDate is null)) and ((collectionversions.cvPublishEndDate >= TIMESTAMP'2025-02-06 18:28:23') or (collectionversions.cvPublishEndDate is null)))  (cost=0.508 rows=0.159) (actual time=0.0207..0.0209 rows=1 loops=28525)
                                -> Covering index lookup on CollectionVersions using idxPublishDate (cID=cv.cID)  (cost=0.508 rows=54.3) (actual time=0.00549..0.0181 rows=127 loops=28525)
```

And here is the improved version of the query to get the same pages.

```
SELECT p.cID, cv.cvDatePublic FROM Pages p
	LEFT JOIN PagePaths pp ON p.cID = pp.cID and pp.ppIsCanonical = true
	LEFT JOIN PageSearchIndex psi ON p.cID = psi.cID
	LEFT JOIN PageTypes pt ON p.ptID = pt.ptID
	INNER JOIN Collections c ON p.cID = c.cID
	INNER JOIN CollectionVersions cv ON p.cID = cv.cID
	INNER JOIN (select cID, max(cvID) as max_cvID from CollectionVersions where cvIsApproved = 1 and ((cvPublishDate <= :cvPublishDate or cvPublishDate is null) and (cvPublishEndDate >= :cvPublishDate or cvPublishEndDate is null)) group by cID) cv_max ON cv_max.cID = p.cID and cv_max.max_cvID = cv.cvID
	LEFT JOIN CollectionSearchIndexAttributes csi ON c.cID = csi.cID
	WHERE (pt.ptHandle = :ptHandle)
		AND (pp.cPath LIKE :cPath)
		AND (pp.ppIsCanonical = 1)
		AND (p.cPointerID < 1)
		AND (p.cIsTemplate = 0)
		AND (p.cIsActive = :cIsActive)
		AND (p.siteTreeID = 1)
		AND (p.cIsSystemPage = 0)
	ORDER BY cv.cvDatePublic desc
	LIMIT 1000
```

This query ensures that the subquery for get max cvID is executed only once per cID, and reduces the overall execution time.

```
-> Limit: 1000 row(s)  (actual time=27.9..27.9 rows=327 loops=1)
    -> Sort: cv.cvDatePublic DESC, limit input to 1000 row(s) per chunk  (actual time=27.9..27.9 rows=327 loops=1)
        -> Stream results  (cost=31.2 rows=1.51) (actual time=21.2..27.7 rows=327 loops=1)
            -> Nested loop inner join  (cost=31.2 rows=1.51) (actual time=21.2..27.7 rows=327 loops=1)
                -> Nested loop inner join  (cost=29.6 rows=1.51) (actual time=21..25.1 rows=327 loops=1)
                    -> Nested loop left join  (cost=29 rows=0.137) (actual time=2.66..6.47 rows=327 loops=1)
                        -> Nested loop left join  (cost=28.9 rows=0.137) (actual time=2.04..5 rows=327 loops=1)
                            -> Nested loop inner join  (cost=28.8 rows=0.137) (actual time=1.1..3.75 rows=327 loops=1)
                                -> Nested loop inner join  (cost=28.7 rows=0.137) (actual time=0.843..3.03 rows=327 loops=1)
                                    -> Filter: ((p.cIsSystemPage = 0) and (p.cIsActive = true) and (p.cIsTemplate = 0) and (p.cPointerID < 1))  (cost=28.1 rows=0.627) (actual time=0.663..1.42 rows=329 loops=1)
                                        -> Index lookup on p using siteTreeID (siteTreeID=1), with index condition: (p.ptID = '8')  (cost=28.1 rows=904) (actual time=0.658..1.36 rows=331 loops=1)
                                    -> Filter: ((pp.ppIsCanonical = 1) and (pp.cPath like '/pressroom/%'))  (cost=0.904 rows=0.219) (actual time=0.00447..0.00476 rows=0.994 loops=329)
                                        -> Index lookup on pp using cID (cID=p.cID)  (cost=0.904 rows=1.11) (actual time=0.00426..0.00452 rows=1.01 loops=329)
                                -> Single-row covering index lookup on c using PRIMARY (cID=p.cID)  (cost=1.35 rows=1) (actual time=0.00206..0.00208 rows=1 loops=327)
                            -> Single-row covering index lookup on psi using PRIMARY (cID=p.cID)  (cost=0.978 rows=1) (actual time=0.0037..0.00372 rows=0.994 loops=327)
                        -> Single-row covering index lookup on csi using PRIMARY (cID=p.cID)  (cost=1.7 rows=1) (actual time=0.00438..0.0044 rows=0.994 loops=327)
                    -> Filter: (cv_max.max_cvID is not null)  (cost=1315..10.8 rows=11) (actual time=0.0567..0.0568 rows=1 loops=327)
                        -> Covering index lookup on cv_max using <auto_key0> (cID=p.cID)  (cost=1446..1456 rows=11) (actual time=0.0566..0.0567 rows=1 loops=327)
                            -> Materialize  (cost=1445..1445 rows=228) (actual time=18.3..18.3 rows=1427 loops=1)
                                -> Group aggregate: max(collectionversions.cvID)  (cost=1423 rows=228) (actual time=0.508..16.1 rows=1427 loops=1)
                                    -> Filter: (((collectionversions.cvPublishDate <= TIMESTAMP'2025-02-06 18:28:23') or (collectionversions.cvPublishDate is null)) and ((collectionversions.cvPublishEndDate >= TIMESTAMP'2025-02-06 18:28:23') or (collectionversions.cvPublishEndDate is null)))  (cost=1400 rows=228) (actual time=0.5..15.8 rows=1427 loops=1)
                                        -> Index lookup on CollectionVersions using cvIsApproved (cvIsApproved=1)  (cost=1400 rows=1428) (actual time=0.496..15.6 rows=1428 loops=1)
                -> Single-row index lookup on cv using PRIMARY (cID=p.cID, cvID=cv_max.max_cvID)  (cost=1.03 rows=1) (actual time=0.00785..0.00787 rows=1 loops=327)
```

## Reduce execution time to get a collection version

In the PageList, we're getting collection versions twice per page. I haven't fixed it yet.
See also: https://github.com/concretecms/concretecms/issues/12457