### PR TITLE
Change to sort by name for Document Library

### DIFF
--- a/concrete/blocks/document_library/controller.php
+++ b/concrete/blocks/document_library/controller.php
@@ -366,7 +366,7 @@ class Controller extends BlockController implements UsesFeatureInterface
         }
 
         $properties = [
-            'title' => 'fv.fvTitle',
+            'title' => 'name',
             'filename' => 'fv.fvFilename',
             'tags' => 'fv.fvTags',
             'date' => 'fv.fvDateAdded',
@@ -890,7 +890,9 @@ class Controller extends BlockController implements UsesFeatureInterface
             $order = $this->displayOrderDesc ? 'desc' : 'asc';
             $orderBy = $this->getSortColumnKey($this->orderBy, 'filelist');
             if ($orderBy) {
-                $list->getQueryObject()->addSelect($orderBy);
+                if ($orderBy !== 'name') {
+                    $list->getQueryObject()->addSelect($orderBy);
+                }
                 $list->sortBy($orderBy, $order);
             }
         }
@@ -902,8 +904,11 @@ class Controller extends BlockController implements UsesFeatureInterface
         if ($getSort) {
             $getSort = $this->getSortColumnKey($getSort);
             if ($getSort) {
-                $list->getQueryObject()->addSelect($getSort);
+                if ($getSort !== 'name') {
+                    $list->getQueryObject()->addSelect($getSort);
+                }
                 $sortDir = $this->request->query->get('dir');
+
                 if ($sortDir) {
                     $list->sortBy($getSort, $sortDir);
                 } else {


### PR DESCRIPTION
Before:
<img width="1267" height="725" alt="image" src="https://github.com/user-attachments/assets/63443157-9992-4a50-8259-07c5cc426b2c" />
<img width="1365" height="468" alt="image" src="https://github.com/user-attachments/assets/2be75468-ddb9-490e-abbc-51bbbc31e26e" />

After:
<img width="1165" height="887" alt="image" src="https://github.com/user-attachments/assets/d54a1e89-87a7-467b-848d-31189fc85eb1" />
<img width="1219" height="939" alt="image" src="https://github.com/user-attachments/assets/b9ab45c5-d780-4d54-a593-d0a2552ed5d5" />


