### PR TITLE
Add ` #[\ReturnTypeWillChange]` to `jsonSerialize` at InstanceLogEntry

### DIFF
--- a/concrete/src/Entity/Board/InstanceLogEntry.php
+++ b/concrete/src/Entity/Board/InstanceLogEntry.php
@@ -119,6 +119,7 @@ class InstanceLogEntry implements \JsonSerializable
         $this->data = $data;
     }
 
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         $data = $this->getData();


### PR DESCRIPTION
After updating to 9.4.1 see the following messages in the logs:

```
Uncaught Exception: Could not convert database value to 'object' as an error was triggered by the unserialization: 'Return type of Concrete\Core\Entity\Board\InstanceLogEntry::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice'
```

This should fix the issue.