### PR TITLE
Fix for #11320

### DIFF
--- a/concrete/controllers/dialog/file/folder.php
+++ b/concrete/controllers/dialog/file/folder.php
@@ -5,7 +5,7 @@ use Concrete\Controller\Backend\UserInterface\File as BackendInterfaceFileContro
 use Concrete\Core\Error\UserMessageException;
 use Concrete\Core\File\EditResponse;
 use Concrete\Core\Tree\Node\Node;
-use URL;
+use Symfony\Component\HttpFoundation\JsonResponse;
 
 class Folder extends BackendInterfaceFileController
 {
@@ -44,13 +44,17 @@ class Folder extends BackendInterfaceFileController
             throw new UserMessageException(t('Invalid source file object.'));
         }
 
+		if ($sourceNode->getTreeNodeParentID() === $destNode->getTreeNodeID()) {
+			throw new UserMessageException(t('The selected destination is the same as the current folder.'));
+		}
+
         if ($this->validateAction()) {
             $sourceNode->move($destNode);
             $response = new EditResponse();
             $response->setFile($this->file);
             $response->setMessage(t('File moved to folder successfully.'));
             $response->setAdditionalDataAttribute('folder', $destNode->getTreeNodeJSON());
-            $response->outputJSON();
+			return new JsonResponse($response);
         }
     }
 }

--- a/concrete/controllers/dialog/file/folder.php
+++ b/concrete/controllers/dialog/file/folder.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Controller\Dialog\File;
 
 use Concrete\Controller\Backend\UserInterface\File as BackendInterfaceFileController;
@@ -9,52 +10,52 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 
 class Folder extends BackendInterfaceFileController
 {
-    protected $viewPath = '/dialogs/file/folder';
+	protected $viewPath = '/dialogs/file/folder';
 
-    protected function canAccess()
-    {
-        return $this->permissions->canViewFileInFileManager();
-    }
+	protected function canAccess()
+	{
+		return $this->permissions->canViewFileInFileManager();
+	}
 
-    public function view()
-    {
+	public function view()
+	{
 
-    }
+	}
 
-    public function submit()
-    {
-        $destNode = Node::getByID($this->request->request->get('folderID'));
-        if (is_object($destNode)) {
-            $dp = new \Permissions($destNode);
-            if (!$dp->canAddTreeSubNode()) {
-                throw new UserMessageException(t('You are not allowed to move files to this location.'));
-            }
-        } else {
-            throw new UserMessageException(t('You have not selected a valid folder.'));
-        }
+	public function submit()
+	{
+		$destNode = Node::getByID($this->request->request->get('folderID'));
+		if (is_object($destNode)) {
+			$dp = new \Permissions($destNode);
+			if (!$dp->canAddTreeSubNode()) {
+				throw new UserMessageException(t('You are not allowed to move files to this location.'));
+			}
+		} else {
+			throw new UserMessageException(t('You have not selected a valid folder.'));
+		}
 
-        $sourceNode = $this->file->getFileNodeObject();
+		$sourceNode = $this->file->getFileNodeObject();
 
-        if (is_object($sourceNode)) {
-            $dp = new \Permissions($sourceNode);
-            if (!$dp->canEditTreeNode()) {
-                throw new UserMessageException(t('You are not allowed to move this file.'));
-            }
-        } else {
-            throw new UserMessageException(t('Invalid source file object.'));
-        }
+		if (is_object($sourceNode)) {
+			$dp = new \Permissions($sourceNode);
+			if (!$dp->canEditTreeNode()) {
+				throw new UserMessageException(t('You are not allowed to move this file.'));
+			}
+		} else {
+			throw new UserMessageException(t('Invalid source file object.'));
+		}
 
 		if ($sourceNode->getTreeNodeParentID() === $destNode->getTreeNodeID()) {
 			throw new UserMessageException(t('The selected destination is the same as the current folder.'));
 		}
 
-        if ($this->validateAction()) {
-            $sourceNode->move($destNode);
-            $response = new EditResponse();
-            $response->setFile($this->file);
-            $response->setMessage(t('File moved to folder successfully.'));
-            $response->setAdditionalDataAttribute('folder', $destNode->getTreeNodeJSON());
+		if ($this->validateAction()) {
+			$sourceNode->move($destNode);
+			$response = new EditResponse();
+			$response->setFile($this->file);
+			$response->setMessage(t('File moved to folder successfully.'));
+			$response->setAdditionalDataAttribute('folder', $destNode->getTreeNodeJSON());
 			return new JsonResponse($response);
-        }
-    }
+		}
+	}
 }

