### PR TITLE
Bugfix/variable reference

### DIFF
--- a/concrete/blocks/express_form/controller.php
+++ b/concrete/blocks/express_form/controller.php
@@ -698,7 +698,8 @@ class Controller extends BlockController implements NotificationProviderInterfac
                 }
                 $notifier = $controller->getNotifier($this);
                 $notifications = $notifier->getNotificationList();
-                array_walk($notifications->getNotifications(), function ($notification) use ($submittedAttributeValues) {
+                $notificationList = $notifications->getNotifications();
+                array_walk($notificationList, function ($notification) use ($submittedAttributeValues) {
                     if (method_exists($notification, "setAttributeValues")) {
                         $notification->setAttributeValues($submittedAttributeValues);
                     }


### PR DESCRIPTION
*Check these before submitting new pull requests*

- [ X] I read the __guidelines for contributing__ linked above. My pull request conforms to the coding style guidelines described within.

- When users submit a form request from my client's website, we receive the following exception: "Only variables should be passed by reference." This error occurs because PHP requires that only variables—not direct function calls or expressions—be passed by reference. Therefore, the solution is to create a new variable and then pass that variable into the array_walk method.
