### PR TITLE
Simplify export styleset

### DIFF
--- a/concrete/src/Entity/StyleCustomizer/Inline/StyleSet.php
+++ b/concrete/src/Entity/StyleCustomizer/Inline/StyleSet.php
@@ -192,6 +192,11 @@ class StyleSet
      */
     protected $hideOnLargeDevice = false;
 
+    public function getID()
+    {
+        return $this->issID;
+    }
+
     /**
      * @param mixed $customClass
      */
@@ -240,36 +245,33 @@ class StyleSet
         return $this->customElementAttribute;
     }
 
-    /**
-     * @param mixed $borderWidth
-     */
-    public function setBorderWidth($borderWidth)
+    public function setBackgroundColor($backgroundColor)
     {
-        $this->borderWidth = $borderWidth;
+        $this->backgroundColor = $backgroundColor;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getBorderWidth()
+    public function getBackgroundColor()
     {
-        return $this->borderWidth;
+        return $this->backgroundColor;
     }
 
-    /**
-     * @param mixed $alignment
-     */
-    public function setAlignment($alignment)
+    public function setBackgroundImageFileID($backgroundImageFileID)
     {
-        $this->alignment = $alignment;
+        $this->backgroundImageFileID = $backgroundImageFileID;
     }
 
-    /**
-     * @return mixed
-     */
-    public function getAlignment()
+    public function getBackgroundImageFileID()
     {
-        return $this->alignment;
+        return $this->backgroundImageFileID;
+    }
+
+    public function getBackgroundImageFileObject()
+    {
+        if ($this->backgroundImageFileID) {
+            $f = \File::getByID($this->backgroundImageFileID);
+
+            return $f;
+        }
     }
 
     /**
@@ -321,22 +323,6 @@ class StyleSet
     }
 
     /**
-     * @param mixed $baseFontSize
-     */
-    public function setBaseFontSize($baseFontSize)
-    {
-        $this->baseFontSize = $baseFontSize;
-    }
-
-    /**
-     * @return mixed
-     */
-    public function getBaseFontSize()
-    {
-        return $this->baseFontSize;
-    }
-
-    /**
      * @param mixed $borderColor
      */
     public function setBorderColor($borderColor)
@@ -369,6 +355,22 @@ class StyleSet
     }
 
     /**
+     * @param mixed $borderWidth
+     */
+    public function setBorderWidth($borderWidth)
+    {
+        $this->borderWidth = $borderWidth;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getBorderWidth()
+    {
+        return $this->borderWidth;
+    }
+
+    /**
      * @param mixed $borderStyle
      */
     public function setBorderRadius($borderRadius)
@@ -385,115 +387,35 @@ class StyleSet
     }
 
     /**
-     * @param mixed $boxShadowBlur
+     * @param mixed $baseFontSize
      */
-    public function setBoxShadowBlur($boxShadowBlur)
+    public function setBaseFontSize($baseFontSize)
     {
-        $this->boxShadowBlur = $boxShadowBlur;
+        $this->baseFontSize = $baseFontSize;
     }
 
     /**
      * @return mixed
      */
-    public function getBoxShadowBlur()
+    public function getBaseFontSize()
     {
-        return $this->boxShadowBlur;
+        return $this->baseFontSize;
     }
 
     /**
-     * @param mixed $boxShadowColor
+     * @param mixed $alignment
      */
-    public function setBoxShadowColor($boxShadowColor)
+    public function setAlignment($alignment)
     {
-        $this->boxShadowColor = $boxShadowColor;
-    }
-
-    /**
-     * @return mixed
-     */
-    public function getBoxShadowColor()
-    {
-        return $this->boxShadowColor;
-    }
-
-    /**
-     * @param mixed $boxShadowHorizontal
-     */
-    public function setBoxShadowHorizontal($boxShadowHorizontal)
-    {
-        $this->boxShadowHorizontal = $boxShadowHorizontal;
+        $this->alignment = $alignment;
     }
 
     /**
      * @return mixed
      */
-    public function getBoxShadowHorizontal()
+    public function getAlignment()
     {
-        return $this->boxShadowHorizontal;
-    }
-
-    /**
-     * @param mixed $boxShadowSpread
-     */
-    public function setBoxShadowSpread($boxShadowSpread)
-    {
-        $this->boxShadowSpread = $boxShadowSpread;
-    }
-
-    /**
-     * @return mixed
-     */
-    public function getBoxShadowSpread()
-    {
-        return $this->boxShadowSpread;
-    }
-
-    /**
-     * @param mixed $boxShadowVertical
-     */
-    public function setBoxShadowVertical($boxShadowVertical)
-    {
-        $this->boxShadowVertical = $boxShadowVertical;
-    }
-
-    /**
-     * @return mixed
-     */
-    public function getBoxShadowVertical()
-    {
-        return $this->boxShadowVertical;
-    }
-
-    /**
-     * @return bool
-     */
-    public function getBoxShadowInset(): ?bool
-    {
-        return $this->boxShadowInset;
-    }
-
-    /**
-     * @param bool $boxShadowInset
-     */
-    public function setBoxShadowInset(bool $boxShadowInset)
-    {
-        $this->boxShadowInset = $boxShadowInset;
-    }
-
-    /**
-     * @param mixed $linkColor
-     */
-    public function setLinkColor($linkColor)
-    {
-        $this->linkColor = $linkColor;
-    }
-
-    /**
-     * @return mixed
-     */
-    public function getLinkColor()
-    {
-        return $this->linkColor;
+        return $this->alignment;
     }
 
     /**
@@ -513,24 +435,35 @@ class StyleSet
     }
 
     /**
-     * @param mixed $rotate
+     * @param mixed $linkColor
      */
-    public function setRotate($rotate)
+    public function setLinkColor($linkColor)
     {
-        $this->rotate = $rotate;
+        $this->linkColor = $linkColor;
     }
 
     /**
      * @return mixed
      */
-    public function getRotate()
+    public function getLinkColor()
     {
-        return $this->rotate;
+        return $this->linkColor;
     }
 
