### PR TITLE
Fix address sanitization (v8)

### DIFF
--- a/concrete/src/Localization/Service/AddressFormat.php
+++ b/concrete/src/Localization/Service/AddressFormat.php
@@ -317,6 +317,8 @@ class AddressFormat
             $lines[] = trim($postalAreaLine);
         }
 
+        $lines = array_map('h', $lines);
+
         if ($format === 'html') {
             return implode('<br>', $lines);
         }


### PR DESCRIPTION
Addresses are not properly sanitized in the output when a country is not specified. This fixes that for version 8.