### PR TITLE
Redirect in case express form submit happens without a valid form

### DIFF
--- a/concrete/src/Controller/Traits/DashboardExpressEntryDetailsTrait.php
+++ b/concrete/src/Controller/Traits/DashboardExpressEntryDetailsTrait.php
@@ -273,11 +273,11 @@ trait DashboardExpressEntryDetailsTrait
             $this->flash('error', t('No details about the form provided.'));
 
             if (is_object($entry)) {
-                return $this->buildRedirect(\URL::to(\Page::getCurrentPage(), 'edit_entry', $entry->getID()))->send();
+                return $this->buildRedirect(\URL::to(\Page::getCurrentPage(), 'edit_entry', $entry->getID()));
             } else if (is_object($entity)) {
-                return $this->buildRedirect(\URL::to(\Page::getCurrentPage(), 'results', $entity->getID()))->send();
+                return $this->buildRedirect(\URL::to(\Page::getCurrentPage(), 'results', $entity->getID()));
             } else {
-                return $this->buildRedirect(\URL::to(\Page::getCurrentPage()))->send();
+                return $this->buildRedirect(\URL::to(\Page::getCurrentPage()));
             }
         }
     }

--- a/concrete/src/Controller/Traits/DashboardExpressEntryDetailsTrait.php
+++ b/concrete/src/Controller/Traits/DashboardExpressEntryDetailsTrait.php
@@ -270,7 +270,15 @@ trait DashboardExpressEntryDetailsTrait
                 }
             }
         } else {
-            throw new \Exception(t('Invalid form.'));
+            $this->flash('error', t('No details about the form provided.'));
+
+            if (is_object($entry)) {
+                return $this->buildRedirect(\URL::to(\Page::getCurrentPage(), 'edit_entry', $entry->getID()))->send();
+            } else if (is_object($entity)) {
+                return $this->buildRedirect(\URL::to(\Page::getCurrentPage(), 'results', $entity->getID()))->send();
+            } else {
+                return $this->buildRedirect(\URL::to(\Page::getCurrentPage()))->send();
+            }
         }
     }
 

--- a/tests/helpers/Page/DashboardPageTestCase.php
+++ b/tests/helpers/Page/DashboardPageTestCase.php
@@ -60,7 +60,7 @@ class DashboardPageTestCase extends PageTestCase
         $app = ApplicationFacade::getFacadeApplication();
         $app->forgetInstance(User::class);
 
-        $session = $this->app->make('session');
+        $session = $app->make('session');
         $session->clear();
     }
 

