### PR TITLE
Always use concrete as CLI command namespace

### DIFF
--- a/concrete/src/Console/Command/ActivateThemeSkinCommand.php
+++ b/concrete/src/Console/Command/ActivateThemeSkinCommand.php
@@ -16,7 +16,11 @@ class ActivateThemeSkinCommand extends Command
 {
     protected function configure()
     {
-        $this->setName('concrete:theme:activate-skin')
+        $this
+            ->setName('concrete:theme:skin:activate')
+            ->setAliases([
+                'concrete:theme:activate-skin',
+            ])
             ->addOption(
                 'site',
                 's',

--- a/concrete/src/Console/Command/BulkUserAssignCommand.php
+++ b/concrete/src/Console/Command/BulkUserAssignCommand.php
@@ -21,7 +21,10 @@ class BulkUserAssignCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('c5:user-group:bulk-assign-users')
+            ->setName('concrete:user:group:assign:bulk')
+            ->setAliases([
+                'c5:user-group:bulk-assign-users',
+            ])
             ->setDescription('Bulk assign users to groups by a given CSV file.')
             ->addOption('csv-file', 'c', InputOption::VALUE_REQUIRED, 'Path to CSV file.')
             ->addOption('group-id', 'g', InputOption::VALUE_REQUIRED, 'The id of the target group.')

--- a/concrete/src/Console/Command/ClearCacheCommand.php
+++ b/concrete/src/Console/Command/ClearCacheCommand.php
@@ -17,7 +17,10 @@ class ClearCacheCommand extends Command
         $okExitCode = static::SUCCESS;
         $errExitCode = static::FAILURE;
         $this
-            ->setName('c5:clear-cache')
+            ->setName('concrete:cache:clear')
+            ->setAliases([
+                'c5:clear-cache',
+            ])
             ->setDescription('Clear the cache')
             ->addOption('thumbnails', 't', InputOption::VALUE_REQUIRED, "Should the thumbnails be removed from the cache? [Y/N]")
             ->addEnvOption()

--- a/concrete/src/Console/Command/CompareSchemaCommand.php
+++ b/concrete/src/Console/Command/CompareSchemaCommand.php
@@ -19,7 +19,10 @@ class CompareSchemaCommand extends Command
         $okExitCode = static::SUCCESS;
         $errExitCode = static::FAILURE;
         $this
-            ->setName('c5:compare-schema')
+            ->setName('concrete:database:schema:compare')
+            ->setAliases([
+                'c5:compare-schema',
+            ])
             ->setDescription('Compares db.xml in Concrete XML schema, Concrete entities, and all installed package schemas and entities with the contents of the database and prints the difference.')
             ->addEnvOption()
             ->setHelp(<<<EOT

--- a/concrete/src/Console/Command/ConfigCommand.php
+++ b/concrete/src/Console/Command/ConfigCommand.php
@@ -15,7 +15,7 @@ class ConfigCommand extends Command
 {
     protected $description = 'Set or get configuration parameters.';
 
-    protected $signature = 'c5:config 
+    protected $signature = 'concrete:config 
         {action : Either "get" or "set"} 
         {item : The config item EG: "concrete.debug.detail"} 
         {value? : The value to set}
@@ -45,6 +45,9 @@ class ConfigCommand extends Command
     protected function configure()
     {
         $this
+            ->setAliases([
+                'c5:config',
+            ])
             ->addEnvOption()
             ->setHelp(
                 <<<'EOT'

--- a/concrete/src/Console/Command/DenylistClear.php
+++ b/concrete/src/Console/Command/DenylistClear.php
@@ -38,7 +38,10 @@ class DenylistClear extends Command
         $automaticBansAll = static::DELETE_AUTOMATIC_BANS_ALL;
         $automaticBansExpired = static::DELETE_AUTOMATIC_BANS_EXPIRED;
         $this
-            ->setName('c5:denylist:clear')
+            ->setName('concrete:ip:denylist:clear')
+            ->setAliases([
+                'c5:denylist:clear',
+            ])
             ->setDescription('Clear denylist-related data')
             ->addArgument('handle', InputArgument::IS_ARRAY, 'List of IP Access Control Category handles (if not specified: apply to all the categories)')
             ->addEnvOption()

--- a/concrete/src/Console/Command/ExecCommand.php
+++ b/concrete/src/Console/Command/ExecCommand.php
@@ -13,7 +13,10 @@ class ExecCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('c5:exec')
+            ->setName('concrete:exec')
+            ->setAliases([
+                'c5:exec',
+            ])
             ->setDescription('Execute a PHP script within the Concrete environment')
             ->addEnvOption()
             ->addArgument('script', InputArgument::REQUIRED, 'The path of the script to be executed')

--- a/concrete/src/Console/Command/Express/ExportCommand.php
+++ b/concrete/src/Console/Command/Express/ExportCommand.php
@@ -27,7 +27,7 @@ class ExportCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'c5:express:export {entity : Which entity to export entries from}';
+    protected $signature = 'concrete:express:entry:export {entity : Which entity to export entries from}';
 
     /**
      * Handle processing calls to this command
@@ -63,6 +63,18 @@ class ExportCommand extends Command
         return $this->outputFormatCsv($entity, $app, $config, $factory);
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Symfony\Component\Console\Command\Command::configure()
+     */
+    protected function configure()
+    {
+        $this->setAliases([
+            'c5:express:export',
+        ]);
+    }
+    
     /**
      * Output the entries as CSV
      *

--- a/concrete/src/Console/Command/FixDatabaseForeignKeys.php
+++ b/concrete/src/Console/Command/FixDatabaseForeignKeys.php
@@ -16,7 +16,7 @@ class FixDatabaseForeignKeys extends Command
     protected $description = 'Fix the foreign keys.';
 
     protected $signature = <<<'EOT'
-c5:database:foreignkey:fix
+concrete:database:foreignkey:fix
     {table? : the name of the database table to be fixed - if not specified we'll fix all the tables in the database}
 EOT
     ;
@@ -39,5 +39,19 @@ EOT
         $foreignKeyFixer->fixForeignKeys($tableNames, $errors);
 
         return $errors->count() === 0 ? static::SUCCESS : static::FAILURE;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Symfony\Component\Console\Command\Command::configure()
+     */
+    protected function configure()
+    {
+        $this
+            ->setAliases([
+                'c5:database:foreignkey:fix',
+            ])
+        ;
     }
 }

--- a/concrete/src/Console/Command/GenerateFileIdentifiersCommand.php
+++ b/concrete/src/Console/Command/GenerateFileIdentifiersCommand.php
@@ -16,7 +16,10 @@ class GenerateFileIdentifiersCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('c5:files:generate-identifiers')
+            ->setName('concrete:file:identifier:generate')
+            ->setAliases([
+                'c5:files:generate-identifiers',
+            ])
             ->setDescription('Create unique identifiers for existing files.')
             ->addOption('reset', 'a', InputOption::VALUE_NONE,
                 "Reset all generated unique identifiers.")

--- a/concrete/src/Console/Command/GenerateIDESymbolsCommand.php
+++ b/concrete/src/Console/Command/GenerateIDESymbolsCommand.php
@@ -17,7 +17,10 @@ class GenerateIDESymbolsCommand extends Command
         $okExitCode = static::SUCCESS;
         $errExitCode = static::FAILURE;
         $this
-            ->setName('c5:ide-symbols')
+            ->setName('concrete:dev:symbols:generate')
+            ->setAliases([
+                'c5:ide-symbols',
+            ])
             ->setDescription('Generate IDE symbols')
             ->addEnvOption()
             ->setCanRunAsRoot(false)

--- a/concrete/src/Console/Command/GenerateSitemapCommand.php
+++ b/concrete/src/Console/Command/GenerateSitemapCommand.php
@@ -20,7 +20,10 @@ class GenerateSitemapCommand extends Command
         $okExitCode = static::SUCCESS;
         $errExitCode = static::FAILURE;
         $this
-            ->setName('c5:sitemap:generate')
+            ->setName('concrete:sitemap:generate')
+            ->setAliases([
+                'c5:sitemap:generate',
+            ])
             ->setDescription('Generate the sitemap in XML format.')
             ->addEnvOption()
             ->setCanRunAsRoot(false)

--- a/concrete/src/Console/Command/InfoCommand.php
+++ b/concrete/src/Console/Command/InfoCommand.php
@@ -14,7 +14,10 @@ class InfoCommand extends Command
         $okExitCode = static::SUCCESS;
         $errExitCode = static::FAILURE;
         $this
-            ->setName('c5:info')
+            ->setName('concrete:info')
+            ->setAliases([
+                'c5:info',
+            ])
             ->setDescription('Get detailed information about this installation.')
             ->addEnvOption()
             ->setHelp(<<<EOT

--- a/concrete/src/Console/Command/InstallCommand.php
+++ b/concrete/src/Console/Command/InstallCommand.php
@@ -59,7 +59,10 @@ class InstallCommand extends Command
         $okExitCode = static::SUCCESS;
         $errExitCode = static::FAILURE;
         $this
-            ->setName('c5:install')
+            ->setName('concrete:install')
+            ->setAliases([
+                'c5:install',
+            ])
             ->setDescription('Install Concrete')
             ->addEnvOption()
             ->setCanRunAsRoot(false)

--- a/concrete/src/Console/Command/InstallLanguageCommand.php
+++ b/concrete/src/Console/Command/InstallLanguageCommand.php
@@ -46,16 +46,19 @@ class InstallLanguageCommand extends Command
         $okExitCode = static::SUCCESS;
         $errExitCode = static::FAILURE;
         $this
-        ->setName('c5:language-install')
-        ->setAliases(['c5:install-language'])
-        ->setDescription('Install or update Concrete languages')
-        ->addEnvOption()
-        ->setCanRunAsRoot(false)
-        ->addOption('--update', 'u', InputOption::VALUE_NONE, 'Update any outdated language files')
-        ->addOption('--add', 'a', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Add new language files')
-        ->addOption('--core', 'c', InputOption::VALUE_NONE, 'Process only a the core')
-        ->addOption('--packages', 'p', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Process only packages (you can specify one or more package handle too)')
-        ->setHelp(<<<EOT
+            ->setName('concrete:language:install')
+            ->setAliases([
+                'c5:language-install',
+                'c5:install-language',
+            ])
+            ->setDescription('Install or update Concrete languages')
+            ->addEnvOption()
+            ->setCanRunAsRoot(false)
+            ->addOption('--update', 'u', InputOption::VALUE_NONE, 'Update any outdated language files')
+            ->addOption('--add', 'a', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Add new language files')
+            ->addOption('--core', 'c', InputOption::VALUE_NONE, 'Process only a the core')
+            ->addOption('--packages', 'p', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Process only packages (you can specify one or more package handle too)')
+            ->setHelp(<<<EOT
 Examples:
             
 # to update all the outdated language files (for the core and for all the packages)
@@ -82,7 +85,8 @@ Returns codes:
             
 More info at https://documentation.concretecms.org/9-x/developers/security/cli-jobs#c5-language-install
 EOT
-            );
+            )
+        ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/concrete/src/Console/Command/InstallPackageCommand.php
+++ b/concrete/src/Console/Command/InstallPackageCommand.php
@@ -25,8 +25,9 @@ class InstallPackageCommand extends Command
         $okExitCode = static::SUCCESS;
         $errExitCode = static::FAILURE;
         $this
-            ->setName('c5:package:install')
+            ->setName('concrete:package:install')
             ->setAliases([
+                'c5:package:install',
                 'c5:package-install',
                 'c5:install-package',
             ])

--- a/concrete/src/Console/Command/InstallThemeCommand.php
+++ b/concrete/src/Console/Command/InstallThemeCommand.php
@@ -14,11 +14,16 @@ class InstallThemeCommand extends Command
 {
     protected function configure()
     {
-        $this->setName('c5:theme:install')
-        ->addOption('activate', 'a', InputOption::VALUE_NONE, 'Activate this theme after install', null)
-        ->setDescription('Install a Concrete Theme')
-        ->setCanRunAsRoot(false)
-        ->addArgument('theme-handle', null, InputOption::VALUE_REQUIRED, 'The handle name of the theme');
+        $this
+            ->setName('concrete:theme:install')
+            ->setAliases([
+                'c5:theme:install',
+            ])
+            ->addOption('activate', 'a', InputOption::VALUE_NONE, 'Activate this theme after install', null)
+            ->setDescription('Install a Concrete Theme')
+            ->setCanRunAsRoot(false)
+            ->addArgument('theme-handle', null, InputOption::VALUE_REQUIRED, 'The handle name of the theme')
+        ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/concrete/src/Console/Command/IsInstalledCommand.php
+++ b/concrete/src/Console/Command/IsInstalledCommand.php
@@ -21,7 +21,10 @@ class IsInstalledCommand extends Command
         $errExitCode = static::FAILURE;
 
         $this
-            ->setName('c5:is-installed')
+            ->setName('concrete:check:installed')
+            ->setAliases([
+                'c5:is-installed',
+            ])
             ->setDescription('Check if Concrete is already installed')
             ->addEnvOption()
             ->setHelp(<<<EOT

--- a/concrete/src/Console/Command/JobCommand.php
+++ b/concrete/src/Console/Command/JobCommand.php
@@ -19,7 +19,10 @@ class JobCommand extends Command
         $okExitCode = static::SUCCESS;
         $errExitCode = static::FAILURE;
         $this
-            ->setName('c5:job')
+            ->setName('concrete:job:run')
+            ->setAliases([
+                'c5:job',
+            ])
             ->setDescription(t('Run a Concrete job'))
             ->addEnvOption()
             ->addOption('set', null, InputOption::VALUE_NONE, t('Find jobs by set instead of job handle'))

--- a/concrete/src/Console/Command/PackPackageCommand.php
+++ b/concrete/src/Console/Command/PackPackageCommand.php
@@ -157,8 +157,9 @@ final class PackPackageCommand extends Command
         $okExitCode = static::SUCCESS;
         $errExitCode = static::FAILURE;
         $this
-            ->setName('c5:package:pack')
+            ->setName('concrete:package:pack')
             ->setAliases([
+                'c5:package:pack',
                 'c5:package-pack',
                 'c5:pack-package',
             ])

--- a/concrete/src/Console/Command/PhpCodingStyleCommand.php
+++ b/concrete/src/Console/Command/PhpCodingStyleCommand.php
@@ -22,7 +22,7 @@ class PhpCodingStyleCommand extends Command
     {
         $defaultWebRoot = PhpFixerOptions::getDefaultWebRoot();
         $this->signature = <<<EOT
-c5:phpcs
+concrete:dev:phpcs:fix
 {--no-cache : Specify this flag to turn off the coding style cache}
 {--webroot={$defaultWebRoot} : Specify the webroot (use - to auto-detect it)}
 {--p|php= : The minimum PHP version }
@@ -89,7 +89,11 @@ EOT
         $okExitCode = static::SUCCESS;
         $errExitCode = static::FAILURE;
 
-        $this->setHelp(<<<EOT
+        $this
+            ->setAliases([
+                'c5:phpcs',
+            ])
+            ->setHelp(<<<EOT
 Check or fix the PHP coding style.
 
 Return values when checking the coding style:
@@ -100,7 +104,8 @@ Return values when applying the coding style:
 - {$okExitCode}: no error occurred
 - {$errExitCode}: some error occurred
 EOT
-        );
+            )
+        ;
     }
 
     /**

--- a/concrete/src/Console/Command/RefreshBoardsCommand.php
+++ b/concrete/src/Console/Command/RefreshBoardsCommand.php
@@ -19,7 +19,10 @@ class RefreshBoardsCommand extends Command
         $errExitCode = static::FAILURE;
 
         $this
-            ->setName('c5:boards:refresh')
+            ->setName('concrete:board:refresh')
+            ->setAliases([
+                'c5:boards:refresh',
+            ])
             ->setDescription('Add content to boards and board instances.')
             ->addOption('--all',  'a',InputOption::VALUE_NONE,
     'Refreshes and regenerates boards.')

--- a/concrete/src/Console/Command/RefreshEntitiesCommand.php
+++ b/concrete/src/Console/Command/RefreshEntitiesCommand.php
@@ -19,7 +19,10 @@ class RefreshEntitiesCommand extends Command
         $errExitCode = static::FAILURE;
 
         $this
-            ->setName('c5:entities:refresh')
+            ->setName('concrete:database:entity:refresh')
+            ->setAliases([
+                'c5:entities:refresh',
+            ])
             ->setDescription('Refresh the Doctrine database entities')
             ->addEnvOption()
             ->setCanRunAsRoot(false)

--- a/concrete/src/Console/Command/ReindexCommand.php
+++ b/concrete/src/Console/Command/ReindexCommand.php
@@ -25,7 +25,10 @@ class ReindexCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('c5:reindex')
+            ->setName('concrete:index:generate')
+            ->setAliases([
+                'c5:reindex',
+            ])
             ->setDescription('Reindex pages, files, users and express entities')
             ->addOption('pages', 'p', InputOption::VALUE_NONE, 'Include pages in the reindex')
             ->addOption('express', 'e', InputOption::VALUE_NONE, 'Include express in the reindex')

--- a/concrete/src/Console/Command/RescanFilesCommand.php
+++ b/concrete/src/Console/Command/RescanFilesCommand.php
@@ -27,7 +27,10 @@ class RescanFilesCommand extends Command
     protected function configure()
     {
         $this
-            ->setName('c5:rescan-files')
+            ->setName('concrete:file:scan')
+            ->setAliases([
+                'c5:rescan-files',
+            ])
             ->setDescription('Rescans all files in the file manager.')
             ->addOption('after',  'a',InputOption::VALUE_REQUIRED, 'Rescan files after a particular file ID.')
             ->addOption('limit',  'l',InputOption::VALUE_REQUIRED, 'Limit the number of files to scan in this batch');

--- a/concrete/src/Console/Command/ResetCommand.php
+++ b/concrete/src/Console/Command/ResetCommand.php
@@ -17,7 +17,10 @@ class ResetCommand extends Command
         $okExitCode = static::SUCCESS;
         $errExitCode = static::FAILURE;
         $this
-            ->setName('c5:reset')
+            ->setName('concrete:reset')
+            ->setAliases([
+                'c5:reset',
+            ])
             ->setDescription('Reset the Concrete installation, deleting files and emptying the database')
             ->addEnvOption()
             ->setCanRunAsRoot(false)

--- a/concrete/src/Console/Command/ServiceCommand.php
+++ b/concrete/src/Console/Command/ServiceCommand.php
@@ -56,7 +56,10 @@ More info at https://documentation.concretecms.org/9-x/developers/security/cli-j
 EOT
         ;
         $this
-            ->setName('c5:service')
+            ->setName('concrete:service')
+            ->setAliases([
+                'c5:service',
+            ])
             ->setDescription('Check or update the web server configuration')
             ->addEnvOption()
             ->addOption('service-version', 'r', InputOption::VALUE_REQUIRED, 'The specific version of the web server software', '')

--- a/concrete/src/Console/Command/SetDatabaseCharacterSetCommand.php
+++ b/concrete/src/Console/Command/SetDatabaseCharacterSetCommand.php
@@ -17,7 +17,7 @@ class SetDatabaseCharacterSetCommand extends Command
     protected $description = 'Set the character set and collation of a database connection.';
 
     protected $signature = <<<'EOT'
-c5:database:charset:set
+concrete:database:charset:set
     {charset : the character set or the collation to be used for the connection}
     {connection? : the name of the connection - if not specified we'll use the default one}
     {--f|force : re-apply the character set/collation even if they should already be in use}
@@ -70,5 +70,19 @@ EOT
         );
 
         return static::SUCCESS;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Symfony\Component\Console\Command\Command::configure()
+     */
+    protected function configure()
+    {
+        $this
+            ->setAliases([
+                'c5:database:charset:set',
+            ])
+        ;
     }
 }

--- a/concrete/src/Console/Command/TaskCommand.php
+++ b/concrete/src/Console/Command/TaskCommand.php
@@ -34,9 +34,14 @@ class TaskCommand extends SymfonyCommand
     public function configure()
     {
         $controller = $this->task->getController();
-        $this->setName(sprintf('task:%s', $controller->getConsoleCommandName()));
-        $this->setDescription($controller->getDescription());
-
+        $nameSuffix = $controller->getConsoleCommandName();
+        $this
+            ->setName("concrete:task:{$nameSuffix}")
+            ->setAliases([
+                "task:{$nameSuffix}",
+            ])
+            ->setDescription($controller->getDescription())
+        ;
         $definition = $controller->getInputDefinition();
         if ($definition) {
             $definition->addToCommand($this);

--- a/concrete/src/Console/Command/TranslatePackageCommand.php
+++ b/concrete/src/Console/Command/TranslatePackageCommand.php
@@ -21,8 +21,9 @@ class TranslatePackageCommand extends Command
         $okExitCode = static::SUCCESS;
         $errExitCode = static::FAILURE;
         $this
-            ->setName('c5:package:translate')
+            ->setName('concrete:package:translate')
             ->setAliases([
+                'c5:package:translate',
                 'c5:package-translate',
                 'c5:translate-package',
             ])

--- a/concrete/src/Console/Command/UninstallPackageCommand.php
+++ b/concrete/src/Console/Command/UninstallPackageCommand.php
@@ -18,8 +18,9 @@ class UninstallPackageCommand extends Command
         $okExitCode = static::SUCCESS;
         $errExitCode = static::FAILURE;
         $this
-            ->setName('c5:package:uninstall')
+            ->setName('concrete:package:uninstall')
             ->setAliases([
+                'c5:package:uninstall',
                 'c5:package-uninstall',
                 'c5:uninstall-package',
             ])

--- a/concrete/src/Console/Command/UpdateCommand.php
+++ b/concrete/src/Console/Command/UpdateCommand.php
@@ -20,7 +20,10 @@ class UpdateCommand extends Command
         $okExitCode = static::SUCCESS;
         $errExitCode = static::FAILURE;
         $this
-            ->setName('c5:update')
+            ->setName('concrete:update')
+            ->setAliases([
+                'c5:update',
+            ])
             ->setDescription('Runs all database migrations to bring the Concrete installation up to date.')
             ->addEnvOption()
             ->setCanRunAsRoot(false)

--- a/concrete/src/Console/Command/UpdatePackageCommand.php
+++ b/concrete/src/Console/Command/UpdatePackageCommand.php
@@ -17,8 +17,9 @@ class UpdatePackageCommand extends Command
         $okExitCode = static::SUCCESS;
         $errExitCode = static::FAILURE;
         $this
-            ->setName('c5:package:update')
+            ->setName('concrete:package:update')
             ->setAliases([
+                'c5:package:update',
                 'c5:package-update',
                 'c5:update-package',
             ])


### PR DESCRIPTION
We currently have CLI commands in two namespaces: the old `c5:` and the new `concrete:`.
What about:

1. always use `concrete:`
2. use sub-namespaces for all commands (eg: from `c5:clear-cache` to `concrete:cache:clear`)

Of course, we have to support the old command names, so let's add some aliases (eg `c5:clear-cache` is now an alias of `concrete:cache:clear`).

Here's the full list of commands as per this PR:

| New Command | Old Command | Previous aliases (kept) | Class |
|---|---|---|---|
| `concrete:board:refresh` | `c5:boards:refresh` | | `RefreshBoardsCommand` |
| `concrete:cache:clear` | `c5:clear-cache` | | `ClearCacheCommand` |
| `concrete:check:installed` | `c5:is-installed` | | `IsInstalledCommand` |
| `concrete:config` | `c5:config` | | `ConfigCommand` |
| `concrete:database:charset:set` | `c5:database:charset:set` | | `SetDatabaseCharacterSetCommand` |
| `concrete:database:entity:refresh` | `c5:entities:refresh` | | `RefreshEntitiesCommand` |
| `concrete:database:foreignkey:fix` | `c5:database:foreignkey:fix` | | `FixDatabaseForeignKeys` |
| `concrete:database:schema:compare` | `c5:compare-schema` | | `CompareSchemaCommand` |
| `concrete:dev:phpcs:fix` | `c5:phpcs` | | `PhpCodingStyleCommand` |
| `concrete:dev:symbols:generate` | `c5:ide-symbols` | | `GenerateIDESymbolsCommand` |
| `concrete:exec` | `c5:exec` | | `ExecCommand` |
| `concrete:express:entry:export` | `c5:express:export` | | `Express\ExportCommand` |
| `concrete:file:identifier:generate` | `c5:files:generate-identifiers` | | `GenerateFileIdentifiersCommand` |
| `concrete:file:scan` | `c5:rescan-files` | | `RescanFilesCommand` |
| `concrete:index:generate` | `c5:reindex` | | `ReindexCommand` |
| `concrete:info` | `c5:info` | | `InfoCommand` |
| `concrete:install` | `c5:install` | | `InstallCommand` |
| `concrete:ip:denylist:clear` | `c5:denylist:clear` | | `DenylistClear` |
| `concrete:job:run` | `c5:job` | | `JobCommand` |
| `concrete:language:install` | `c5:language-install` | `c5:install-language` | `InstallLanguageCommand` |
| `concrete:package:install` | `c5:package:install` | `c5:package-install`<br />`c5:install-package` | `InstallPackageCommand` |
| `concrete:package:pack` | `c5:package:pack` | `c5:package-pack`<br />`c5:pack-package` | `PackPackageCommand` |
| `concrete:package:translate` | `c5:package:translate` | `c5:package-translate`<br />`c5:translate-package` | `TranslatePackageCommand` |
| `concrete:package:uninstall` | `c5:package:uninstall` | `c5:package-uninstall`<br />`c5:uninstall-package` | `UninstallPackageCommand` |
| `concrete:package:update` | `c5:package:update` | | `UpdatePackageCommand` |
| `concrete:reset` | `c5:reset` | | `ResetCommand` |
| `concrete:scheduler:run` | == | | `RunSchedulerCommand` |
| `concrete:scheduler:run-dev` | == | | `RunSchedulerInForegroundCommand` |
| `concrete:service` | `c5:service` | | `ServiceCommand` |
| `concrete:sitemap:generate` | `c5:sitemap:generate` | | `GenerateSitemapCommand` |
| `concrete:task:…` | `task:…` | | `TaskCommand` |
| `concrete:theme:activate` | == | | `ActivateThemeCommand` |
| `concrete:theme:install` | `c5:theme:install` | | `InstallThemeCommand` |
| `concrete:theme:skin:activate` | `concrete:theme:activate-skin` | | `ActivateThemeSkinCommand` |
| `concrete:update` | `c5:update` | `c5:package-update`<br />`c5:update-package` | `UpdateCommand` |
| `concrete:user:group:assign:bulk` | `c5:user-group:bulk-assign-users` | | `BulkUserAssignCommand` |



The new names seem rather verbose and long (that is, a bit harder to be used).
But of course you can use shorthands for them. For example: instead of running
```
concrete:database:entity:refresh
```
you can run
```
c:database:ent:ref
```
or even
```
c:d:e:r
```
