### PR TITLE
Feature block: fix exporting/importing to/from CIF

### DIFF
--- a/concrete/blocks/feature/controller.php
+++ b/concrete/blocks/feature/controller.php
@@ -1,15 +1,15 @@
 <?php
 namespace Concrete\Block\Feature;
 
+use Concrete\Core\Block\BlockController;
 use Concrete\Core\Editor\LinkAbstractor;
+use Concrete\Core\Error\UserMessageException;
 use Concrete\Core\Feature\Features;
 use Concrete\Core\Feature\UsesFeatureInterface;
-use Concrete\Core\Html\Service\FontAwesomeIcon;
-use Concrete\Core\Validation\SanitizeService;
-use Page;
-use Concrete\Core\Block\BlockController;
-use Core;
 use Concrete\Core\File\File;
+use Concrete\Core\Form\Service\DestinationPicker\DestinationPicker;
+use Concrete\Core\Html\Service\FontAwesomeIcon;
+use Concrete\Core\Page\Page;
 
 class Controller extends BlockController implements UsesFeatureInterface
 {
@@ -54,8 +54,9 @@ class Controller extends BlockController implements UsesFeatureInterface
     protected $btCacheBlockOutput = true;
     protected $btCacheBlockOutputOnPost = true;
     protected $btCacheBlockOutputForRegisteredUsers = true;
-    protected $btExportPageColumns = array('internalLinkCID');
-    protected $btExportFileColumns = array('fID');
+    protected $btExportPageColumns = ['internalLinkCID'];
+    protected $btExportFileColumns = ['fID'];
+    protected $btExportContentColumns = ['paragraph'];
     protected $btInterfaceHeight = 520;
     protected $btTable = 'btFeature';
 
@@ -84,7 +85,7 @@ class Controller extends BlockController implements UsesFeatureInterface
             if (!empty($this->internalLinkCID)) {
                 $linkToC = Page::getByID($this->internalLinkCID);
 
-                return (empty($linkToC) || $linkToC->error) ? '' : Core::make('helper/navigation')->getLinkToCollection(
+                return (empty($linkToC) || $linkToC->error) ? '' : $this->app->make('helper/navigation')->getLinkToCollection(
                     $linkToC
                 );
             } else {
@@ -119,6 +120,10 @@ class Controller extends BlockController implements UsesFeatureInterface
         $this->set('titleFormat', 'h4');
         $this->edit();
         $this->set('bf', null);
+        $this->set('destinationPicker', $this->app->make(DestinationPicker::class));
+        $this->set('linkDestinationPickers', $this->getLinkDestinationPickers());
+        $this->set('linkDestinationHandle', 'none');
+        $this->set('linkDestinationValue', null);
     }
 
     public function view()
@@ -140,9 +145,19 @@ class Controller extends BlockController implements UsesFeatureInterface
             $bf = $this->getFileObject();
         }
         $this->set('bf', $bf);
-
-
         $this->requireAsset('css', 'font-awesome');
+        $this->set('destinationPicker', $this->app->make(DestinationPicker::class));
+        $this->set('linkDestinationPickers', $this->getLinkDestinationPickers());
+        if ($this->internalLinkCID) {
+            $this->set('linkDestinationHandle', 'page');
+            $this->set('linkDestinationValue', $this->internalLinkCID);
+        } elseif ((string) $this->externalLink !== '') {
+            $this->set('linkDestinationHandle', 'external_url');
+            $this->set('linkDestinationValue', $this->externalLink);
+        } else {
+            $this->set('linkDestinationHandle', 'none');
+            $this->set('linkDestinationValue', null);
+        }
     }
 
     /**
@@ -202,38 +217,48 @@ class Controller extends BlockController implements UsesFeatureInterface
 
     public function save($args)
     {
-        switch (isset($args['linkType']) ? intval($args['linkType']) : 0) {
-            case 1:
-                $args['externalLink'] = '';
-                break;
-            case 2:
-                $args['internalLinkCID'] = 0;
-                break;
-            default:
-                $args['externalLink'] = '';
-                $args['internalLinkCID'] = 0;
-                break;
-        }
-        $args['paragraph'] = isset($args['paragraph']) ? LinkAbstractor::translateTo($args['paragraph']) : '';
-        /** @var SanitizeService $security */
+        $errors = $this->app->make('error');
         $security = $this->app->make('helper/security');
