### PR TITLE
Fix theme grid layout name when theme does not support grid framework

### DIFF
--- a/concrete/src/Area/Layout/ThemeGridLayout.php
+++ b/concrete/src/Area/Layout/ThemeGridLayout.php
@@ -74,7 +74,12 @@ class ThemeGridLayout extends Layout
 
     public function getDisplayName()
     {
-        return t2('%s Column %s Layout', '%s Columns %s Layout', $this->getAreaLayoutNumColumns(), $this->getThemeGridFrameworkObject()->getPageThemeGridFrameworkName());
+        $framework = $this->getThemeGridFrameworkObject();
+        $frameworkName = '';
+        if (is_object($framework)) {
+            $frameworkName = $framework->getPageThemeGridFrameworkName();
+        }
+        return t2('%s Column %s Layout', '%s Columns %s Layout', $this->getAreaLayoutNumColumns(), $frameworkName);
     }
 
     /**

--- a/tests/tests/Area/AreaLayoutTest.php
+++ b/tests/tests/Area/AreaLayoutTest.php
@@ -83,4 +83,43 @@ class AreaLayoutTest extends ConcreteDatabaseTestCase
 
         $req->clearCurrentPage();
     }
+
+    public function testThemeGridAreaLayoutContainerWithoutFramework()
+    {
+        $this->truncateTables();
+
+        $layout = \Concrete\Core\Area\Layout\ThemeGridLayout::add();
+        $layout->addLayoutColumn()->setAreaLayoutColumnSpan(4);
+        $column = $layout->addLayoutColumn();
+        $column->setAreaLayoutColumnSpan(2);
+        $column->setAreaLayoutColumnOffset(2);
+        $layout->addLayoutColumn()->setAreaLayoutColumnSpan(6);
+
+        $elemental = \Concrete\Core\Page\Theme\Theme::add('elemental');
+        $service = \Core::make('site/type');
+        if (!$service->getDefault()) {
+            $service->installDefault();
+        }
+        $service = \Core::make('site');
+        if (!$service->getDefault()) {
+            $service->installDefault();
+        }
+
+        $themeStub = $this->createStub(get_class($elemental));
+        $themeStub->method('supportsGridFramework')->willReturn(false);
+
+        Page::addHomePage();
+        Core::make('cache/request')->disable();
+
+        $pageStub = $this->createStub(Page::class);
+        $pageStub->method('getCollectionThemeObject')->willReturn($themeStub);
+
+        $req = Request::getInstance();
+        $req->setCurrentPage($pageStub);
+
+        $layout = Layout::getByID(1);
+        $this->assertInstanceOf(ThemeGridLayout::class, $layout);
+
+        $this->assertEquals('3 Columns  Layout', $layout->getDisplayName());
+    }
 }

--- a/tests/tests/Area/AreaLayoutTest.php
+++ b/tests/tests/Area/AreaLayoutTest.php
@@ -121,5 +121,8 @@ class AreaLayoutTest extends ConcreteDatabaseTestCase
         $this->assertInstanceOf(ThemeGridLayout::class, $layout);
 
         $this->assertEquals('3 Columns  Layout', $layout->getDisplayName());
+
+        // Revert current page to a non-stubbed page
+        $req->setCurrentPage(Page::getByID(1));
     }
 }

--- a/tests/tests/Area/AreaLayoutTest.php
+++ b/tests/tests/Area/AreaLayoutTest.php
@@ -88,7 +88,7 @@ class AreaLayoutTest extends ConcreteDatabaseTestCase
     {
         $this->truncateTables();
 
-        $layout = \Concrete\Core\Area\Layout\ThemeGridLayout::add();
+        $layout = ThemeGridLayout::add();
         $layout->addLayoutColumn()->setAreaLayoutColumnSpan(4);
         $column = $layout->addLayoutColumn();
         $column->setAreaLayoutColumnSpan(2);
@@ -96,11 +96,11 @@ class AreaLayoutTest extends ConcreteDatabaseTestCase
         $layout->addLayoutColumn()->setAreaLayoutColumnSpan(6);
 
         $elemental = \Concrete\Core\Page\Theme\Theme::add('elemental');
-        $service = \Core::make('site/type');
+        $service = Core::make('site/type');
         if (!$service->getDefault()) {
             $service->installDefault();
         }
-        $service = \Core::make('site');
+        $service = Core::make('site');
         if (!$service->getDefault()) {
             $service->installDefault();
         }

--- a/tests/tests/Area/AreaLayoutTest.php
+++ b/tests/tests/Area/AreaLayoutTest.php
@@ -122,7 +122,6 @@ class AreaLayoutTest extends ConcreteDatabaseTestCase
 
         $this->assertEquals('3 Columns  Layout', $layout->getDisplayName());
 
-        // Revert current page to a non-stubbed page
-        $req->setCurrentPage(Page::getByID(1));
+        $req->clearCurrentPage();
     }
 }


### PR DESCRIPTION
When theme grid layout framework is not supported by the given theme, calling `$layout->getDisplayName()` currently fails due to the unexisting theme grid framework object. This fixes the issues with an added test case.