### PR TITLE
Use the context aware translation function

### DIFF
--- a/concrete/attributes/text/form.php
+++ b/concrete/attributes/text/form.php
@@ -4,6 +4,6 @@
         $this->field('value'),
         $value,
         [
-            'placeholder' => h(t($akTextPlaceholder))
+            'placeholder' => h(tc('AttributeKeyPlaceholder',$akTextPlaceholder))
         ]
     );


### PR DESCRIPTION
Placeholder translations must also have the right context in order to be translated.