### PR TITLE
Sanitize HTML but not text format

### DIFF
--- a/concrete/src/Localization/Service/AddressFormat.php
+++ b/concrete/src/Localization/Service/AddressFormat.php
@@ -317,9 +317,8 @@ class AddressFormat
             $lines[] = trim($postalAreaLine);
         }
 
-        $lines = array_map('h', $lines);
-
         if ($format === 'html') {
+            $lines = array_map('h', $lines);
             return implode('<br>', $lines);
         }
 


### PR DESCRIPTION
Addresses [mlocati's concern](https://github.com/concretecms/concretecms/pull/12511#issuecomment-2771203946) about sanitizing HTML entities when getting the string value of Address