### PR TITLE
Do not throw an exception at the messenger backend when unauthorized

### DIFF
--- a/concrete/controllers/backend/messenger.php
+++ b/concrete/controllers/backend/messenger.php
@@ -11,6 +11,7 @@ use Concrete\Core\Messenger\Transport\TransportManager;
 use Concrete\Core\Validation\CSRF\Token;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnMessageLimitListener;
 use Symfony\Component\Messenger\EventListener\StopWorkerOnTimeLimitListener;
 use Symfony\Component\Messenger\RoutableMessageBus;
@@ -75,7 +76,7 @@ class Messenger extends AbstractController
             $worker->run();
             return $this->responseFactory->createResponse();
         }
-        throw new \Exception(t('Access Denied'));
+        return new JsonResponse(t('Access Denied'), 401);
     }
 
 }

--- a/tests/tests/Controller/Backend/MessengerTest.php
+++ b/tests/tests/Controller/Backend/MessengerTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\Tests\Controller\Backend;
+
+use Concrete\Core\Http\Request;
+use Concrete\Core\Http\ServerInterface;
+use Concrete\Tests\TestCase;
+use Core;
+
+class MessengerTest extends TestCase
+{
+    public function testUnauthorizedResponse()
+    {
+        $url = 'http://www.dummyco.com/ccm/system/messenger/consume';
+
+        $server = Core::make(ServerInterface::class);
+
+        $request = Request::create($url, 'GET', []);
+        $response = $server->handleRequest($request);
+
+        $this->assertEquals($response->getStatusCode(), 401);
+        $this->assertEquals($response->getContent(), json_encode("Access Denied"));
+    }
+}


### PR DESCRIPTION
When the messenger backend is requested with an invalid authentication token, it currently throws an exception which is logged. Sometimes people leave their browsers open and later on this endpoint is requested as unauthorized after the session is already invalidated.

This kept filling the logs, so I believe a better way is to just return an HTTP 401 in that case which is not logged in the application logs.