+
         $args['icon'] = isset($args['icon']) ? $security->sanitizeString($args['icon']) : '';
+        $args['fID'] = empty($args['fID']) ? 0 : (int) $args['fID'];
         $args['title'] = isset($args['title']) ? $security->sanitizeString($args['title']) : '';
         $args['titleFormat'] = isset($args['titleFormat']) ? $security->sanitizeString($args['titleFormat']) : '';
-        $args['internalLinkCID'] = isset($args['internalLinkCID']) ? $security->sanitizeInt($args['internalLinkCID']) : 0;
-        $args['externalLink'] = isset($args['externalLink']) ? $security->sanitizeURL($args['externalLink']) : '';
-        unset($args['linkType']);
-
-        $args = $args + [
-            'fID' => 0,
-        ];
-        $args['fID'] = $args['fID'] != '' ? $args['fID'] : 0;
+        $args['paragraph'] = isset($args['paragraph']) ? LinkAbstractor::translateTo($args['paragraph']) : '';
+        if (($args['_fromCIF'] ?? null) === true) {
+            $args['internalLinkCID'] = empty($args['internalLinkCID']) ? 0 : (int) $args['internalLinkCID'];
+        } else {
+            [$linkHandle, $linkValue] = $this->app->make(DestinationPicker::class)->decode('link', $this->getLinkDestinationPickers(), $errors, t('Link'), $args);
+            $args['externalLink'] = $linkHandle === 'external_url' ? $security->sanitizeURL($linkValue) : '';
+            $args['internalLinkCID'] = $linkHandle === 'page' ? $linkValue : 0;
+        }
+        if ($errors->has()) {
+            throw new UserMessageException($errors->toText());
+        }
         parent::save($args);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Block\BlockController::getImportData()
+     */
+    protected function getImportData($blockNode, $page)
+    {
+        return parent::getImportData($blockNode, $page) + ['_fromCIF' => true];
     }
 
     public function getUsedFiles()
     {
         return [$this->getFileID()];
     }
-    
+
+    protected function getLinkDestinationPickers(): array
+    {
+        return [
+            'none',
+            'page',
+            'external_url' => ['maxlength' => 255],
+        ];
+    }
 }

--- a/concrete/blocks/feature/form.php
+++ b/concrete/blocks/feature/form.php
@@ -1,43 +1,36 @@
 <?php
-defined('C5_EXECUTE') or die("Access Denied.");
-/** @var \Concrete\Block\Feature\Controller $controller */
-/** @var \Concrete\Core\Form\Service\Form $form */
-$bID = $bID ?? 0;
-$icon = $icon ?? '';
-$title = $title ?? '';
-$titleFormat = $titleFormat ?? '';
-$internalLinkCID = $internalLinkCID ?? 0;
-$externalLink = $externalLink ?? '';
 
 use Concrete\Core\Application\Service\FileManager;
-use Concrete\Core\Entity\File\File;
-use Concrete\Core\Form\Service\DestinationPicker\DestinationPicker;
-use Concrete\Core\Form\Service\Widget\PageSelector;
 use Concrete\Core\Support\Facade\Application;
 
+defined('C5_EXECUTE') or die('Access Denied.');
+
 /**
- * @var DestinationPicker $destinationPicker
+ * @var \Concrete\Block\Feature\Controller $controller
+ * @var \Concrete\Core\Form\Service\Form $form
+ * @var Concrete\Core\Form\Service\DestinationPicker\DestinationPicker $destinationPicker
+ * @var array $linkDestinationPickers
+ * @var string $linkDestinationHandle
+ * @var mixed $linkDestinationValue
  * @var string $sizingOption
  * @var array $themeResponsiveImageMap
- * @var array $thumbnailTypes
  * @var array $selectedThumbnailTypes
  * @var array $imageLinkPickers
  * @var string $imageLinkHandle
  * @var mixed $imageLinkValue
  * @var int $constrainImage
- * @var File|null $bfo
+ * @var Concrete\Core\Entity\File\File|null $bf
  */
 