--- a/tests/helpers/Page/DashboardPageTestCase.php
+++ b/tests/helpers/Page/DashboardPageTestCase.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace Concrete\TestHelpers\Page;
+
+use Concrete\Core\Attribute\Key\Category;
+use Concrete\Core\Encryption\PasswordHasher;
+use Concrete\Core\Page\Single as SinglePage;
+use Concrete\Core\Permission\Access\Entity\Type as AccessEntityType;
+use Concrete\Core\Permission\Category as PermissionCategory;
+use Concrete\Core\Permission\Key\Key as PermissionKey;
+use Concrete\Core\Support\Facade\Application as ApplicationFacade;
+use Concrete\Core\User\UserInfo;
+use Concrete\Core\Http\Request;
+use Concrete\Core\Http\ServerInterface;
+use Concrete\TestHelpers\Page\PageTestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class DashboardPageTestCase extends PageTestCase
+{
+    /** @var string|null */
+    protected static $pageUrl;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        $app = ApplicationFacade::getFacadeApplication();
+
+        Category::add('user');
+        Category::add('collection');
+        AccessEntityType::add('page_owner', 'Page Owner');
+        AccessEntityType::add('group', 'Group');
+        PermissionCategory::add('page');
+        PermissionKey::add('page', 'view_page', 'View Page', '', 0, 0);
+        PermissionKey::add('page', 'view_page_versions', 'View Page Versions', '', 0, 0);
+        PermissionKey::add('page', 'edit_page_contents', 'Edit Page Contents', '', 0, 0);
+        PermissionKey::add('page', 'edit_page_properties', 'Edit Page Properties', '', 0, 0);
+
+        $hasher = $app->make(PasswordHasher::class);
+        $adminInfo = UserInfo::addSuperUser(
+            $hasher->hashPassword('p4ssW0!rd'),
+            'admin@example.org'
+        );
+        // Persist the admin login
+        $admin = $adminInfo->getUserObject();
+        $admin->persist();
+
+        if (!isset(static::$pageUrl)) {
+          throw new \Exception("Please set the page URL for the test.");
+        }
+
+        $login = SinglePage::add(static::$pageUrl);
+    }
+
+    public function __construct($name = null, array $data = [], $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+
+        // General
+        $this->tables[] = 'Config';
+        // Pages
+        $this->tables[] = 'PageThemeCustomStyles';
+
+        // Users & permissions
+        $this->tables[] = 'UserGroups';
+        $this->tables[] = 'Groups';
+        $this->tables[] = 'TreeTypes';
+        $this->tables[] = 'TreeNodes';
+        $this->tables[] = 'TreeNodePermissionAssignments';
+        $this->tables[] = 'AreaPermissionAssignments';
+        $this->tables[] = 'PermissionAccess';
+        $this->tables[] = 'PermissionAccessEntities';
+        $this->tables[] = 'PermissionAccessEntityGroups';
+        $this->tables[] = 'PermissionAccessList';
+        $this->tables[] = 'PermissionKeyCategories';
+        $this->tables[] = 'PermissionKeys';
+        $this->tables[] = 'TreeNodeTypes';
+        $this->tables[] = 'Trees';
+        $this->tables[] = 'TreeGroupNodes';
+        // Blocks
+        $this->tables[] = 'BlockTypes';
+        $this->tables[] = 'Blocks';
+        // Stacks
+        $this->tables[] = 'Stacks';
+
+        // Users
+        $this->metadatas[] = 'Concrete\Core\Entity\User\User';
+        $this->metadatas[] = 'Concrete\Core\Entity\User\UserSignup';
+        $this->metadatas[] = 'Concrete\Core\Entity\Attribute\Category';
+        $this->metadatas[] = 'Concrete\Core\Entity\Attribute\Type';
+        $this->metadatas[] = 'Concrete\Core\Entity\Attribute\Key\Key';
+        $this->metadatas[] = 'Concrete\Core\Entity\Attribute\Key\UserValue';
+        $this->metadatas[] = 'Concrete\Core\Entity\Attribute\Key\UserKey';
+        // Messenger
+        $this->metadatas[] = 'Concrete\Core\Entity\Command\Process';
+        $this->metadatas[] = 'Concrete\Core\Entity\Command\TaskProcess';
+        // Blocks
+        $this->metadatas[] = 'Concrete\Core\Entity\Block\BlockType\BlockType';
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        $session = $this->app->make('session');
+        $session->getFlashBag()->clear();
+    }
+
+    protected function getCookies(): array
+    {
+        $cookieName = $this->app['config']->get('concrete.session.name');
+        $session = $this->app['session'];
+
+        return [$cookieName => $session->getId()];
+    }
+
+    protected function sendRequest(Request $request): Response
+    {
+        // Make the request variables available through the PHP defaults that
+        // concrete5 controllers are using
+        $request->overrideGlobals();
+
+        $server = $this->app->make(ServerInterface::class);
+
+        // The controller "sends" the request, i.e. prints it to the current
+        // PHP thread STDOUT which is why we want to hide this from the test
+        // output.
+        ob_start();
+        $response = $server->handleRequest($request);
+        $contents = ob_get_contents();
+        ob_end_clean();
+
+        return $response;
+    }
+
+    protected function assertFlashMessage($type, $message): void
+    {
+        $session = $this->app->make('session');
+        $pageMessages = $session->getFlashBag()->get('page_message');
+        if (!is_array($pageMessages)) {
+            $pageMessages = [];
+        }
+        $storedMessage = ['undefined', 'undefined', false];
+        foreach ($pageMessages as $msg) {
+            if ($msg[0] === $type) {
+                $storedMessage = $msg;
+                break;
+            }
+        }
+
+        $this->assertEquals($type, $storedMessage[0]);
+        $this->assertEquals($message, $storedMessage[1]);
+    }
+}

