### PR TITLE
Fix exporting aliases of deleted blocks

### DIFF
--- a/concrete/src/Block/Block.php
+++ b/concrete/src/Block/Block.php
@@ -900,7 +900,9 @@ EOT
      */
     public function isAliasOfMasterCollection()
     {
-        return $this->getBlockCollectionObject()->isBlockAliasedFromMasterCollection($this);
+        $blockCollection = $this->getBlockCollectionObject();
+
+        return $blockCollection ? $blockCollection->isBlockAliasedFromMasterCollection($this) : false;
     }
 
     /**


### PR DESCRIPTION
Consider this case:

1. Add a block to  a page
2. Copy that block to the Concrete clipboard
3. Add the copied block from the clipboard to the page
4. Delete the original block

When we try to export that block copy we have this error:

```
Call to a member function isBlockAliasedFromMasterCollection() on null
```

Let's fix this issue.