### PR TITLE
Check attribute validation data is set before validation

### DIFF
--- a/concrete/attributes/address/controller.php
+++ b/concrete/attributes/address/controller.php
@@ -37,7 +37,7 @@ class Controller extends AttributeTypeController implements
     public $akDefaultCountry;
     public $akCustomCountries;
     public $akGeolocateCountry;
-    
+
     protected $searchIndexFieldDefinition = [
         'address1' => [
             'type' => 'string',
@@ -144,6 +144,10 @@ class Controller extends AttributeTypeController implements
 
     public function validateForm($data)
     {
+        if (!is_array($data)) {
+            return false;
+        }
+
         if (empty($data['country'])) {
             return false;
         }

--- a/concrete/attributes/boolean/controller.php
+++ b/concrete/attributes/boolean/controller.php
@@ -194,7 +194,7 @@ class Controller extends AttributeTypeController implements SimpleTextExportable
     // if this gets run we assume we need it to be validated/checked
     public function validateForm($data)
     {
-        return isset($data['value']) && $data['value'] == 1;
+        return is_array($data) && isset($data['value']) && $data['value'] == 1;
     }
 
     public function getAttributeKeySettingsClass()

--- a/concrete/attributes/date_time/controller.php
+++ b/concrete/attributes/date_time/controller.php
@@ -126,7 +126,7 @@ class Controller extends AttributeTypeController implements SimpleTextExportable
         if ($this->akDateDisplayMode === null) {
             $this->load();
         }
-        if (isset($data['value']) && $data['value'] != '') {
+        if (is_array($data) && isset($data['value']) && $data['value'] != '') {
             return true;
         } else {
             return false;

--- a/concrete/attributes/email/controller.php
+++ b/concrete/attributes/email/controller.php
@@ -35,6 +35,9 @@ class Controller extends DefaultController
      */
     public function validateForm($data)
     {
+        if (!is_array($data)) {
+            $data = [];
+        }
         if (empty($data['value'])) {
             return new FieldNotPresentError(new AttributeField($this->getAttributeKey()));
         }

--- a/concrete/attributes/express/controller.php
+++ b/concrete/attributes/express/controller.php
@@ -222,7 +222,7 @@ class Controller extends AttributeTypeController implements
 
     public function validateForm($p)
     {
-        return $p['value'] != false;
+        return is_array($p) && $p['value'] != false;
     }
 
     public function validateValue()

--- a/concrete/attributes/express/controller.php
+++ b/concrete/attributes/express/controller.php
@@ -222,7 +222,7 @@ class Controller extends AttributeTypeController implements
 
     public function validateForm($p)
     {
-        return is_array($p) && $p['value'] != false;
+        return is_array($p) && isset($p['value']) && $p['value'] != false;
     }
 
     public function validateValue()

--- a/concrete/attributes/image_file/controller.php
+++ b/concrete/attributes/image_file/controller.php
@@ -105,7 +105,7 @@ class Controller extends AttributeTypeController implements
         }
         return $url;
     }
-    
+
     public function exportValue(\SimpleXMLElement $akn)
     {
         $av = $akn->addChild('value');
@@ -218,6 +218,12 @@ class Controller extends AttributeTypeController implements
 
     public function validateForm($data)
     {
+        if (!is_array($data)) {
+            $data = [];
+        }
+        if (!isset($data['value'])) {
+            $data['value'] = null;
+        }
         if ($this->getAttributeKeySettings()->isModeFileManager()) {
             if ((int) ($data['value']) > 0) {
                 $f = File::getByID((int) ($data['value']));

--- a/concrete/attributes/number/controller.php
+++ b/concrete/attributes/number/controller.php
@@ -83,7 +83,7 @@ class Controller extends AttributeTypeController implements SimpleTextExportable
 
     public function validateForm($p)
     {
-        return !empty($p['value']);
+        return is_array($p) && !empty($p['value']);
     }
 
     public function validateValue()

--- a/concrete/attributes/page_selector/controller.php
+++ b/concrete/attributes/page_selector/controller.php
@@ -127,7 +127,7 @@ class Controller extends AttributeTypeController implements
 
     public function validateForm($p)
     {
-        return is_array($p) && $p['value'] != false;
+        return is_array($p) && isset($p['value']) && $p['value'] != false;
     }
 
     public function validateValue()

--- a/concrete/attributes/page_selector/controller.php
+++ b/concrete/attributes/page_selector/controller.php
@@ -127,7 +127,7 @@ class Controller extends AttributeTypeController implements
 
     public function validateForm($p)
     {
-        return $p['value'] != false;
+        return is_array($p) && $p['value'] != false;
     }
 
     public function validateValue()

--- a/concrete/attributes/user_group/controller.php
+++ b/concrete/attributes/user_group/controller.php
@@ -285,7 +285,7 @@ class Controller extends AttributeTypeController implements
     {
         $this->loadSettings();
         $selectedGroup = null;
-        if (isset($data['value'])) {
+        if (is_array($data) && isset($data['value'])) {
             $selectedGroup = Group::getByID((int) ($data['value']));
         }
         if ($selectedGroup) {

--- a/concrete/attributes/user_selector/controller.php
+++ b/concrete/attributes/user_selector/controller.php
@@ -136,7 +136,7 @@ class Controller extends AttributeTypeController implements
 
     public function validateForm($p)
     {
-        return is_array($p) && $p['value'] != false;
+        return is_array($p) && isset($p['value']) && $p['value'] != false;
     }
 
     public function validateValue()

--- a/concrete/attributes/user_selector/controller.php
+++ b/concrete/attributes/user_selector/controller.php
@@ -136,7 +136,7 @@ class Controller extends AttributeTypeController implements
 
     public function validateForm($p)
     {
-        return $p['value'] != false;
+        return is_array($p) && $p['value'] != false;
     }
 
     public function validateValue()

--- a/concrete/src/Attribute/DefaultController.php
+++ b/concrete/src/Attribute/DefaultController.php
@@ -93,7 +93,7 @@ class DefaultController extends AttributeTypeController implements SimpleTextExp
 
     public function validateForm($data)
     {
-        return isset($data['value']) && $data['value'] != '';
+        return is_array($data) && isset($data['value']) && $data['value'] != '';
     }
 
     /**

--- a/tests/helpers/Attribute/AttributeTypeTestCase.php
+++ b/tests/helpers/Attribute/AttributeTypeTestCase.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Concrete\TestHelpers\Attribute;
+
+use Concrete\Core\Attribute\Type as AttributeType;
+use Concrete\Core\Support\Facade\Application as ApplicationFacade;
+use Concrete\Core\Attribute\Key\Category;
+use Concrete\Core\Attribute\Key\CollectionKey;
+use Concrete\TestHelpers\Database\ConcreteDatabaseTestCase;
+
+abstract class AttributeTypeTestCase extends ConcreteDatabaseTestCase
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @see ConcreteDatabaseTestCase::$metadatas
+     */
+    protected $metadatas = [
+        'Concrete\Core\Entity\Site\Type',
+        'Concrete\Core\Entity\Site\Site',
+        'Concrete\Core\Entity\Site\Locale',
+        'Concrete\Core\Entity\Site\Tree',
+        'Concrete\Core\Entity\Site\SiteTree',
+        'Concrete\Core\Entity\Attribute\Category',
+        'Concrete\Core\Entity\Summary\Category',
+        'Concrete\Core\Entity\Page\Summary\PageTemplate',
+        'Concrete\Core\Entity\Attribute\Key\Key',
+        'Concrete\Core\Entity\Attribute\Key\PageKey',
+        'Concrete\Core\Entity\Attribute\Type',
+        'Concrete\Core\Entity\Attribute\Value\Value\TextareaValue',
+        'Concrete\Core\Entity\Attribute\Value\Value\TextValue',
+        'Concrete\Core\Entity\Attribute\Value\Value\BooleanValue',
+        'Concrete\Core\Entity\Attribute\Value\Value\Value',
+        'Concrete\Core\Entity\User\User',
+        'Concrete\Core\Entity\User\UserSignup',
+        'Concrete\Core\Entity\Attribute\Value\Value',
+        'Concrete\Core\Entity\Attribute\Value\PageValue',
+        'Concrete\Core\Entity\Attribute\Key\UserValue',
+        'Concrete\Core\Entity\Attribute\Key\UserKey',
+    ];
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see ConcreteDatabaseTestCase::$tables
+     */
+    protected $tables = [
+        'Collections',
+        'CollectionAttributeValues',
+        'Pages',
+        'PageSearchIndex',
+        'PageTypes',
+        'CollectionSearchIndexAttributes',
+        'CollectionVersions',
+    ];
+
+    /** @var string */
+    protected $atHandle;
+
+    /** @var Concrete\Core\Entity\Attribute\Type */
+    protected $at;
+
+    /** @var Concrete\Core\Attribute\Controller */
+    protected $ctrl;
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \PHPUnit\Framework\TestCase::setUp()
+     */
+    public function setUp(): void
+    {
+        // Truncate tables
+        $this->truncateTables();
+
+        parent::setUp();
+
+        $app = ApplicationFacade::getFacadeApplication();
+        $service = $app->make('site');
+        if (!$service->getDefault()) {
+            $service->installDefault('en_US');
+        }
+
+        $this->at = AttributeType::add($this->atHandle, $this->atHandle);
+        $this->ctrl = $this->at->getController();
+
+        Category::add('collection');
+        $key = CollectionKey::add($this->at, ['akHandle' => 'test', 'akName' => 'Test']);
+        $this->ctrl->setAttributeKey($key);
+    }
+}

--- a/tests/tests/Attribute/Type/AddressTest.php
+++ b/tests/tests/Attribute/Type/AddressTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Concrete\Tests\Attribute\Type;
+
+use Concrete\TestHelpers\Attribute\AttributeTypeTestCase;
+
+class AddressTest extends AttributeTypeTestCase
+{
+    protected $atHandle = 'address';
+
+    public function __construct($name = null, array $data = [], $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+
+        $this->metadatas[] = 'Concrete\Core\Entity\Attribute\Key\Settings\AddressSettings';
+    }
+
+    public function testValidateFormEmptyArray(): void
+    {
+        $this->assertFalse($this->ctrl->validateForm(null));
+    }
+}

--- a/tests/tests/Attribute/Type/BooleanTest.php
+++ b/tests/tests/Attribute/Type/BooleanTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Concrete\Tests\Attribute\Type;
+
+use Concrete\TestHelpers\Attribute\AttributeTypeTestCase;
+
+class BooleanTest extends AttributeTypeTestCase
+{
+    protected $atHandle = 'boolean';
+
+    public function __construct($name = null, array $data = [], $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+
+        $this->metadatas[] = 'Concrete\Core\Entity\Attribute\Key\Settings\BooleanSettings';
+    }
+
+    public function testValidateFormEmptyArray(): void
+    {
+        $this->assertFalse($this->ctrl->validateForm(null));
+    }
+}

--- a/tests/tests/Attribute/Type/CalendarEventTest.php
+++ b/tests/tests/Attribute/Type/CalendarEventTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Concrete\Tests\Attribute\Type;
+
+use Concrete\TestHelpers\Attribute\AttributeTypeTestCase;
+
+class CalendarEventTest extends AttributeTypeTestCase
+{
+    protected $atHandle = 'calendar_event';
+
+    public function __construct($name = null, array $data = [], $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+
+        $this->metadatas[] = 'Concrete\Core\Entity\Attribute\Key\Settings\EmptySettings';
+    }
+
+    public function testValidateFormEmptyArray(): void
+    {
+        $this->assertFalse($this->ctrl->validateForm(null));
+    }
+}

--- a/tests/tests/Attribute/Type/CalendarTest.php
+++ b/tests/tests/Attribute/Type/CalendarTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Concrete\Tests\Attribute\Type;
+
+use Concrete\TestHelpers\Attribute\AttributeTypeTestCase;
+
+class CalendarTest extends AttributeTypeTestCase
+{
+    protected $atHandle = 'calendar';
+
+    public function __construct($name = null, array $data = [], $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+
+        $this->metadatas[] = 'Concrete\Core\Entity\Attribute\Key\Settings\EmptySettings';
+    }
+
+    public function testValidateFormEmptyArray(): void
+    {
+        $this->assertFalse($this->ctrl->validateForm(null));
+    }
+}

--- a/tests/tests/Attribute/Type/DateTimeTest.php
+++ b/tests/tests/Attribute/Type/DateTimeTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Concrete\Tests\Attribute\Type;
+
+use Concrete\TestHelpers\Attribute\AttributeTypeTestCase;
+
+class DateTimeTest extends AttributeTypeTestCase
+{
+    protected $atHandle = 'date_time';
+
+    public function __construct($name = null, array $data = [], $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+
+        $this->metadatas[] = 'Concrete\Core\Entity\Attribute\Key\Settings\DateTimeSettings';
+    }
+
+    public function testValidateFormEmptyArray(): void
+    {
+        $this->assertFalse($this->ctrl->validateForm(null));
+    }
+}

--- a/tests/tests/Attribute/Type/EmailTest.php
+++ b/tests/tests/Attribute/Type/EmailTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Concrete\Tests\Attribute\Type;
+
+use Concrete\TestHelpers\Attribute\AttributeTypeTestCase;
+use Concrete\Core\Error\ErrorList\Error\FieldNotPresentError;
+
+class EmailTest extends AttributeTypeTestCase
+{
+    protected $atHandle = 'email';
+
+    public function __construct($name = null, array $data = [], $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+
+        $this->metadatas[] = 'Concrete\Core\Entity\Attribute\Key\Settings\TextSettings';
+    }
+
+    public function testValidateFormEmptyArray(): void
+    {
+        $this->assertInstanceOf(FieldNotPresentError::class, $this->ctrl->validateForm(null));
+    }
+}

--- a/tests/tests/Attribute/Type/ExpressTest.php
+++ b/tests/tests/Attribute/Type/ExpressTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Concrete\Tests\Attribute\Type;
+
+use Concrete\TestHelpers\Attribute\AttributeTypeTestCase;
+
+class ExpressTest extends AttributeTypeTestCase
+{
+    protected $atHandle = 'express';
+
+    public function __construct($name = null, array $data = [], $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+
+        $this->metadatas[] = 'Concrete\Core\Entity\Attribute\Key\Settings\ExpressSettings';
+    }
+
+    public function testValidateFormEmptyArray(): void
+    {
+        $this->assertFalse($this->ctrl->validateForm(null));
+    }
+}

--- a/tests/tests/Attribute/Type/ImageFileTest.php
+++ b/tests/tests/Attribute/Type/ImageFileTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Concrete\Tests\Attribute\Type;
+
+use Concrete\TestHelpers\Attribute\AttributeTypeTestCase;
+use Concrete\Core\Error\ErrorList\Error\FieldNotPresentError;
+
+class ImageFileTest extends AttributeTypeTestCase
+{
+    protected $atHandle = 'image_file';
+
+    public function __construct($name = null, array $data = [], $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+
+        $this->metadatas[] = 'Concrete\Core\Entity\Attribute\Key\Settings\ImageFileSettings';
+    }
+
+    public function testValidateFormEmptyArray(): void
+    {
+        $this->assertInstanceOf(FieldNotPresentError::class, $this->ctrl->validateForm(null));
+    }
+}

--- a/tests/tests/Attribute/Type/NumberTest.php
+++ b/tests/tests/Attribute/Type/NumberTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Concrete\Tests\Attribute\Type;
+
+use Concrete\TestHelpers\Attribute\AttributeTypeTestCase;
+
+class NumberTest extends AttributeTypeTestCase
+{
+    protected $atHandle = 'number';
+
+    public function __construct($name = null, array $data = [], $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+
+        $this->metadatas[] = 'Concrete\Core\Entity\Attribute\Key\Settings\EmptySettings';
+    }
+
+    public function testValidateFormEmptyArray(): void
+    {
+        $this->assertFalse($this->ctrl->validateForm(null));
+    }
+}

--- a/tests/tests/Attribute/Type/PageSelectorTest.php
+++ b/tests/tests/Attribute/Type/PageSelectorTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Concrete\Tests\Attribute\Type;
+
+use Concrete\TestHelpers\Attribute\AttributeTypeTestCase;
+
+class PageSelectorTest extends AttributeTypeTestCase
+{
+    protected $atHandle = 'page_selector';
+
+    public function __construct($name = null, array $data = [], $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+
+        $this->metadatas[] = 'Concrete\Core\Entity\Attribute\Key\Settings\EmptySettings';
+    }
+
+    public function testValidateFormEmptyArray(): void
+    {
+        $this->assertFalse($this->ctrl->validateForm(null));
+    }
+}

--- a/tests/tests/Attribute/Type/SelectTest.php
+++ b/tests/tests/Attribute/Type/SelectTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Concrete\Tests\Attribute\Type;
+
+use Concrete\TestHelpers\Attribute\AttributeTypeTestCase;
+
+class SelectTest extends AttributeTypeTestCase
+{
+    protected $atHandle = 'select';
+
+    public function __construct($name = null, array $data = [], $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+
+        $this->metadatas[] = 'Concrete\Core\Entity\Attribute\Key\Settings\SelectSettings';
+        $this->metadatas[] = 'Concrete\Core\Entity\Attribute\Value\Value\SelectValueOptionList';
+    }
+
+    public function testValidateFormEmptyArray(): void
+    {
+        $this->assertFalse($this->ctrl->validateForm(null));
+    }
+}

--- a/tests/tests/Attribute/Type/TelephoneTest.php
+++ b/tests/tests/Attribute/Type/TelephoneTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Concrete\Tests\Attribute\Type;
+
+use Concrete\TestHelpers\Attribute\AttributeTypeTestCase;
+
+class TelephoneTest extends AttributeTypeTestCase
+{
+    protected $atHandle = 'telephone';
+
+    public function __construct($name = null, array $data = [], $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+
+        $this->metadatas[] = 'Concrete\Core\Entity\Attribute\Key\Settings\TextSettings';
+    }
+
+    public function testValidateFormEmptyArray(): void
+    {
+        $this->assertFalse($this->ctrl->validateForm(null));
+    }
+}

--- a/tests/tests/Attribute/Type/TextTest.php
+++ b/tests/tests/Attribute/Type/TextTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Concrete\Tests\Attribute\Type;
+
+use Concrete\TestHelpers\Attribute\AttributeTypeTestCase;
+
+class TextTest extends AttributeTypeTestCase
+{
+    protected $atHandle = 'text';
+
+    public function __construct($name = null, array $data = [], $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+
+        $this->metadatas[] = 'Concrete\Core\Entity\Attribute\Key\Settings\TextSettings';
+    }
+
+    public function testValidateFormEmptyArray(): void
+    {
+        $this->assertFalse($this->ctrl->validateForm(null));
+    }
+}

--- a/tests/tests/Attribute/Type/TextareaTest.php
+++ b/tests/tests/Attribute/Type/TextareaTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Concrete\Tests\Attribute\Type;
+
+use Concrete\TestHelpers\Attribute\AttributeTypeTestCase;
+
+class TextareaTest extends AttributeTypeTestCase
+{
+    protected $atHandle = 'textarea';
+
+    public function __construct($name = null, array $data = [], $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+
+        $this->metadatas[] = 'Concrete\Core\Entity\Attribute\Key\Settings\TextareaSettings';
+    }
+
+    public function testValidateFormEmptyArray(): void
+    {
+        $this->assertFalse($this->ctrl->validateForm(null));
+    }
+}

--- a/tests/tests/Attribute/Type/TopicsTest.php
+++ b/tests/tests/Attribute/Type/TopicsTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Concrete\Tests\Attribute\Type;
+
+use Concrete\TestHelpers\Attribute\AttributeTypeTestCase;
+
+class TopicsTest extends AttributeTypeTestCase
+{
+    protected $atHandle = 'topics';
+
+    public function __construct($name = null, array $data = [], $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+
+        $this->metadatas[] = 'Concrete\Core\Entity\Attribute\Key\Settings\TopicsSettings';
+    }
+
+    public function testValidateFormEmptyArray(): void
+    {
+        $this->assertFalse($this->ctrl->validateForm(null));
+    }
+}

--- a/tests/tests/Attribute/Type/UrlTest.php
+++ b/tests/tests/Attribute/Type/UrlTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Concrete\Tests\Attribute\Type;
+
+use Concrete\TestHelpers\Attribute\AttributeTypeTestCase;
+
+class UrlTest extends AttributeTypeTestCase
+{
+    protected $atHandle = 'url';
+
+    public function __construct($name = null, array $data = [], $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+
+        $this->metadatas[] = 'Concrete\Core\Entity\Attribute\Key\Settings\TextSettings';
+    }
+
+    public function testValidateFormEmptyArray(): void
+    {
+        $this->assertFalse($this->ctrl->validateForm(null));
+    }
+}

--- a/tests/tests/Attribute/Type/UserGroupTest.php
+++ b/tests/tests/Attribute/Type/UserGroupTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Concrete\Tests\Attribute\Type;
+
+use Concrete\TestHelpers\Attribute\AttributeTypeTestCase;
+use Concrete\Core\Error\ErrorList\Error\FieldNotPresentError;
+
+class UserGroupTest extends AttributeTypeTestCase
+{
+    protected $atHandle = 'user_group';
+
+    public function __construct($name = null, array $data = [], $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+
+        $this->metadatas[] = 'Concrete\Core\Entity\Attribute\Key\Settings\UserGroupSettings';
+    }
+
+    public function testValidateFormEmptyArray(): void
+    {
+        $this->assertInstanceOf(FieldNotPresentError::class, $this->ctrl->validateForm(null));
+    }
+}

--- a/tests/tests/Attribute/Type/UserSelectorTest.php
+++ b/tests/tests/Attribute/Type/UserSelectorTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Concrete\Tests\Attribute\Type;
+
+use Concrete\TestHelpers\Attribute\AttributeTypeTestCase;
+
+class UserSelectorTest extends AttributeTypeTestCase
+{
+    protected $atHandle = 'user_selector';
+
+    public function __construct($name = null, array $data = [], $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+
+        $this->metadatas[] = 'Concrete\Core\Entity\Attribute\Key\Settings\EmptySettings';
+    }
+
+    public function testValidateFormEmptyArray(): void
+    {
+        $this->assertFalse($this->ctrl->validateForm(null));
+    }
+}


### PR DESCRIPTION
There was an error in the logs that sometimes the attribute form validation fails through composer form because the post data is not set for the attribute.

The route that caused this error was: `/ccm/system/panels/details/page/composer/publish`.

The error in the logs:
```
/.../concrete/attributes/express/controller.php:225 Trying to access array offset on null (2)
```

This can happen as the validation happens here:
https://github.com/concretecms/concretecms/blob/e94a0ed7dc24d76455daada71441fccca3819acf/concrete/src/Attribute/StandardValidator.php#L39

And the value passed to the validation can be null as defined here:
https://github.com/concretecms/concretecms/blob/e94a0ed7dc24d76455daada71441fccca3819acf/concrete/src/Attribute/Controller.php#L518-L521