### PR TITLE
Deprecate the global id() function

### DIFF
--- a/concrete/bootstrap/helpers.php
+++ b/concrete/bootstrap/helpers.php
@@ -84,13 +84,9 @@ function h($input)
 }
 
 /**
- * Class member access on instantiation.
- *
- *     id(new Block)->render();
- *
- * @param mixed $mixed
- *
- * @return mixed mixed
+ * @deprecated
+ * Since PHP 5.4 you can write: (new Block())->render();
+ * Since PHP 8.4 you can write: new Block()->render();
  */
 function id($mixed)
 {


### PR DESCRIPTION
[Since PHP 5.4](https://3v4l.org/6OsB0) we can use
```php
(new ClassName())->method();
(new ClassName)->method();
```
Furthermore, [since PHP 8.4](https://3v4l.org/gcSHa) we even use
```php
new ClassName()->method();
```
([but not](https://3v4l.org/j31C5) `new ClassName->method()`)