### PR TITLE
Adding a board setting to disable automatic refresh/regeneration

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -435,6 +435,23 @@ return [
 
     /*
      * ------------------------------------------------------------------------
+     * Boards settings
+     * ------------------------------------------------------------------------
+     */
+    'boards' => [
+        /*
+         * If true, we will attempt to automatically update boards
+         * when their content items (pages, events, etc...) change
+         * Set this to false via the web UI if you're using the console command
+         * or other means to keep the boards up to date.
+         *
+         * @var bool
+         */
+        'automatically_refresh_instances' => true,
+    ],
+
+    /*
+     * ------------------------------------------------------------------------
      * Events settings
      * ------------------------------------------------------------------------
      */

--- a/concrete/controllers/single_page/dashboard/system/boards/settings.php
+++ b/concrete/controllers/single_page/dashboard/system/boards/settings.php
@@ -11,6 +11,8 @@ class Settings extends DashboardPageController
         $config = $this->app->make('config');
         $logBoardInstances = (int) $config->get('concrete.log.boards.instances');
         $this->set('logBoardInstances', $logBoardInstances);
+        $automaticallyRefreshInstances = (int) $config->get('concrete.boards.automatically_refresh_instances');
+        $this->set('automaticallyRefreshInstances', $automaticallyRefreshInstances);
     }
 
     public function save()
@@ -22,7 +24,9 @@ class Settings extends DashboardPageController
             $config = $this->app->make('config');
             $logBoardInstances = $this->request->request->getBoolean('log_board_instances');
             $config->save('concrete.log.boards.instances', $logBoardInstances);
-            $this->flash('success', t('Board instance logging configuration saved.'));
+            $automaticallyRefreshInstances = $this->request->request->getBoolean('automatically_refresh_instances');
+            $config->save('concrete.boards.automatically_refresh_instances', $automaticallyRefreshInstances);
+            $this->flash('success', t('Board settings saved.'));
             return $this->buildRedirect($this->action('view'));
         }
         $this->view();

--- a/concrete/single_pages/dashboard/system/boards/settings.php
+++ b/concrete/single_pages/dashboard/system/boards/settings.php
@@ -16,6 +16,19 @@
             </p>
         </div>
     </fieldset>
+    <fieldset>
+        <legend><?=t('Updates'); ?></legend>
+        <div class="form-group">
+            <div class="form-check">
+                <?= $form->checkbox('automatically_refresh_instances', 1, $automaticallyRefreshInstances); ?>
+                <?= $form->label('automatically_refresh_instances', t('Automatically Refresh Instances'), ['class' => 'form-check-label']); ?>
+            </div>
+
+            <p class="help-block">
+                <?= t('If enabled, automatically update boards when their content items change. Disable if you are using the console command to do this.'); ?>
+            </p>
+        </div>
+    </fieldset>
     <div class="ccm-dashboard-form-actions-wrapper">
         <div class="ccm-dashboard-form-actions">
             <button class="btn btn-primary float-end" type="submit"><?= t('Save'); ?></button>

--- a/concrete/src/Board/Command/AbstractUpdateBoardInstanceCommandHandler.php
+++ b/concrete/src/Board/Command/AbstractUpdateBoardInstanceCommandHandler.php
@@ -39,7 +39,7 @@ abstract class AbstractUpdateBoardInstanceCommandHandler implements LoggerAwareI
         Application $app,
         BoardDataSourceManager $boardDataSourceManager,
         EntityManager $entityManager,
