### PR TITLE
Fix exporting block aliases to XML

### DIFF
--- a/concrete/blocks/core_scrapbook_display/controller.php
+++ b/concrete/blocks/core_scrapbook_display/controller.php
@@ -5,6 +5,7 @@ namespace Concrete\Block\CoreScrapbookDisplay;
 use Concrete\Core\Block\Block;
 use Concrete\Core\Block\BlockController;
 use Concrete\Core\Block\View\BlockViewTemplate;
+use Concrete\Core\Utility\Service\Xml;
 
 /**
  * The controller for the core scrapbook display block. This block is automatically used when a block is copied into a
@@ -124,8 +125,9 @@ class Controller extends BlockController
 
     private function exportChildren(\SimpleXMLElement $from, \SimpleXMLElement $to)
     {
+        $xml = $this->app->make(Xml::class);
         foreach ($from->children() as $fromChild) {
-            $toChild = $to->addChild($fromChild->getName(), (string) $fromChild);
+            $toChild = $xml->createChildElement($to, $fromChild->getName(), (string) $fromChild);
             foreach ($fromChild->attributes() as $attribute) {
                 $toChild[$attribute->getName()] = (string) $attribute;
             }

--- a/concrete/src/Utility/Service/Xml.php
+++ b/concrete/src/Utility/Service/Xml.php
@@ -60,8 +60,6 @@ class Xml
     /**
      * Append a new CDATA section to an existing element.
      * Please remark that \r\n and \r sequences will be converted to \n - see https://www.w3.org/TR/2008/REC-xml-20081126/#sec-line-ends
-     *
-     * @param scalar|\DateTimeInterface|\Stringable $value
      */
     public function appendCData(SimpleXMLElement $element, string $value): void
     {

--- a/concrete/src/Utility/Service/Xml.php
+++ b/concrete/src/Utility/Service/Xml.php
@@ -66,7 +66,7 @@ class Xml
     public function appendCData(SimpleXMLElement $element, string $value): void
     {
         $domElement = dom_import_simplexml($element);
-        $domElement->appendChild($domElement->ownerDocument->createCDataSection($this->serialize($value)));
+        $domElement->appendChild($domElement->ownerDocument->createCDataSection($value));
     }
 
     /**


### PR DESCRIPTION
When we export a block alias as XML, we first export the original block to a temporary SimpleXML element.

For example, the temporary XML element could be something like this:

```xml
<block type="blockTypeHandle">
    <data table="blockTable">
        <record>
            <field><![CDATA[ &nbsp; ]]></paragraph>
        </record>
    </data>
</block>
```

Without the fix of this PR, the final XML after copying the fields would be

```xml
<block type="blockTypeHandle">
    <data table="blockTable">
        <record>
            <field> &nbsp; </paragraph>
        </record>
    </data>
</block>
```

which is not a valid XML (`&nbsp;` is not a valid XML entity)