### PR TITLE
Use most recent version of setup-php GH Action

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -60,7 +60,7 @@ jobs:
           fetch-depth: 2
 
       - name: "Install PHP"
-        uses: shivammathur/setup-php@2.11.0
+        uses: shivammathur/setup-php@v2
         with:
           php-version: "${{ matrix.php-version }}"
           extensions: mbstring, xml, ctype, iconv, intl, pdo_mysql, mysql


### PR DESCRIPTION
This should hopefully prevent the tests from failing with the following error message:

PHPUnit\Framework\Exception: PHP Startup: Unable to load dynamic library 'pdo_sqlsrv.so'
