### PR TITLE
CIF: fix exporting files identified by their UUID

### DIFF
--- a/concrete/src/Backup/ContentExporter.php
+++ b/concrete/src/Backup/ContentExporter.php
@@ -74,7 +74,7 @@ class ContentExporter
     }
 
     /**
-     * @param int|string|mixed $fID the ID of the file
+     * @param int|string|mixed $fID the ID or the UUID of the file
      *
      * @return string|null
      *
@@ -82,10 +82,13 @@ class ContentExporter
      */
     public static function replaceFileWithPlaceHolder($fID)
     {
-        if (!is_numeric($fID) || ($fID = (int) $fID) <= 0) {
+        if (uuid_is_valid((string) $fID)) {
+            $f = File::getByUUID($fID);
+        } elseif (is_numeric($fID) && ($fID = (int) $fID) > 0) {
+            $f = File::getByID($fID);
+        } else {
             return null;
         }
-        $f = File::getByID($fID);
         $fv = $f ? $f->getApprovedVersion() : null;
         if (!$fv) {
             return null;


### PR DESCRIPTION
For example, if we export a Rich Text with this content (DB format):

```html
<a href="{CCM:FID_DL_fdcf9d6a-90ba-4d09-a6d4-766c1c55c25f}">FILE</a>
<a href="{CCM:CID_294}">PAGE</a>
```

before this change we have:

```html
<a href="">FILE</a>
<a href="{ccm:export:page:/features}">PAGE</a>
```

with this change we'll have:

```html
<a href="{ccm:export:file:651743690952:back_mountain.jpg}">FILE</a>
<a href="{ccm:export:page:/features}">PAGE</a>
```
