### PR TITLE
Don't call OpenGraph::getTags() if there's no current page

### DIFF
--- a/concrete/elements/header_required.php
+++ b/concrete/elements/header_required.php
@@ -154,11 +154,13 @@ if ($c !== null && $config->get('multilingual.set_alternate_hreflang') && !$c->i
     }
 }
 
-$openGraph = app(OpenGraph::class);
-if ($openGraph->isEnabled()) {
-    echo "\n\n\t";
-    foreach ($openGraph->getTags($c) as $tag) {
-        echo $tag . "\n\t";
+if ($c !== null) {
+    $openGraph = app(OpenGraph::class);
+    if ($openGraph->isEnabled()) {
+        echo "\n\n\t";
+        foreach ($openGraph->getTags($c) as $tag) {
+            echo $tag . "\n\t";
+        }
     }
 }
 


### PR DESCRIPTION
Fix #12576

ATM this is the only place in the core where we currently call `OpenGraph::getTags()`