### PR TITLE
Improve some buttons to clarify that users are submitting a workflow

### DIFF
--- a/concrete/elements/page_types/composer/form/output/buttons.php
+++ b/concrete/elements/page_types/composer/form/output/buttons.php
@@ -7,15 +7,20 @@ $publishDate = $v->getPublishDate();
 ?>
 
 <?php if ($cp->canApprovePageVersions()) {
-
+    /** @var \Concrete\Core\Application\Service\Composer $composer */
     $composer = Core::make('helper/concrete/composer');
     $publishTitle = $composer->getPublishButtonTitle($page);
-
+    $publishButtonActivated = $composer->getPublishButtonActivated($page);
     ?>
 
-    <div class="float-end btn-group" data-page-type-composer-form-btns="publish">
-        <button type="button" data-page-type-composer-form-btn="publish" class="ps-3 pe-3 btn btn-primary"><?=$publishTitle?></button>
-        <button data-page-type-composer-form-btn="schedule" type="button" class="ps-3 pe-3 btn btn-primary <?php if ($publishDate) { ?>active<?php } ?>">
+    <div class="float-end btn-group"
+         data-page-type-composer-form-btns="publish"
+        <?php if (!$publishButtonActivated) { ?> title="<?= t('This version is already submitted to Workflow.') ?>"<?php } ?>>
+        <button type="button"
+                data-page-type-composer-form-btn="publish"
+                class="ps-3 pe-3 btn btn-primary"
+                <?php if (!$publishButtonActivated) { ?> disabled<?php } ?>><?=$publishTitle?></button>
+        <button data-page-type-composer-form-btn="schedule" type="button" class="ps-3 pe-3 btn btn-primary <?php if ($publishDate) { ?>active<?php } ?>"<?php if (!$publishButtonActivated) { ?> disabled<?php } ?>>
             <i class="fas fa-clock"></i>
         </button>
     </div>
@@ -148,5 +153,9 @@ $publishDate = $v->getPublishDate();
                 }
             });
         });
+        let publishBtnWrapper = document.querySelector('div[data-page-type-composer-form-btns=publish]');
+        if (publishBtnWrapper) {
+            new bootstrap.Tooltip(publishBtnWrapper);
+        }
     });
 </script>

--- a/concrete/src/Application/Service/Composer.php
+++ b/concrete/src/Application/Service/Composer.php
@@ -111,6 +111,15 @@ class Composer
         return $publishTitle;
     }
 