+$bID = $bID ?? 0;
+$icon = $icon ?? '';
+$title = $title ?? '';
+$titleFormat = $titleFormat ?? '';
+
 $app = Application::getFacadeApplication();
-/** @var PageSelector $pageSelector */
-$pageSelector = $app->make(PageSelector::class);
-/** @var FileManager $fileManager */
 $fileManager = $app->make(FileManager::class);
 
-$thumbnailTypes['0'] = t('Full Size');
-
 ?>
-
 <fieldset>
     <legend><?=t('Display')?></legend>
     <div class="form-group ccm-block-select-icon">
@@ -75,25 +68,7 @@ $thumbnailTypes['0'] = t('Full Size');
 
 <fieldset>
     <legend><?=t('Link')?></legend>
-
-    <div class="form-group">
-        <select name="linkType" data-select="feature-link-type" class="form-select">
-            <option value="0" <?=(empty($externalLink) && empty($internalLinkCID) ? 'selected="selected"' : '')?>><?=t('None')?></option>
-            <option value="1" <?=(empty($externalLink) && !empty($internalLinkCID) ? 'selected="selected"' : '')?>><?=t('Another Page')?></option>
-            <option value="2" <?=(!empty($externalLink) ? 'selected="selected"' : '')?>><?=t('External URL')?></option>
-        </select>
-    </div>
-
-    <div data-select-contents="feature-link-type-internal" style="display: none;" class="form-group">
-        <?=$form->label('internalLinkCID', t('Choose Page:'))?>
-        <?= Loader::helper('form/page_selector')->selectPage('internalLinkCID', $internalLinkCID); ?>
-    </div>
-
-    <div data-select-contents="feature-link-type-external" style="display: none;" class="form-group">
-        <?=$form->label('externalLink', t('URL'))?>
-        <?= $form->text('externalLink', $externalLink); ?>
-    </div>
-
+    <?= $destinationPicker->generate('link', $linkDestinationPickers, $linkDestinationHandle, $linkDestinationValue) ?>
 </fieldset>
 
 <script type="text/javascript">
@@ -104,20 +79,6 @@ $(function() {
             components: config.components
         })
     })
-    $('select[data-select=feature-link-type]').on('change', function() {
-       if ($(this).val() == '0') {
-           $('div[data-select-contents=feature-link-type-internal]').hide();
-           $('div[data-select-contents=feature-link-type-external]').hide();
-       }
-       if ($(this).val() == '1') {
-           $('div[data-select-contents=feature-link-type-internal]').show();
-           $('div[data-select-contents=feature-link-type-external]').hide();
-       }
-       if ($(this).val() == '2') {
-           $('div[data-select-contents=feature-link-type-internal]').hide();
-           $('div[data-select-contents=feature-link-type-external]').show();
-       }
-    }).trigger('change');
 });
 </script>
 


### PR DESCRIPTION
When we export a feature block, we have something like this:

```xml
<block type="feature" name="">
   <data table="btFeature">
      <record>
         <icon>fas fa-address-book</icon>
         <title>aaa</title>
         <paragraph><![CDATA[<p><a href="{CCM:CID_239}">asds</a></p>
]]></paragraph>
         <externalLink />
         <internalLinkCID>{ccm:export:page:/test}</internalLinkCID>
         <titleFormat>h2</titleFormat>
         <fID>{ccm:export:file:701750316851:icon.png}</fID>
      </record>
   </data>
</block>
```

There are some problems here:

1. we don't format the `paragraph` field for exporting (we have `CCM:CID_239` instead of `{ccm:export:page:/test}`)
2. when we import that CIF, the link will get lost, since the `save()` method assumes the data comes from the UI (which sends a `linkType` field. but we don't have it in the CIF). When importing from CIF we already have the final fields (they are extracted from the `getImportData()` method

Also, what about using a destination picker for selecting the link target?
