### PR TITLE
Fix issues with the search block and page list with unexpected parameters

### DIFF
--- a/concrete/blocks/search/controller.php
+++ b/concrete/blocks/search/controller.php
@@ -170,7 +170,7 @@ class Controller extends BlockController implements UsesFeatureInterface
 
         return $this->hText;
     }
-    
+
     public function getRequiredFeatures(): array
     {
         return [
@@ -291,7 +291,11 @@ class Controller extends BlockController implements UsesFeatureInterface
             } else {
                 $resultsPage = null;
                 $c = Page::getCurrentPage();
-                $resultsURL = $c->getCollectionPath();
+                if (is_object($c)) {
+                    $resultsURL = $c->getCollectionPath();
+                } else {
+                    $resultsURL = '/';
+                }
             }
         }
 
@@ -306,7 +310,11 @@ class Controller extends BlockController implements UsesFeatureInterface
 
         //run query if display results elsewhere not set, or the cID of this page is set
         if ($resultsPage === null && (string) $this->resultsURL === '') {
-            if ((string) $this->request->request('query') !== '' || $this->request->request('akID') || $this->request->request('month')) {
+            $query = $this->request->request('query');
+            if (!is_string($query)) {
+                $query = '';
+            }
+            if ($query !== '' || $this->request->request('akID') || $this->request->request('month')) {
                 $this->do_search();
             }
         }
@@ -472,6 +480,9 @@ class Controller extends BlockController implements UsesFeatureInterface
         $search_paths = $this->request->request('search_paths');
         if (is_array($search_paths)) {
             foreach ($search_paths as $path) {
+                if (!is_string($path)) {
+                    continue;
+                }
                 if ($path === '') {
                     continue;
                 }

--- a/tests/tests/Block/SearchTest.php
+++ b/tests/tests/Block/SearchTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Concrete\Tests\Block;
+
+use BlockType;
+use Concrete\Core\Attribute\Key\Category as AttributeCategory;
+use Concrete\Block\Search\Controller;
+use Concrete\Core\Support\Facade\Application;
+use Concrete\Core\Http\Request;
+use Concrete\Core\Page\Page;
+use Concrete\TestHelpers\Block\BlockTypeTestCase;
+
+class SearchTest extends BlockTypeTestCase
+{
+    protected $btHandle = 'search';
+
+    protected $requestData = [
+        'lipsum' => [
+            'title' => 'Lorem ipsum dolor sit amet',
+            'buttonText' => 'Search',
+        ],
+    ];
+
+    protected $expectedRecordData = [
+        'lipsum' => [
+            'title' => 'Lorem ipsum dolor sit amet',
+            'buttonText' => 'Search',
+            'baseSearchPath' => '',
+            'search_all' => 0,
+            'allow_user_options' => 0,
+            'postTo_cID' => 0,
+            'resultsURL' => '',
+        ],
+    ];
+
+    /** @var Request */
+    private $origRequest;
+
+    public static function setUpBeforeClass():void
+    {
+        parent::setUpBeforeClass();
+
+        AttributeCategory::add('collection');
+    }
+
+    public function __construct($name = null, array $data = [], $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+
+        $this->tables[] = 'btSearch';
+        $this->tables[] = 'CollectionVersions';
+        $this->tables[] = 'CollectionSearchIndexAttributes';
+        $this->tables[] = 'Pages';
+        $this->tables[] = 'PageTypes';
+        $this->tables[] = 'PageSearchIndex';
+        $this->tables[] = 'PermissionAccessEntityTypes';
+        $this->tables[] = 'PermissionKeys';
+        $this->tables[] = 'PermissionKeyCategories';
+        $this->tables[] = 'PagePermissionAssignments';
+        $this->tables[] = 'BlockPermissionAssignments';
+
+        $this->metadatas[] = 'Concrete\Core\Entity\Attribute\Category';
+        $this->metadatas[] = 'Concrete\Core\Entity\Attribute\Key\Key';
+        $this->metadatas[] = 'Concrete\Core\Entity\Attribute\Value\Value';
+        $this->metadatas[] = 'Concrete\Core\Entity\Attribute\Key\PageKey';
+        $this->metadatas[] = 'Concrete\Core\Entity\Attribute\Value\PageValue';
+    }
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->origRequest = Request::getInstance();
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        Request::setInstance($this->origRequest);
+    }
+
+    public function testSearchWithUnexpectedQuery(): void
+    {
+        // Tests only that the code does not cause any errors/exceptions
+        $this->expectNotToPerformAssertions();
+
+        $this->runSearch(['query' => ['foo' => 'bar']]);
+    }
+
+    public function testSearchWithUnexpectedSearchPath(): void
+    {
+        // Tests only that the code does not cause any errors/exceptions
+        $this->expectNotToPerformAssertions();
+
+        $this->runSearch([
+            'query' => 'test',
+            'search_paths' => [['foo' => 'bar']]
+        ]);
+    }
+
+    public function testSearchWithMultipleSearchPaths(): void
+    {
+        // Tests only that the code does not cause any errors/exceptions
+        $this->expectNotToPerformAssertions();
+
+        $this->runSearch([
+            'query' => 'test',
+            'search_paths' => ['/foo', '/bar']
+        ]);
+    }
+
+    private function runSearch($params): void
+    {
+        $request = new Request($params);
+        $request->setCurrentPage(Page::getByID(1));
+        Request::setInstance($request);
+
+        $btc = $this->getBlockController();
+
+        $btc->view();
+    }
+
+    private function getBlockController(): Controller
+    {
+        $bt = BlockType::installBlockType($this->btHandle);
+        $btx = BlockType::getByID(1);
+        $class = $btx->getBlockTypeClass();
+        $btc = new $class();
+        $btc->setApplication(Application::getFacadeApplication());
+
+        return $btc;
+    }
+}

--- a/tests/tests/Page/PageListTest.php
+++ b/tests/tests/Page/PageListTest.php
@@ -310,16 +310,17 @@ class PageListTest extends PageTestCase
         $nl = new \Concrete\Core\Page\PageList();
         $nl->includeAliases();
         $nl->ignorePermissions();
-        $nl->sortByName();
+        $nl->getQueryObject()->addOrderBy('cv.cvName', 'asc');
+        $nl->getQueryObject()->addOrderBy('p.cID', 'asc');
         $total = $nl->getPagination()->getTotalResults();
         $results = $nl->getPagination()->setMaxPerPage(10)->getCurrentPageResults();
         $this->assertEquals(18, $total);
         $this->assertCount(10, $results);
-        $this->assertTrue($results[1]->isAlias());
-        $this->assertEquals('Another Fun Page', $results[1]->getCollectionName());
-        $this->assertEquals($results[1]->getCollectionID(), $subject->getCollectionID());
-        $this->assertEquals(20, $results[1]->getCollectionPointerOriginalID());
-        $this->assertEquals(8, $results[1]->getCollectionID());
+        $this->assertTrue($results[2]->isAlias());
+        $this->assertEquals('Another Fun Page', $results[2]->getCollectionName());
+        $this->assertEquals($results[2]->getCollectionID(), $subject->getCollectionID());
+        $this->assertEquals(20, $results[2]->getCollectionPointerOriginalID());
+        $this->assertEquals(8, $results[2]->getCollectionID());
     }
 
     public function testIndexedSearch()

--- a/tests/tests/Page/PageListTest.php
+++ b/tests/tests/Page/PageListTest.php
@@ -315,11 +315,11 @@ class PageListTest extends PageTestCase
         $results = $nl->getPagination()->setMaxPerPage(10)->getCurrentPageResults();
         $this->assertEquals(18, $total);
         $this->assertCount(10, $results);
-        $this->assertTrue($results[2]->isAlias());
-        $this->assertEquals('Another Fun Page', $results[2]->getCollectionName());
-        $this->assertEquals($results[2]->getCollectionID(), $subject->getCollectionID());
-        $this->assertEquals(20, $results[2]->getCollectionPointerOriginalID());
-        $this->assertEquals(8, $results[2]->getCollectionID());
+        $this->assertTrue($results[1]->isAlias());
+        $this->assertEquals('Another Fun Page', $results[1]->getCollectionName());
+        $this->assertEquals($results[1]->getCollectionID(), $subject->getCollectionID());
+        $this->assertEquals(20, $results[1]->getCollectionPointerOriginalID());
+        $this->assertEquals(8, $results[1]->getCollectionID());
     }
 
     public function testIndexedSearch()