-        Repository $config,
+        Repository $config
     )
     {
         $this->app = $app;

--- a/concrete/src/Board/Command/AbstractUpdateBoardInstanceCommandHandler.php
+++ b/concrete/src/Board/Command/AbstractUpdateBoardInstanceCommandHandler.php
@@ -5,10 +5,16 @@ namespace Concrete\Core\Board\Command;
 use Concrete\Core\Application\Application;
 use Concrete\Core\Board\DataSource\Driver\Manager as BoardDataSourceManager;
 use Concrete\Core\Board\DataSource\Driver\NotifierAwareDriverInterface;
+use Concrete\Core\Logging\Channels;
+use Concrete\Core\Logging\LoggerAwareInterface;
+use Concrete\Core\Logging\LoggerAwareTrait;
 use Doctrine\ORM\EntityManager;
+use Illuminate\Config\Repository;
 
-abstract class AbstractUpdateBoardInstanceCommandHandler
+abstract class AbstractUpdateBoardInstanceCommandHandler implements LoggerAwareInterface
 {
+    use LoggerAwareTrait;
+
     /**
      * @var EntityManager
      */
@@ -20,15 +26,36 @@ abstract class AbstractUpdateBoardInstanceCommandHandler
     protected $app;
 
     /**
+     * @var Repository
+     */
+    protected $config;
+
+    /**
      * @var BoardDataSourceManager
      */
     protected $boardDataSourceManager;
 
-    public function __construct(Application $app, BoardDataSourceManager $boardDataSourceManager, EntityManager $entityManager)
+    public function __construct(
+        Application $app,
+        BoardDataSourceManager $boardDataSourceManager,
+        EntityManager $entityManager,
+        Repository $config,
+    )
     {
         $this->app = $app;
         $this->boardDataSourceManager = $boardDataSourceManager;
         $this->entityManager = $entityManager;
+        $this->config = $config;
+    }
+
+    public function getLoggerChannel()
+    {
+        return Channels::CHANNEL_BOARD;
+    }
+
+    protected function performUpdate(): bool
+    {
+        return (bool) $this->config->get('concrete.boards.automatically_refresh_instances');
     }
 
     protected function getInstances(AbstractUpdateBoardInstanceCommand $command): array

--- a/concrete/src/Board/Command/RefreshRelevantBoardInstancesCommandHandler.php
+++ b/concrete/src/Board/Command/RefreshRelevantBoardInstancesCommandHandler.php
@@ -6,10 +6,15 @@ class RefreshRelevantBoardInstancesCommandHandler extends AbstractUpdateBoardIns
 {
     public function __invoke(RefreshRelevantBoardInstancesCommand $command): void
     {
-        foreach ($this->getInstances($command) as $instance) {
-            $refreshCommand = new RefreshBoardInstanceCommand();
-            $refreshCommand->setInstance($instance);
-            $this->app->executeCommand($refreshCommand);
+        if ($this->performUpdate()) {
+            $this->logger->debug(t('Automatic board instance refresh triggered.'));
+            foreach ($this->getInstances($command) as $instance) {
+                $refreshCommand = new RefreshBoardInstanceCommand();
+                $refreshCommand->setInstance($instance);
+                $this->app->executeCommand($refreshCommand);
+            }
+        } else {
+            $this->logger->debug(t('Automatic board instance refresh requested but skipped due to configuration.'));
         }
     }
     

--- a/concrete/src/Board/Command/RegenerateRelevantBoardInstancesCommandHandler.php
+++ b/concrete/src/Board/Command/RegenerateRelevantBoardInstancesCommandHandler.php
@@ -6,11 +6,16 @@ class RegenerateRelevantBoardInstancesCommandHandler extends AbstractUpdateBoard
 {
     public function __invoke(RegenerateRelevantBoardInstancesCommand $command)
     {
-        foreach ($this->getInstances($command) as $instance) {
-            $regenerateCommand = new RegenerateBoardInstanceCommand();
-            $regenerateCommand->setDefer(true);
-            $regenerateCommand->setInstance($instance);
-            $this->app->executeCommand($regenerateCommand);
+        if ($this->performUpdate()) {
+            $this->logger->debug(t('Automatic board instance regeneration triggered.'));
+            foreach ($this->getInstances($command) as $instance) {
+                $regenerateCommand = new RegenerateBoardInstanceCommand();
+                $regenerateCommand->setDefer(true);
+                $regenerateCommand->setInstance($instance);
+                $this->app->executeCommand($regenerateCommand);
+            }
+        } else {
+            $this->logger->debug(t('Automatic board instance regeneration requested but skipped due to configuration.'));
         }
     }
 


### PR DESCRIPTION
In 9.4, we update boards so that any time you add a page or a calendar event (or update/delete them), we would attempt to keep any boards referencing that content up to date. In some situations, it might be preferable to manually keep boards up to date on a separate schedule. So if you use the `c5:boards:refresh` console command to keep your boards up to date, you can now uncheck this checkbox for a performance improvement to your site.

<img width="1482" alt="Screenshot 2025-07-01 at 6 26 24 AM" src="https://github.com/user-attachments/assets/5f70f5aa-93ee-4e86-8835-549d933f998e" />
