### PR TITLE
Add to the list of configured RSS feeds a URL to the each feed

### DIFF
--- a/concrete/single_pages/dashboard/pages/feeds.php
+++ b/concrete/single_pages/dashboard/pages/feeds.php
@@ -264,10 +264,15 @@ if ($controller->getAction() == 'add'
         <ul class="item-select-list">
             <?php foreach ($feeds as $feed) {
                 ?>
-                <li>
-                    <a href="<?= $view->action('edit', $feed->getID()) ?>">
+                <li class="d-flex">
+
+                    <a class="flex-fill" href="<?= $view->action('edit', $feed->getID()) ?>">
                         <i class="fas fa-rss"></i> <?= $feed->getFeedDisplayTitle() ?>
                     </a>
+                    <a class="text-primary" href="<?= \Concrete\Core\Support\Facade\Url::to('/rss/'. $feed->getHandle());?>" target="_blank">
+                        <i class="fas fa-link"></i> <?= t('View Feed URL'); ?>
+                    </a>
+
                 </li>
                 <?php
             }


### PR DESCRIPTION
When RSS feeds are configured in the dashboard there's no reference to where the actual RSS feeds are generated.
This simply adds to each list item a link to the feed for quick reference/checking.

<img width="919" height="275" alt="feeds" src="https://github.com/user-attachments/assets/d7083e3a-d60c-40e7-bd40-fad974bcc337" />
