### PR TITLE
Fix shell command built from environment values 

### DIFF
--- a/build/tasks/generate-constants.js
+++ b/build/tasks/generate-constants.js
@@ -4,10 +4,12 @@ module.exports = function(grunt, config, parameters, done) {
 		done(false);
 	}
 	try {
-		var fs = require('fs'), c5fs = require('../libraries/fs'), exec = require('child_process').exec;
+		var fs = require('fs'), c5fs = require('../libraries/fs'), execFile = require('child_process').execFile, path = require('path');
 		var webRoot = fs.realpathSync(config.DIR_BASE);
-		exec(
-			'php -d short_open_tag=On ' + c5fs.escapeShellArg(__dirname + '/../libraries/generate-constants.php') + ' ' + c5fs.escapeShellArg(webRoot),
+		var phpScript = path.join(__dirname, '..', 'libraries', 'generate-constants.php');
+		execFile(
+			'php',
+			['-d', 'short_open_tag=On', phpScript, webRoot],
 			{},
 			function(error, stdout, stderr) {
 				if(error) {


### PR DESCRIPTION
https://github.com/concretecms/concretecms/blob/229845a2344d2dc235aa3d43a8b176f9db3fd80c/build/tasks/generate-constants.js#L7-L10

Dynamically constructing a shell command with values from the local environment, such as file paths, may inadvertently change the meaning of the shell command. Such changes can occur when an environment value contains characters that the shell interprets in a special way, for instance quotes and spaces. This can result in the shell command misbehaving, or even allowing a malicious user to execute arbitrary commands on the system.


fix the problem, we should avoid constructing a shell command as a single string and passing it to `child_process.exec`, which invokes a shell and interprets the string. Instead, we should use `child_process.execFile`, which takes the command and its arguments as separate parameters, passing them directly to the executable without shell interpretation. This prevents any shell metacharacters or spaces in the arguments from being interpreted by the shell.

Specifically, in `build/tasks/generate-constants.js`, replace the use of `exec` with `execFile`. The command should be `php`, and the arguments should be `['-d', 'short_open_tag=On', path_to_generate_constants_php, webRoot]`, where `path_to_generate_constants_php` is the resolved path to the PHP script. We should use Node's `path.join` to construct the path, and avoid using `c5fs.escapeShellArg` since `execFile` does not require shell escaping.
- Import `path` if not already imported.
- Replace the call to `exec` with a call to `execFile`, passing the command and arguments as separate parameters.
- Use `path.join` to construct the path to the PHP script.


*Check these before submitting new pull requests*

- [x] I read the __guidelines for contributing__ linked above. My pull request conforms to the coding style guidelines described within.

If this condition is met, feel free to delete this whole message and to submit your pull request.

Thank you, your help is really appreciated!
