### PR TITLE
ContentExporter: add PHPDoc and check for all values - Fixed

### DIFF
--- a/concrete/src/Backup/ContentExporter.php
+++ b/concrete/src/Backup/ContentExporter.php
@@ -1,19 +1,12 @@
 <?php
 namespace Concrete\Core\Backup;
 
-use Block;
+use Concrete\Core\File\File;
 use Concrete\Core\Page\Feed;
+use Concrete\Core\Page\Page;
 use Concrete\Core\Page\Type\Composer\FormLayoutSetControl;
+use Concrete\Core\Page\Type\Type as PageType;
 use Concrete\Core\Tree\Node\Type\FileFolder;
-use File;
-use FileList;
-use Job;
-use Loader;
-use Package;
-use Page;
-use PageTemplate;
-use PageTheme;
-use PageType;
 
 class ContentExporter
 {

--- a/concrete/src/Backup/ContentExporter.php
+++ b/concrete/src/Backup/ContentExporter.php
@@ -53,70 +53,128 @@ class ContentExporter
         }
     }
 
+    /**
+     * @param int|string|mixed $cID the ID of the page
+     *
+     * @return string|null
+     *
+     * @example {ccm:export:page:/path/to/page}
+     */
     public static function replacePageWithPlaceHolder($cID)
     {
-        if ($cID > 0) {
-            $c = Page::getByID($cID);
-            if ($c && !$c->isError()) {
-                return '{ccm:export:page:' . $c->getCollectionPath() . '}';
-            }
+        if (!is_numeric($cID) || ($cID = (int) $cID) <= 0) {
+            return null;
         }
+        $c = Page::getByID($cID);
+        if (!$c || $c->isError()) {
+            return null;
+        }
+
+        return '{ccm:export:page:' . $c->getCollectionPath() . '}';
     }
 
+    /**
+     * @param int|string|mixed $fID the ID of the file
+     *
+     * @return string|null
+     *
+     * @example {ccm:export:file:123456789012:atomik-logo.png}
+     */
     public static function replaceFileWithPlaceHolder($fID)
     {
-        if ($fID > 0) {
-            $f = File::getByID($fID);
-            if (is_object($f)) {
-                return '{ccm:export:file:' . $f->getPrefix() . ':' . $f->getFileName() . '}';
-            }
+        if (!is_numeric($fID) || ($fID = (int) $fID) <= 0) {
+            return null;
         }
+        $f = File::getByID($fID);
+        $fv = $f ? $f->getApprovedVersion() : null;
+        if (!$fv) {
+            return null;
+        }
+
+        return '{ccm:export:file:' . $fv->getPrefix() . ':' . $fv->getFileName() . '}';
     }
 
+    /**
+     * @param array|int[]|string[] $cID
+     *
+     * @return string|null
+     *
+     * @example {ccm:export:page:/path/to/page}
+     */
     public static function replacePageWithPlaceHolderInMatch($cID)
     {
-        if ($cID[1] > 0) {
-            $cID = $cID[1];
-
-            return self::replacePageWithPlaceHolder($cID);
-        }
+        return empty($cID[1]) ? null : self::replacePageWithPlaceHolder($cID[1]);
     }
 
+    /**
+     * @param array|int[]|string[] $fID
+     *
+     * @return string|null
+     *
+     * @example {ccm:export:file:123456789012:atomik-logo.png}
+     */
     public static function replaceFileWithPlaceHolderInMatch($fID)
     {
-        if ($fID[1] > 0) {
-            $fID = $fID[1];
-
-            return self::replaceFileWithPlaceHolder($fID);
-        }
+        return empty($fID[1]) ? null : self::replaceFileWithPlaceHolder($fID[1]);
     }
 
+    /**
+     * @param int|string|mixed $ptID the ID of the page type
+     *
+     * @return string|null
+     *
+     * @example {ccm:export:pagetype:blog_entry}
+     */
     public static function replacePageTypeWithPlaceHolder($ptID)
     {
-        if ($ptID > 0) {
-            $ct = PageType::getByID($ptID);
-
-            return '{ccm:export:pagetype:' . $ct->getPageTypeHandle() . '}';
+        if (!is_numeric($ptID) || ($ptID = (int) $ptID) <= 0) {
+            return null;
         }
+        $ct = PageType::getByID($ptID);
+        if (!$ct) {
+            return null;
+        }
+
+        return '{ccm:export:pagetype:' . $ct->getPageTypeHandle() . '}';
     }
 
+    /**
+     * @param int|string|mixed $treeNodeID the ID of the file folder
+     *
+     * @return string|null
+     *
+     * @example {ccm:export:filefolder:/Documents}
+     */
     public static function replaceFileFolderWithPlaceHolder($treeNodeID)
     {
-        if ($treeNodeID > 0) {
-            $folder = FileFolder::getByID($treeNodeID);
-
-            return '{ccm:export:filefolder:' . $folder->getTreeNodeDisplayPath() . '}';
+        if (!is_numeric($treeNodeID) || ($treeNodeID = (int) $treeNodeID) <= 0) {
+            return null;
         }
+        $folder = FileFolder::getByID($treeNodeID);
+        if (!$folder) {
+            return null;
+        }
+
+        return '{ccm:export:filefolder:' . $folder->getTreeNodeDisplayPath() . '}';
     }
 
-
+    /**
+     * @param int|string|mixed $pfID the ID of the page feed
+     *
+     * @return string|null
+     *
+     * @example {ccm:export:pagefeed:blog}
+     */
     public static function replacePageFeedWithPlaceholder($pfID)
     {
-        if ($pfID > 0) {
-            $pf = Feed::getByID($pfID);
-
-            return '{ccm:export:pagefeed:' . $pf->getHandle() . '}';
+        if (!is_numeric($pfID) || ($pfID = (int) $pfID) <= 0) {
+            return null;
         }
+        $pf = Feed::getByID($pfID);
+        if (!$pf) {
+            return null;
+        }
+
+        return '{ccm:export:pagefeed:' . $pf->getHandle() . '}';
     }
-    
 }

--- a/concrete/src/Editor/LinkAbstractor.php
+++ b/concrete/src/Editor/LinkAbstractor.php
@@ -429,9 +429,10 @@ class LinkAbstractor extends ConcreteObject
             foreach ($r->find('concrete-picture') as $picture) {
                 $fID = $picture->fid;
                 $f = $entityManager->find(File::class, $fID);
-                if (is_object($f)) {
+                $fv = $f ? $f->getApprovedVersion() : null;
+                if ($fv) {
                     $picture->fid = false;
-                    $picture->file = $f->getPrefix() . ':' . $f->getFilename();
+                    $picture->file = $fv->getPrefix() . ':' . $fv->getFilename();
                 }
             }
             $text = (string) $r->restore_noise($r);

--- a/tests/tests/Editor/LinkAbstractorTest.php
+++ b/tests/tests/Editor/LinkAbstractorTest.php
@@ -145,22 +145,25 @@ class LinkAbstractorTest extends ConcreteDatabaseTestCase
 
             // Create a mock file object and make the mocked entity manager return
             // that.
+            $mockFileVersion = $this->getMockBuilder(\Concrete\Core\Entity\File\Version::class)
+                ->disableOriginalConstructor()
+                ->getMock()
+            ;
+            $mockFileVersion->expects($this->exactly(2))
+                ->method('getPrefix')
+                ->willReturn('123456789012')
+            ;
+            $mockFileVersion->expects($this->exactly(2))
+                ->method('getFilename')
+                ->willReturn('test_file.jpg')
+            ;
             $mockFile = $this->getMockBuilder('Concrete\Core\Entity\File\File')
                 ->disableOriginalConstructor()
                 ->getMock();
-            $mockFile->expects($this->any())
-                ->method('__call')
-                ->will($this->returnCallback(function ($method, $args) {
-                    if ($method === 'getPrefix') {
-                        return '123456789012';
-                    } elseif ($method === 'getFileName' ||
-                        $method === 'getFilename'
-                    ) {
-                        return 'test_file.jpg';
-                    }
-
-                    return null;
-                }));
+            $mockFile->expects($this->exactly(2))
+                ->method('getApprovedVersion')
+                ->willReturn($mockFileVersion)
+            ;
 
             $em->expects($this->exactly(2))
                 ->method('find')

--- a/tests/tests/Editor/LinkAbstractorTest.php
+++ b/tests/tests/Editor/LinkAbstractorTest.php
@@ -87,108 +87,114 @@ class LinkAbstractorTest extends ConcreteDatabaseTestCase
 
         // Mock the cache class so that we can return a mocked page object
         // without initializing the page related database tables.
-        $origCache = Core::make('cache/request');
-        $cache = $this->getMockBuilder('Concrete\Core\Cache\Level\RequestCache')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $app->bind('cache/request', function () use ($cache) {
-            return $cache;
-        });
+        try {
+            $origCache = Core::make('cache/request');
+            $cache = $this->getMockBuilder('Concrete\Core\Cache\Level\RequestCache')
+                ->disableOriginalConstructor()
+                ->getMock();
+            $app->bind('cache/request', function () use ($cache) {
+                return $cache;
+            });
 
-        // Make the local request cache enabled always.
-        $cache->expects($this->any())->method('isEnabled')->willReturn(true);
+            // Make the local request cache enabled always.
+            $cache->expects($this->any())->method('isEnabled')->willReturn(true);
 
-        // Mock the entity manager so that we can return a mocked file object
-        // without initializing the files related database tables.
-        $origEm = Core::make(EntityManagerInterface::class);
-        $em = $this->getMockBuilder(EntityManagerInterface::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $app->bind(EntityManagerInterface::class, function () use ($em) {
-            return $em;
-        });
+            // Mock the entity manager so that we can return a mocked file object
+            // without initializing the files related database tables.
+            $origEm = Core::make(EntityManagerInterface::class);
+            $em = $this->getMockBuilder(EntityManagerInterface::class)
+                ->disableOriginalConstructor()
+                ->getMock();
+            $app->bind(EntityManagerInterface::class, function () use ($em) {
+                return $em;
+            });
 
-        // Create a mock page object and corresponding cache item to return by
-        // the mocked cache class.
-        $mockPage = $this->getMockBuilder('Concrete\Core\Page\Page')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $mockPage->expects($this->once())
-            ->method('getCollectionPath')
-            ->willReturn('/test/page/path');
-        $pageCacheItem = $this->getMockBuilder('Stash\Item')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $pageCacheItem->expects($this->once())
-            ->method('isMiss')
-            ->willReturn(false);
-        $pageCacheItem->expects($this->once())
-            ->method('get')
-            ->willReturn($mockPage);
+            // Create a mock page object and corresponding cache item to return by
+            // the mocked cache class.
+            $mockPage = $this->getMockBuilder('Concrete\Core\Page\Page')
+                ->disableOriginalConstructor()
+                ->getMock();
+            $mockPage->expects($this->once())
+                ->method('getCollectionPath')
+                ->willReturn('/test/page/path');
+            $pageCacheItem = $this->getMockBuilder('Stash\Item')
+                ->disableOriginalConstructor()
+                ->getMock();
+            $pageCacheItem->expects($this->once())
+                ->method('isMiss')
+                ->willReturn(false);
+            $pageCacheItem->expects($this->once())
+                ->method('get')
+                ->willReturn($mockPage);
 
-        // Bind the cache getEntry method to return the corresponding page
-        // cache item.
-        $cache->expects($this->once())
-            ->method('getItem')
-            ->with(
-                CacheLocal::key('page', '123/RECENT/Concrete\Core\Page\Page')
-            )
-            ->willReturn($pageCacheItem);
+            // Bind the cache getEntry method to return the corresponding page
+            // cache item.
+            $cache->expects($this->once())
+                ->method('getItem')
+                ->with(
+                    CacheLocal::key('page', '123/RECENT/Concrete\Core\Page\Page')
+                )
+                ->willReturn($pageCacheItem);
 
-        // Test that the link abstractor exports the page correctly
-        $input = '<a href="{CCM:CID_123}">Link</a>';
-        $this->assertEquals(
-            '<a href="{ccm:export:page:/test/page/path}">Link</a>',
-            LinkAbstractor::export($input)
-        );
+            // Test that the link abstractor exports the page correctly
+            $input = '<a href="{CCM:CID_123}">Link</a>';
+            $this->assertEquals(
+                '<a href="{ccm:export:page:/test/page/path}">Link</a>',
+                LinkAbstractor::export($input)
+            );
 
-        // Create a mock file object and make the mocked entity manager return
-        // that.
-        $mockFile = $this->getMockBuilder('Concrete\Core\Entity\File\File')
-            ->disableOriginalConstructor()
-            ->getMock();
-        $mockFile->expects($this->any())
-            ->method('__call')
-            ->will($this->returnCallback(function ($method, $args) {
-                if ($method === 'getPrefix') {
-                    return '123456789012';
-                } elseif ($method === 'getFileName' ||
-                    $method === 'getFilename'
-                ) {
-                    return 'test_file.jpg';
-                }
+            // Create a mock file object and make the mocked entity manager return
+            // that.
+            $mockFile = $this->getMockBuilder('Concrete\Core\Entity\File\File')
+                ->disableOriginalConstructor()
+                ->getMock();
+            $mockFile->expects($this->any())
+                ->method('__call')
+                ->will($this->returnCallback(function ($method, $args) {
+                    if ($method === 'getPrefix') {
+                        return '123456789012';
+                    } elseif ($method === 'getFileName' ||
+                        $method === 'getFilename'
+                    ) {
+                        return 'test_file.jpg';
+                    }
 
-                return null;
-            }));
+                    return null;
+                }));
 
-        $em->expects($this->exactly(2))
-            ->method('find')
-            ->with(
-                $this->equalTo('Concrete\Core\Entity\File\File'),
-                $this->equalTo(123)
-            )
-            ->willReturn($mockFile);
+            $em->expects($this->exactly(2))
+                ->method('find')
+                ->with(
+                    $this->equalTo('Concrete\Core\Entity\File\File'),
+                    $this->equalTo(123)
+                )
+                ->willReturn($mockFile);
 
-        // Test that the link abstractor exports the file correctly
-        $input = '<a href="{CCM:FID_DL_123}">Link</a>';
-        $this->assertEquals(
-            '<a href="{ccm:export:file:123456789012:test_file.jpg}">Link</a>',
-            LinkAbstractor::export($input)
-        );
+            // Test that the link abstractor exports the file correctly
+            $input = '<a href="{CCM:FID_DL_123}">Link</a>';
+            $this->assertEquals(
+                '<a href="{ccm:export:file:123456789012:test_file.jpg}">Link</a>',
+                LinkAbstractor::export($input)
+            );
 
-        // The that the link abstractor exports the images correctly
-        $input = '<concrete-picture fID="123" />';
-        $this->assertEquals(
-            '<concrete-picture file="123456789012:test_file.jpg" />',
-            LinkAbstractor::export($input)
-        );
-
-        // Revert to the defaults
-        $app->bind('cache/request', function () use ($origCache) {
-            return $origCache;
-        });
-        $app->bind(EntityManagerInterface::class, function () use ($origEm) {
-            return $origEm;
-        });
+            // The that the link abstractor exports the images correctly
+            $input = '<concrete-picture fID="123" />';
+            $this->assertEquals(
+                '<concrete-picture file="123456789012:test_file.jpg" />',
+                LinkAbstractor::export($input)
+            );
+        } finally {
+            // Revert to the defaults
+            if (isset($origCache)) {
+                $app->bind('cache/request', function () use ($origCache) {
+                    return $origCache;
+                });
+            }
+            if (isset($origEm)) {
+                $app->bind(EntityManagerInterface::class, function () use ($origEm) {
+                    return $origEm;
+                });
+            }
+        }
     }
 }


### PR DESCRIPTION
#12496 added some checks for the stuff in the ContentExporter.

It also included a minor optimization: instead of calling `$file->getPrefix()`, we called `$fv = $file->getApprovedVersion()` and `$fv->getPrefix()`. This is safer, and a tiny bit faster, but breaks tests in `LinkAbstractorTest::testExport()`.

Since tests inside it fails, the cache and entitymanager mocked at the beginning of the method aren't reverted, so any subsequent tests that use cache and entitymanager will have errors like `Call to a member function findOneBy() on null` and `Call to a member function setCache() on null`.

So, in #12510 @aembler had to revert the changes of #12496

So:
1. let's reapply the changes of #12496
2. correcrly revert the stuff mocked in `LinkAbstractorTest::testExport()` (see https://github.com/concretecms/concretecms/commit/5690e4b175dd75dcd482421e43a9516b23ac06b3?w=1)

The `LinkAbstractorTest::testExport()` tests will fail, but we won't have any other strange errors (I'll update this PR once tests complete).