--- a/concrete/controllers/dialog/tree/node/file_folder/move.php
+++ b/concrete/controllers/dialog/tree/node/file_folder/move.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Controller\Dialog\Tree\Node\FileFolder;
 
 use Concrete\Controller\Dialog\Tree\Node as NodeController;
@@ -11,58 +12,58 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 
 class Move extends NodeController
 {
-    protected $viewPath = '/dialogs/tree/node/file_folder/move';
+	protected $viewPath = '/dialogs/tree/node/file_folder/move';
 
-    protected function canAccess()
-    {
-        $node = $this->getNode();
-        $np = new Checker($node);
-        return $np->canEditTreeNode();
-    }
+	protected function canAccess()
+	{
+		$node = $this->getNode();
+		$np = new Checker($node);
+		return $np->canEditTreeNode();
+	}
 
-    public function view()
-    {
-        $node = $this->getNode();
-        if (!($node instanceof FileFolder)) {
-            throw new \UserMessageException(t('You may not move this folder node.'));
-        }
-        $this->set('currentFolder', $node);
-    }
+	public function view()
+	{
+		$node = $this->getNode();
+		if (!($node instanceof FileFolder)) {
+			throw new \UserMessageException(t('You may not move this folder node.'));
+		}
+		$this->set('currentFolder', $node);
+	}
 
-    public function submit()
-    {
-        $destNode = Node::getByID($this->request->request->get('folderID'));
-        if (is_object($destNode)) {
-            $dp = new Checker($destNode);
-            if (!$dp->canAddTreeSubNode()) {
-                throw new UserMessageException(t('You are not allowed to move folders to this location.'));
-            }
-        } else {
-            throw new UserMessageException(t('You have not selected a valid folder.'));
-        }
+	public function submit()
+	{
+		$destNode = Node::getByID($this->request->request->get('folderID'));
+		if (is_object($destNode)) {
+			$dp = new Checker($destNode);
+			if (!$dp->canAddTreeSubNode()) {
+				throw new UserMessageException(t('You are not allowed to move folders to this location.'));
+			}
+		} else {
+			throw new UserMessageException(t('You have not selected a valid folder.'));
+		}
 
-        $sourceNode = $this->getNode();
+		$sourceNode = $this->getNode();
 
-        if (is_object($sourceNode)) {
-            $dp = new Checker($sourceNode);
-            if (!$dp->canEditTreeNode()) {
-                throw new UserMessageException(t('You are not allowed to move this folder.'));
-            }
-        } else {
-            throw new UserMessageException(t('Invalid source file object.'));
-        }
+		if (is_object($sourceNode)) {
+			$dp = new Checker($sourceNode);
+			if (!$dp->canEditTreeNode()) {
+				throw new UserMessageException(t('You are not allowed to move this folder.'));
+			}
+		} else {
+			throw new UserMessageException(t('Invalid source file object.'));
+		}
 
 		if ($sourceNode->getTreeNodeParentID() === $destNode->getTreeNodeID()) {
 			throw new UserMessageException(t('The selected destination is the same as the current folder.'));
 		}
 
-        if ($this->validateAction()) {
-            $sourceNode->move($destNode);
-            $response = new EditResponse();
-            $response->setMessage(t('File moved to folder successfully.'));
+		if ($this->validateAction()) {
+			$sourceNode->move($destNode);
+			$response = new EditResponse();
+			$response->setMessage(t('File moved to folder successfully.'));
 			$response->setAdditionalDataAttribute('sourceFolder', $sourceNode->getTreeNodeJSON());
-            $response->setAdditionalDataAttribute('folder', $destNode->getTreeNodeJSON());
-            return new JsonResponse($response);
-        }
-    }
+			$response->setAdditionalDataAttribute('folder', $destNode->getTreeNodeJSON());
+			return new JsonResponse($response);
+		}
+	}
 }

