### PR TITLE
Exclude IDE-only files from classmap

### DIFF
--- a/concrete/composer.json
+++ b/concrete/composer.json
@@ -24,7 +24,11 @@
   "autoload": {
     "psr-4": {
       "Concrete\\Core\\": "src"
-    }
+    },
+    "exclude-from-classmap": [
+        "src/Support/.phpstorm.meta.php",
+        "src/Support/__IDE_SYMBOLS__.php"
+    ]
   },
   "bin": [
     "bin/concrete",


### PR DESCRIPTION
I ran the `c5:ide-symbols` CLI command to generate a couple of files that are only used by IDEs (`concrete/src/Support/.phpstorm.meta.php` and `concrete/src/Support/.__IDE_SYMBOLS__.php`).

Now, when I run `composer install --optimize-autoloader` I see some some warnings like these:

```
Class Area located in ./concrete/src/Support/__IDE_SYMBOLS__.php does not comply with psr-4 autoloading standard (rule: Concrete\Core\ => ./concrete/src). Skipping.
Class Asset located in ./concrete/src/Support/__IDE_SYMBOLS__.php does not comply with psr-4 autoloading standard (rule: Concrete\Core\ => ./concrete/src). Skipping.
Class AssetList located in ./concrete/src/Support/__IDE_SYMBOLS__.php does not comply with psr-4 autoloading standard (rule: Concrete\Core\ => ./concrete/src). Skipping.
Class AttributeSet located in ./concrete/src/Support/__IDE_SYMBOLS__.php does not comply with psr-4 autoloading standard (rule: Concrete\Core\ => ./concrete/src). Skipping.
Class AuthenticationType located in ./concrete/src/Support/__IDE_SYMBOLS__.php does not comply with psr-4 autoloading standard (rule: Concrete\Core\ => ./concrete/src). Skipping.
Class Block located in ./concrete/src/Support/__IDE_SYMBOLS__.php does not comply with psr-4 autoloading standard (rule: Concrete\Core\ => ./concrete/src). Skipping.
[... and others...]
```

This PR should fix this issue.