### PR TITLE
Fix concretecsm #12535: Add condition - if handler already exists - skip

### DIFF
--- a/concrete/src/Logging/Configuration/AdvancedConfiguration.php
+++ b/concrete/src/Logging/Configuration/AdvancedConfiguration.php
@@ -30,6 +30,9 @@ class AdvancedConfiguration implements ConfigurationInterface
             $allConfig = $config['loggers'][Channels::META_CHANNEL_ALL];
             $channels = array_merge(Channels::getCoreChannels(), [Channels::CHANNEL_APPLICATION]);
             foreach($channels as $channel) {
+                if (array_key_exists($channel, $config['loggers'])) {
+                    continue;
+                }
                 $config['loggers'][$channel] = $allConfig;
             }
             unset($config['loggers'][Channels::META_CHANNEL_ALL]);


### PR DESCRIPTION
see: #12535