--- a/concrete/controllers/dialog/tree/node/file_folder/move.php
+++ b/concrete/controllers/dialog/tree/node/file_folder/move.php
@@ -52,10 +52,15 @@ class Move extends NodeController
             throw new UserMessageException(t('Invalid source file object.'));
         }
 
+		if ($sourceNode->getTreeNodeParentID() === $destNode->getTreeNodeID()) {
+			throw new UserMessageException(t('The selected destination is the same as the current folder.'));
+		}
+
         if ($this->validateAction()) {
             $sourceNode->move($destNode);
             $response = new EditResponse();
             $response->setMessage(t('File moved to folder successfully.'));
+			$response->setAdditionalDataAttribute('sourceFolder', $sourceNode->getTreeNodeJSON());
             $response->setAdditionalDataAttribute('folder', $destNode->getTreeNodeJSON());
             return new JsonResponse($response);
         }

--- a/concrete/views/dialogs/file/bulk/folder.php
+++ b/concrete/views/dialogs/file/bulk/folder.php
@@ -37,6 +37,11 @@ use Concrete\Core\View\View;
         ConcreteEvent.unsubscribe('AjaxFormSubmitSuccess.updateFolder');
         ConcreteEvent.subscribe('AjaxFormSubmitSuccess.updateFolder', function (e, data) {
             if (data.form === 'move-to-folder') {
+                if (data.response.files.length > 0) {
+                    data.response.files.forEach(function (file) {
+                        $('tr[data-details-url$="files/details/' + file.fID + '"]').remove();
+                    });
+                }
                 ConcreteEvent.publish('FolderUpdateRequestComplete', {
                     'folder': data.response.folder
                 });

--- a/concrete/views/dialogs/file/folder.php
+++ b/concrete/views/dialogs/file/folder.php
@@ -48,6 +48,11 @@ if (isset($f) && (is_object($f))) {
             ConcreteEvent.unsubscribe('AjaxFormSubmitSuccess.updateFolder');
             ConcreteEvent.subscribe('AjaxFormSubmitSuccess.updateFolder', function (e, data) {
                 if (data.form === 'move-to-folder') {
+                    if (data.response.files.length > 0) {
+                        data.response.files.forEach(function (file) {
+                            $('tr[data-details-url$="files/details/' + file.fID + '"]').remove();
+                        });
+                    }
                     ConcreteEvent.publish('FolderUpdateRequestComplete', {
                         'folder': data.response.folder
                     });

--- a/concrete/views/dialogs/tree/node/file_folder/edit.php
+++ b/concrete/views/dialogs/tree/node/file_folder/edit.php
@@ -25,7 +25,8 @@
             });
             ConcreteEvent.unsubscribe('AjaxFormSubmitSuccess.updateTreeNode');
             ConcreteEvent.subscribe('AjaxFormSubmitSuccess.updateTreeNode', function(e, data) {
-                if (data.form == 'edit-file-folder-node') {
+                if (data.form === 'edit-file-folder-node') {
+                    $('tr[data-details-url$="files/search/folder/' + data.response.treeNodeID + '"] td.ccm-search-results-name').text(data.response.title);
                     ConcreteEvent.publish('ConcreteTreeUpdateTreeNode', {'node': data.response});
                 }
             });

--- a/concrete/views/dialogs/tree/node/file_folder/move.php
+++ b/concrete/views/dialogs/tree/node/file_folder/move.php
@@ -44,6 +44,9 @@ $folderID = $currentFolder->getTreeNodeParentID();
             ConcreteEvent.unsubscribe('AjaxFormSubmitSuccess.updateFolder');
             ConcreteEvent.subscribe('AjaxFormSubmitSuccess.updateFolder', function (e, data) {
                 if (data.form === 'move-to-folder') {
+                    if (data.response.sourceFolder) {
+                        $('tr[data-details-url$="files/search/folder/' + data.response.sourceFolder.treeNodeID + '"]').remove();
+                    }
                     ConcreteEvent.publish('FolderUpdateRequestComplete', {
                         'folder': data.response.folder
                     });


### PR DESCRIPTION
This PR addresses the following issues:

- Files or folders are not removed immediately from the list after being moved to another folder.
- Folder names are not updated immediately after being renamed.
- Moving a file or folder to the same destination is incorrectly allowed.

see: #11320 