### PR TITLE
Add an option to log stack traces of uncaught exceptions

### DIFF
--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -529,6 +529,11 @@ return [
          */
         'api' => false,
 
+        /*
+         * Whether to log stack traces of uncaught exceptions
+         */
+        'stack_trace' => false,
+
         'enable_dashboard_report' => true,
 
         'boards' => [

--- a/concrete/controllers/single_page/dashboard/system/environment/logging.php
+++ b/concrete/controllers/single_page/dashboard/system/environment/logging.php
@@ -53,6 +53,7 @@ class Logging extends DashboardPageController
         $this->set('coreLoggingLevel', $config->get('concrete.log.configuration.simple.core_logging_level'));
         $this->set('handler', $config->get('concrete.log.configuration.simple.handler'));
         $this->set('logFile', $config->get('concrete.log.configuration.simple.file.file'));
+        $this->set('logStackTrace', (bool) $config->get('concrete.log.stack_trace'));
     }
 
     /**
@@ -125,6 +126,7 @@ class Logging extends DashboardPageController
         $config->save('concrete.log.configuration.simple.file.file', $logFile);
         $config->save('concrete.log.configuration.simple.core_logging_level', $loggingLevel);
         $config->save('concrete.log.configuration.simple.handler', $handler);
+        $config->save('concrete.log.stack_trace', filter_var($request->request->get('log_stack_trace'), FILTER_VALIDATE_BOOLEAN));
 
         return new RedirectResponse($this->action('logging_saved'));
     }

--- a/concrete/single_pages/dashboard/system/environment/logging.php
+++ b/concrete/single_pages/dashboard/system/environment/logging.php
@@ -15,6 +15,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
  * @var string $handler
  * @var string $logFile
  * @var string $loggingMode
+ * @var bool $logStackTrace
  */
 
 ?>
@@ -101,6 +102,10 @@ defined('C5_EXECUTE') or die('Access Denied.');
 
     <fieldset>
         <legend><?=t('Reporting'); ?></legend>
+        <div class="form-check">
+            <?= $form->checkbox('log_stack_trace', 1, $logStackTrace); ?>
+            <?= $form->label('log_stack_trace', t('Log Stack Traces of Uncaught Exceptions'), ['class' => 'form-check-label']) ?>
+        </div>
         <div class="form-group">
             <div class="form-check">
                 <?= $form->checkbox('enable_dashboard_report', 1, $enableDashboardReport); ?>

--- a/concrete/src/Logging/Configuration/SimpleConfiguration.php
+++ b/concrete/src/Logging/Configuration/SimpleConfiguration.php
@@ -5,10 +5,9 @@ namespace Concrete\Core\Logging\Configuration;
 use Concrete\Core\Application\ApplicationAwareInterface;
 use Concrete\Core\Application\ApplicationAwareTrait;
 use Concrete\Core\Logging\Channels;
-use Concrete\Core\Logging\Processor\ConcretePageProcessor;
+use Concrete\Core\Logging\Processor;
 use Monolog\Logger;
 use Monolog\Processor\PsrLogMessageProcessor;
-use Concrete\Core\Logging\Processor\ConcreteUserProcessor;
 
 abstract class SimpleConfiguration implements ConfigurationInterface, ApplicationAwareInterface
 {
@@ -61,8 +60,9 @@ abstract class SimpleConfiguration implements ConfigurationInterface, Applicatio
 
         $logger->pushHandler($handler);
         $logger->pushProcessor($this->app->make(PsrLogMessageProcessor::class));
-        $logger->pushProcessor($this->app->make(ConcreteUserProcessor::class));
-        $logger->pushProcessor($this->app->make(ConcretePageProcessor::class));
+        $logger->pushProcessor($this->app->make(Processor\ConcreteUserProcessor::class));
+        $logger->pushProcessor($this->app->make(Processor\ConcretePageProcessor::class));
+        $logger->pushProcessor($this->app->make(Processor\StackTraceProcessor::class));
 
         return $logger;
     }

--- a/concrete/src/Logging/Processor/StackTraceProcessor.php
+++ b/concrete/src/Logging/Processor/StackTraceProcessor.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Concrete\Core\Logging\Processor;
+
+use Concrete\Core\Config\Repository\Repository;
+use Throwable;
+
+/**
+ * A processor for adding the exception stack traces to the logged errors
+ */
+class StackTraceProcessor
+{
+    /**
+     * @var \Concrete\Core\Config\Repository\Repository
+     */
+    protected $config;
+
+    public function __construct(Repository $config)
+    {
+        $this->config = $config;
+    }
+
+    /**
+     * Invoke this processor
+     *
+     * @param array $record The given monolog record
+     *
+     * @return array The modified record
+     */
+    public function __invoke(array $record): array
+    {
+        $throwable = $record['context']['exception'] ?? null;
+        if ($throwable instanceof Throwable && $this->isLoggingStackTrace()) {
+            $message = rtrim((string) ($record['message'] ?? ''));
+            if ($message !== '') {
+                $message .= "\n";
+            }
+            $record['message'] = $message . t('Stack Trace: %s', $throwable->getTraceAsString());
+        }
+
+        return $record;
+    }
+
+    /**
+     * Should we log the stack trace of uncaught exceptions?
+     */
+    protected function isLoggingStackTrace(): bool
+    {
+        return (bool) $this->config->get('concrete.log.stack_trace');
+    }
+}

--- a/tests/tests/Logging/LogTest.php
+++ b/tests/tests/Logging/LogTest.php
@@ -58,7 +58,7 @@ class LogTest extends ConcreteDatabaseTestCase
         $processors = $applicationLogger->getProcessors();
         $handlers = $applicationLogger->getHandlers();
         $this->assertCount(1, $handlers);
-        $this->assertCount(3, $processors);
+        $this->assertCount(4, $processors);
         $this->assertInstanceOf(DatabaseHandler::class, $handlers[0]);
         $this->assertEquals(Logger::DEBUG, $handlers[0]->getLevel());
 
@@ -171,7 +171,7 @@ class LogTest extends ConcreteDatabaseTestCase
         $filesystem->delete($file);
 
         $this->assertCount(1, $logger->getHandlers());
-        $this->assertCount(3, $logger->getProcessors()); // needs to have psr processor and the Concrete processors.
+        $this->assertCount(4, $logger->getProcessors()); // needs to have psr processor and the Concrete processors.
     }
 
     public function testLoggingFacade()
