### PR TITLE
Fix #12566: Fix revert toolbar mobile button class

### DIFF
--- a/concrete/elements/dashboard/navigation/mobile.php
+++ b/concrete/elements/dashboard/navigation/mobile.php
@@ -18,7 +18,7 @@ $app = Concrete\Core\Support\Facade\Facade::getFacadeApplication();
 $sh = $app->make('helper/concrete/dashboard/sitemap');
 if ($sh->canViewSitemapPanel()) {
     ?>
-    <li class="float-end d-block d-md-none">
+    <li class="float-end ccm-toolbar-mobile-add-pages-button d-block d-md-none">
         <a href="<?= URL::to('/ccm/system/dialogs/page/add_mobile') ?>"
            class="dialog-launch"
            dialog-width="640"


### PR DESCRIPTION
https://github.com/concretecms/concretecms/issues/12566#issuecomment-3079982781

Before:
<img width="513" height="456" alt="image" src="https://github.com/user-attachments/assets/cdca409c-fbb6-49ef-b5fe-e3499abea0cc" />

After:
<img width="476" height="470" alt="image" src="https://github.com/user-attachments/assets/36624bf1-bcfd-4fcd-9eb1-f9f6f938e95c" />

@aembler 
could you please explain how to add css for application?
as i see it is kind of bedrock things

Problem is:
`<a href="http://localhost:8899/ccm/system/dialogs/page/add_mobile" class="dialog-launch ccm-toolbar-icon" dialog-width="640" dialog-height="640" dialog-modal="false" dialog-title="Add Page">
            <svg><use xlink:href="#icon-sitemap"></use></svg>
        </a>` 

 implements width and height of `div#ccm-toolbar>ul>li>a`  and it broke toolbar
        
Setting `width: auto; height: auto;`  is potential fix
       
       
<img width="1028" height="643" alt="image" src="https://github.com/user-attachments/assets/bf754a13-95f7-40b8-8028-c271a6793a86" />

