### PR TITLE
Update Sitemap Generation Task to Support Multiple Sites

### DIFF
--- a/concrete/composer.json
+++ b/concrete/composer.json
@@ -125,7 +125,8 @@
     "tubalmartin/cssmin": "^4.1",
     "ssddanbrown/htmldiff": "^1.0",
     "zircote/swagger-php": "4.9.2",
-    "concretecms/dependency-patches": "^1.7.2"
+    "concretecms/dependency-patches": "^1.7.2",
+    "symfony/mime": "^5.4"
   },
   "replace": {
     "laminas/laminas-cache-storage-adapter-apc": "*",

--- a/concrete/controllers/frontend/sitemap.php
+++ b/concrete/controllers/frontend/sitemap.php
@@ -1,0 +1,22 @@
+<?php
+namespace Concrete\Controller\Frontend;
+
+use Concrete\Core\Controller\Controller;
+use Concrete\Core\Http\ResponseFactoryInterface;
+use Concrete\Core\Page\Sitemap\SitemapWriter;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\File\Exception\FileNotFoundException;
+
+class Sitemap extends Controller
+{
+    public function view()
+    {
+        try {
+            $sitemapXML = $this->app->make(SitemapWriter::class)->getOutputFilename();
+
+            return new BinaryFileResponse($sitemapXML);
+        } catch (FileNotFoundException $e) {
+            return $this->app->make(ResponseFactoryInterface::class)->notFound('');
+        }
+    }
+}

--- a/concrete/routes/sitemap.php
+++ b/concrete/routes/sitemap.php
@@ -1,0 +1,13 @@
+<?php defined('C5_EXECUTE') or die('Access Denied.');
+/**
+ * @var Concrete\Core\Routing\Router $router
+ * @var Concrete\Core\Application\Application $app
+ */
+
+/*
+ * Base path: <none>
+ * Namespace: <none>
+ */
+
+$sitemapXMLPath = '/' . ltrim(str_replace(DIRECTORY_SEPARATOR, '/', (string) $app['config']->get('concrete.sitemap_xml.file')), '/');
+$router->all($sitemapXMLPath, '\Concrete\Controller\Frontend\Sitemap::view');

--- a/concrete/src/Page/Sitemap/PageListGenerator.php
+++ b/concrete/src/Page/Sitemap/PageListGenerator.php
@@ -208,7 +208,8 @@ class PageListGenerator
     public function getSite()
     {
         if ($this->site === false) {
-            $this->site = $this->app->make('site')->getDefault();
+            $siteService = $this->app->make('site');
+            $this->site = $siteService->getActiveSiteForEditing() ?: $siteService->getDefault();
         }
 
         return $this->site;

--- a/concrete/src/Page/Sitemap/SitemapWriter.php
+++ b/concrete/src/Page/Sitemap/SitemapWriter.php
@@ -98,6 +98,11 @@ class SitemapWriter
     /**
      * @var string
      */
+    private $siteOutputFilename = '';
+
+    /**
+     * @var string
+     */
     private $temporaryDirectory = '';
 
     public function __construct(Application $app, Filesystem $filesystem, EventDispatcher $director)
@@ -216,7 +221,7 @@ class SitemapWriter
      */
     public function setOutputFilename($outputFilename)
     {
-        $this->outputFilename = (string) $outputFilename;
+        $this->siteOutputFilename = (string) $outputFilename;
 
         return $this;
     }
@@ -226,19 +231,39 @@ class SitemapWriter
      *
      * @return string
      */
-    public function getOutputFilename()
+    public function getSiteOutputFilename()
     {
-        $result = $this->outputFilename;
+        $result = $this->siteOutputFilename;
         if ($result === '') {
             $config = $this->app->make('config');
-            $relativeName = '/' . ltrim(str_replace(DIRECTORY_SEPARATOR, '/', (string) $config->get('concrete.sitemap_xml.file')), '/');
+            $relativeName = '/' . ltrim(str_replace(\DIRECTORY_SEPARATOR, '/', (string) $config->get('concrete.sitemap_xml.file')), '/');
             if ($relativeName === '/') {
                 $relativeName = '/sitemap.xml';
             }
-            $result = rtrim(DIR_BASE, '/') . $relativeName;
+            $result = rtrim(\DIR_BASE, '/') . $relativeName;
         }
 
         return $result;
+    }
+
+    /**
+     * Get the path to the sitemap to be generated.
+     *
+     * @return string
+     */
+    public function getOutputFilename()
+    {
+        if ($this->outputFilename === '') {
+            $outputDir = \DIR_FILES_UPLOADED_STANDARD . \DIRECTORY_SEPARATOR . 'sitemaps';
+            if (!is_dir($outputDir)) {
+                @mkdir($outputDir);
+            }
+
+            $site = $this->app->make('site')->getSite();
+            $this->outputFilename = $outputDir . \DIRECTORY_SEPARATOR . $site->getSiteHandle() . '.xml';
+        }
+
+        return $this->outputFilename;
     }
 
     /**
@@ -248,7 +273,7 @@ class SitemapWriter
      */
     public function getSitemapUrl()
     {
-        $outputFilename = $this->getOutputFilename();
+        $outputFilename = $this->getSiteOutputFilename();
         if (strpos($outputFilename, DIR_BASE . '/') === 0) {
             $result = (string) $this->getSitemapGenerator()->resolveUrl(substr($outputFilename, strlen(DIR_BASE)));
         } else {

--- a/concrete/src/Routing/SystemRouteList.php
+++ b/concrete/src/Routing/SystemRouteList.php
@@ -102,6 +102,8 @@ class SystemRouteList implements RouteListInterface
             ->routes('search.php')
         ;
 
+        $router->buildGroup()->routes('sitemap.php');
+
         $router->buildGroup()->routes('express.php');
 
         $router->buildGroup()->routes('marketplace.php');


### PR DESCRIPTION
This update enhances the existing sitemap generation task to support multi-site. It ensures that each site in the system can have its own sitemap generated independently, improving SEO and deployment flexibility across different domains.