### PR TITLE
ValueInspector: allow using DI, add PHPDoc, avoid deprecated methods

### DIFF
--- a/concrete/src/Backup/ContentImporter/ContentImporterServiceProvider.php
+++ b/concrete/src/Backup/ContentImporter/ContentImporterServiceProvider.php
@@ -33,6 +33,7 @@ class ContentImporterServiceProvider extends ServiceProvider
                 return $inspector;
             }
         );
+        $this->app->alias('import/value_inspector', ValueInspector\ValueInspectorInterface::class);
 
         $this->app->singleton(
             'import/item/manager',

--- a/concrete/src/Backup/ContentImporter/ContentImporterServiceProvider.php
+++ b/concrete/src/Backup/ContentImporter/ContentImporterServiceProvider.php
@@ -1,17 +1,12 @@
 <?php
+
 namespace Concrete\Core\Backup\ContentImporter;
 
-use Concrete\Core\Backup\ContentImporter\ValueInspector\InspectionRoutine\FileFolderRoutine;
-use Concrete\Core\Backup\ContentImporter\ValueInspector\InspectionRoutine\FileRoutine;
-use Concrete\Core\Backup\ContentImporter\ValueInspector\InspectionRoutine\ImageRoutine;
-use Concrete\Core\Backup\ContentImporter\ValueInspector\InspectionRoutine\PageFeedRoutine;
-use Concrete\Core\Backup\ContentImporter\ValueInspector\InspectionRoutine\PageRoutine;
-use Concrete\Core\Backup\ContentImporter\ValueInspector\InspectionRoutine\PageTypeRoutine;
-use Concrete\Core\Backup\ContentImporter\ValueInspector\InspectionRoutine\PictureRoutine;
-use Concrete\Core\Backup\ContentImporter\ValueInspector\ValueInspector;
+use Concrete\Core\Application\Application;
+use Concrete\Core\Backup\ContentImporter\Importer\Manager as ImporterManager;
+use Concrete\Core\Backup\ContentImporter\ValueInspector\InspectionRoutine;
 use Concrete\Core\Export\Item\Express\EntryStore;
 use Concrete\Core\Foundation\Service\Provider as ServiceProvider;
-use Concrete\Core\Backup\ContentImporter\Importer\Manager as ImporterManager;
 
 class ContentImporterServiceProvider extends ServiceProvider
 {
@@ -19,44 +14,38 @@ class ContentImporterServiceProvider extends ServiceProvider
     {
         $this->app->bind(
             'import/value_inspector/core',
-            function ($app) {
-                $inspector = new ValueInspector();
-
-                return $inspector;
+            static function (Application $app): ValueInspector\ValueInspectorInterface {
+                return new ValueInspector\ValueInspector();
             }
         );
-
-        $this->app->bindshared(
+        $this->app->singleton(
             'import/value_inspector',
-            function ($app) {
-                /*
-                 * @var \Concrete\Core\Backup\ContentImporter\ValueInspector\ValueInspector
-                 */
+            static function (Application $app): ValueInspector\ValueInspectorInterface {
                 $inspector = $app->make('import/value_inspector/core');
-                $inspector->registerInspectionRoutine(new PageRoutine());
-                $inspector->registerInspectionRoutine(new PictureRoutine());
-                $inspector->registerInspectionRoutine(new FileRoutine());
-                $inspector->registerInspectionRoutine(new PageFeedRoutine());
-                $inspector->registerInspectionRoutine(new PageTypeRoutine());
-                $inspector->registerInspectionRoutine(new FileFolderRoutine());
-                $inspector->registerInspectionRoutine(new ImageRoutine());
+                $inspector->registerInspectionRoutine(new InspectionRoutine\PageRoutine());
+                $inspector->registerInspectionRoutine(new InspectionRoutine\PictureRoutine());
+                $inspector->registerInspectionRoutine(new InspectionRoutine\FileRoutine());
+                $inspector->registerInspectionRoutine(new InspectionRoutine\PageFeedRoutine());
+                $inspector->registerInspectionRoutine(new InspectionRoutine\PageTypeRoutine());
+                $inspector->registerInspectionRoutine(new InspectionRoutine\FileFolderRoutine());
+                $inspector->registerInspectionRoutine(new InspectionRoutine\ImageRoutine());
 
                 return $inspector;
             }
         );
 
-        $this->app->bindshared(
+        $this->app->singleton(
             'import/item/manager',
-            function ($app) {
+            static function (Application $app): ImporterManager {
                 $importer = $app->make(ImporterManager::class);
                 foreach($app->make('config')->get('app.importer_routines') as $routine) {
                     $importer->registerImporterRoutine($app->make($routine));
                 }
+
                 return $importer;
             }
         );
 
         $this->app->singleton(EntryStore::class);
-
     }
 }

--- a/concrete/src/Backup/ContentImporter/ValueInspector/InspectionRoutine/FileFolderRoutine.php
+++ b/concrete/src/Backup/ContentImporter/ValueInspector/InspectionRoutine/FileFolderRoutine.php
@@ -1,20 +1,36 @@
 <?php
+
 namespace Concrete\Core\Backup\ContentImporter\ValueInspector\InspectionRoutine;
 
 use Concrete\Core\Backup\ContentImporter\ValueInspector\Item\FileFolderItem;
 
 class FileFolderRoutine extends AbstractRegularExpressionRoutine
 {
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\InspectionRoutine\RoutineInterface::getHandle()
+     */
     public function getHandle()
     {
         return 'file_folder';
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\InspectionRoutine\AbstractRegularExpressionRoutine::getRegularExpression()
+     */
     public function getRegularExpression()
     {
         return '/{ccm:export:filefolder:(.*?)\}/i';
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\InspectionRoutine\AbstractRegularExpressionRoutine::getItem()
+     */
     public function getItem($identifier)
     {
         return new FileFolderItem($identifier);

--- a/concrete/src/Backup/ContentImporter/ValueInspector/InspectionRoutine/FileRoutine.php
+++ b/concrete/src/Backup/ContentImporter/ValueInspector/InspectionRoutine/FileRoutine.php
@@ -1,29 +1,45 @@
 <?php
+
 namespace Concrete\Core\Backup\ContentImporter\ValueInspector\InspectionRoutine;
 
 use Concrete\Core\Backup\ContentImporter\ValueInspector\Item\FileItem;
 
 class FileRoutine extends AbstractRegularExpressionRoutine
 {
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\InspectionRoutine\RoutineInterface::getHandle()
+     */
     public function getHandle()
     {
         return 'file';
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\InspectionRoutine\AbstractRegularExpressionRoutine::getRegularExpression()
+     */
     public function getRegularExpression()
     {
         return '/{ccm:export:file:(.*?)\}/i';
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\InspectionRoutine\AbstractRegularExpressionRoutine::getItem()
+     */
     public function getItem($identifier)
     {
-        $prefix = null;
-        $filename = null;
-        if (strpos($identifier, ':') > -1) {
-            list($prefix, $filename) = explode(':', $identifier);
+        if (str_contains($identifier, ':')) {
+            [$prefix, $filename] = explode(':', $identifier);
         } else {
             $filename = $identifier;
+            $prefix = null;
         }
+
         return new FileItem($filename, $prefix);
     }
 }

--- a/concrete/src/Backup/ContentImporter/ValueInspector/InspectionRoutine/ImageRoutine.php
+++ b/concrete/src/Backup/ContentImporter/ValueInspector/InspectionRoutine/ImageRoutine.php
@@ -1,29 +1,45 @@
 <?php
+
 namespace Concrete\Core\Backup\ContentImporter\ValueInspector\InspectionRoutine;
 
 use Concrete\Core\Backup\ContentImporter\ValueInspector\Item\ImageItem;
 
 class ImageRoutine extends AbstractRegularExpressionRoutine
 {
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\InspectionRoutine\RoutineInterface::getHandle()
+     */
     public function getHandle()
     {
         return 'image';
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\InspectionRoutine\AbstractRegularExpressionRoutine::getRegularExpression()
+     */
     public function getRegularExpression()
     {
         return '/{ccm:export:image:(.*?)\}/i';
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\InspectionRoutine\AbstractRegularExpressionRoutine::getItem()
+     */
     public function getItem($identifier)
     {
-        $prefix = null;
-        $filename = null;
-        if (strpos($identifier, ':') > -1) {
-            list($prefix, $filename) = explode(':', $identifier);
+        if (str_contains($identifier, ':')) {
+            [$prefix, $filename] = explode(':', $identifier);
         } else {
             $filename = $identifier;
+            $prefix = null;
         }
+
         return new ImageItem($filename, $prefix);
     }
 }

--- a/concrete/src/Backup/ContentImporter/ValueInspector/InspectionRoutine/PageFeedRoutine.php
+++ b/concrete/src/Backup/ContentImporter/ValueInspector/InspectionRoutine/PageFeedRoutine.php
@@ -1,20 +1,36 @@
 <?php
+
 namespace Concrete\Core\Backup\ContentImporter\ValueInspector\InspectionRoutine;
 
 use Concrete\Core\Backup\ContentImporter\ValueInspector\Item\PageFeedItem;
 
 class PageFeedRoutine extends AbstractRegularExpressionRoutine
 {
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\InspectionRoutine\RoutineInterface::getHandle()
+     */
     public function getHandle()
     {
         return 'page_feed';
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\InspectionRoutine\AbstractRegularExpressionRoutine::getRegularExpression()
+     */
     public function getRegularExpression()
     {
         return '/{ccm:export:pagefeed:(.*?)\}/i';
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\InspectionRoutine\AbstractRegularExpressionRoutine::getItem()
+     */
     public function getItem($identifier)
     {
         return new PageFeedItem($identifier);

--- a/concrete/src/Backup/ContentImporter/ValueInspector/InspectionRoutine/PageRoutine.php
+++ b/concrete/src/Backup/ContentImporter/ValueInspector/InspectionRoutine/PageRoutine.php
@@ -1,20 +1,36 @@
 <?php
+
 namespace Concrete\Core\Backup\ContentImporter\ValueInspector\InspectionRoutine;
 
 use Concrete\Core\Backup\ContentImporter\ValueInspector\Item\PageItem;
 
 class PageRoutine extends AbstractRegularExpressionRoutine
 {
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\InspectionRoutine\RoutineInterface::getHandle()
+     */
     public function getHandle()
     {
         return 'page';
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\InspectionRoutine\AbstractRegularExpressionRoutine::getRegularExpression()
+     */
     public function getRegularExpression()
     {
         return '/{ccm:export:page:(.*?)\}/i';
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\InspectionRoutine\AbstractRegularExpressionRoutine::getItem()
+     */
     public function getItem($identifier)
     {
         return new PageItem($identifier);

--- a/concrete/src/Backup/ContentImporter/ValueInspector/InspectionRoutine/PageTypeRoutine.php
+++ b/concrete/src/Backup/ContentImporter/ValueInspector/InspectionRoutine/PageTypeRoutine.php
@@ -1,20 +1,36 @@
 <?php
+
 namespace Concrete\Core\Backup\ContentImporter\ValueInspector\InspectionRoutine;
 
 use Concrete\Core\Backup\ContentImporter\ValueInspector\Item\PageTypeItem;
 
 class PageTypeRoutine extends AbstractRegularExpressionRoutine
 {
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\InspectionRoutine\RoutineInterface::getHandle()
+     */
     public function getHandle()
     {
         return 'page_type';
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\InspectionRoutine\AbstractRegularExpressionRoutine::getRegularExpression()
+     */
     public function getRegularExpression()
     {
         return '/{ccm:export:pagetype:(.*?)\}/i';
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\InspectionRoutine\AbstractRegularExpressionRoutine::getItem()
+     */
     public function getItem($identifier)
     {
         return new PageTypeItem($identifier);

--- a/concrete/src/Backup/ContentImporter/ValueInspector/InspectionRoutine/PictureRoutine.php
+++ b/concrete/src/Backup/ContentImporter/ValueInspector/InspectionRoutine/PictureRoutine.php
@@ -1,30 +1,45 @@
 <?php
+
 namespace Concrete\Core\Backup\ContentImporter\ValueInspector\InspectionRoutine;
 
 use Concrete\Core\Backup\ContentImporter\ValueInspector\Item\PictureItem;
 
 class PictureRoutine extends AbstractRegularExpressionRoutine
 {
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\InspectionRoutine\RoutineInterface::getHandle()
+     */
     public function getHandle()
     {
         return 'picture';
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\InspectionRoutine\AbstractRegularExpressionRoutine::getRegularExpression()
+     */
     public function getRegularExpression()
     {
         return '/\<concrete-picture\s[^>]*?file\s*=\s*[\'"]([^\'"]*?)[\'"][^>]*?>/i';
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\InspectionRoutine\AbstractRegularExpressionRoutine::getItem()
+     */
     public function getItem($identifier)
     {
-        $prefix = null;
-        $filename = null;
-        if (strpos($identifier, ':') > -1) {
-            list($prefix, $filename) = explode(':', $identifier);
+        if (str_contains($identifier, ':')) {
+            [$prefix, $filename] = explode(':', $identifier);
         } else {
             $filename = $identifier;
+            $prefix = null;
         }
+
         return new PictureItem($filename, $prefix);
     }
-
 }

--- a/concrete/src/Backup/ContentImporter/ValueInspector/InspectionRoutine/RoutineInterface.php
+++ b/concrete/src/Backup/ContentImporter/ValueInspector/InspectionRoutine/RoutineInterface.php
@@ -1,16 +1,31 @@
 <?php
+
 namespace Concrete\Core\Backup\ContentImporter\ValueInspector\InspectionRoutine;
 
 interface RoutineInterface
 {
+    /**
+     * Get a handle that uniquely identifies this routing.
+     *
+     * @return string
+     */
     public function getHandle();
 
     /**
-     * @param $content
+     * Extracts the items contained in a content.
+     *
+     * @param string|mixed $content
      *
      * @return \Concrete\Core\Backup\ContentImporter\ValueInspector\Item\ItemInterface[]
      */
     public function match($content);
 
+    /**
+     * Replace the content with tie items found in it.
+     *
+     * @param string|mixed $content
+     *
+     * @return string|mixed
+     */
     public function replaceContent($content);
 }

--- a/concrete/src/Backup/ContentImporter/ValueInspector/Item/AbstractItem.php
+++ b/concrete/src/Backup/ContentImporter/ValueInspector/Item/AbstractItem.php
@@ -1,22 +1,39 @@
 <?php
+
 namespace Concrete\Core\Backup\ContentImporter\ValueInspector\Item;
 
 abstract class AbstractItem implements ItemInterface
 {
+    /**
+     * @var string|mixed
+     */
     protected $reference;
 
+    /**
+     * @param string|mixed $reference the reference found in the content
+     */
+    public function __construct($reference)
+    {
+        $this->reference = $reference;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\Item\ItemInterface::getReference()
+     */
     public function getReference()
     {
         return $this->reference;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\Item\ItemInterface::getContentValue()
+     */
     public function getContentValue()
     {
         return $this->getFieldValue();
-    }
-
-    public function __construct($reference)
-    {
-        $this->reference = $reference;
     }
 }

--- a/concrete/src/Backup/ContentImporter/ValueInspector/Item/FileFolderItem.php
+++ b/concrete/src/Backup/ContentImporter/ValueInspector/Item/FileFolderItem.php
@@ -1,30 +1,52 @@
 <?php
+
 namespace Concrete\Core\Backup\ContentImporter\ValueInspector\Item;
 
 use Concrete\Core\Tree\Node\Node;
 
 class FileFolderItem extends AbstractItem
 {
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\Item\ItemInterface::getDisplayName()
+     */
     public function getDisplayName()
     {
         return t('Page Template');
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\Item\ItemInterface::getContentObject()
+     *
+     * @return \Concrete\Core\Tree\Node\Type\FileFolder|null
+     */
     public function getContentObject()
     {
+        $reference = (string) $this->getReference();
         $folderNodes = Node::getNodesOfType('file_folder');
         foreach ($folderNodes as $folderNode) {
-            if ($folderNode->getTreeNodeDisplayPath() == $this->getReference()) {
+            if ($folderNode->getTreeNodeDisplayPath() === $reference) {
                 return $folderNode;
             }
         }
+
         return null;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\Item\ItemInterface::getFieldValue()
+     *
+     * @return int|null
+     */
     public function getFieldValue()
     {
-        if ($o = $this->getContentObject()) {
-            return $o->getTreeNodeID();
-        }
+        $folderNode = $this->getContentObject();
+
+        return $folderNode ? $folderNode->getTreeNodeID() : null;
     }
 }

--- a/concrete/src/Backup/ContentImporter/ValueInspector/Item/ImageItem.php
+++ b/concrete/src/Backup/ContentImporter/ValueInspector/Item/ImageItem.php
@@ -1,23 +1,36 @@
 <?php
+
 namespace Concrete\Core\Backup\ContentImporter\ValueInspector\Item;
 
 class ImageItem extends FileItem
 {
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\Item\ItemInterface::getDisplayName()
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\Item\FileItem::getDisplayName()
+     */
     public function getDisplayName()
     {
         return t('Image');
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\Item\ItemInterface::getContentValue()
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\Item\FileItem::getContentValue()
+     *
+     * @return string|null
+     */
     public function getContentValue()
     {
-        if ($o = $this->getContentObject()) {
-            if ($o->getFileUUID()) {
-                $identifier = $o->getFileUUID();
-            } else {
-                $identifier = $o->getFileID();
-            }
-            return sprintf("{CCM:FID_%s}", $identifier);
+        $file = $this->getContentObject();
+        if ($file === null) {
+            return null;
         }
-    }
+        $uuid = $file->getFileUUID();
 
+        return sprintf('{CCM:FID_%s}', $uuid ?: $file->getFileID());
+    }
 }

--- a/concrete/src/Backup/ContentImporter/ValueInspector/Item/ItemInterface.php
+++ b/concrete/src/Backup/ContentImporter/ValueInspector/Item/ItemInterface.php
@@ -1,11 +1,49 @@
 <?php
+
 namespace Concrete\Core\Backup\ContentImporter\ValueInspector\Item;
 
 interface ItemInterface
 {
+    /**
+     * Get the display name of this item (representing the item class, not the found object).
+     *
+     * @return string
+     */
     public function getDisplayName();
+
+    /**
+     * Get the reference found in the content.
+     *
+     * @return string|mixed
+     *
+     * @example a FileItem can return '123456789012:filename.ext' or 'filename.ext'
+     */
     public function getReference();
+
+    /**
+     * Resolve the actual Concrete object.
+     *
+     * @return object|null returns null if the actual object can't be found
+     *
+     * @example a FileItem can return a File instance
+     */
     public function getContentObject();
+
+    /**
+     * Get the value to be inserted in the content representing the object.
+     *
+     * @return string|mixed|null Return null if the actual object can't be found
+     *
+     * @example a FileItem can return '{CCM:FID_DL_123}'
+     */
     public function getContentValue();
+
+    /**
+     * Get a value that uniquely identifies the found object.
+     *
+     * @return mixed|null Return null if the actual object can't be found
+     *
+     * @example a FileItem can return a file ID
+     */
     public function getFieldValue();
 }

--- a/concrete/src/Backup/ContentImporter/ValueInspector/Item/PageFeedItem.php
+++ b/concrete/src/Backup/ContentImporter/ValueInspector/Item/PageFeedItem.php
@@ -1,31 +1,61 @@
 <?php
+
 namespace Concrete\Core\Backup\ContentImporter\ValueInspector\Item;
 
 use Concrete\Core\Page\Feed;
 
 class PageFeedItem extends AbstractItem
 {
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\Item\ItemInterface::getDisplayName()
+     */
     public function getDisplayName()
     {
         return t('RSS Feed');
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\Item\ItemInterface::getContentObject()
+     *
+     * @return \Concrete\Core\Entity\Page\Feed|null
+     */
     public function getContentObject()
     {
-        return Feed::getByHandle($this->getReference());
+        $reference = (string) $this->getReference();
+
+        return $reference === '' ? null : Feed::getByHandle($reference);
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\Item\ItemInterface::getContentValue()
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\Item\AbstractItem::getContentValue()
+     *
+     * @return \League\Url\UrlInterface|null
+     */
     public function getContentValue()
     {
-        if ($o = $this->getContentObject()) {
-            return $o->getFeedURL();
-        }
+        $feed = $this->getContentObject();
+
+        return $feed ? $feed->getFeedURL() : null;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\Item\ItemInterface::getFieldValue()
+     *
+     * @return int|null
+     */
     public function getFieldValue()
     {
-        if ($o = $this->getContentObject()) {
-            return $o->getID();
-        }
+        $feed = $this->getContentObject();
+
+        return $feed ? $feed->getID() : null;
     }
 }

--- a/concrete/src/Backup/ContentImporter/ValueInspector/Item/PageItem.php
+++ b/concrete/src/Backup/ContentImporter/ValueInspector/Item/PageItem.php
@@ -1,38 +1,66 @@
 <?php
+
 namespace Concrete\Core\Backup\ContentImporter\ValueInspector\Item;
 
 use Concrete\Core\Page\Page;
 
 class PageItem extends AbstractItem
 {
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\Item\ItemInterface::getDisplayName()
+     */
     public function getDisplayName()
     {
         return t('Page');
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\Item\ItemInterface::getContentObject()
+     *
+     * @return \Concrete\Core\Page\Page|null
+     */
     public function getContentObject()
     {
-        if ($this->getReference() == '/' || $this->getReference() == '') {
-            return Page::getByID(Page::getHomePageID(), 'ACTIVE');
+        $reference = (string) $this->getReference();
+        if ($reference === '' || $reference === '/') {
+            $page = Page::getByID(Page::getHomePageID(), 'ACTIVE');
+        } else {
+            $page = Page::getByPath($reference, 'ACTIVE');
         }
 
-        $c = Page::getByPath($this->getReference(), 'ACTIVE');
-        if (is_object($c) && !$c->isError()) {
-            return $c;
-        }
+        return $page && !$page->isError() ? $page : null;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\Item\ItemInterface::getContentValue()
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\Item\AbstractItem::getContentValue()
+     *
+     * @return string|null
+     */
     public function getContentValue()
     {
-        if ($o = $this->getContentObject()) {
-            return sprintf("{CCM:CID_%s}", $o->getCollectionID());
-        }
+        $page = $this->getContentObject();
+
+        return $page ? sprintf('{CCM:CID_%s}', $page->getCollectionID()) : null;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\Item\ItemInterface::getFieldValue()
+     *
+     * @return int|null
+     */
     public function getFieldValue()
     {
-        if ($o = $this->getContentObject()) {
-            return $o->getCollectionID();
-        }
+        $page = $this->getContentObject();
+
+        return $page ? $page->getCollectionID() : null;
     }
 }

--- a/concrete/src/Backup/ContentImporter/ValueInspector/Item/PageTemplateItem.php
+++ b/concrete/src/Backup/ContentImporter/ValueInspector/Item/PageTemplateItem.php
@@ -1,24 +1,44 @@
 <?php
+
 namespace Concrete\Core\Backup\ContentImporter\ValueInspector\Item;
 
 use Concrete\Core\Page\Template;
 
 class PageTemplateItem extends AbstractItem
 {
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\Item\ItemInterface::getDisplayName()
+     */
     public function getDisplayName()
     {
         return t('Page Template');
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\Item\ItemInterface::getContentObject()
+     *
+     * @return \Concrete\Core\Entity\Page\Template|null
+     */
     public function getContentObject()
     {
         return Template::getByHandle($this->getReference());
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\Item\ItemInterface::getFieldValue()
+     *
+     * @return int|null
+     */
     public function getFieldValue()
     {
-        if ($o = $this->getContentObject()) {
-            return $o->getPageTemplateID();
-        }
+        $template = $this->getContentObject();
+
+        return $template ? $template->getPageTemplateID() : null;
     }
 }

--- a/concrete/src/Backup/ContentImporter/ValueInspector/Item/PageTypeItem.php
+++ b/concrete/src/Backup/ContentImporter/ValueInspector/Item/PageTypeItem.php
@@ -1,24 +1,44 @@
 <?php
+
 namespace Concrete\Core\Backup\ContentImporter\ValueInspector\Item;
 
 use Concrete\Core\Page\Type\Type;
 
 class PageTypeItem extends AbstractItem
 {
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\Item\ItemInterface::getDisplayName()
+     */
     public function getDisplayName()
     {
         return t('Page Type');
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\Item\ItemInterface::getContentObject()
+     *
+     * @return \Concrete\Core\Page\Type\Type|null
+     */
     public function getContentObject()
     {
         return Type::getByHandle($this->getReference());
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\Item\ItemInterface::getFieldValue()
+     *
+     * @return int|null
+     */
     public function getFieldValue()
     {
-        if ($o = $this->getContentObject()) {
-            return $o->getPageTypeID();
-        }
+        $pageType = $this->getContentObject();
+
+        return $pageType ? $pageType->getPageTypeID() : null;
     }
 }

--- a/concrete/src/Backup/ContentImporter/ValueInspector/Item/PictureItem.php
+++ b/concrete/src/Backup/ContentImporter/ValueInspector/Item/PictureItem.php
@@ -1,17 +1,32 @@
 <?php
+
 namespace Concrete\Core\Backup\ContentImporter\ValueInspector\Item;
 
 class PictureItem extends FileItem
 {
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\Item\ItemInterface::getDisplayName()
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\Item\FileItem::getDisplayName()
+     */
     public function getDisplayName()
     {
         return t('Picture');
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\Item\ItemInterface::getContentValue()
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\Item\FileItem::getContentValue()
+     *
+     * @return string|null
+     */
     public function getContentValue()
     {
-        if ($o = $this->getContentObject()) {
-            return '<concrete-picture fID="' . $o->getFileID() . '" />';
-        }
+        $file = $this->getContentObject();
+
+        return $file ? "<concrete-picture fID=\"{$file->getFileID()}\" />" : null;
     }
 }

--- a/concrete/src/Backup/ContentImporter/ValueInspector/Item/StackItem.php
+++ b/concrete/src/Backup/ContentImporter/ValueInspector/Item/StackItem.php
@@ -1,37 +1,65 @@
 <?php
+
 namespace Concrete\Core\Backup\ContentImporter\ValueInspector\Item;
 
-use Concrete\Core\Page\Feed;
 use Concrete\Core\Page\Stack\Stack;
 
 class StackItem extends AbstractItem
 {
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\Item\ItemInterface::getDisplayName()
+     */
     public function getDisplayName()
     {
         return t('Stack');
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\Item\ItemInterface::getContentObject()
+     *
+     * @return \Concrete\Core\Page\Stack\Stack|null
+     */
     public function getContentObject()
     {
-        $stack = Stack::getByPath($this->getReference());
-        if (!is_object($stack)) {
-            // this is kinda weak.
-            $stack = Stack::getByName($this->getReference());
+        $reference = $this->getReference();
+        $stack = Stack::getByPath($reference);
+        if (!$stack) {
+            $stack = Stack::getByName($reference);
         }
-        return $stack;
+
+        return $stack ?: null;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\Item\ItemInterface::getContentValue()
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\Item\AbstractItem::getContentValue()
+     *
+     * @return string|null the name of the stack
+     */
     public function getContentValue()
     {
-        if ($o = $this->getContentObject()) {
-            return $o->getCollectionName();
-        }
+        $stack = $this->getContentObject();
+
+        return $stack ? $stack->getCollectionName() : null;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\Item\ItemInterface::getFieldValue()
+     *
+     * @return int|null the ID of the stack
+     */
     public function getFieldValue()
     {
-        if ($o = $this->getContentObject()) {
-            return $o->getCollectionID();
-        }
+        $stack = $this->getContentObject();
+
+        return $stack ? $stack->getCollectionID() : null;
     }
 }

--- a/concrete/src/Backup/ContentImporter/ValueInspector/ResultInterface.php
+++ b/concrete/src/Backup/ContentImporter/ValueInspector/ResultInterface.php
@@ -1,9 +1,27 @@
 <?php
+
 namespace Concrete\Core\Backup\ContentImporter\ValueInspector;
 
 interface ResultInterface
 {
+    /**
+     * Get the items matched by inspection routines.
+     *
+     * @return \Concrete\Core\Backup\ContentImporter\ValueInspector\Item\ItemInterface[]
+     */
     public function getMatchedItems();
+
+    /**
+     * Get the content with the replaced values.
+     *
+     * @return string|mixed
+     */
     public function getReplacedContent();
+
+    /**
+     * Get the value replacing the content (or the original content if no replacements has been found).
+     *
+     * @return string|mixed
+     */
     public function getReplacedValue();
 }

--- a/concrete/src/Backup/ContentImporter/ValueInspector/ValueInspector.php
+++ b/concrete/src/Backup/ContentImporter/ValueInspector/ValueInspector.php
@@ -1,22 +1,34 @@
 <?php
+
 namespace Concrete\Core\Backup\ContentImporter\ValueInspector;
 
 use Concrete\Core\Backup\ContentImporter\ValueInspector\InspectionRoutine\RoutineInterface;
 
 class ValueInspector implements ValueInspectorInterface
 {
-    protected $routines = array();
+    /**
+     * @var \Concrete\Core\Backup\ContentImporter\ValueInspector\InspectionRoutine\RoutineInterface[]
+     */
+    protected $routines = [];
 
     public function registerInspectionRoutine(RoutineInterface $routine)
     {
         $this->routines[$routine->getHandle()] = $routine;
     }
 
+    /**
+     * @return \Concrete\Core\Backup\ContentImporter\ValueInspector\InspectionRoutine\RoutineInterface[]
+     */
     public function getInspectionRoutines()
     {
         return $this->routines;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Backup\ContentImporter\ValueInspector\ValueInspectorInterface::inspect()
+     */
     public function inspect($content)
     {
         $result = new Result($content);

--- a/concrete/src/Backup/ContentImporter/ValueInspector/ValueInspectorInterface.php
+++ b/concrete/src/Backup/ContentImporter/ValueInspector/ValueInspectorInterface.php
@@ -1,7 +1,15 @@
 <?php
+
 namespace Concrete\Core\Backup\ContentImporter\ValueInspector;
 
 interface ValueInspectorInterface
 {
+    /**
+     * Inspect a content.
+     *
+     * @param string|mixed $content
+     *
+     * @return \Concrete\Core\Backup\ContentImporter\ValueInspector\ResultInterface
+     */
     public function inspect($content);
 }

--- a/tests/tests/Backup/ContentImporterValueInspectorTest.php
+++ b/tests/tests/Backup/ContentImporterValueInspectorTest.php
@@ -2,6 +2,7 @@
 
 namespace Concrete\Tests\Backup;
 
+use Concrete\Core\Backup\ContentImporter\ValueInspector\ValueInspectorInterface;
 use Concrete\Core\File\Import\FileImporter;
 use Concrete\TestHelpers\File\FileStorageTestCase;
 
@@ -20,7 +21,7 @@ class ContentImporterValueInspectorTest extends FileStorageTestCase
     public function testMake()
     {
         $inspector = app('import/value_inspector/core');
-        $this->assertInstanceOf('\Concrete\Core\Backup\ContentImporter\ValueInspector\ValueInspectorInterface', $inspector);
+        $this->assertInstanceOf(ValueInspectorInterface::class, $inspector);
     }
 
     public function testRegister()
@@ -33,6 +34,8 @@ class ContentImporterValueInspectorTest extends FileStorageTestCase
     public function testMakeCore()
     {
         $inspector = app('import/value_inspector');
+        $inspector2 = app(ValueInspectorInterface::class);
+        $this->assertSame($inspector, $inspector2);
         $this->assertEquals(7, count($inspector->getInspectionRoutines()));
     }
 

--- a/tests/tests/Backup/ContentImporterValueInspectorTest.php
+++ b/tests/tests/Backup/ContentImporterValueInspectorTest.php
@@ -4,7 +4,6 @@ namespace Concrete\Tests\Backup;
 
 use Concrete\Core\File\Import\FileImporter;
 use Concrete\TestHelpers\File\FileStorageTestCase;
-use Core;
 
 class ContentImporterValueInspectorTest extends FileStorageTestCase
 {
@@ -20,20 +19,20 @@ class ContentImporterValueInspectorTest extends FileStorageTestCase
 
     public function testMake()
     {
-        $inspector = Core::make('import/value_inspector/core');
+        $inspector = app('import/value_inspector/core');
         $this->assertInstanceOf('\Concrete\Core\Backup\ContentImporter\ValueInspector\ValueInspectorInterface', $inspector);
     }
 
     public function testRegister()
     {
-        $inspector = Core::make('import/value_inspector/core');
+        $inspector = app('import/value_inspector/core');
         $inspector->registerInspectionRoutine(new \Concrete\Core\Backup\ContentImporter\ValueInspector\InspectionRoutine\PageRoutine());
         $this->assertEquals(1, count($inspector->getInspectionRoutines()));
     }
 
     public function testMakeCore()
     {
-        $inspector = Core::make('import/value_inspector');
+        $inspector = app('import/value_inspector');
         $this->assertEquals(7, count($inspector->getInspectionRoutines()));
     }
 
@@ -58,7 +57,7 @@ class ContentImporterValueInspectorTest extends FileStorageTestCase
      */
     public function testMatchedSimpleValues($content, $reference, $itemClass)
     {
-        $inspector = Core::make('import/value_inspector');
+        $inspector = app('import/value_inspector');
         $result = $inspector->inspect($content, false);
         $items = $result->getMatchedItems();
         $this->assertEquals(1, count($items));
@@ -78,7 +77,7 @@ class ContentImporterValueInspectorTest extends FileStorageTestCase
         Excellent! <a href="{ccm:export:page:/}">See you later!</a>
 EOL;
 
-        $inspector = Core::make('import/value_inspector');
+        $inspector = app('import/value_inspector');
         $result = $inspector->inspect($content);
         $items = $result->getMatchedItems();
         $this->assertEquals(4, count($items));
@@ -100,7 +99,7 @@ EOL;
         Finally, we're also going to link to a pagetype here: {ccm:export:pagetype:blog_entry}.
 EOL;
 
-        $inspector = Core::make('import/value_inspector');
+        $inspector = app('import/value_inspector');
         $result = $inspector->inspect($content);
         $items = $result->getMatchedItems();
         $this->assertEquals(4, count($items));
@@ -121,7 +120,7 @@ EOL;
         $this->getStorageLocation();
 
 
-        $importer = Core::make(FileImporter::class);
+        $importer = app(FileImporter::class);
         $prefix = $importer->generatePrefix();
         \Concrete\Core\File\File::add('test.jpg', $prefix);
 
@@ -135,7 +134,7 @@ EOL;
         <p>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip <concrete-picture fID="1" /></p>
 EOL;
 
-        $inspector = Core::make('import/value_inspector');
+        $inspector = app('import/value_inspector');
         $result = $inspector->inspect($content);
 
         $this->assertEquals($expected, $result->getReplacedContent());


### PR DESCRIPTION
I'd like to use `Concrete\Core\Backup\ContentImporter\ValueInspector\ValueInspectorInterface` as a dependency, but at the moment it's not bound in our container.

What about making `ValueInspectorInterface` an alias of the existing `'import/value_inspector'`?

Also, what about adding some PHPDoc to the inspector classes?