### PR TITLE
Disable pdo_sqlsrv PHP extensions in GitHub Actions

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -63,7 +63,7 @@ jobs:
         uses: shivammathur/setup-php@2.11.0
         with:
           php-version: "${{ matrix.php-version }}"
-          extensions: mbstring, xml, ctype, iconv, intl, pdo_mysql, mysql
+          extensions: none, mbstring, xml, ctype, iconv, intl, pdo_mysql, mysql
           coverage: ${{ env.CODE_COVERAGE }}
           ini-values: memory_limit=-1, pcov.directory=concrete, pcov.exclude="~(vendor|tests|js|css|config)~"
           tools: ${{matrix.composer}}


### PR DESCRIPTION
This should hopefully prevent the tests from failing with the following error message:

PHPUnit\Framework\Exception: PHP Startup: Unable to load dynamic library 'pdo_sqlsrv.so'
