### PR TITLE
[Feature] Dispatch event "on_add_canonical_page_path" when adding a canonical path

### DIFF
--- a/concrete/controllers/panel/detail/page/location.php
+++ b/concrete/controllers/panel/detail/page/location.php
@@ -3,6 +3,8 @@ namespace Concrete\Controller\Panel\Detail\Page;
 
 use Concrete\Controller\Backend\UserInterface\Page as BackendInterfacePageController;
 use Concrete\Core\Entity\Page\PagePath;
+use Concrete\Core\Page\PagePathEvent;
+use Events;
 use PageEditResponse;
 use PermissionKey;
 use Exception;
@@ -134,6 +136,11 @@ class Location extends BackendInterfacePageController
                         $p->setPageObject($this->page);
                         if ($canonical == $i) {
                             $p->setPagePathIsCanonical(true);
+                            
+                            // Dispatch event when adding a canonical path
+                            $event = new PagePathEvent($this->page);
+                            $event->setPagePath($p->getPagePath());
+                            Events::dispatch('on_add_canonical_page_path', $event);
                         }
                         \ORM::entityManager()->persist($p);
                     }


### PR DESCRIPTION
There was a case where our client wanted to track who added or updated the canonical page path.

If such an event exists, we can attach an event listener to log these actions for traceability.