### PR TITLE
allow marked middlewares to run when page is cached

### DIFF
--- a/concrete/src/Application/Application.php
+++ b/concrete/src/Application/Application.php
@@ -7,6 +7,7 @@ use Concrete\Core\Cache\Page\PageCache;
 use Concrete\Core\Cache\Page\PageCacheRecord;
 use Concrete\Core\Entity\Site\Site;
 use Concrete\Core\Foundation\ClassAutoloader;
+use Concrete\Core\Foundation\ClassLoader;
 use Concrete\Core\Foundation\EnvironmentDetector;
 use Concrete\Core\Foundation\Runtime\DefaultRuntime;
 use Concrete\Core\Foundation\Runtime\RuntimeInterface;
@@ -39,7 +40,7 @@ class Application extends Container
 {
     protected $installed = null;
     protected $environment = null;
-  
+
     /**
      * @var \Concrete\Core\Package\Package[]
      */
@@ -222,6 +223,21 @@ class Application extends Container
             $this->make(MutexInterface::class)->execute(Update::MUTEX_KEY, function () {
                 Update::updateToCurrentVersion();
             });
+        }
+    }
+
+    public function setupPackageAutoload(string $handle)
+    {
+        /**
+         * @var PackageService $packageService
+         */
+        $packageService = $this->make(PackageService::class);
+        $config = $this->make('config');
+        $packageEntity = $packageService->getByHandle($handle);
+        $packageController = $packageService->getClass($packageEntity->getPackageHandle());
+        if (!$packageController instanceof BrokenPackage) {
+            $config->package($packageController);
+            $this->packages[] = $packageController;
         }
     }
 
@@ -510,5 +526,5 @@ class Application extends Container
     {
         return $this->singleton($abstract, $concrete);
     }
-    
+
 }

--- a/concrete/src/Foundation/Runtime/Boot/DefaultBooter.php
+++ b/concrete/src/Foundation/Runtime/Boot/DefaultBooter.php
@@ -206,11 +206,8 @@ class DefaultBooter implements BootInterface, ApplicationAwareInterface
 
         $middlewareCache = [];
         foreach ($middlewareConfig as $middleware) {
-            if (is_array($middleware)) {
-                $runBeforeCache = isset($middleware['run_during_cache']) && $middleware['run_during_cache'] === true;
-                if ($runBeforeCache) {
-                    $middlewareCache[] = $middleware;
-                }
+            if (is_array($middleware) && !empty($middleware['run_during_cache'])) {
+                $middlewareCache[] = $middleware;
             }
         }
 
@@ -223,14 +220,10 @@ class DefaultBooter implements BootInterface, ApplicationAwareInterface
          */
         $stack = $this->app->make(StackInterface::class);
         foreach ($middlewareCache as $middleware) {
-            if (is_array($middleware)) {
-                $stack = $stack->withMiddleware(
-                    $this->app->make($middleware['class']),
-                    $middleware['priority'] ?? 10
-                );
-            } elseif (is_string($middleware)) {
-                $stack = $stack->withMiddleware($this->app->make($middleware));
-            }
+            $stack = $stack->withMiddleware(
+                $this->app->make($middleware['class']),
+                $middleware['priority'] ?? 10
+            );
         }
 
         /**

--- a/concrete/src/Foundation/Runtime/Boot/DefaultBooter.php
+++ b/concrete/src/Foundation/Runtime/Boot/DefaultBooter.php
@@ -220,8 +220,12 @@ class DefaultBooter implements BootInterface, ApplicationAwareInterface
          */
         $stack = $this->app->make(StackInterface::class);
         foreach ($middlewareCache as $middleware) {
+            if (isset($middleware['package'])) {
+                $this->app->setupPackageAutoload($middleware['package']);
+            }
+            $class = $middleware['class'];
             $stack = $stack->withMiddleware(
-                $this->app->make($middleware['class']),
+                $this->app->make($class),
                 $middleware['priority'] ?? 10
             );
         }

--- a/concrete/src/Foundation/Runtime/Boot/DefaultBooter.php
+++ b/concrete/src/Foundation/Runtime/Boot/DefaultBooter.php
@@ -8,6 +8,8 @@ use Concrete\Core\Application\ApplicationAwareTrait;
 use Concrete\Core\Asset\AssetList;
 use Concrete\Core\File\Type\TypeList;
 use Concrete\Core\Foundation\ClassAutoloader;
+use Concrete\Core\Http\Middleware\DispatcherDelegate;
+use Concrete\Core\Http\Middleware\StackInterface;
 use Concrete\Core\Http\Request;
 use Concrete\Core\Routing\RedirectResponse;
 use Concrete\Core\Routing\SystemRouteList;
@@ -168,6 +170,16 @@ class DefaultBooter implements BootInterface, ApplicationAwareInterface
              * ----------------------------------------------------------------------------
              */
             if ($response = $this->checkCache($app, $request)) {
+                /*
+                 * ----------------------------------------------------------------------------
+                 * Execute middleware before returning page cache
+                 * ----------------------------------------------------------------------------
+                 */
+                $middlewareResponse = $this->executeCacheMiddleware($request, $config);
+                if ($middlewareResponse instanceof Response) {
+                    return $middlewareResponse;
+                }
+
                 return $response;
             }
 
@@ -178,6 +190,57 @@ class DefaultBooter implements BootInterface, ApplicationAwareInterface
              */
             $this->initializePackages($app);
         }