--- a/tests/helpers/Page/DashboardPageTestCase.php
+++ b/tests/helpers/Page/DashboardPageTestCase.php
@@ -10,6 +10,7 @@ use Concrete\Core\Permission\Category as PermissionCategory;
 use Concrete\Core\Permission\Key\Key as PermissionKey;
 use Concrete\Core\Support\Facade\Application as ApplicationFacade;
 use Concrete\Core\User\UserInfo;
+use Concrete\Core\User\User;
 use Concrete\Core\Http\Request;
 use Concrete\Core\Http\ServerInterface;
 use Concrete\TestHelpers\Page\PageTestCase;
@@ -43,13 +44,24 @@ class DashboardPageTestCase extends PageTestCase
         );
         // Persist the admin login
         $admin = $adminInfo->getUserObject();
-        $admin->persist();
+        $admin->persist(false);
 
         if (!isset(static::$pageUrl)) {
           throw new \Exception("Please set the page URL for the test.");
         }
 
         $login = SinglePage::add(static::$pageUrl);
+    }
+
+    public static function tearDownAfterClass(): void
+    {
+        parent::tearDownAfterClass();
+
+        $app = ApplicationFacade::getFacadeApplication();
+        $app->forgetInstance(User::class);
+
+        $session = $this->app->make('session');
+        $session->clear();
     }
 
     public function __construct($name = null, array $data = [], $dataName = '')

--- a/tests/tests/Controller/SinglePage/Dashboard/ExpressEntriesTest.php
+++ b/tests/tests/Controller/SinglePage/Dashboard/ExpressEntriesTest.php
@@ -52,11 +52,6 @@ class ExpressEntriesTest extends DashboardPageTestCase
         $this->metadatas[] = 'Concrete\Core\Entity\Attribute\Key\Settings\TextSettings';
     }
 
