### PR TITLE
Allow defining custom parent dir for VolatileDirectory

### DIFF
--- a/concrete/src/File/FileServiceProvider.php
+++ b/concrete/src/File/FileServiceProvider.php
@@ -63,12 +63,13 @@ class FileServiceProvider extends ServiceProvider
             return StorageLocation::getDefault();
         });
 
-        $this->app->bindIf(Service\VolatileDirectory::class, function (Application $app) {
-            return new VolatileDirectory(
-                $app->make(\Illuminate\Filesystem\Filesystem::class),
-                $app->make('helper/file')->getTemporaryDirectory()
-            );
-        });
+        $this->app
+            ->when(Service\VolatileDirectory::class)
+            ->needs('$parentDirectory')
+            ->give(static function (Application $app) {
+                return $app->make('helper/file')->getTemporaryDirectory();
+            })
+        ;
 
         $this->app->bind(ProcessorManager::class, function (Application $app) {
             $config = $app->make('config');


### PR DESCRIPTION
With the following code:

```php
use Concrete\Core\File\Service\VolatileDirectory:

$dir = app(VolatileDirectory::class);
```

We can create a directory that automatically gets deleted once it's no more used.

It's created in the default Concrete temporary directory (`application/files/tmp`), and there's no clean way to override it.

What about letting users define where that temporary directory is created? With this change we can have something like

```php
use Concrete\Core\File\Service\VolatileDirectory:

$dir = app(VolatileDirectory::class, ['parentDirectory' => '/tmp']);
```
