### PR TITLE
Add a collapse button for the edit bar

### DIFF
--- a/concrete/single_pages/dashboard/blocks/stacks/view.php
+++ b/concrete/single_pages/dashboard/blocks/stacks/view.php
@@ -96,7 +96,10 @@ if (isset($neutralStack)) {
             $deleteLabels = null;
         ?>
             <nav class="navbar navbar-expand-lg bg-body-tertiary px-3">
-                <div class="collapse navbar-collapse">
+                <button class="navbar-toggler px-2 py-0" type="button" data-bs-toggle="collapse" data-bs-target=".navbar-collapse.edit-bar" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="<?= t('Toggle navigation') ?>">
+                    <i class="fas fa-chevron-down" style="font-size: 0.8rem;"></i>
+                </button>
+                <div class="collapse navbar-collapse edit-bar">
                     <ul class="navbar-nav me-auto">
                         <?php
                         if ($areaPermissions->canAddBlocks()) {


### PR DESCRIPTION
Add button to uncollapse edit bar:
Mobile view:
![image](https://github.com/user-attachments/assets/c3308991-5a71-4e0e-be18-2d21b27411ed)
![image](https://github.com/user-attachments/assets/feb94cd9-c4c1-4987-82d5-8ebd9e04f58a)

Desktop View:
![image](https://github.com/user-attachments/assets/900604b1-e86f-4cb0-91d6-8dba4f4aa2c9)