### PR TITLE
Export content columns with LinkAbstractor

### DIFF
--- a/concrete/blocks/content/controller.php
+++ b/concrete/blocks/content/controller.php
@@ -7,8 +7,6 @@ use Concrete\Core\Editor\LinkAbstractor;
 use Concrete\Core\Feature\Features;
 use Concrete\Core\Feature\UsesFeatureInterface;
 use Concrete\Core\File\Tracker\FileTrackableInterface;
-use Concrete\Core\Page\Page;
-use Concrete\Core\Utility\Service\Xml;
 
 /**
  * The controller for the content block.
@@ -78,6 +76,13 @@ class Controller extends BlockController implements FileTrackableInterface, Uses
     protected $btCacheBlockOutputLifetime = 0; //until manually updated or cleared
 
     /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Block\BlockController::$btExportContentColumns
+     */
+    protected $btExportContentColumns = ['content'];
+
+    /**
      * {@inhertdoc}.
      */
     public function getRequiredFeatures(): array
@@ -143,34 +148,6 @@ class Controller extends BlockController implements FileTrackableInterface, Uses
     public function getContentEditMode()
     {
         return LinkAbstractor::translateFromEditMode($this->content);
-    }
-
-    /**
-     * @param \SimpleXMLElement $blockNode
-     * @param Page $page
-     *
-     * @return array<string, string>
-     */
-    public function getImportData($blockNode, $page)
-    {
-        $content = $blockNode->data->record->content;
-        $content = LinkAbstractor::import($content);
-
-        return ['content' => $content];
-    }
-
-    /**
-     * @param \SimpleXMLElement $blockNode
-     *
-     * @return void
-     */
-    public function export(\SimpleXMLElement $blockNode)
-    {
-        $data = $blockNode->addChild('data');
-        $data->addAttribute('table', $this->btTable);
-        $record = $data->addChild('record');
-        $content = LinkAbstractor::export($this->content);
-        $this->app->make(Xml::class)->createChildElement($record, 'content', $content);
     }
 
     /**

--- a/concrete/src/Block/BlockController.php
+++ b/concrete/src/Block/BlockController.php
@@ -5,6 +5,7 @@ use Concrete\Core\Area\Area;
 use Concrete\Core\Backup\ContentExporter;
 use Concrete\Core\Backup\ContentImporter;
 use Concrete\Core\Block\View\BlockViewTemplate;
+use Concrete\Core\Database\Connection\Connection;
 use Concrete\Core\Editor\LinkAbstractor;
 use Concrete\Core\Entity\Block\BlockType\BlockType;
 use Concrete\Core\Error\ErrorList\ErrorList;
@@ -414,7 +415,7 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
         } else {
             $tables = [$this->getBlockTypeDatabaseTable()];
         }
-        $db = Database::connection();
+        $db = $this->app->make(Connection::class);
 
         $xml = $this->app->make(Xml::class);
         foreach ($tables as $tbl) {
@@ -426,9 +427,9 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
             $columns = $db->MetaColumns($tbl);
             // remove columns we don't want
             unset($columns['bid']);
-            $r = $db->Execute('select * from ' . $tbl . ' where bID = ?', [$this->bID]);
+            $r = $db->executeQuery('select * from ' . $tbl . ' where bID = ?', [$this->bID]);
             $btExportPageColumns = $this->getBlockTypeExportPageColumns();
-            while ($record = $r->fetch()) {
+            while (($record = $r->fetchAssociative()) !== false) {
                 $tableRecord = $data->addChild('record');
                 foreach ($record as $key => $value) {
                     if (isset($columns[strtolower($key)])) {

--- a/concrete/src/Block/BlockController.php
+++ b/concrete/src/Block/BlockController.php
@@ -427,11 +427,12 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
             // remove columns we don't want
             unset($columns['bid']);
             $r = $db->Execute('select * from ' . $tbl . ' where bID = ?', [$this->bID]);
+            $btExportPageColumns = $this->getBlockTypeExportPageColumns();
             while ($record = $r->fetch()) {
                 $tableRecord = $data->addChild('record');
                 foreach ($record as $key => $value) {
                     if (isset($columns[strtolower($key)])) {
-                        if (in_array($key, $this->btExportPageColumns)) {
+                        if (in_array($key, $btExportPageColumns)) {
                             $tableRecord->addChild($key, ContentExporter::replacePageWithPlaceHolder($value));
                         } elseif (in_array($key, $this->btExportFileColumns)) {
                             $tableRecord->addChild($key, ContentExporter::replaceFileWithPlaceHolder($value));
@@ -533,11 +534,12 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
         $args = [];
         $inspector = \Core::make('import/value_inspector');
         if (isset($blockNode->data)) {
+            $btExportPageColumns = $this->getBlockTypeExportPageColumns();
             foreach ($blockNode->data as $data) {
                 if ($data['table'] == $this->getBlockTypeDatabaseTable()) {
                     if (isset($data->record)) {
                         foreach ($data->record->children() as $key => $node) {
-                            if (in_array($key, $this->btExportPageColumns)
+                            if (in_array($key, $btExportPageColumns)
                                 || in_array($key, $this->btExportFileColumns)
                                 || in_array($key, $this->btExportPageTypeColumns)
                                 || in_array($key, $this->btExportPageFeedColumns)
@@ -563,6 +565,7 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
     {
         $inspector = \Core::make('import/value_inspector');
         if (isset($blockNode->data)) {
+            $btExportPageColumns = $this->getBlockTypeExportPageColumns();
             foreach ($blockNode->data as $data) {
                 if (strtoupper((string) $data['table']) != strtoupper((string) $this->getBlockTypeDatabaseTable())) {
                     $table = (string) $data['table'];
@@ -572,7 +575,7 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
                             $aar->bID = $b->getBlockID();
                             foreach ($record->children() as $key => $node) {
                                 $nodeName = $node->getName();
-                                if (in_array($key, $this->btExportPageColumns)
+                                if (in_array($key, $btExportPageColumns)
                                     || in_array($key, $this->btExportFileColumns)
                                     || in_array($key, $this->btExportPageTypeColumns)
                                     || in_array($key, $this->btExportPageFeedColumns)

--- a/concrete/src/Block/BlockController.php
+++ b/concrete/src/Block/BlockController.php
@@ -50,12 +50,49 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
     protected $btCacheBlockOutputOnPost = false;
     protected $btCacheBlockOutputForRegisteredUsers = false;
     protected $bActionCID;
+
+    /**
+     * The names of the columns that contain a page ID.
+     *
+     * @var string[]
+     */
     protected $btExportPageColumns = [];