+    }
+
+    /**
+     * Execute middleware that should run before returning page cache.
+     *
+     * @param Request $request
+     * @param Repository $config
+     *
+     * @return Response|null
+     */
+    private function executeCacheMiddleware(Request $request, Repository $config): ?Response
+    {
+        $middlewareConfig = $config->get('app.middleware', []);
+
+        $middlewareCache = [];
+        foreach ($middlewareConfig as $middleware) {
+            if (is_array($middleware)) {
+                $runBeforeCache = isset($middleware['run_during_cache']) && $middleware['run_during_cache'] === true;
+                if ($runBeforeCache) {
+                    $middlewareCache[] = $middleware;
+                }
+            }
+        }
+
+        if (empty($middlewareCache)) {
+            return null;
+        }
+
+        /**
+         * @var StackInterface $stack
+         */
+        $stack = $this->app->make(StackInterface::class);
+        foreach ($middlewareCache as $middleware) {
+            if (is_array($middleware)) {
+                $stack = $stack->withMiddleware(
+                    $this->app->make($middleware['class']),
+                    $middleware['priority'] ?? 10
+                );
+            } elseif (is_string($middleware)) {
+                $stack = $stack->withMiddleware($this->app->make($middleware));
+            }
+        }
+
+        /**
+         * @var DispatcherDelegate $dispatcherDelegate
+         */
+        $dispatcherDelegate = $this->app->make(DispatcherDelegate::class);
+
+        $stack = $stack->withDispatcher($dispatcherDelegate);
+
+        return $stack->process($request);
     }
 
     /**
@@ -312,7 +375,7 @@ class DefaultBooter implements BootInterface, ApplicationAwareInterface
         $autoloader
             ->addClassAliases($config->get('app.aliases', []), true)
             ->addClassAliases($config->get('app.facades', []), false)
-        ;        
+        ;
         // Autoload aliases to prevent typehinting errors
         class_exists('Request');
     }


### PR DESCRIPTION
This allows middlewares to run when the page is cached, so as an example you can add in the app.middleware config the following 

```
<?php

return [
    'middleware' => [
        [
            'priority' => 1,
            'class' => \Application\Http\Middleware\TestMiddleware::class,
            'run_during_cache' => true
        ],
    ],
];
```

and then create the middleware as normal e.g 

```
<?php

namespace Application\Http\Middleware;

use Concrete\Core\Routing\Redirect;
use Concrete\Core\Support\Facade\Application;
use Symfony\Component\HttpFoundation\Request;
use Concrete\Core\Http\Middleware\MiddlewareInterface;
use Concrete\Core\Http\Middleware\DelegateInterface;

class TestMiddleware implements MiddlewareInterface
{
    public function process(Request $request, DelegateInterface $frame)
    {
        if ($request->get('check_cache')) {
            $response = Redirect::to('/some-page');
            $response->send();
            Application::getFacadeApplication()->shutdown();
        }

        return $frame->next($request);
    }
}
```

Resolves this issue I raised https://github.com/concretecms/concretecms/issues/12344 