### PR TITLE
Fix core_stack_display export/import

### DIFF
--- a/concrete/blocks/core_stack_display/controller.php
+++ b/concrete/blocks/core_stack_display/controller.php
@@ -110,12 +110,16 @@ class Controller extends BlockController implements TrackableInterface, UsesFeat
      */
     public function getImportData($blockNode, $page)
     {
-        $args = [];
-        $content = (string) $blockNode->stack;
-        $stack = Stack::getByName($content);
-        $args['stID'] = 0;
-        if (is_object($stack)) {
-            $args['stID'] = $stack->getCollectionID();
+        $args = ['stID' => 0];
+        $pathOrName = isset($blockNode->stack) ? trim((string) $blockNode->stack) : '';
+        if ($pathOrName !== '') {
+            $stack = $pathOrName[0] === '/' ? Stack::getByPath($pathOrName) : null;
+            if (!$stack) {
+                $stack = Stack::getByName($pathOrName);
+            }
+            if ($stack) {
+                $args['stID'] = (int) $stack->getCollectionID();
+            }
         }
 
         return $args;
@@ -209,7 +213,26 @@ class Controller extends BlockController implements TrackableInterface, UsesFeat
     {
         $stack = $this->getStack(false);
         if ($stack !== null) {
-            $this->app->make(Xml::class)->createChildElement($blockNode, 'stack', $stack->getCollectionName());
+            if ($stack->getStackType() == Stack::ST_TYPE_GLOBAL_AREA) {
+                $pathOrName = $stack->getCollectionName();
+            } else {
+                $pathParts = [$stack->getCollectionHandle()];
+                $parentID = $stack->getCollectionParentID();
+                while ($parentID) {
+                    $parentPage = Page::getByID($parentID);
+                    if (!$parentPage || $parentPage->isError()) {
+                        break;
+                    }
+                    $pathPart = $parentPage->getCollectionHandle();
+                    if (ltrim(STACKS_PAGE_PATH, '/') === $pathPart) {
+                        break;
+                    }
+                    $pathParts[] = $pathPart;
+                    $parentID = $parentPage->getCollectionParentID();
+                }
+                $pathOrName = '/' . implode('/', array_reverse($pathParts));
+            }
+            $this->app->make(Xml::class)->createChildElement($blockNode, 'stack', $pathOrName);
         }
     }
 


### PR DESCRIPTION
Let's assume we have two stacks with the same name under two different folders, eg

```
├─ A
│  └─ Stack Name
│
└─ B
   └─ Stack Name

```

At the moment, when we export a core_stack_display block, we have:

```xml
<block type="core_stack_display">
   <stack>Stack Name</stack>
</block>
```

We import, we look for a stack named "Stack Name": this leads to undefined behaviour (which stack gets picked? Who knows...).

So, what about exporting stack *paths* instead?

```xml
<block type="core_stack_display">
   <stack>/a/stack-handle</stack>
</block>
```

Then, when we import, we first try to look for a stack by path, next by name.

