### PR TITLE
Fix importing Rich Text content data

### DIFF
--- a/concrete/src/Block/BlockController.php
+++ b/concrete/src/Block/BlockController.php
@@ -544,10 +544,11 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
                                 || in_array($key, $this->btExportFileColumns)
                                 || in_array($key, $this->btExportPageTypeColumns)
                                 || in_array($key, $this->btExportPageFeedColumns)
-                                || in_array($key, $this->btExportFileFolderColumns)) {
-                                    $result = $inspector->inspect((string) $node);
-                                    $args[$node->getName()] = $result->getReplacedValue();
-                            } else if (in_array($key, $this->btExportContentColumns)) {
+                                || in_array($key, $this->btExportFileFolderColumns)
+                            ) {
+                                $result = $inspector->inspect((string) $node);
+                                $args[$node->getName()] = $result->getReplacedValue();
+                            } elseif (in_array($key, $this->btExportContentColumns)) {
                                 $args[$node->getName()] = LinkAbstractor::import((string) $node);
                             } else {
                                 $args[$node->getName()] = (string) $node;
@@ -579,10 +580,11 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
                                     || in_array($key, $this->btExportFileColumns)
                                     || in_array($key, $this->btExportPageTypeColumns)
                                     || in_array($key, $this->btExportPageFeedColumns)
-                                    || in_array($key, $this->btExportFileFolderColumns)) {
-                                        $result = $inspector->inspect((string) $node);
-                                        $aar->{$nodeName} = $result->getReplacedValue();
-                                } else if (in_array($key, $this->btExportContentColumns)) {
+                                    || in_array($key, $this->btExportFileFolderColumns)
+                                ) {
+                                    $result = $inspector->inspect((string) $node);
+                                    $aar->{$nodeName} = $result->getReplacedValue();
+                                } elseif (in_array($key, $this->btExportContentColumns)) {
                                     $aar->{$nodeName} = LinkAbstractor::import((string) $node);
                                 } else {
                                     $aar->{$nodeName} = (string) $node;

--- a/concrete/src/Block/BlockController.php
+++ b/concrete/src/Block/BlockController.php
@@ -548,8 +548,7 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
                                     $result = $inspector->inspect((string) $node);
                                     $args[$node->getName()] = $result->getReplacedValue();
                             } else if (in_array($key, $this->btExportContentColumns)) {
-                                $result = $inspector->inspect((string) $node);
-                                $args[$node->getName()] = $result->getReplacedContent();
+                                $args[$node->getName()] = LinkAbstractor::import((string) $node);
                             } else {
                                 $args[$node->getName()] = (string) $node;
                             }
@@ -584,8 +583,7 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
                                         $result = $inspector->inspect((string) $node);
                                         $aar->{$nodeName} = $result->getReplacedValue();
                                 } else if (in_array($key, $this->btExportContentColumns)) {
-                                    $result = $inspector->inspect((string) $node);
-                                    $aar->{$nodeName} = $result->getReplacedContent();
+                                    $aar->{$nodeName} = LinkAbstractor::import((string) $node);
                                 } else {
                                     $aar->{$nodeName} = (string) $node;
                                 }


### PR DESCRIPTION
Since #11517 block controllers can define a `$btExportContentColumns` property, defining the fields that contain rich text.

But we should import them with `LinkAbstractor::import()` instead of `ValueInspector`, isn't it? At least, that's what the content block did before #12494 got merged.