### PR TITLE
Add new method to the Seo class and make the class properties protected from private

### DIFF
--- a/concrete/src/Html/Service/Seo.php
+++ b/concrete/src/Html/Service/Seo.php
@@ -3,11 +3,11 @@ namespace Concrete\Core\Html\Service;
 
 class Seo
 {
-    private $siteName = '';
-    private $titleSegments = array();
-    private $titleSegmentSeparator = ' :: ';
-    private $titleFormat = '%1$s :: %2$s';
-    private $hasCustomTitle = false;
+    protected $siteName = '';
+    protected $titleSegments = array();
+    protected $titleSegmentSeparator = ' :: ';
+    protected $titleFormat = '%1$s :: %2$s';
+    protected $hasCustomTitle = false;
 
     public function setSiteName($name)
     {

--- a/concrete/src/Html/Service/Seo.php
+++ b/concrete/src/Html/Service/Seo.php
@@ -33,7 +33,7 @@ class Seo
         return $this;
     }
 
-    public function getTitleSegments(): array
+    public function getTitleSegments()
     {
         return $this->titleSegments;
     }

--- a/concrete/src/Html/Service/Seo.php
+++ b/concrete/src/Html/Service/Seo.php
@@ -1,12 +1,17 @@
 <?php
+
 namespace Concrete\Core\Html\Service;
 
 class Seo
 {
     protected $siteName = '';
-    protected $titleSegments = array();
+
+    protected $titleSegments = [];
+
     protected $titleSegmentSeparator = ' :: ';
+
     protected $titleFormat = '%1$s :: %2$s';
+
     protected $hasCustomTitle = false;
 
     public function setSiteName($name)
@@ -49,7 +54,7 @@ class Seo
 
     public function clearTitleSegments()
     {
-        $this->titleSegments = array();
+        $this->titleSegments = [];
     }
 
     public function setTitleFormat($format)

--- a/concrete/src/Html/Service/Seo.php
+++ b/concrete/src/Html/Service/Seo.php
@@ -28,6 +28,11 @@ class Seo
         return $this;
     }
 
+    public function getTitleSegments(): array
+    {
+        return $this->titleSegments;
+    }
+
     public function addTitleSegment($segment)
     {
         array_push($this->titleSegments, $segment);


### PR DESCRIPTION
We encountered a situation where we needed to extend the core SEO class for some customizations. However, we had to repeat all the methods because the properties were set to `private`. 
Let's change the properties to `protected` and add a new method called `getTitleSegments()`. This will provide developers with greater flexibility.