### PR TITLE
Fix bug in OpenGraph::getTags()

### DIFF
--- a/concrete/src/Sharing/OpenGraph/OpenGraph.php
+++ b/concrete/src/Sharing/OpenGraph/OpenGraph.php
@@ -138,7 +138,7 @@ class OpenGraph
             $tags[] = $tag;
         }
         if ($site->getSiteCanonicalURL()) {
-            $tags[] = $this->createTag(self::TAG_OG_URL, (string) $this->resolverManager->resolve($page));
+            $tags[] = $this->createTag(self::TAG_OG_URL, (string) $this->resolverManager->resolve([$page]));
         }
         $imageAttribute = $this->config->get('social.opengraph.field_og_thumbnail');
         if ($imageAttribute['value_from'] === 'page_attribute') {


### PR DESCRIPTION
Fix this error:

```
ResolverManager::resolve(): Argument #1 ($args) must be of type array, Concrete\Core\Page\Page given
```

[My fault](https://github.com/concretecms/concretecms/pull/12559/files#diff-04ade898fbe1ef6f1403c81fc4161399ca1e733080eb220d1476252b7cf79158R141), sorry.