-    public function getID()
+    /**
+     * @param mixed $marginTop
+     */
+    public function setMarginTop($marginTop)
     {
-        return $this->issID;
+        $this->marginTop = $marginTop;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getMarginTop()
+    {
+        return $this->marginTop;
     }
 
     /**
@@ -582,19 +515,19 @@ class StyleSet
     }
 
     /**
-     * @param mixed $marginTop
+     * @param mixed $paddingTop
      */
-    public function setMarginTop($marginTop)
+    public function setPaddingTop($paddingTop)
     {
-        $this->marginTop = $marginTop;
+        $this->paddingTop = $paddingTop;
     }
 
     /**
      * @return mixed
      */
-    public function getMarginTop()
+    public function getPaddingTop()
     {
-        return $this->marginTop;
+        return $this->paddingTop;
     }
 
     /**
@@ -646,56 +579,115 @@ class StyleSet
     }
 
     /**
-     * @param mixed $paddingTop
+     * @param mixed $rotate
      */
-    public function setPaddingTop($paddingTop)
+    public function setRotate($rotate)
     {
-        $this->paddingTop = $paddingTop;
+        $this->rotate = $rotate;
     }
 
     /**
      * @return mixed
      */
-    public function getPaddingTop()
+    public function getRotate()
     {
-        return $this->paddingTop;
+        return $this->rotate;
     }
 
-    public function setBackgroundColor($backgroundColor)
+    /**
+     * @param mixed $boxShadowHorizontal
+     */
+    public function setBoxShadowHorizontal($boxShadowHorizontal)
     {
-        $this->backgroundColor = $backgroundColor;
-    }
-
-    public function setBackgroundImageFileID($backgroundImageFileID)
-    {
-        $this->backgroundImageFileID = $backgroundImageFileID;
-    }
-
-    public function getBackgroundColor()
-    {
-        return $this->backgroundColor;
-    }
-
-    public function getBackgroundImageFileID()
-    {
-        return $this->backgroundImageFileID;
-    }
-
-    public function getBackgroundImageFileObject()
-    {
-        if ($this->backgroundImageFileID) {
-            $f = \File::getByID($this->backgroundImageFileID);
-
-            return $f;
-        }
+        $this->boxShadowHorizontal = $boxShadowHorizontal;
     }
 
     /**
      * @return mixed
      */
-    public function getHideOnExtraSmallDevice()
+    public function getBoxShadowHorizontal()
     {
-        return $this->hideOnExtraSmallDevice;
+        return $this->boxShadowHorizontal;
+    }
+
+    /**
+     * @param mixed $boxShadowVertical
+     */
+    public function setBoxShadowVertical($boxShadowVertical)
+    {
+        $this->boxShadowVertical = $boxShadowVertical;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getBoxShadowVertical()
+    {
+        return $this->boxShadowVertical;
+    }
+
+    /**
+     * @param mixed $boxShadowBlur
+     */
+    public function setBoxShadowBlur($boxShadowBlur)
+    {
+        $this->boxShadowBlur = $boxShadowBlur;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getBoxShadowBlur()
+    {
+        return $this->boxShadowBlur;
+    }
+
+    /**
+     * @param mixed $boxShadowSpread
+     */
+    public function setBoxShadowSpread($boxShadowSpread)
+    {
+        $this->boxShadowSpread = $boxShadowSpread;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getBoxShadowSpread()
+    {
+        return $this->boxShadowSpread;
+    }
+
+    /**
+     * @param mixed $boxShadowColor
+     */
+    public function setBoxShadowColor($boxShadowColor)
+    {
+        $this->boxShadowColor = $boxShadowColor;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getBoxShadowColor()
+    {
+        return $this->boxShadowColor;
+    }
+
+    /**
+     * @param bool $boxShadowInset
+     */
+    public function setBoxShadowInset(bool $boxShadowInset)
+    {
+        $this->boxShadowInset = $boxShadowInset;
+    }
+
+    /**
+     * @return bool
+     */
+    public function getBoxShadowInset(): ?bool
+    {
+        return $this->boxShadowInset;
     }
 
     /**
@@ -709,9 +701,9 @@ class StyleSet
     /**
      * @return mixed
      */
-    public function getHideOnSmallDevice()
+    public function getHideOnExtraSmallDevice()
     {
-        return $this->hideOnSmallDevice;
+        return $this->hideOnExtraSmallDevice;
     }
 
     /**
@@ -725,9 +717,9 @@ class StyleSet
     /**
      * @return mixed
      */
-    public function getHideOnMediumDevice()
+    public function getHideOnSmallDevice()
     {
-        return $this->hideOnMediumDevice;
+        return $this->hideOnSmallDevice;
     }
 
     /**
@@ -741,9 +733,9 @@ class StyleSet
     /**
      * @return mixed
      */
-    public function getHideOnLargeDevice()
+    public function getHideOnMediumDevice()
     {
-        return $this->hideOnLargeDevice;
+        return $this->hideOnMediumDevice;
     }
 
     /**
@@ -752,6 +744,14 @@ class StyleSet
     public function setHideOnLargeDevice($hideOnLargeDevice)
     {
         $this->hideOnLargeDevice = $hideOnLargeDevice;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getHideOnLargeDevice()
+    {
+        return $this->hideOnLargeDevice;
     }
 
     public function save()

--- a/concrete/src/Entity/StyleCustomizer/Inline/StyleSet.php
+++ b/concrete/src/Entity/StyleCustomizer/Inline/StyleSet.php
@@ -14,181 +14,253 @@ class StyleSet
     /**
      * @ORM\Id @ORM\Column(type="integer")
      * @ORM\GeneratedValue
+     *
+     * @var int|null NULL it not saved yet
      */
     protected $issID;
 
     /**
      * @ORM\Column(type="string", nullable=true)
+     *
+     * @var string|null
      */
     protected $customClass;
 
     /**
      * @ORM\Column(type="string", nullable=true)
+     *
+     * @var string|null
      */
     protected $customID;
 
     /**
      * @ORM\Column(type="string", nullable=true)
+     *
+     * @var string|null
      */
     protected $customElementAttribute;
 
     /**
      * @ORM\Column(type="string", nullable=true)
+     *
+     * @var string|null
      */
     protected $backgroundColor;
 
     /**
      * @ORM\Column(type="integer")
+     *
+     * @var int
      */
     protected $backgroundImageFileID = 0;
 
     /**
      * @ORM\Column(type="string", nullable=true)
+     *
+     * @var string|null
      */
     protected $backgroundRepeat = 'no-repeat';
 
     /**
      * @ORM\Column(type="string", nullable=true)
+     *
+     * @var string|null
      */
     protected $backgroundSize = 'auto';
 
     /**
      * @ORM\Column(type="string", nullable=true)
+     *
+     * @var string|null
      */
     protected $backgroundPosition = '0% 0%';
 
     /**
      * @ORM\Column(type="string", nullable=true)
+     *
+     * @var string|null
      */
     protected $borderColor;
 
     /**
      * @ORM\Column(type="string", nullable=true)
+     *
+     * @var string|null
      */
     protected $borderStyle;
 
     /**
      * @ORM\Column(type="string", nullable=true)
+     *
+     * @var string|null
      */
     protected $borderWidth;
 
     /**
      * @ORM\Column(type="string", nullable=true)
+     *
+     * @var string|null
      */
     protected $borderRadius;
 
     /**
      * @ORM\Column(type="string", nullable=true)
+     *
+     * @var string|null
      */
     protected $baseFontSize;
 
     /**
      * @ORM\Column(type="string", nullable=true)
+     *
+     * @var string|null
      */
     protected $alignment;
 
     /**
      * @ORM\Column(type="string", nullable=true)
+     *
+     * @var string|null
      */
     protected $textColor;
 
     /**
      * @ORM\Column(type="string", nullable=true)
+     *
+     * @var string|null
      */
     protected $linkColor;
 
     /**
      * @ORM\Column(type="string", nullable=true)
+     *
+     * @var string|null
      */
     protected $marginTop;
 
     /**
      * @ORM\Column(type="string", nullable=true)
+     *
+     * @var string|null
      */
     protected $marginBottom;
 
     /**
      * @ORM\Column(type="string", nullable=true)
+     *
+     * @var string|null
      */
     protected $marginLeft;
 
     /**
      * @ORM\Column(type="string", nullable=true)
+     *
+     * @var string|null
      */
     protected $marginRight;
 
     /**
      * @ORM\Column(type="string", nullable=true)
+     *
+     * @var string|null
      */
     protected $paddingTop;
 
     /**
      * @ORM\Column(type="string", nullable=true)
+     *
+     * @var string|null
      */
     protected $paddingBottom;
 
     /**
      * @ORM\Column(type="string", nullable=true)
+     *
+     * @var string|null
      */
     protected $paddingLeft;
 
     /**
      * @ORM\Column(type="string", nullable=true)
+     *
+     * @var string|null
      */
     protected $paddingRight;
 
     /**
      * @ORM\Column(type="string", nullable=true)
+     *
+     * @var string|null
      */
     protected $rotate;
 
     /**
      * @ORM\Column(type="string", nullable=true)
+     *
+     * @var string|null
      */
     protected $boxShadowHorizontal;
 
     /**
      * @ORM\Column(type="string", nullable=true)
+     *
+     * @var string|null
      */
     protected $boxShadowVertical;
 
     /**
      * @ORM\Column(type="string", nullable=true)
+     *
+     * @var string|null
      */
     protected $boxShadowBlur;
 
     /**
      * @ORM\Column(type="string", nullable=true)
+     *
+     * @var string|null
      */
     protected $boxShadowSpread;
 
     /**
      * @ORM\Column(type="string", nullable=true)
+     *
+     * @var string|null
      */
     protected $boxShadowColor;
 
     /**
      * @ORM\Column(type="boolean", nullable=true)
+     *
+     * @var bool|null
      */
     protected $boxShadowInset = false;
 
     /**
      * @ORM\Column(type="boolean", nullable=true)
+     *
+     * @var bool|null
      */
     protected $hideOnExtraSmallDevice = false;
 
     /**
      * @ORM\Column(type="boolean", nullable=true)
+     *
+     * @var bool|null
      */
     protected $hideOnSmallDevice = false;
 
     /**
      * @ORM\Column(type="boolean", nullable=true)
+     *
+     * @var bool|null
      */
     protected $hideOnMediumDevice = false;
 
     /**
      * @ORM\Column(type="boolean", nullable=true)
+     *
+     * @var bool|null
      */
     protected $hideOnLargeDevice = false;
 

--- a/concrete/src/Entity/StyleCustomizer/Inline/StyleSet.php
+++ b/concrete/src/Entity/StyleCustomizer/Inline/StyleSet.php
@@ -959,6 +959,13 @@ class StyleSet
         }
     }
 
+    /**
+     * @param int $class the value of one of the GridFramework::DEVICE_CLASSES_HIDE_ON_... constants
+     *
+     * @return bool|null
+     *
+     * @see \Concrete\Core\Page\Theme\GridFramework\GridFramework
+     */
     public function isHiddenOnDevice($class)
     {
         switch ($class) {

--- a/concrete/src/Entity/StyleCustomizer/Inline/StyleSet.php
+++ b/concrete/src/Entity/StyleCustomizer/Inline/StyleSet.php
@@ -2,6 +2,7 @@
 namespace Concrete\Core\Entity\StyleCustomizer\Inline;
 
 use Concrete\Core\Backup\ContentExporter;
+use Concrete\Core\File\File;
 use Concrete\Core\Page\Theme\GridFramework\GridFramework;
 use Doctrine\ORM\Mapping as ORM;
 
@@ -357,11 +358,9 @@ class StyleSet
      */
     public function getBackgroundImageFileObject()
     {
-        if ($this->backgroundImageFileID) {
-            $f = \File::getByID($this->backgroundImageFileID);
+        $fID = $this->getBackgroundImageFileID();
 
-            return $f;
-        }
+        return $fID ? File::getByID($fID) : null;
     }
 
     /**

--- a/concrete/src/Entity/StyleCustomizer/Inline/StyleSet.php
+++ b/concrete/src/Entity/StyleCustomizer/Inline/StyleSet.php
@@ -15,7 +15,7 @@ class StyleSet
      * @ORM\Id @ORM\Column(type="integer")
      * @ORM\GeneratedValue
      *
-     * @var int|null NULL it not saved yet
+     * @var int|null NULL if and only if not yet saved
      */
     protected $issID;
 
@@ -264,13 +264,16 @@ class StyleSet
      */
     protected $hideOnLargeDevice = false;
 
+    /**
+     * @return int|null NULL if and only if not yet saved
+     */
     public function getID()
     {
         return $this->issID;
     }
 
     /**
-     * @param mixed $customClass
+     * @param string|null $customClass
      */
     public function setCustomClass($customClass)
     {
@@ -278,7 +281,7 @@ class StyleSet
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getCustomClass()
     {
@@ -286,7 +289,7 @@ class StyleSet
     }
 
     /**
-     * @param mixed $customID
+     * @param string|null $customID
      */
     public function setCustomID($customID)
     {
@@ -294,7 +297,7 @@ class StyleSet
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getCustomID()
     {
@@ -302,7 +305,7 @@ class StyleSet
     }
 
     /**
-     * @param mixed $customElementAttribute
+     * @param string|null $customElementAttribute
      */
     public function setCustomElementAttribute($customElementAttribute)
     {
@@ -310,33 +313,48 @@ class StyleSet
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getCustomElementAttribute()
     {
         return $this->customElementAttribute;
     }
 
+    /**
+     * @param string|null $backgroundColor
+     */
     public function setBackgroundColor($backgroundColor)
     {
         $this->backgroundColor = $backgroundColor;
     }
 
+    /**
+     * @return string|null
+     */
     public function getBackgroundColor()
     {
         return $this->backgroundColor;
     }
 
+    /**
+     * @param int $backgroundImageFileID
+     */
     public function setBackgroundImageFileID($backgroundImageFileID)
     {
-        $this->backgroundImageFileID = $backgroundImageFileID;
+        $this->backgroundImageFileID = (int) $backgroundImageFileID;
     }
 
+    /**
+     * @return int
+     */
     public function getBackgroundImageFileID()
     {
         return $this->backgroundImageFileID;
     }
 
+    /**
+     * @return \Concrete\Core\Entity\File\File|null
+     */
     public function getBackgroundImageFileObject()
     {
         if ($this->backgroundImageFileID) {
@@ -347,7 +365,7 @@ class StyleSet
     }
 
     /**
-     * @param mixed $backgroundRepeat
+     * @param string|null $backgroundRepeat
      */
     public function setBackgroundRepeat($backgroundRepeat)
     {
@@ -355,7 +373,7 @@ class StyleSet
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getBackgroundRepeat()
     {
@@ -363,7 +381,7 @@ class StyleSet
     }
 
     /**
-     * @param mixed $backgroundSize
+     * @param string|null $backgroundSize
      */
     public function setBackgroundSize($backgroundSize)
     {
@@ -371,7 +389,7 @@ class StyleSet
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getBackgroundSize()
     {
@@ -379,7 +397,7 @@ class StyleSet
     }
 
     /**
-     * @param mixed $backgroundPosition
+     * @param string|null $backgroundPosition
      */
     public function setBackgroundPosition($backgroundPosition)
     {
@@ -387,7 +405,7 @@ class StyleSet
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getBackgroundPosition()
     {
@@ -395,7 +413,7 @@ class StyleSet
     }
 
     /**
-     * @param mixed $borderColor
+     * @param string|null $borderColor
      */
     public function setBorderColor($borderColor)
     {
@@ -403,7 +421,7 @@ class StyleSet
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getBorderColor()
     {
@@ -411,7 +429,7 @@ class StyleSet
     }
 
     /**
-     * @param mixed $borderStyle
+     * @param string|null $borderStyle
      */
     public function setBorderStyle($borderStyle)
     {
@@ -419,7 +437,7 @@ class StyleSet
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getBorderStyle()
     {
@@ -427,7 +445,7 @@ class StyleSet
     }
 
     /**
-     * @param mixed $borderWidth
+     * @param string|null $borderWidth
      */
     public function setBorderWidth($borderWidth)
     {
@@ -435,7 +453,7 @@ class StyleSet
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getBorderWidth()
     {
@@ -443,7 +461,7 @@ class StyleSet
     }
 
     /**
-     * @param mixed $borderStyle
+     * @param string|null $borderStyle
      */
     public function setBorderRadius($borderRadius)
     {
@@ -451,7 +469,7 @@ class StyleSet
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getBorderRadius()
     {
@@ -459,7 +477,7 @@ class StyleSet
     }
 
     /**
-     * @param mixed $baseFontSize
+     * @param string|null $baseFontSize
      */
     public function setBaseFontSize($baseFontSize)
     {
@@ -467,7 +485,7 @@ class StyleSet
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getBaseFontSize()
     {
@@ -475,7 +493,7 @@ class StyleSet
     }
 
     /**
-     * @param mixed $alignment
+     * @param string|null $alignment
      */
     public function setAlignment($alignment)
     {
@@ -483,7 +501,7 @@ class StyleSet
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getAlignment()
     {
@@ -491,7 +509,7 @@ class StyleSet
     }
 
     /**
-     * @param mixed $textColor
+     * @param string|null $textColor
      */
     public function setTextColor($textColor)
     {
@@ -499,7 +517,7 @@ class StyleSet
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getTextColor()
     {
@@ -507,7 +525,7 @@ class StyleSet
     }
 
     /**
-     * @param mixed $linkColor
+     * @param string|null $linkColor
      */
     public function setLinkColor($linkColor)
     {
@@ -515,7 +533,7 @@ class StyleSet
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getLinkColor()
     {
@@ -523,7 +541,7 @@ class StyleSet
     }
 
     /**
-     * @param mixed $marginTop
+     * @param string|null $marginTop
      */
     public function setMarginTop($marginTop)
     {
@@ -531,7 +549,7 @@ class StyleSet
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getMarginTop()
     {
@@ -539,7 +557,7 @@ class StyleSet
     }
 
     /**
-     * @param mixed $marginBottom
+     * @param string|null $marginBottom
      */
     public function setMarginBottom($marginBottom)
     {
@@ -547,7 +565,7 @@ class StyleSet
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getMarginBottom()
     {
@@ -555,7 +573,7 @@ class StyleSet
     }
 
     /**
-     * @param mixed $marginLeft
+     * @param string|null $marginLeft
      */
     public function setMarginLeft($marginLeft)
     {
@@ -563,7 +581,7 @@ class StyleSet
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getMarginLeft()
     {
@@ -571,7 +589,7 @@ class StyleSet
     }
 
     /**
-     * @param mixed $marginRight
+     * @param string|null $marginRight
      */
     public function setMarginRight($marginRight)
     {
@@ -579,7 +597,7 @@ class StyleSet
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getMarginRight()
     {
@@ -587,7 +605,7 @@ class StyleSet
     }
 
     /**
-     * @param mixed $paddingTop
+     * @param string|null $paddingTop
      */
     public function setPaddingTop($paddingTop)
     {
@@ -595,7 +613,7 @@ class StyleSet
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getPaddingTop()
     {
@@ -603,7 +621,7 @@ class StyleSet
     }
 
     /**
-     * @param mixed $paddingBottom
+     * @param string|null $paddingBottom
      */
     public function setPaddingBottom($paddingBottom)
     {
@@ -611,7 +629,7 @@ class StyleSet
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getPaddingBottom()
     {
@@ -619,7 +637,7 @@ class StyleSet
     }
 
     /**
-     * @param mixed $paddingLeft
+     * @param string|null $paddingLeft
      */
     public function setPaddingLeft($paddingLeft)
     {
@@ -627,7 +645,7 @@ class StyleSet
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getPaddingLeft()
     {
@@ -635,7 +653,7 @@ class StyleSet
     }
 
     /**
-     * @param mixed $paddingRight
+     * @param string|null $paddingRight
      */
     public function setPaddingRight($paddingRight)
     {
@@ -643,7 +661,7 @@ class StyleSet
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getPaddingRight()
     {
@@ -651,7 +669,7 @@ class StyleSet
     }
 
     /**
-     * @param mixed $rotate
+     * @param string|null $rotate
      */
     public function setRotate($rotate)
     {
@@ -659,7 +677,7 @@ class StyleSet
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getRotate()
     {
@@ -667,7 +685,7 @@ class StyleSet
     }
 
     /**
-     * @param mixed $boxShadowHorizontal
+     * @param string|null $boxShadowHorizontal
      */
     public function setBoxShadowHorizontal($boxShadowHorizontal)
     {
@@ -675,7 +693,7 @@ class StyleSet
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getBoxShadowHorizontal()
     {
@@ -683,7 +701,7 @@ class StyleSet
     }
 
     /**
-     * @param mixed $boxShadowVertical
+     * @param string|null $boxShadowVertical
      */
     public function setBoxShadowVertical($boxShadowVertical)
     {
@@ -691,7 +709,7 @@ class StyleSet
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getBoxShadowVertical()
     {
@@ -699,7 +717,7 @@ class StyleSet
     }
 
     /**
-     * @param mixed $boxShadowBlur
+     * @param string|null $boxShadowBlur
      */
     public function setBoxShadowBlur($boxShadowBlur)
     {
@@ -707,7 +725,7 @@ class StyleSet
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getBoxShadowBlur()
     {
@@ -715,7 +733,7 @@ class StyleSet
     }
 
     /**
-     * @param mixed $boxShadowSpread
+     * @param string|null $boxShadowSpread
      */
     public function setBoxShadowSpread($boxShadowSpread)
     {
@@ -723,7 +741,7 @@ class StyleSet
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getBoxShadowSpread()
     {
@@ -731,7 +749,7 @@ class StyleSet
     }
 
     /**
-     * @param mixed $boxShadowColor
+     * @param string|null $boxShadowColor
      */
     public function setBoxShadowColor($boxShadowColor)
     {
@@ -739,31 +757,25 @@ class StyleSet
     }
 
     /**
-     * @return mixed
+     * @return string|null
      */
     public function getBoxShadowColor()
     {
         return $this->boxShadowColor;
     }
 
-    /**
-     * @param bool $boxShadowInset
-     */
     public function setBoxShadowInset(bool $boxShadowInset)
     {
         $this->boxShadowInset = $boxShadowInset;
     }
 
-    /**
-     * @return bool
-     */
     public function getBoxShadowInset(): ?bool
     {
         return $this->boxShadowInset;
     }
 
     /**
-     * @param mixed $hideOnExtraSmallDevice
+     * @param bool|null $hideOnExtraSmallDevice
      */
     public function setHideOnExtraSmallDevice($hideOnExtraSmallDevice)
     {
@@ -771,7 +783,7 @@ class StyleSet
     }
 
     /**
-     * @return mixed
+     * @return bool|null
      */
     public function getHideOnExtraSmallDevice()
     {
@@ -779,7 +791,7 @@ class StyleSet
     }
 
     /**
-     * @param mixed $hideOnSmallDevice
+     * @param bool|null $hideOnSmallDevice
      */
     public function setHideOnSmallDevice($hideOnSmallDevice)
     {
@@ -787,7 +799,7 @@ class StyleSet
     }
 
     /**
-     * @return mixed
+     * @return bool|null
      */
     public function getHideOnSmallDevice()
     {
@@ -795,7 +807,7 @@ class StyleSet
     }
 
     /**
-     * @param mixed $hideOnMediumDevice
+     * @param bool|null $hideOnMediumDevice
      */
     public function setHideOnMediumDevice($hideOnMediumDevice)
     {
@@ -803,7 +815,7 @@ class StyleSet
     }
 
     /**
-     * @return mixed
+     * @return bool|null
      */
     public function getHideOnMediumDevice()
     {
@@ -811,7 +823,7 @@ class StyleSet
     }
 
     /**
-     * @param mixed $hideOnLargeDevice
+     * @param bool|null $hideOnLargeDevice
      */
     public function setHideOnLargeDevice($hideOnLargeDevice)
     {
@@ -819,7 +831,7 @@ class StyleSet
     }
 
     /**
-     * @return mixed
+     * @return bool|null
      */
     public function getHideOnLargeDevice()
     {

--- a/concrete/src/Entity/StyleCustomizer/Inline/StyleSet.php
+++ b/concrete/src/Entity/StyleCustomizer/Inline/StyleSet.php
@@ -4,6 +4,7 @@ namespace Concrete\Core\Entity\StyleCustomizer\Inline;
 use Concrete\Core\Backup\ContentExporter;
 use Concrete\Core\File\File;
 use Concrete\Core\Page\Theme\GridFramework\GridFramework;
+use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping as ORM;
 
 /**
@@ -839,7 +840,7 @@ class StyleSet
 
     public function save()
     {
-        $em = \ORM::entityManager();
+        $em = app(EntityManagerInterface::class);
         $em->persist($this);
         $em->flush();
     }

--- a/concrete/src/Entity/StyleCustomizer/Inline/StyleSet.php
+++ b/concrete/src/Entity/StyleCustomizer/Inline/StyleSet.php
@@ -939,19 +939,19 @@ class StyleSet
         if (($value = (string) $this->getBoxShadowColor()) !== '') {
             $style->addChild('boxShadowColor', $value);
         }
-        if (($value = $this->getBoxShadowInset()) !== null) {
+        if (($value = (bool) $this->getBoxShadowInset()) !== false) {
             $style->addChild('boxShadowInset', $value ? '1' : '0');
         }
-        if (($value = $this->getHideOnExtraSmallDevice()) !== null) {
+        if (($value = (bool) $this->getHideOnExtraSmallDevice()) !== false) {
             $style->addChild('hideOnExtraSmallDevice', $value ? '1' : '0');
         }
-        if (($value = $this->getHideOnSmallDevice()) !== null) {
+        if (($value = (bool) $this->getHideOnSmallDevice()) !== false) {
             $style->addChild('hideOnSmallDevice', $value ? '1' : '0');
         }
-        if (($value = $this->getHideOnMediumDevice()) !== null) {
+        if (($value = (bool) $this->getHideOnMediumDevice()) !== false) {
             $style->addChild('hideOnMediumDevice', $value ? '1' : '0');
         }
-        if (($value = $this->getHideOnLargeDevice()) !== null) {
+        if (($value = (bool) $this->getHideOnLargeDevice()) !== false) {
             $style->addChild('hideOnLargeDevice', $value ? '1' : '0');
         }
         if ($style->count() === 0) {

--- a/concrete/src/Entity/StyleCustomizer/Inline/StyleSet.php
+++ b/concrete/src/Entity/StyleCustomizer/Inline/StyleSet.php
@@ -6,6 +6,7 @@ use Concrete\Core\File\File;
 use Concrete\Core\Page\Theme\GridFramework\GridFramework;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Mapping as ORM;
+use SimpleXMLElement;
 
 /**
  * @ORM\Entity
@@ -845,47 +846,117 @@ class StyleSet
         $em->flush();
     }
 
-    public function export(\SimpleXMLElement $node)
+    public function export(SimpleXMLElement $node)
     {
-        $node = $node->addChild('style');
-        $node->addChild('customClass', $this->getCustomClass());
-        $node->addChild('customID', $this->getCustomID());
-        $node->addChild('customElementAttribute', $this->getCustomElementAttribute());
-        $node->addChild('backgroundColor', $this->getBackgroundColor());
-        $fID = $this->backgroundImageFileID;
-        if ($fID) {
-            $node->addChild('backgroundImage', ContentExporter::replaceFileWithPlaceHolder($fID));
+        $style = $node->addChild('style');
+        if (($value = (string) $this->getCustomClass()) !== '') {
+            $style->addChild('customClass', $value);
         }
-        $node->addChild('backgroundRepeat', $this->getBackgroundRepeat());
-        $node->addChild('backgroundSize', $this->getBackgroundSize());
-        $node->addChild('backgroundPosition', $this->getBackgroundPosition());
-        $node->addChild('borderColor', $this->getBorderColor());
-        $node->addChild('borderStyle', $this->getBorderStyle());
-        $node->addChild('borderWidth', $this->getBorderWidth());
-        $node->addChild('borderRadius', $this->getBorderRadius());
-        $node->addChild('baseFontSize', $this->getBaseFontSize());
-        $node->addChild('alignment', $this->getAlignment());
-        $node->addChild('textColor', $this->getTextColor());
-        $node->addChild('linkColor', $this->getLinkColor());
-        $node->addChild('marginTop', $this->getMarginTop());
-        $node->addChild('marginBottom', $this->getMarginBottom());
-        $node->addChild('marginLeft', $this->getMarginLeft());
-        $node->addChild('marginRight', $this->getMarginRight());
-        $node->addChild('paddingTop', $this->getPaddingTop());
-        $node->addChild('paddingBottom', $this->getPaddingBottom());
-        $node->addChild('paddingLeft', $this->getPaddingLeft());
-        $node->addChild('paddingRight', $this->getPaddingRight());
-        $node->addChild('rotate', $this->getRotate());
-        $node->addChild('boxShadowHorizontal', $this->getBoxShadowHorizontal());
-        $node->addChild('boxShadowVertical', $this->getBoxShadowVertical());
-        $node->addChild('boxShadowBlur', $this->getBoxShadowBlur());
-        $node->addChild('boxShadowSpread', $this->getBoxShadowSpread());
-        $node->addChild('boxShadowColor', $this->getBoxShadowColor());
-        $node->addChild('boxShadowInset', $this->getBoxShadowInset());
-        $node->addChild('hideOnExtraSmallDevice', $this->getHideOnExtraSmallDevice());
-        $node->addChild('hideOnSmallDevice', $this->getHideOnSmallDevice());
-        $node->addChild('hideOnMediumDevice', $this->getHideOnMediumDevice());
-        $node->addChild('hideOnLargeDevice', $this->getHideOnLargeDevice());
+        if (($value = (string) $this->getCustomID()) !== '') {
+            $style->addChild('customID', $value);
+        }
+        if (($value = (string) $this->getCustomElementAttribute()) !== '') {
+            $style->addChild('customElementAttribute', $value);
+        }
+        if (($value = (string) $this->getBackgroundColor()) !== '') {
+            $style->addChild('backgroundColor', $value);
+        }
+        if (($value = (int) $this->getBackgroundImageFileID()) !== 0) {
+            $style->addChild('backgroundImage', ContentExporter::replaceFileWithPlaceHolder($value));
+        }
+        if (($value = (string) $this->getBackgroundRepeat()) !== '') {
+            $style->addChild('backgroundRepeat', $value);
+        }
+        if (($value = (string) $this->getBackgroundSize()) !== '') {
+            $style->addChild('backgroundSize', $value);
+        }
+        if (($value = (string) $this->getBackgroundPosition()) !== '') {
+            $style->addChild('backgroundPosition', $value);
+        }
+        if (($value = (string) $this->getBorderColor()) !== '') {
+            $style->addChild('borderColor', $value);
+        }
+        if (($value = (string) $this->getBorderStyle()) !== '') {
+            $style->addChild('borderStyle', $value);
+        }
+        if (($value = (string) $this->getBorderWidth()) !== '') {
+            $style->addChild('borderWidth', $value);
+        }
+        if (($value = (string) $this->getBorderRadius()) !== '') {
+            $style->addChild('borderRadius', $value);
+        }
+        if (($value = (string) $this->getBaseFontSize()) !== '') {
+            $style->addChild('baseFontSize', $value);
+        }
+        if (($value = (string) $this->getAlignment()) !== '') {
+            $style->addChild('alignment', $value);
+        }
+        if (($value = (string) $this->getTextColor()) !== '') {
+            $style->addChild('textColor', $value);
+        }
+        if (($value = (string) $this->getLinkColor()) !== '') {
+            $style->addChild('linkColor', $value);
+        }
+        if (($value = (string) $this->getMarginTop()) !== '') {
+            $style->addChild('marginTop', $value);
+        }
+        if (($value = (string) $this->getMarginBottom()) !== '') {
+            $style->addChild('marginBottom', $value);
+        }
+        if (($value = (string) $this->getMarginLeft()) !== '') {
+            $style->addChild('marginLeft', $value);
+        }
+        if (($value = (string) $this->getMarginRight()) !== '') {
+            $style->addChild('marginRight', $value);
+        }
+        if (($value = (string) $this->getPaddingTop()) !== '') {
+            $style->addChild('paddingTop', $value);
+        }
+        if (($value = (string) $this->getPaddingBottom()) !== '') {
+            $style->addChild('paddingBottom', $value);
+        }
+        if (($value = (string) $this->getPaddingLeft()) !== '') {
+            $style->addChild('paddingLeft', $value);
+        }
+        if (($value = (string) $this->getPaddingRight()) !== '') {
+            $style->addChild('paddingRight', $value);
+        }
+        if (($value = (string) $this->getRotate()) !== '') {
+            $style->addChild('rotate', $value);
+        }
+        if (($value = (string) $this->getBoxShadowHorizontal()) !== '') {
+            $style->addChild('boxShadowHorizontal', $value);
+        }
+        if (($value = (string) $this->getBoxShadowVertical()) !== '') {
+            $style->addChild('boxShadowVertical', $value);
+        }
+        if (($value = (string) $this->getBoxShadowBlur()) !== '') {
+            $style->addChild('boxShadowBlur', $value);
+        }
+        if (($value = (string) $this->getBoxShadowSpread()) !== '') {
+            $style->addChild('boxShadowSpread', $value);
+        }
+        if (($value = (string) $this->getBoxShadowColor()) !== '') {
+            $style->addChild('boxShadowColor', $value);
+        }
+        if (($value = $this->getBoxShadowInset()) !== null) {
+            $style->addChild('boxShadowInset', $value ? '1' : '0');
+        }
+        if (($value = $this->getHideOnExtraSmallDevice()) !== null) {
+            $style->addChild('hideOnExtraSmallDevice', $value ? '1' : '0');
+        }
+        if (($value = $this->getHideOnSmallDevice()) !== null) {
+            $style->addChild('hideOnSmallDevice', $value ? '1' : '0');
+        }
+        if (($value = $this->getHideOnMediumDevice()) !== null) {
+            $style->addChild('hideOnMediumDevice', $value ? '1' : '0');
+        }
+        if (($value = $this->getHideOnLargeDevice()) !== null) {
+            $style->addChild('hideOnLargeDevice', $value ? '1' : '0');
+        }
+        if ($style->count() === 0) {
+            unset($node->style);
+        }
     }
 
     public function isHiddenOnDevice($class)

--- a/concrete/src/Entity/StyleCustomizer/Inline/StyleSet.php
+++ b/concrete/src/Entity/StyleCustomizer/Inline/StyleSet.php
@@ -23,62 +23,14 @@ class StyleSet
     protected $customClass;
 
     /**
-     * @param mixed $customClass
-     */
-    public function setCustomClass($customClass)
-    {
-        $this->customClass = $customClass;
-    }
-
-    /**
-     * @return mixed
-     */
-    public function getCustomClass()
-    {
-        return $this->customClass;
-    }
-
-    /**
      * @ORM\Column(type="string", nullable=true)
      */
     protected $customID;
 
     /**
-     * @param mixed $customID
-     */
-    public function setCustomID($customID)
-    {
-        $this->customID = $customID;
-    }
-
-    /**
-     * @return mixed
-     */
-    public function getCustomID()
-    {
-        return $this->customID;
-    }
-
-    /**
      * @ORM\Column(type="string", nullable=true)
      */
     protected $customElementAttribute;
-
-    /**
-     * @param mixed $customElementAttribute
-     */
-    public function setCustomElementAttribute($customElementAttribute)
-    {
-        $this->customElementAttribute = $customElementAttribute;
-    }
-
-    /**
-     * @return mixed
-     */
-    public function getCustomElementAttribute()
-    {
-        return $this->customElementAttribute;
-    }
 
     /**
      * @ORM\Column(type="string", nullable=true)
@@ -124,22 +76,6 @@ class StyleSet
      * @ORM\Column(type="string", nullable=true)
      */
     protected $borderRadius;
-
-    /**
-     * @param mixed $borderWidth
-     */
-    public function setBorderWidth($borderWidth)
-    {
-        $this->borderWidth = $borderWidth;
-    }
-
-    /**
-     * @return mixed
-     */
-    public function getBorderWidth()
-    {
-        return $this->borderWidth;
-    }
 
     /**
      * @ORM\Column(type="string", nullable=true)
@@ -255,6 +191,70 @@ class StyleSet
      * @ORM\Column(type="boolean", nullable=true)
      */
     protected $hideOnLargeDevice = false;
+
+    /**
+     * @param mixed $customClass
+     */
+    public function setCustomClass($customClass)
+    {
+        $this->customClass = $customClass;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getCustomClass()
+    {
+        return $this->customClass;
+    }
+
+    /**
+     * @param mixed $customID
+     */
+    public function setCustomID($customID)
+    {
+        $this->customID = $customID;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getCustomID()
+    {
+        return $this->customID;
+    }
+
+    /**
+     * @param mixed $customElementAttribute
+     */
+    public function setCustomElementAttribute($customElementAttribute)
+    {
+        $this->customElementAttribute = $customElementAttribute;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getCustomElementAttribute()
+    {
+        return $this->customElementAttribute;
+    }
+
+    /**
+     * @param mixed $borderWidth
+     */
+    public function setBorderWidth($borderWidth)
+    {
+        $this->borderWidth = $borderWidth;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getBorderWidth()
+    {
+        return $this->borderWidth;
+    }
 
     /**
      * @param mixed $alignment
@@ -479,8 +479,6 @@ class StyleSet
     {
         $this->boxShadowInset = $boxShadowInset;
     }
-
-
 
     /**
      * @param mixed $linkColor

--- a/concrete/src/Entity/StyleCustomizer/Inline/StyleSet.php
+++ b/concrete/src/Entity/StyleCustomizer/Inline/StyleSet.php
@@ -764,6 +764,9 @@ class StyleSet
     public function export(\SimpleXMLElement $node)
     {
         $node = $node->addChild('style');
+        $node->addChild('customClass', $this->getCustomClass());
+        $node->addChild('customID', $this->getCustomID());
+        $node->addChild('customElementAttribute', $this->getCustomElementAttribute());
         $node->addChild('backgroundColor', $this->getBackgroundColor());
         $fID = $this->backgroundImageFileID;
         if ($fID) {
@@ -772,22 +775,22 @@ class StyleSet
         $node->addChild('backgroundRepeat', $this->getBackgroundRepeat());
         $node->addChild('backgroundSize', $this->getBackgroundSize());
         $node->addChild('backgroundPosition', $this->getBackgroundPosition());
-        $node->addChild('borderWidth', $this->getBorderWidth());
         $node->addChild('borderColor', $this->getBorderColor());
         $node->addChild('borderStyle', $this->getBorderStyle());
+        $node->addChild('borderWidth', $this->getBorderWidth());
         $node->addChild('borderRadius', $this->getBorderRadius());
         $node->addChild('baseFontSize', $this->getBaseFontSize());
         $node->addChild('alignment', $this->getAlignment());
         $node->addChild('textColor', $this->getTextColor());
         $node->addChild('linkColor', $this->getLinkColor());
-        $node->addChild('paddingTop', $this->getPaddingTop());
-        $node->addChild('paddingBottom', $this->getPaddingBottom());
-        $node->addChild('paddingLeft', $this->getPaddingLeft());
-        $node->addChild('paddingRight', $this->getPaddingRight());
         $node->addChild('marginTop', $this->getMarginTop());
         $node->addChild('marginBottom', $this->getMarginBottom());
         $node->addChild('marginLeft', $this->getMarginLeft());
         $node->addChild('marginRight', $this->getMarginRight());
+        $node->addChild('paddingTop', $this->getPaddingTop());
+        $node->addChild('paddingBottom', $this->getPaddingBottom());
+        $node->addChild('paddingLeft', $this->getPaddingLeft());
+        $node->addChild('paddingRight', $this->getPaddingRight());
         $node->addChild('rotate', $this->getRotate());
         $node->addChild('boxShadowHorizontal', $this->getBoxShadowHorizontal());
         $node->addChild('boxShadowVertical', $this->getBoxShadowVertical());
@@ -795,9 +798,6 @@ class StyleSet
         $node->addChild('boxShadowSpread', $this->getBoxShadowSpread());
         $node->addChild('boxShadowColor', $this->getBoxShadowColor());
         $node->addChild('boxShadowInset', $this->getBoxShadowInset());
-        $node->addChild('customClass', $this->getCustomClass());
-        $node->addChild('customID', $this->getCustomID());
-        $node->addChild('customElementAttribute', $this->getCustomElementAttribute());
         $node->addChild('hideOnExtraSmallDevice', $this->getHideOnExtraSmallDevice());
         $node->addChild('hideOnSmallDevice', $this->getHideOnSmallDevice());
         $node->addChild('hideOnMediumDevice', $this->getHideOnMediumDevice());

--- a/concrete/src/StyleCustomizer/Inline/StyleSet.php
+++ b/concrete/src/StyleCustomizer/Inline/StyleSet.php
@@ -40,39 +40,40 @@ class StyleSet
      */
     public static function import(SimpleXMLElement $node)
     {
+        $xmlService = app(Xml::class);
         $o = new StyleSetEntity();
+        $o->setCustomClass((string) $node->customClass);
+        $o->setCustomID((string) $node->customID);
+        $o->setCustomElementAttribute((string) $node->customElementAttribute);
         $o->setBackgroundColor((string) $node->backgroundColor);
         $filename = (string) $node->backgroundImage;
         if ($filename) {
-            $app = Application::getFacadeApplication();
-            $inspector = $app->make('import/value_inspector');
+            $inspector = app('import/value_inspector');
             $result = $inspector->inspect($filename);
             $fID = $result->getReplacedValue();
             if ($fID) {
                 $o->setBackgroundImageFileID($fID);
             }
         }
-        $xmlService = app(Xml::class);
-
         $o->setBackgroundRepeat((string) $node->backgroundRepeat);
         $o->setBackgroundSize((string) $node->backgroundSize);
         $o->setBackgroundPosition((string) $node->backgroundPosition);
-        $o->setBorderWidth((string) $node->borderWidth);
         $o->setBorderColor((string) $node->borderColor);
         $o->setBorderStyle((string) $node->borderStyle);
+        $o->setBorderWidth((string) $node->borderWidth);
         $o->setBorderRadius((string) $node->borderRadius);
         $o->setBaseFontSize((string) $node->baseFontSize);
         $o->setAlignment((string) $node->alignment);
         $o->setTextColor((string) $node->textColor);
         $o->setLinkColor((string) $node->linkColor);
-        $o->setPaddingTop((string) $node->paddingTop);
-        $o->setPaddingBottom((string) $node->paddingBottom);
-        $o->setPaddingLeft((string) $node->paddingLeft);
-        $o->setPaddingRight((string) $node->paddingRight);
         $o->setMarginTop((string) $node->marginTop);
         $o->setMarginBottom((string) $node->marginBottom);
         $o->setMarginLeft((string) $node->marginLeft);
         $o->setMarginRight((string) $node->marginRight);
+        $o->setPaddingTop((string) $node->paddingTop);
+        $o->setPaddingBottom((string) $node->paddingBottom);
+        $o->setPaddingLeft((string) $node->paddingLeft);
+        $o->setPaddingRight((string) $node->paddingRight);
         $o->setRotate((string) $node->rotate);
         $o->setBoxShadowHorizontal((string) $node->boxShadowHorizontal);
         $o->setBoxShadowVertical((string) $node->boxShadowVertical);
@@ -80,9 +81,6 @@ class StyleSet
         $o->setBoxShadowSpread((string) $node->boxShadowSpread);
         $o->setBoxShadowColor((string) $node->boxShadowColor);
         $o->setBoxShadowInset($xmlService->getBool($node->boxShadowInset));
-        $o->setCustomClass((string) $node->customClass);
-        $o->setCustomID((string) $node->customID);
-        $o->setCustomElementAttribute((string) $node->customElementAttribute);
         $o->setHideOnExtraSmallDevice($xmlService->getBool($node->hideOnExtraSmallDevice));
         $o->setHideOnSmallDevice($xmlService->getBool($node->hideOnSmallDevice));
         $o->setHideOnMediumDevice($xmlService->getBool($node->hideOnMediumDevice));


### PR DESCRIPTION
When blocks have custom styles, we currently export all the style properties.
Since usually we only define a few of them, we often have a ton of empty fields.

For example, by setting only the "custom class", we currently have this CIF:

```xml
<style>
  <backgroundColor />
  <backgroundRepeat>no-repeat</backgroundRepeat>
  <backgroundSize>auto</backgroundSize>
  <backgroundPosition>0% 0%</backgroundPosition>
  <borderWidth />
  <borderColor />
  <borderStyle />
  <borderRadius />
  <baseFontSize />
  <alignment />
  <textColor />
  <linkColor />
  <paddingTop />
  <paddingBottom />
  <paddingLeft />
  <paddingRight />
  <marginTop />
  <marginBottom />
  <marginLeft />
  <marginRight />
  <rotate />
  <boxShadowHorizontal />
  <boxShadowVertical />
  <boxShadowBlur />
  <boxShadowSpread />
  <boxShadowColor />
  <boxShadowInset />
  <customClass>my-custom-class</customClass>
  <customID />
  <customElementAttribute />
  <hideOnExtraSmallDevice />
  <hideOnSmallDevice />
  <hideOnMediumDevice />
  <hideOnLargeDevice />
</style>
```

With this PR, we'll have:

```xml
<style>
  <customClass>my-custom-class</customClass>
  <backgroundRepeat>no-repeat</backgroundRepeat>
  <backgroundSize>auto</backgroundSize>
  <backgroundPosition>0% 0%</backgroundPosition>
</style>
```