-    public function setUp(): void
-    {
-        parent::setUp();
-    }
-
     public function testUnexistingFormSubmitWithoutEntity(): void
     {
         $id = '00000000-0000-0000-0000-000000000000';

--- a/tests/tests/Controller/SinglePage/Dashboard/ExpressEntriesTest.php
+++ b/tests/tests/Controller/SinglePage/Dashboard/ExpressEntriesTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Concrete\Tests\Controller\SinglePage\Dashboard;
+
+use Concrete\Core\Attribute\Key\Category;
+use Concrete\Core\Entity\Express\Entity;
+use Concrete\Core\Entity\Express\Entry;
+use Concrete\Core\Http\Request;
+use Concrete\Core\Support\Facade\Application as ApplicationFacade;
+use Concrete\TestHelpers\Page\DashboardPageTestCase;
+use Doctrine\ORM\EntityManagerInterface;
+use Express;
+
+class ExpressEntriesTest extends DashboardPageTestCase
+{
+    protected static $pageUrl = '/dashboard/express/entries';
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        \Concrete\Core\Tree\Node\NodeType::add('category');
+        \Concrete\Core\Tree\Node\NodeType::add('express_entry_category');
+        \Concrete\Core\Tree\TreeType::add('express_entry_results');
+        \Concrete\Core\Tree\Node\NodeType::add('express_entry_results');
+
+        $tree = \Concrete\Core\Tree\Type\ExpressEntryResults::add();
+
+        Category::add('express');
+
+        $app = ApplicationFacade::getFacadeApplication();
+        $factory = $app->make('\Concrete\Core\Attribute\TypeFactory');
+        $factory->add('text', 'Text');
+
+        $builder = Express::buildObject('project', 'projects', 'Project');
+        $builder->addAttribute('text', 'Project Name', 'project_name');
+        $project = $builder->save();
+    }
+
+    public function __construct($name = null, array $data = [], $dataName = '')
+    {
+        parent::__construct($name, $data, $dataName);
+
+        $this->metadatas[] = 'Concrete\Core\Entity\Express\Entity';
+        $this->metadatas[] = 'Concrete\Core\Entity\Express\Entry';
+        $this->metadatas[] = 'Concrete\Core\Entity\Express\Association';
+        $this->metadatas[] = 'Concrete\Core\Entity\Express\Form';
+        $this->metadatas[] = 'Concrete\Core\Entity\Attribute\Key\ExpressKey';
+        $this->metadatas[] = 'Concrete\Core\Entity\Attribute\Value\ExpressValue';
+        $this->metadatas[] = 'Concrete\Core\Entity\Attribute\Value\Value\Value';
+        $this->metadatas[] = 'Concrete\Core\Entity\Attribute\Value\Value\TextValue';
+        $this->metadatas[] = 'Concrete\Core\Entity\Attribute\Key\Settings\TextSettings';
+    }
+
+    public function setUp(): void
+    {
+        parent::setUp();
+    }
+
+    public function testUnexistingFormSubmitWithoutEntity(): void
+    {
+        $id = '00000000-0000-0000-0000-000000000000';
+        $url = sprintf('http://www.dummyco.com/dashboard/express/entries/submit/%s', $id);
+        $request = Request::create($url, 'GET', [], $this->getCookies());
+        $response = $this->sendRequest($request);
+
+        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertEquals(
+            'http://www.dummyco.com/path/to/server/index.php/dashboard/express/entries',
+            $response->headers->get('Location')
+        );
+        $this->assertFlashMessage('error', 'No details about the form provided.');
+    }
+
+    public function testUnexistingFormSubmitWithEntity(): void
+    {
+        $em = $this->app->make(EntityManagerInterface::class);
+        $r = $em->getRepository(Entity::class);
+        $entity = $r->findOneBy([]);
+
+        $url = sprintf('http://www.dummyco.com/dashboard/express/entries/submit/%s', $entity->getId());
+        $request = Request::create($url, 'GET', [], $this->getCookies());
+        $response = $this->sendRequest($request);
+
+        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertEquals(
+            sprintf('http://www.dummyco.com/path/to/server/index.php/dashboard/express/entries/results/%s', $entity->getId()),
+            $response->headers->get('Location')
+        );
+        $this->assertFlashMessage('error', 'No details about the form provided.');
+    }
+
+    public function testUnexistingFormSubmitWithEntry(): void
+    {
+        $em = $this->app->make(EntityManagerInterface::class);
+        $r = $em->getRepository(Entity::class);
+        $entity = $r->findOneBy([]);
+
+        $builder = Express::buildEntry($entity)->setProjectName('Test');
+        $entry = $builder->save();
+
+        $url = sprintf('http://www.dummyco.com/dashboard/express/entries/submit/%s', $entity->getId());
+        $request = Request::create($url, 'POST', ['entry_id' => $entry->getId()], $this->getCookies());
+        $response = $this->sendRequest($request);
+
+        $this->assertEquals(302, $response->getStatusCode());
+        $this->assertEquals(
+            sprintf('http://www.dummyco.com/path/to/server/index.php/dashboard/express/entries/edit_entry/%d', $entry->getId()),
+            $response->headers->get('Location')
+        );
+        $this->assertFlashMessage('error', 'No details about the form provided.');
+    }
+}


### PR DESCRIPTION
When users submit express forms, they end up in URL `/dashboard/express/entries/submit/{entityId}` (with the actual entity ID).

According to logs, users may sometimes request this URL as a GET request, possibly because currently the page throws an error in case a valid form ID is not provided. These GET requests cause exceptions to be stored in the logs that I would like to get rid of.

Instead of throwing an exception, redirect the user to the best guessed location in order to avoid such log entries.