+
+    /**
+     * The names of the columns that contain a file ID.
+     *
+     * @var string[]
+     */
     protected $btExportFileColumns = [];
+
+    /**
+     * The names of the columns that contain rich text (that is, HTML with possibly links to files and pages).
+     *
+     * @var string[]
+     */
     protected $btExportContentColumns = [];
+
+    /**
+     * The names of the columns that contain a page type ID.
+     *
+     * @var string[]
+     */
     protected $btExportPageTypeColumns = [];
+
+    /**
+     * The names of the columns that contain a feed ID.
+     *
+     * @var string[]
+     */
     protected $btExportPageFeedColumns = [];
+
+    /**
+     * The names of the columns that contain a file folder ID.
+     *
+     * @var string[]
+     */
     protected $btExportFileFolderColumns = [];
+
     protected $btWrapperClass = '';
     protected $btDefaultSet;
     protected $identifier;
@@ -95,6 +132,11 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
         return $this->getBlockTypeName();
     }
 
+    /**
+     * Get the names of the columns that contain page IDs.
+     *
+     * @return string[]
+     */
     public function getBlockTypeExportPageColumns()
     {
         return $this->btExportPageColumns;

--- a/concrete/src/Block/BlockController.php
+++ b/concrete/src/Block/BlockController.php
@@ -4,8 +4,9 @@ namespace Concrete\Core\Block;
 use Concrete\Core\Area\Area;
 use Concrete\Core\Backup\ContentExporter;
 use Concrete\Core\Backup\ContentImporter;
-use Concrete\Core\Entity\Block\BlockType\BlockType;
 use Concrete\Core\Block\View\BlockViewTemplate;
+use Concrete\Core\Entity\Block\BlockType\BlockType;
+use Concrete\Core\Error\ErrorList\ErrorList;
 use Concrete\Core\File\Tracker\FileTrackableInterface;
 use Concrete\Core\Legacy\BlockRecord;
 use Concrete\Core\Page\Controller\PageController;
@@ -19,7 +20,6 @@ use Database;
 use Events;
 use Package;
 use Page;
-use Concrete\Core\Error\ErrorList\ErrorList;
 
 class BlockController extends \Concrete\Core\Controller\AbstractController
 {

--- a/concrete/src/Block/BlockController.php
+++ b/concrete/src/Block/BlockController.php
@@ -5,6 +5,7 @@ use Concrete\Core\Area\Area;
 use Concrete\Core\Backup\ContentExporter;
 use Concrete\Core\Backup\ContentImporter;
 use Concrete\Core\Block\View\BlockViewTemplate;
+use Concrete\Core\Editor\LinkAbstractor;
 use Concrete\Core\Entity\Block\BlockType\BlockType;
 use Concrete\Core\Error\ErrorList\ErrorList;
 use Concrete\Core\File\Tracker\FileTrackableInterface;
@@ -398,6 +399,8 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
                             $tableRecord->addChild($key, ContentExporter::replacePageFeedWithPlaceHolder($value));
                         } elseif (in_array($key, $this->btExportFileFolderColumns)) {
                             $tableRecord->addChild($key, ContentExporter::replaceFileFolderWithPlaceHolder($value));
+                        } elseif (in_array($key, $this->btExportContentColumns)) {
+                            $tableRecord->addChild($key, LinkAbstractor::export((string) $value));
                         } else {
                             $xml->createChildElement($tableRecord, $key, $value);
                         }


### PR DESCRIPTION
When we import blocks data from XML, we use these fields to automatically translate special data:

- `btExportContentColumns` for the columns that contain rich text
- `btExportFileColumns` for the columns that contain a file ID
- `btExportFileFolderColumns` for the columns that contain a file folder ID
- `btExportPageColumns` for the columns that contain a page ID
- `btExportPageFeedColumns` for the columns that contain a feed ID
- `btExportPageTypeColumns` for the columns that contain a page type ID

When we export the blocks data to XML, we use all of them except `btExportContentColumns`, and I don't see any reason for that.
I only see drawbacks... For example, the Content block must implement its own `export()` method.
Also, since the Content block doesn't define the value of `btExportContentColumns`, it has to implement its own `getImportData()` method (not needed if we define `btExportContentColumns`).