### PR TITLE
Keep current page in edit mode while user is active in the page

### DIFF
--- a/concrete/controllers/frontend/heartbeat.php
+++ b/concrete/controllers/frontend/heartbeat.php
@@ -3,7 +3,9 @@
 namespace Concrete\Controller\Frontend;
 
 use Concrete\Core\Controller\Controller;
+use Concrete\Core\Database\Connection\Connection;
 use Concrete\Core\Http\ResponseFactoryInterface;
+use Concrete\Core\Page\Page;
 use Concrete\Core\Session\SessionValidator;
 use Concrete\Core\User\User;
 
@@ -17,9 +19,30 @@ class Heartbeat extends Controller
             $user = $this->app->make(User::class);
             if ($user->isRegistered()) {
                 $user->updateOnlineCheck();
+                $this->refreshPageEditMode($user);
             }
         }
 
         return $this->app->make(ResponseFactoryInterface::class)->json(true);
+    }
+
+    private function refreshPageEditMode(User $loggedInUser): void
+    {
+        if (($cID = $this->request->query->getInt('cID')) <= 0) {
+            return;
+        }
+        $page = Page::getByID($cID);
+        if (!$page || $page->isError() || !$page->isCheckedOutByMe()) {
+            return;
+        }
+        $cn = $this->app->make(Connection::class);
+        $cn->executeStatement(
+            'UPDATE Pages SET cCheckedOutDatetimeLastEdit = ? WHERE cID = ? AND cCheckedOutUID = ? LIMIT 1',
+            [
+                $this->app->make('helper/date')->getOverridableNow(),
+                $cID,
+                (int) $loggedInUser->getUserID(),
+            ]
+        );
     }
 }

--- a/concrete/controllers/frontend/heartbeat.php
+++ b/concrete/controllers/frontend/heartbeat.php
@@ -3,7 +3,6 @@
 namespace Concrete\Controller\Frontend;
 
 use Concrete\Core\Controller\Controller;
-use Concrete\Core\Database\Connection\Connection;
 use Concrete\Core\Http\ResponseFactoryInterface;
 use Concrete\Core\Page\Page;
 use Concrete\Core\Session\SessionValidator;
@@ -28,21 +27,11 @@ class Heartbeat extends Controller
 
     private function refreshPageEditMode(User $loggedInUser): void
     {
-        if (($cID = $this->request->query->getInt('cID')) <= 0) {
-            return;
+        if (($cID = $this->request->query->getInt('cID')) !== 0) {
+            $page = Page::getByID($cID);
+            if ($page && !$page->isError() && $page->isCheckedOutByMe()) {
+                $loggedInUser->refreshCollectionEdit($page);
+            }
         }
-        $page = Page::getByID($cID);
-        if (!$page || $page->isError() || !$page->isCheckedOutByMe()) {
-            return;
-        }
-        $cn = $this->app->make(Connection::class);
-        $cn->executeStatement(
-            'UPDATE Pages SET cCheckedOutDatetimeLastEdit = ? WHERE cID = ? AND cCheckedOutUID = ? LIMIT 1',
-            [
-                $this->app->make('helper/date')->getOverridableNow(),
-                $cID,
-                (int) $loggedInUser->getUserID(),
-            ]
-        );
     }
 }

--- a/concrete/src/User/User.php
+++ b/concrete/src/User/User.php
@@ -1044,7 +1044,7 @@ class User extends ConcreteObject
             $datetime = $dh->getOverridableNow();
 
             $q = 'update Pages set cCheckedOutDatetimeLastEdit = ? where cID = ?';
-            $r = $db->executeQuery($q, [$datetime, $cID]);
+            $db->executeQuery($q, [$datetime, $cID]);
 
             $c->cCheckedOutDatetimeLastEdit = $datetime;
         }


### PR DESCRIPTION
Sometimes it happens that you refresh a page that you are editing, and find yourself with edit mode turned off.

That's because we don't update the last time the user interacted with the page.

Let's fix this.

PS: requires https://github.com/concretecms/bedrock/pull/382
