### PR TITLE
Fix `AreaLayout::getByID()` with an unexisting layout ID

### DIFF
--- a/concrete/src/Area/Layout/Layout.php
+++ b/concrete/src/Area/Layout/Layout.php
@@ -57,8 +57,8 @@ abstract class Layout extends ConcreteObject
 
         $al = null;
         $db = Database::connection();
-        $row = $db->GetRow('select arLayoutID, arLayoutIsPreset, arLayoutUsesThemeGridFramework from AreaLayouts where arLayoutID = ?', [$arLayoutID]);
-        if (is_array($row) && array_key_exists('arLayoutID', $row) && $row['arLayoutID']) {
+        $row = $db->fetchAssociative('select arLayoutID, arLayoutIsPreset, arLayoutUsesThemeGridFramework from AreaLayouts where arLayoutID = ?', [$arLayoutID]);
+        if (is_array($row) && $row['arLayoutID']) {
             if ($row['arLayoutUsesThemeGridFramework']) {
                 $al = new ThemeGridLayout();
             } elseif ($row['arLayoutIsPreset']) {

--- a/concrete/src/Area/Layout/Layout.php
+++ b/concrete/src/Area/Layout/Layout.php
@@ -58,7 +58,7 @@ abstract class Layout extends ConcreteObject
         $al = null;
         $db = Database::connection();
         $row = $db->GetRow('select arLayoutID, arLayoutIsPreset, arLayoutUsesThemeGridFramework from AreaLayouts where arLayoutID = ?', [$arLayoutID]);
-        if (is_array($row) && $row['arLayoutID']) {
+        if (is_array($row) && array_key_exists('arLayoutID', $row) && $row['arLayoutID']) {
             if ($row['arLayoutUsesThemeGridFramework']) {
                 $al = new ThemeGridLayout();
             } elseif ($row['arLayoutIsPreset']) {

--- a/tests/tests/Area/AreaLayoutTest.php
+++ b/tests/tests/Area/AreaLayoutTest.php
@@ -42,6 +42,12 @@ class AreaLayoutTest extends ConcreteDatabaseTestCase
         $this->assertEquals('<div class="ccm-layout-column-wrapper" id="ccm-layout-column-wrapper-1"></div>', (string) $formatter->getLayoutContainerHtmlObject());
     }
 
+    public function testUnexistingLayoutContainer(): void
+    {
+        $layout = Layout::getByID(1337);
+        $this->assertNull($layout);
+    }
+
     public function testThemeGridAreaLayoutContainer()
     {
         $this->truncateTables();

--- a/tests/tests/Controller/Frontend/StylesheetTest.php
+++ b/tests/tests/Controller/Frontend/StylesheetTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\Tests\Controller\Frontend;
+
+use Concrete\Core\Http\Request;
+use Concrete\Core\Http\ServerInterface;
+use Concrete\TestHelpers\Database\ConcreteDatabaseTestCase;
+use Core;
+
+class StylesheetTest extends ConcreteDatabaseTestCase
+{
+    protected $tables = ['AreaLayouts'];
+
+    public function testUnexistingLayout()
+    {
+        $url = sprintf('http://www.dummyco.com/ccm/system/css/layout/%d', 1337);
+
+        $server = Core::make(ServerInterface::class);
+
+        $request = Request::create($url, 'GET', []);
+        $response = $server->handleRequest($request);
+
+        $this->assertEquals($response->getStatusCode(), 200);
+        $this->assertEquals($response->getContent(), "");
+    }
+}


### PR DESCRIPTION
As the title describes, calling `Concrete\Core\Area\Layout\Layout::getByID()` would result in a failure with newer PHP versions because the `$db->GetRow(...)` method returns an empty array in this case.

This fixes the issue with an added test case.