### PR TITLE
Add Permission\Checker methods to __IDE_SYMBOLS__.php

### DIFF
--- a/concrete/src/Console/Command/GenerateIDESymbolsCommand.php
+++ b/concrete/src/Console/Command/GenerateIDESymbolsCommand.php
@@ -42,7 +42,11 @@ EOT
             if ($p !== false) {
                 unset($what[$p]);
             }
-            $output->write('Generating fake PHP classes to help IDE... ');
+            if (app()->isInstalled()) {
+                $output->write('Generating fake PHP classes to help IDE... ');
+            } else {
+                $output->write('Generating fake PHP classes to help IDE <fg=yellow>(PARTIAL since Concrete is not installed)</>... ');
+            }
             $this->generateIDEClasses();
             $output->writeln('<info>done.</info>');
         }

--- a/concrete/src/Console/Command/GenerateIDESymbolsCommand.php
+++ b/concrete/src/Console/Command/GenerateIDESymbolsCommand.php
@@ -43,13 +43,8 @@ EOT
                 unset($what[$p]);
             }
             $output->write('Generating fake PHP classes to help IDE... ');
-            if (!Core::make('app')->isInstalled()) {
-                $output->writeln('<error>failed: Concrete is not installed.</error>');
-                $rc = static::FAILURE;
-            } else {
-                $this->generateIDEClasses();
-                $output->writeln('<info>done.</info>');
-            }
+            $this->generateIDEClasses();
+            $output->writeln('<info>done.</info>');
         }
         $p = array_search('phpstorm', $what);
         if ($p !== false || in_array('all', $what)) {

--- a/concrete/src/Support/Symbol/CheckerGenerator.php
+++ b/concrete/src/Support/Symbol/CheckerGenerator.php
@@ -1,0 +1,333 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\Core\Support\Symbol;
+
+use Concrete\Core\File\Service\File as FileService;
+use Concrete\Core\Permission\Category;
+use Concrete\Core\Permission\Checker;
+use Concrete\Core\Permission\Key\Key;
+use Concrete\Core\Permission\ObjectInterface;
+use Concrete\Core\Support\Symbol\CheckerGenerator\Method;
+use ReflectionClass;
+use ReflectionMethod;
+use Throwable;
+
+class CheckerGenerator
+{
+    /**
+     * @var \Concrete\Core\File\Service\File
+     */
+    private $fileService;
+
+    /**
+     * @var \Concrete\Core\Support\Symbol\CheckerGenerator\Method[]|null
+     */
+    private $methods;
+
+    /**
+     * @var string|null
+     */
+    private $namespace;
+
+    public function __construct(FileService $fileService)
+    {
+        $this->fileService = $fileService;
+    }
+
+    public function getNamespace(): string
+    {
+        if ($this->namespace === null) {
+            $fqName = Checker::class;
+            $p = strrpos($fqName, '\\');
+            $this->namespace = $p === false ? '' : substr($fqName, 0, $p);
+        }
+
+        return $this->namespace;
+    }
+
+    public function renderLines(string $padding = '    '): array
+    {
+        $lines = [];
+        $lines[] = 'class Checker';
+        $lines[] = '{';
+        $first = true;
+        foreach ($this->getMethods() as $method) {
+            if ($first) {
+                $first = false;
+            } else {
+                $lines[] = '';
+            }
+            $phpDocsLines = [];
+            if (($descriptions = $method->getDescriptions()) !== []) {
+                if ($phpDocsLines !== []) {
+                    $phpDocsLines[] = '';
+                }
+                foreach ($descriptions as $description) {
+                    foreach (explode("\n", $description) as $line) {
+                        $phpDocsLines[] = $line;
+                    }
+                }
+            }
+            if (($forObjectOfClasses = $method->getForObjectOfClasses()) !== []) {
+                if ($phpDocsLines !== []) {
+                    $phpDocsLines[] = '';
+                }
+                $phpDocsLines[] = 'For objects of the following classes:';
+                foreach ($forObjectOfClasses as $forObjectOfClass) {
+                    $phpDocsLines[] = "- {$forObjectOfClass}";
+                }
+            }
+            if (($categoryKeyHandles = $method->getCategoryKeyHandles()) !== []) {
+                if ($phpDocsLines !== []) {
+                    $phpDocsLines[] = '';
+                }
+                $phpDocsLines[] = 'Permission category handles: ' . implode(', ', $categoryKeyHandles);
+            }
+            if (($sees = $method->getSees()) !== []) {
+                if ($phpDocsLines !== []) {
+                    $phpDocsLines[] = '';
+                }
+                foreach ($sees as $see) {
+                    $phpDocsLines[] = "@see \\{$see}";
+                }
+            }
+            if ($method->isDeprecated()) {
+                if ($phpDocsLines !== []) {
+                    $phpDocsLines[] = '';
+                }
+                $phpDocsLines[] = '@deprecated';
+            }
+            if ($phpDocsLines !== []) {
+                $lines[] = "{$padding}/**";
+                foreach ($phpDocsLines as $line) {
+                    $lines[] = "{$padding} * {$line}";
+                }
+                $lines[] = "{$padding} */";
+            }
+            $lines[] = "{$padding}public function {$method->getName()}({$method->getArguments()}) {}";
+        }
+        $lines[] = '}';
+
+        return $lines;
+    }
+
+    /**
+     * @return \Concrete\Core\Support\Symbol\CheckerGenerator\Method[]
+     */
+    private function getMethods(): array
+    {
+        if ($this->methods === null) {
+            $this->methods = $this->listMethods();
+        }
+
+        return $this->methods;
+    }
+
+    /**
+     * @return \Concrete\Core\Support\Symbol\CheckerGenerator\Method[]
+     */
+    private function listMethods(): array
+    {
+        $all = $this->listMethodsIn('Concrete\Core', DIR_BASE_CORE . '/' . DIRNAME_CLASSES);
+        foreach (Category::getList() as $category) {
+            $all = array_merge($all, $this->generateMethodsFromCategory($category->getPermissionKeyCategoryHandle()));
+        }
+        $merged = [];
+        foreach ($all as $item) {
+            foreach ($merged as $prev) {
+                if ($prev->isCompatibleWith($item)) {
+                    $prev->merge($item);
+                    continue 2;
+                }
+            }
+            $merged[] = $item;
+        }
+        usort($merged, static function (Method $a, Method $b): int {
+            $cmp = strnatcasecmp($a->getName(), $b->getName());
+            if ($cmp === 0) {
+                $cmp = strnatcasecmp($a->getArguments(), $b->getArguments());
+            }
+
+            return $cmp;
+        });
+
+        return $merged;
+    }
+
+    /**
+     * @return \Concrete\Core\Support\Symbol\CheckerGenerator\Method[]
+     */
+    private function listMethodsIn(string $namespacePrefix, string $parentDirectory): array
+    {
+        $result = [];
+        $matches = null;
+        foreach ($this->fileService->getDirectoryContents($parentDirectory) as $name) {
+            if ($name === '__IDE_SYMBOLS__.php') {
+                continue;
+            }
+            if (preg_match('/^(\w.*)\.php/i', $name, $matches)) {
+                $className = $namespacePrefix . '\\' . $matches[1];
+                if (class_exists($className)) {
+                    $interfaces = class_implements($className);
+                    if (in_array(ObjectInterface::class, $interfaces)) {
+                        $result = array_merge($result, $this->analyzeObjectInterfaceClass($className));
+                    }
+                }
+            } else {
+                $fullPath = $parentDirectory . '/' . $name;
+                if (is_dir($fullPath)) {
+                    $namespace = ($namespacePrefix === '' ? '' : "{$namespacePrefix}\\") . $name;
+                    $result = array_merge($result, $this->listMethodsIn($namespace, $fullPath));
+                }
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return \Concrete\Core\Support\Symbol\CheckerGenerator\Method[]
+     */
+    private function analyzeObjectInterfaceClass(string $objectInterfaceClassName): array
+    {
+        $result = [];
+        $objectInterfaceClass = new ReflectionClass($objectInterfaceClassName);
+        if ($objectInterfaceClass->isAbstract()) {
+            return $result;
+        }
+        $objectInterfaceClassName = $objectInterfaceClass->getName();
+        $objectInterfaceInstance = $objectInterfaceClass->newInstanceWithoutConstructor();
+        /** @var \Concrete\Core\Permission\ObjectInterface $objectInterfaceInstance */
+        if (!is_string($categoryHandle = $objectInterfaceInstance->getPermissionObjectKeyCategoryHandle())) {
+            $categoryHandle = '';
+        }
+        if ($categoryHandle !== '') {
+            $category = Category::getByHandle($categoryHandle);
+            if ($category) {
+                $result = array_merge($result, $this->generateMethodsFromCategory($categoryHandle, $objectInterfaceClassName));
+            }
+        }
+        $responseClassName = $objectInterfaceInstance->getPermissionResponseClassName();
+        $canonicalResponseClassName = null;
+        if (!class_exists($responseClassName)) {
+            switch ($objectInterfaceClassName) {
+                case 'Concrete\Core\Workflow\BasicWorkflow':
+                case 'Concrete\Core\Workflow\EmptyWorkflow':
+                    $canonicalResponseClassName = '';
+                    break;
+            }
+        }
+        if ($canonicalResponseClassName === null) {
+            $responseClass = new ReflectionClass($responseClassName);
+            $canonicalResponseClassName = $responseClass->getName();
+        }
+        if ($canonicalResponseClassName !== '') {
+            $result = array_merge($result, $this->generateMethodsFromResponseClass($canonicalResponseClassName, $objectInterfaceClassName, $categoryHandle));
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return \Concrete\Core\Support\Symbol\CheckerGenerator\Method[]
+     */
+    private function generateMethodsFromCategory(string $categoryHandle, string $objectInterfaceClassName = ''): array
+    {
+        $result = [];
+        foreach (Key::getList($categoryHandle) as $key) {
+            $name = 'can' . camelcase($key->getPermissionKeyHandle());
+            $method = new Method($name);
+            $method
+                ->addDescription($key->getPermissionKeyDescription() ?: $key->getPermissionKeyName() ?: '')
+                ->addForObjectOfClass($objectInterfaceClassName)
+                ->addCategoryKeyHandle($categoryHandle)
+            ;
+            $result[] = $method;
+        }
+
+        return $result;
+    }
+
+    private function generateMethodsFromResponseClass(string $responseClassName, string $objectInterfaceClassName = '', string $categoryHandle = ''): array
+    {
+        $responseClass = new ReflectionClass($responseClassName);
+        $result = [];
+        foreach ($responseClass->getMethods(ReflectionMethod::IS_PUBLIC) as $methodInfo) {
+            if (!preg_match('/^can[A-Z]/', $methodInfo->getName())) {
+                continue;
+            }
+            $params = [];
+            foreach ($methodInfo->getParameters() as $parameter) {
+                $param = '';
+                if ($parameter->isArray()) {
+                    $param .= 'array ';
+                } else {
+                    try {
+                        if (is_object($parameter->getClass())) {
+                            $param .= $parameter->getClass()->getName() . ' ';
+                        }
+                    } catch (Throwable $_) {
+                    }
+                }
+                if ($parameter->isPassedByReference()) {
+                    $param .= "&";
+                }
+                $param .= '$' . $parameter->getName();
+
+                if ($parameter->isOptional()) {
+                    $defaultValue = null;
+                    if (method_exists($parameter, 'getDefaultValueConstantName')) {
+                        $defaultValue = $parameter->getDefaultValueConstantName();
+                    }
+                    if ($defaultValue) {
+                        // Strip out wrong namespaces.
+                        $matches = null;
+                        if (preg_match('/.\\\\(\\w+)$/', $defaultValue, $matches) && defined($matches[1])) {
+                            $defaultValue = $matches[1];
+                        }
+                    } else {
+                        $v = $parameter->getDefaultValue();
+                        switch (gettype($v)) {
+                            case 'boolean':
+                            case 'integer':
+                            case 'double':
+                            case 'NULL':
+                                $defaultValue = json_encode($v);
+                                break;
+                            case 'string':
+                                $defaultValue = '"' . addslashes($v) . '"';
+                                break;
+                            case 'array':
+                                if (count($v)) {
+                                    $defaultValue = trim(var_export($v, true));
+                                } else {
+                                    $defaultValue = 'array()';
+                                }
+                                break;
+                            case 'object':
+                            case 'resource':
+                            default:
+                                $defaultValue = trim(var_export($v, true));
+                                break;
+                        }
+                    }
+                    $param .= ' = ' . $defaultValue;
+                }
+                $params[] = $param;
+            }
+            $phpDoc = (string) $methodInfo->getDocComment();
+            $method = new Method($methodInfo->getName(), implode(', ', $params));
+            $method
+                ->setDeprecated(str_contains($phpDoc, '@deprecated'))
+                ->addForObjectOfClass($objectInterfaceClassName)
+                ->addCategoryKeyHandle($categoryHandle)
+                ->addSee($methodInfo->getDeclaringClass()->getName() . '::' . $methodInfo->getName() . '()')
+            ;
+            $result[] = $method;
+        }
+
+        return $result;
+    }
+}

--- a/concrete/src/Support/Symbol/CheckerGenerator.php
+++ b/concrete/src/Support/Symbol/CheckerGenerator.php
@@ -39,6 +39,7 @@ class CheckerGenerator
     public function __construct(FileService $fileService, bool $isInstalled)
     {
         $this->fileService = $fileService;
+        $this->isInstalled = $isInstalled;
     }
 
     public function getNamespace(): string

--- a/concrete/src/Support/Symbol/CheckerGenerator/Method.php
+++ b/concrete/src/Support/Symbol/CheckerGenerator/Method.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\Core\Support\Symbol\CheckerGenerator;
+
+class Method
+{
+    /**
+     * @var $string
+     */
+    private $name;
+
+    /**
+     * @var $string
+     */
+    private $arguments;
+
+    /**
+     * @var bool
+     */
+    private $deprecated = false;
+
+    /**
+     * @var $string[]
+     */
+    private $descriptions = [];
+
+    /**
+     * @var $string[]
+     */
+    private $forObjectOfClasses = [];
+
+    /**
+     * @var $string[]
+     */
+    private $categoryKeyHandles = [];
+
+    /**
+     * @var $string[]
+     */
+    private $sees = [];
+
+    public function __construct(string $name, string $arguments = '')
+    {
+        $this->name = $name;
+        $this->arguments = $arguments;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getArguments(): string
+    {
+        return $this->arguments;
+    }
+
+    /**
+     * @return $this
+     */
+    public function setDeprecated(bool $value): self
+    {
+        $this->deprecated = $value;
+
+        return $this;
+    }
+
+    public function isDeprecated(): bool
+    {
+        return $this->deprecated;
+    }
+
+    /**
+     * @return $this
+     */
+    public function addDescription(string $value): self
+    {
+        $value = trim($value);
+        if ($value !== '') {
+            $value = str_replace("\r", "\n", str_replace("\r\n", "\n", $value));
+            if (!in_array($value, $this->descriptions, true)) {
+                $this->descriptions[] = $value;
+            }
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getDescriptions(): array
+    {
+        return $this->descriptions;
+    }
+
+    /**
+     * @return $this
+     */
+    public function addForObjectOfClass(string $value): self
+    {
+        if ($value !== '' && !in_array($value, $this->forObjectOfClasses, true)) {
+            $this->forObjectOfClasses[] = $value;
+            sort($this->forObjectOfClasses, SORT_STRING);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getForObjectOfClasses(): array
+    {
+        return $this->forObjectOfClasses;
+    }
+
+    /**
+     * @return $this
+     */
+    public function addCategoryKeyHandle(string $value): self
+    {
+        if ($value !== '' && !in_array($value, $this->categoryKeyHandles, true)) {
+            $this->categoryKeyHandles[] = $value;
+            sort($this->categoryKeyHandles, SORT_STRING);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getCategoryKeyHandles(): array
+    {
+        return $this->categoryKeyHandles;
+    }
+
+    /**
+     * @return $this
+     */
+    public function addSee(string $value): self
+    {
+        if ($value !== '' && !in_array($value, $this->sees, true)) {
+            $this->sees[] = $value;
+            sort($this->sees, SORT_STRING);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getSees(): array
+    {
+        return $this->sees;
+    }
+
+    public function isCompatibleWith(self $other): bool
+    {
+        if (strcasecmp($this->getName(), $other->getName()) !== 0) {
+            return false;
+        }
+        if ($this->getArguments() !== $other->getArguments()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @return $this
+     */
+    public function merge(self $other): self
+    {
+        if (!$other->isDeprecated()) {
+            $this->setDeprecated(false);
+        }
+        foreach ($other->getDescriptions() as $value) {
+            $this->addDescription($value);
+        }
+        foreach ($other->getForObjectOfClasses() as $value) {
+            $this->addForObjectOfClass($value);
+        }
+        foreach ($other->getCategoryKeyHandles() as $value) {
+            $this->addCategoryKeyHandle($value);
+        }
+        foreach ($other->getSees() as $value) {
+            $this->addSee($value);
+        }
+
+        return $this;
+    }
+}

--- a/concrete/src/Support/Symbol/SymbolGenerator.php
+++ b/concrete/src/Support/Symbol/SymbolGenerator.php
@@ -48,7 +48,7 @@ class SymbolGenerator
             }
             $this->registerClass($alias, $class);
         }
-        $this->checkerGenerator = app(CheckerGenerator::class);
+        $this->checkerGenerator = app(CheckerGenerator::class, ['isInstalled' => $this->isInstalled]);
     }
 
     /**


### PR DESCRIPTION
By running the `c5:ide-symbols` CLI command, Concrete creates the file `__IDE_SYMBOLS__.php` full of useful aliases of the core classes (used just by IDEs).

What about adding to that file the methods of the `Concrete\Core\Permission\Checker` class we can use for various objects?

With this change. `__IDE_SYMBOLS__.php` will also contain the following:

```php
namespace Concrete\Core\Permission
{
    class Checker
    {
        /**
         * Access API
         * 
         * Permission category handles: admin
         */
        public function canAccessApi() {}
    
        /**
         * Access RSS Feed
         * 
         * For objects of the following classes:
         * - Concrete\Core\Entity\Calendar\Calendar
         * 
         * Permission category handles: calendar
         */
        public function canAccessCalendarRssFeed() {}
    
        /**
         * Access RSS Feeds
         * 
         * Permission category handles: calendar_admin
         */
        public function canAccessCalendarRssFeeds() {}
    
        /**
         * For objects of the following classes:
         * - Concrete\Core\Tree\Node\Type\FileFolder
         * 
         * Permission category handles: file_folder
         * 
         * @see \Concrete\Core\Permission\Response\FileFolderResponse::canAccessFileManager()
         * 
         * @deprecated
         */
        public function canAccessFileManager() {}
    
        /**
         * Access Group Search
         * 
         * For objects of the following classes:
         * - Concrete\Core\User\UserInfo
         * 
         * Permission category handles: user
         */
        public function canAccessGroupSearch() {}
    
        /**
         * Access Page Type Defaults
         * 
         * Permission category handles: admin
         */
        public function canAccessPageDefaults() {}
    
        /**
         * Access Page Type Permissions
         * 
         * Permission category handles: admin
         */
        public function canAccessPageTypePermissions() {}
    
        /**
         * Access Sitemap
         * 
         * Permission category handles: sitemap
         */
        public function canAccessSitemap() {}
    
        /**
         * Access Task Permissions
         * 
         * Permission category handles: admin
         */
        public function canAccessTaskPermissions() {}
    
        /**
         * Controls whether a user can view the search user interface.
         * 
         * For objects of the following classes:
         * - Concrete\Core\User\UserInfo
         * 
         * Permission category handles: user
         */
        public function canAccessUserSearch() {}
    
        /**
         * Controls whether a user can export site users or not
         * 
         * For objects of the following classes:
         * - Concrete\Core\User\UserInfo
         * 
         * Permission category handles: user
         */
        public function canAccessUserSearchExport() {}
    
        /**
         * Activate/Deactivate User
         * 
         * For objects of the following classes:
         * - Concrete\Core\User\UserInfo
         * 
         * Permission category handles: user
         */
        public function canActivateUser() {}
    
        /**
         * Can add a block to any area on the site. If someone is added here they can add blocks to any area (unless that area has permissions that override these global permissions.)
         * 
         * Permission category handles: block_type
         */
        public function canAddBlock() {}
    
        /**
         * For objects of the following classes:
         * - Concrete\Core\Area\Area
         * - Concrete\Core\Area\GlobalArea
         * - Concrete\Core\Area\SubArea
         * 
         * Permission category handles: area
         * 
         * @see \Concrete\Core\Permission\Response\AreaResponse::canAddBlock()
         */
        public function canAddBlock($blockTypeOrBlock) {}
    
        /**
         * For objects of the following classes:
         * - Concrete\Core\Area\Area
         * - Concrete\Core\Area\GlobalArea
         * - Concrete\Core\Area\SubArea
         * 
         * Permission category handles: area
         * 
         * @see \Concrete\Core\Permission\Response\AreaResponse::canAddBlocks()
         */
        public function canAddBlocks() {}
    
        /**
         * Can add blocks to this area. This setting overrides the global Add Block permission for this area.
         * 
         * For objects of the following classes:
         * - Concrete\Core\Area\Area
         * - Concrete\Core\Area\GlobalArea
         * - Concrete\Core\Area\SubArea
         * 
         * Permission category handles: area
         */
        public function canAddBlockToArea() {}
    
        /**
         * For objects of the following classes:
         * - Concrete\Core\Multilingual\Page\Section\Section
         * - Concrete\Core\Page\Page
         * - Concrete\Core\Page\Stack\Stack
         * 
         * Permission category handles: multilingual_section, page
         * 
         * @see \Concrete\Core\Permission\Response\PageResponse::canAddBlockType()
         */
        public function canAddBlockType($bt) {}
    
        /**
         * Add Board
         * 
         * Permission category handles: board_admin
         */
        public function canAddBoard() {}
    
        /**
         * Add Calendar
         * 
         * Permission category handles: calendar_admin
         */
        public function canAddCalendar() {}
    
        /**
         * Add Calendar Event
         * 
         * For objects of the following classes:
         * - Concrete\Core\Entity\Calendar\Calendar
         * 
         * Permission category handles: calendar
         */
        public function canAddCalendarEvent() {}
    
        /**
         * Add Calendar Events
         * 
         * Permission category handles: calendar_admin
         */
        public function canAddCalendarEvents() {}
    
        /**
         * For objects of the following classes:
         * - Concrete\Core\Tree\Node\Type\Category
         * - Concrete\Core\Tree\Node\Type\ExpressEntryCategory
         * - Concrete\Core\Tree\Node\Type\ExpressEntryResults
         * - Concrete\Core\Tree\Node\Type\ExpressEntrySiteResults
         * 
         * Permission category handles: category_tree_node, express_tree_node
         * 
         * @see \Concrete\Core\Permission\Response\CategoryTreeNodeResponse::canAddCategoryTreeNode()
         * @see \Concrete\Core\Permission\Response\ExpressTreeNodeResponse::canAddCategoryTreeNode()
         */
        public function canAddCategoryTreeNode() {}
    
        /**
         * Add Message to Conversation
         * 
         * For objects of the following classes:
         * - Concrete\Core\Conversation\Conversation
         * - Concrete\Core\Conversation\Message\Message
         * 
         * Permission category handles: conversation
         */
        public function canAddConversationMessage() {}

        [...]
    }
}
```