@@ -385,6 +385,7 @@ class LogTest extends ConcreteDatabaseTestCase
         $app->shouldReceive('make')->withArgs([Processor\ConcreteUserProcessor::class])->andReturn($noop);
         $app->shouldReceive('make')->withArgs([PsrLogMessageProcessor::class])->andReturn($noop);
         $app->shouldReceive('make')->withArgs([Processor\ConcretePageProcessor::class])->andReturn($noop);
+        $app->shouldReceive('make')->withArgs([Processor\StackTraceProcessor::class])->andReturn($noop);
 
         return $app;
     }

--- a/tests/tests/Logging/LogTest.php
+++ b/tests/tests/Logging/LogTest.php
@@ -15,8 +15,7 @@ use Concrete\Core\Logging\GroupLogger;
 use Concrete\Core\Logging\Handler\DatabaseHandler;
 use Concrete\Core\Logging\LogEntry;
 use Concrete\Core\Logging\LoggerFactory;
-use Concrete\Core\Logging\Processor\ConcretePageProcessor;
-use Concrete\Core\Logging\Processor\ConcreteUserProcessor;
+use Concrete\Core\Logging\Processor;
 use Concrete\Core\Support\Facade\Facade;
 use Concrete\Core\Support\Facade\Log;
 use Concrete\TestHelpers\Database\ConcreteDatabaseTestCase;
@@ -383,9 +382,9 @@ class LogTest extends ConcreteDatabaseTestCase
         $noop = function($data) { return $data; };
 
         $app = M::mock(Application::class);
-        $app->shouldReceive('make')->withArgs([ConcreteUserProcessor::class])->andReturn($noop);
+        $app->shouldReceive('make')->withArgs([Processor\ConcreteUserProcessor::class])->andReturn($noop);
         $app->shouldReceive('make')->withArgs([PsrLogMessageProcessor::class])->andReturn($noop);
-        $app->shouldReceive('make')->withArgs([ConcretePageProcessor::class])->andReturn($noop);
+        $app->shouldReceive('make')->withArgs([Processor\ConcretePageProcessor::class])->andReturn($noop);
 
         return $app;
     }

--- a/tests/tests/Logging/LogTest.php
+++ b/tests/tests/Logging/LogTest.php
@@ -196,7 +196,7 @@ class LogTest extends ConcreteDatabaseTestCase
         $this->assertEquals(1, count($log->getHandlers()));
 
         $handler = new \Monolog\Handler\TestHandler(Logger::CRITICAL, false);
-        $listener = \Events::addListener('on_logger_create', function ($event) use ($handler) {
+        \Events::addListener('on_logger_create', function ($event) use ($handler) {
             $logger = $event->getLogger();
             $formatter = new \Monolog\Formatter\LineFormatter();
             $handler->setFormatter($formatter);

--- a/tests/tests/Logging/LogTest.php
+++ b/tests/tests/Logging/LogTest.php
@@ -5,6 +5,7 @@ namespace Concrete\Tests\Logging;
 use Concrete\Core\Application\Application;
 use Concrete\Core\Database\Connection\Connection;
 use Concrete\Core\Entity\Page\PagePath;
+use Concrete\Core\Entity\User;
 use Concrete\Core\Logging\Channels;
 use Concrete\Core\Logging\Configuration\AdvancedConfiguration;
 use Concrete\Core\Logging\Configuration\ConfigurationFactory;
@@ -12,6 +13,7 @@ use Concrete\Core\Logging\Configuration\SimpleDatabaseConfiguration;
 use Concrete\Core\Logging\Configuration\SimpleFileConfiguration;
 use Concrete\Core\Logging\GroupLogger;
 use Concrete\Core\Logging\Handler\DatabaseHandler;
+use Concrete\Core\Logging\LogEntry;
 use Concrete\Core\Logging\LoggerFactory;
 use Concrete\Core\Logging\Processor\ConcretePageProcessor;
 use Concrete\Core\Logging\Processor\ConcreteUserProcessor;
@@ -22,9 +24,7 @@ use Illuminate\Filesystem\Filesystem;
 use Mockery as M;
 use Monolog\Formatter\LineFormatter;
 use Monolog\Logger;
-use Concrete\Core\Logging\LogEntry;
 use Monolog\Processor\PsrLogMessageProcessor;
-use Concrete\Core\Entity\User;
 
 class LogTest extends ConcreteDatabaseTestCase
 {


### PR DESCRIPTION
I went crazy trying to figure out where an error occurred: in the log I only had a generic "Syntax Error".

How about adding the ability to save the stack trace in the logs?