+    public function getApproveButtonTitle(Page $c)
+    {
+        if ($this->canSubmitWorkflow($c)) {
+            return t('Submit to Workflow');
+        }
+
+        return t('Approve');
+    }
+
     public function displayPublishScheduleSettings(?Page $c = null)
     {
         View::element('pages/schedule', array(

--- a/concrete/src/Application/Service/Composer.php
+++ b/concrete/src/Application/Service/Composer.php
@@ -5,6 +5,8 @@ use Concrete\Core\Page\Page;
 use Concrete\Core\Page\Type\Type;
 use Concrete\Core\Permission\Key\Key;
 use Concrete\Core\Page\Type\Composer\Control\Control as PageTypeComposerControl;
+use Concrete\Core\Workflow\Progress\PageProgress;
+use Concrete\Core\Workflow\Request\ApprovePageRequest;
 use View;
 
 class Composer
@@ -42,18 +44,12 @@ class Composer
         }
     }
 
-    public function getPublishButtonTitle(Page $c)
+    public function canSubmitWorkflow(Page $c): bool
     {
-        if ($c->isPageDraft()) {
-            $publishTitle = t('Publish Page');
-        } else {
-            $publishTitle = t('Publish Changes');
-        }
-
         $pk = Key::getByHandle('approve_page_versions');
         $pk->setPermissionObject($c);
         $pa = $pk->getPermissionAccessObject();
-        $workflows = array();
+        $workflows = [];
         $canApproveWorkflow = true;
         if (is_object($pa)) {
             $workflows = $pa->getWorkflows();
@@ -65,6 +61,51 @@ class Composer
         }
 
         if (count($workflows) > 0 && !$canApproveWorkflow) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public function getPublishButtonActivated(Page $c): bool
+    {
+        if ($c->isPageDraft()) {
+            $target = Page::getByID($c->getPageDraftTargetParentPageID());
+            if (is_object($target) && !$target->isError() && $target->overrideTemplatePermissions()) {
+                $c = $target;
+            }
+        }
+
+        if ($this->canSubmitWorkflow($c)) {
+            /** @var PageProgress[] $workflowList */
+            $workflowList = PageProgress::getList($c);
+            foreach ($workflowList as $wf) {
+                $wfr = $wf->getWorkflowRequestObject();
+                if ($wfr instanceof ApprovePageRequest) {
+                    if ((int) $wfr->getRequestedVersionID() === (int) $c->getVersionID()) {
+                        // If current version is already submitted to approve workflow, disable submit button
+                        return false;
+                    }
+                }
+            }
+        }
+
+        return true;
+    }
+
+    public function getPublishButtonTitle(Page $c)
+    {
+        if ($c->isPageDraft()) {
+            $publishTitle = t('Publish Page');
+            $target = Page::getByID($c->getPageDraftTargetParentPageID());
+            if (is_object($target) && !$target->isError() && $target->overrideTemplatePermissions()) {
+                $c = $target;
+            }
+        } else {
+            $publishTitle = t('Publish Changes');
+        }
+
+        if ($this->canSubmitWorkflow($c)) {
             $publishTitle = t('Submit to Workflow');
         }
         return $publishTitle;

--- a/concrete/views/panels/details/page/composer.php
+++ b/concrete/views/panels/details/page/composer.php
@@ -173,6 +173,7 @@ var ConcretePageComposerDetail = {
             }
         });
 
+        ConcreteEvent.unsubscribe('PanelComposerPublish');
         ConcreteEvent.subscribe('PanelComposerPublish',function(e, data) {
             // Disable the autosaver completely so that it is not posting a
             // request after the publish event has been called. This could

--- a/concrete/views/panels/page/check_in.php
+++ b/concrete/views/panels/page/check_in.php
@@ -15,11 +15,13 @@ $require_version_comments = (bool) Config::get('concrete.misc.require_version_co
 
     $composer = Core::make('helper/concrete/composer');
     $publishTitle = $composer->getPublishButtonTitle($c);
-
+    $publishButtonActivated = $composer->getPublishButtonActivated($c);
     ?>
 <div class="ccm-panel-check-in-publish">
-    <?php $publishAction = (is_object($publishErrors) && $publishErrors->has()) ? false : true ?>
-    <div class="btn-group d-flex" role="group">
+    <?php $publishAction = !((isset($publishErrors) && is_object($publishErrors) && $publishErrors->has()) || !$publishButtonActivated) ?>
+    <div class="btn-group d-flex" role="group"
+         data-panel-check-in-btns="publish"
+        <?php if (!$publishButtonActivated) { ?> title="<?= t('This version is already submitted to Workflow.') ?>"<?php } ?>>
         <button id="ccm-check-in-publish" type="submit" name="action" value="publish"
                 class="pe-3 ps-3 btn btn-primary" <?=$publishAction ?: 'disabled' ?>>
             <?=$publishTitle?>
@@ -108,6 +110,11 @@ $(function() {
     $("#ccm-check-in-schedule, #ccm-check-in-schedule-wrapper .remove").click(function () {
         toggleScheduler();
     });
+
+    let publishBtnWrapper = document.querySelector('div[data-panel-check-in-btns=publish]');
+    if (publishBtnWrapper) {
+        new bootstrap.Tooltip(publishBtnWrapper);
+    }
 });
 </script>
 

--- a/concrete/views/panels/page/versions.php
+++ b/concrete/views/panels/page/versions.php
@@ -2,6 +2,7 @@
 
 defined('C5_EXECUTE') or die('Access Denied.');
 
+use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\Support\Facade\Url;
 
 /** @var Concrete\Controller\Panel\Page\Versions $controller */
@@ -9,6 +10,9 @@ use Concrete\Core\Support\Facade\Url;
 /** @var Concrete\Core\Page\Collection\Version\EditResponse $response */
 /** @var Concrete\Core\Page\Page $c */
 /** @var bool|null $isDialogMode  */
+/** @var \Concrete\Core\Application\Service\Composer $composer */
+$composer = Application::getFacadeApplication()->make('helper/concrete/composer');
+$approveTitle = $composer->getApproveButtonTitle($c);
 ?>
 
 <script type="text/template" class="tbody">
@@ -126,11 +130,11 @@ use Concrete\Core\Support\Facade\Url;
                 <div class="dropdown-menu">
                     <% if (cvIsApproved || cIsDraft) { %>
                         <span class="dropdown-item ui-state-disabled">
-                            <?php echo t('Approve') ?>
+                            <?php echo $approveTitle ?>
                         </span>
                     <% } else { %>
                         <a href="#" data-version-menu-task="approve" data-version-id="<%-cvID%>" class="dropdown-item">
-                            <?php echo t('Approve') ?>
+                            <?php echo $approveTitle ?>
                         </a>
                     <%  } %>
 


### PR DESCRIPTION
Fixes #9306

* Change the label of "Approve" in the version menu to "Submit to Workflow" when you can't approve a "approve page" workflow request
* Improve "Submit to Workflow" button in composer and check-in panels
  * Disable "Submit to Workflow" button if another workflow request has already been sent to prevent sending multiple workflow requests
  * Change "Publish" button label to "Submit to Workflow" also in the drafts folder
  * Prevent multiple sending workflow requests when you opens composer panel multiple times

<img width="422" height="155" alt="Screenshot 2025-08-12 at 18 11 14" src="https://github.com/user-attachments/assets/dd54e5cb-1b94-45ff-9ece-887513b5b9c5" />
<img width="383" height="365" alt="Screenshot 2025-08-12 at 18 58 13" src="https://github.com/user-attachments/assets/a1e97074-8fdb-4a5a-9255-0ad637b1b9d2" />
