### PR TITLE
Feature #12555 : Display SVG in File Manager and small bug fix

### DIFF
--- a/concrete/single_pages/dashboard/files/details.php
+++ b/concrete/single_pages/dashboard/files/details.php
@@ -80,17 +80,29 @@ if ($view->controller->getAction() == 'preview_version') { ?>
                             </li>
                             <?php
                         }
-                        if ($genericType === \Concrete\Core\File\Type\Type::T_IMAGE
+                        if ($genericType === \Concrete\Core\File\Type\Type::T_IMAGE 
                             && $filePermissions->canEditFileContents()) {
+                            // If it's an SVG there will be not thumbnails to edit, so we don't show the thumbnails option. It would also make no sense given the nature of SVG as an image format.
+                            if ($fileVersion->getTypeObject()->isSVG()) {
+                                $dialogURL = '/ccm/system/file/view?fID=';
+                                $dialogLinkLabel = t('View');
+                                $dialogLinkTitle = t('View this SVG.');
+                                $dialogTitle = t('View');
+                            } else {
+                                $dialogURL = '/ccm/system/dialogs/file/thumbnails?fID=';
+                                $dialogLinkLabel = t('Thumbnails');
+                                $dialogLinkTitle = t('Adjust the thumbnails for this image.');
+                                $dialogTitle = t('Edit');
+                            }
                             ?>
                             <li><a
                                     data-bs-placement="left"
                                     class="dropdown-item launch-tooltip dialog-launch"
-                                    dialog-title="<?= t('Edit') ?>"
+                                    dialog-title="<?= $dialogTitle ?>"
                                     dialog-width="90%" dialog-height="75%"
-                                    title="<?= t('Adjust the thumbnails for this image.') ?>"
-                                    href="<?=URL::to('/ccm/system/dialogs/file/thumbnails?fID=' . $file->getFileID())?>"
-                            ><?= t('Thumbnails') ?></a></li>
+                                    title="<?= $dialogLinkTitle ?>"
+                                    href="<?=URL::to($dialogURL . $file->getFileID())?>"
+                            ><?= $dialogLinkLabel ?></a></li>
                             <?php
                         }
                         if ($fileVersion->canEdit() && $filePermissions->canEditFileContents()) {

--- a/concrete/src/Entity/File/Version.php
+++ b/concrete/src/Entity/File/Version.php
@@ -1853,7 +1853,7 @@ class Version implements ObjectInterface
      */
     public function getDetailThumbnailImage()
     {
-        if ($this->getTypeObject()->supportsThumbnails()) {
+        if ($this->getTypeObject()->supportsThumbnails() || $this->getTypeObject()->isSVG()) {
             $app = Application::getFacadeApplication();
             $config = $app->make('config');
             $type = ThumbnailType::getByHandle($config->get('concrete.icons.file_manager_detail.handle'));
@@ -1869,9 +1869,11 @@ class Version implements ObjectInterface
                 /** @var ThumbnailPlaceholderService $thumbnailPlaceholderService */
                 $thumbnailPlaceholderService = $app->make(ThumbnailPlaceholderService::class);
                 $result = $thumbnailPlaceholderService->getThumbnailPlaceholder($this, $type->getBaseVersion());
-            } else {
-                $result = $this->getTypeObject()->getThumbnail();
+            } elseif ($this->getTypeObject()->isSVG()) {
+                $result = '<img class="ccm-file-manager-detail-thumbnail" src="' . $this->getThumbnailURL($type->getBaseVersion()) . '" />';
             }
+        } else {
+            $result = $this->getTypeObject()->getThumbnail();
         }
 
         return $result;
@@ -1884,7 +1886,8 @@ class Version implements ObjectInterface
      */
     public function getListingThumbnailImage()
     {
-        if ($this->getTypeObject()->supportsThumbnails()) {
+        // SVG will not have an existing thumbnail nor will it be generating one so it will be handled and displayed as a source image.
+        if ($this->getTypeObject()->supportsThumbnails() || $this->getTypeObject()->isSVG()) {
             $app = Application::getFacadeApplication();
             $config = $app->make('config');
             $listingType = ThumbnailType::getByHandle($config->get('concrete.icons.file_manager_listing.handle'));


### PR DESCRIPTION
### SVG Display in the File Manager

This adds the possibility to display SVG images in the File Manager in answer to #12555 

1. As a detail image in the File Manager's list
2. As a larger Image in the "details" view of the File Manager
3. As an even larger image from the details view, replacing the thumbnails view.

Normally, the details view provides access to image thumbnails, if any. It wouldn't make sense for SVG files, so the option is replaced with a simple "View the SVG file" option instead.

### Small bug fix

This also resolves a minor issue in the "Details" view. Files that are not images and cannot have thumbnails, such as PDF files, were not showing anything. This fixes it to display the Generic Icon for the file type, the same already used in the File Manager's list.

