### PR TITLE
Fix: HTTPS requests bypassing configured proxy

### DIFF
--- a/concrete/src/Http/Client/Factory.php
+++ b/concrete/src/Http/Client/Factory.php
@@ -56,9 +56,7 @@ class Factory
         }
 
         if (isset($url)) {
-            $result['proxy'] = [
-                'http' => (string) $url
-            ];
+            $result['proxy'] = (string) $url;
         }
 
         return $result;


### PR DESCRIPTION
Fix #12619

Just pass a url to apply the proxy to all protocols.
See: https://docs.guzzlephp.org/en/stable/request-options.html#proxy