### PR TITLE
Remove force_download option from view_inline

### DIFF
--- a/concrete/controllers/single_page/download_file.php
+++ b/concrete/controllers/single_page/download_file.php
@@ -188,8 +188,6 @@ class DownloadFile extends PageController
                     header("Content-type: $mimeType");
                     echo $approvedVersion->getFileContents();
                     $this->app->shutdown();
-                } else {
-                    $this->force_download($file);
                 }
             }
         }


### PR DESCRIPTION
Description:
This PR addresses the issue identified in #12606 by removing the force_download option from the view_inline function. As discussed in the issue, inline viewing of files (e.g., audio) currently falls back to a forced download due to the absence of a proper return statement from force_download. By removing this fallback, we restore correct inline display behavior for all supported file types.

Change summary:

Removed the force_download invocation within view_inline when the file’s MIME type isn't text, PDF, image, or video.

Issue: Relates to https://github.com/concretecms/concretecms/issues/12606

Please review and let me know if any further adjustments are needed.