@@ -365,6 +365,34 @@ class PageListTest extends PageTestCase
         $nl->filterByPath('/test-page-1', false);
         $pagination = $nl->getPagination();
         $this->assertEquals(1, $pagination->getNBResults());
+    }
+
+    public function testFilterByMultiplePaths()
+    {
+        $this->createPage('More Fun', '/test-page-1/foobler');
+        $this->createPage('Extreme Fun', '/test-page-2');
+
+        $this->list->filterByPath('/test-page-1');
+        $this->list->filterByPath('/test-page-2');
+        $totalResults = $this->list->getTotalResults();
+        $this->assertEquals(4, $totalResults);
+    }
+
+    public function testFilterByPathWithArray()
+    {
+        $this->createPage('More Fun', '/test-page-1/foobler');
+
+        $this->list->filterByPath(['/test-page-1']);
+        $totalResults = $this->list->getTotalResults();
+        $this->assertEquals(18, $totalResults);
+    }
+
+    public function testFilterByPagesWithCustomStyles()
+    {
+        $this->list->filterByPagesWithCustomStyles();
+        $this->list->filterByPagesWithCustomStyles();
+        $totalResults = $this->list->getTotalResults();
+        $this->assertEquals(0, $totalResults);
     }
 
     public function testBasicFeedSave()


### PR DESCRIPTION
This fixes some issues with the search block and the page list object when unexpected parameters are passed from the URL, typically during security scans. These errors keep filling the logs.

## Issue 1 - The `query` parameter

1. Add a search block to a page
2. Submit the search through the block
3. Modify the URL parameters as `?query[foo]=bar`
4. See error

## Issue 2 - The `search_paths` parameter

1. Add a search block to a page
2. Add a search block to another page
3. Configure a "Beneath another page" parameter pointing to the first page
4. Submit the search through the form to end up on the other page with the search parameters
5. Modify the URL parameters as follows:
  * `?query=foo&search_paths[]=/foo&search_paths[]=/bar`
  * `?query=foo&search_paths[]=/foo&search_paths[][]=/bar`
  * `?query=foo&search_paths[foo][]=/foo`
7. See error in all cases