### PR TITLE
[v8] Backport core scrapbook display export

### DIFF
--- a/concrete/blocks/core_scrapbook_display/controller.php
+++ b/concrete/blocks/core_scrapbook_display/controller.php
@@ -4,6 +4,7 @@ namespace Concrete\Block\CoreScrapbookDisplay;
 use Concrete\Core\Block\BlockController;
 use Block;
 use Concrete\Core\Block\View\BlockViewTemplate;
+use Concrete\Core\Utility\Service\Xml;
 
 /**
  * The controller for the core scrapbook display block. This block is automatically used when a block is copied into a
@@ -66,15 +67,27 @@ class Controller extends BlockController
 
     public function export(\SimpleXMLElement $blockNode)
     {
-        $b = Block::getByID($this->bOriginalID);
-        $bc = $b->getInstance();
-        if ($bc) {
-            $blockNode['type'] = $b->getBlockTypeHandle();
-            $blockNode['name'] = $b->getBlockName();
-            if ($b->getBlockFilename() != '') {
-                $blockNode['custom-template'] = $b->getBlockFilename();
+        $block = Block::getByID($this->bOriginalID);
+        if ($block) {
+            $clonedBlock = clone $blockNode;
+            $block->export($clonedBlock);
+            $otherBlockNode = $clonedBlock->children()[0];
+            foreach ($otherBlockNode->attributes() as $attribute) {
+                $blockNode[$attribute->getName()] = (string) $attribute;
             }
-            return $bc->export($blockNode);
+            $this->exportChildren($otherBlockNode, $blockNode);
+        }
+    }
+
+    private function exportChildren(\SimpleXMLElement $from, \SimpleXMLElement $to)
+    {
+        $xml = $this->app->make(Xml::class);
+        foreach ($from->children() as $fromChild) {
+            $toChild = $xml->createChildElement($to, $fromChild->getName(), (string) $fromChild);
+            foreach ($fromChild->attributes() as $attribute) {
+                $toChild[$attribute->getName()] = (string) $attribute;
+            }
+            $this->exportChildren($fromChild, $toChild);
         }
     }
 

--- a/concrete/src/Utility/Service/Xml.php
+++ b/concrete/src/Utility/Service/Xml.php
@@ -1,15 +1,114 @@
 <?php
+
 namespace Concrete\Core\Utility\Service;
+
+use DateTimeInterface;
+use SimpleXMLElement;
 
 class Xml
 {
-    public function createCDataNode(\SimpleXMLElement $x, $nodeName, $content)
-    {
-        $node = $x->addChild($nodeName);
-        $node = dom_import_simplexml($node);
-        $no = $node->ownerDocument;
-        $node->appendChild($no->createCDataSection($content));
+    const FLAG_PRESERVE_CARRIAGE_RETURNS = 0b1;
 
-        return $node;
+    /**
+     * Extract a boolean from an element or an attribute value.
+     *
+     * @param bool|null $default what should be returned if the element/attribute does not exist, or if it does not contain a boolean representation ('true', 'yes', 'on', '1', 'false', 'no', '0', '')
+     *
+     * @return bool|null returns NULL if and only if $default is null and the attribute/element doesn't exist (or it has an invalid value)
+     */
+    public function getBool(SimpleXMLElement $elementOrAttribute = null, $default = false)
+    {
+        /*
+         * $element['nonExistingAttribute'] returns null
+         * $element->nonExistingChildElement returns a SimpleXMLElement whose name is an empty string
+         * (yep! "isset($element->nonExistingChildElement)" return false, but "$element->nonExistingChildElement" is a SimpleXMLElement !) 
+         */
+        if ($elementOrAttribute === null || $elementOrAttribute->getName() === '') {
+            return $default;
+        }
+        $result = filter_var((string) $elementOrAttribute, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+
+        return $result !== null ? $result : $default;
+    }
+
+    /**
+     * Create a new element with the specified value.
+     *
+     * @param string $childName
+     * @param scalar|\DateTimeInterface|\Stringable $value
+     * @param int $flags
+     *
+     * @return \SimpleXMLElement
+     */
+    public function createChildElement(SimpleXMLElement $parentElement, $childName, $value, $flags = 0)
+    {
+        $serialized = $this->serialize($value);
+        $hasCarriageReturns = str_contains($serialized, "\r");
+        if ($hasCarriageReturns && ($flags & static::FLAG_PRESERVE_CARRIAGE_RETURNS) === static::FLAG_PRESERVE_CARRIAGE_RETURNS) {
+            // We can't use CDATA if we want to preserve \r - see https://www.w3.org/TR/2008/REC-xml-20081126/#sec-line-ends
+            $newElement = $parentElement->addChild($childName, $serialized);
+        } elseif ($this->shouldUseCData($serialized)) {
+            $newElement = $parentElement->addChild($childName);
+            $this->appendCData($newElement, $serialized);
+        } else {
+            if ($hasCarriageReturns) {
+                $serialized = strtr($serialized, ["\r\n" => "\n", "\r" => "\n"]);
+            }
+            $newElement = $parentElement->addChild($childName, $serialized);
+        }
+
+        return $newElement;
+    }
+
+    /**
+     * Append a new CDATA section to an existing element.
+     * Please remark that \r\n and \r sequences will be converted to \n - see https://www.w3.org/TR/2008/REC-xml-20081126/#sec-line-ends
+     *
+     * @param string $value
+     *
+     * @return void
+     */
+    public function appendCData(SimpleXMLElement $element, $value)
+    {
+        $domElement = dom_import_simplexml($element);
+        $domElement->appendChild($domElement->ownerDocument->createCDataSection((string) $value));
+    }
+
+    /**
+     * @deprecated use the createChildElement() method
+     */
+    public function createCDataNode(SimpleXMLElement $x, $nodeName, $content)
+    {
+        return $this->createChildElement($x, (string) $nodeName, (string) $content);
+    }
+
+    /**
+     * @param scalar|\DateTimeInterface|\Stringable $value
+     *
+     * @return string
+     */
+    protected function serialize($value)
+    {
+        if ($value instanceof DateTimeInterface) {
+            return $value->format('Y-m-d H:i:s');
+        }
+
+        return (string) $value;
+    }
+
+    /**
+     * Using a CDATA section is not mandatory: it'd be enough to call htmlentities(..., ENT_XML1).
+     * But CDATA is much more readable, so let's use it when values contains characters that
+     * must be escaped).
+     *
+     * @param string $value
+     *
+     * @return bool
+     *
+     * @see https://www.w3.org/TR/2008/REC-xml-20081126/#syntax
+     */
+    protected function shouldUseCData($value)
+    {
+        return strpbrk($value, "&<>") !== false; // '>' is not strictly required, only ']]>' is, but libxml2 escapes even '>' alone
     }
 }


### PR DESCRIPTION
Let's port some of the export fixes from ConcreteCMS v9 to concrete5 v8 (someone may want to export data from an old v8 website to build a v9 website).

This includes parts of #11805, as well as #11784 and #12505