### PR TITLE
Fix view_express_entity action of express_entry_detail controller

### DIFF
--- a/concrete/blocks/express_entry_detail/controller.php
+++ b/concrete/blocks/express_entry_detail/controller.php
@@ -5,6 +5,7 @@ namespace Concrete\Block\ExpressEntryDetail;
 use Concrete\Core\Attribute\Key\CollectionKey;
 use Concrete\Core\Block\BlockController;
 use Concrete\Core\Entity\Express\Entity;
+use Concrete\Core\Entity\Express\Entry;
 use Concrete\Core\Entity\Express\Form;
 use Concrete\Core\Express\Form\Context\FrontendViewContext;
 use Concrete\Core\Express\Form\Renderer;
@@ -147,11 +148,14 @@ class Controller extends BlockController implements UsesFeatureInterface
         }
     }
 
+    /**
+     * @param int|string|null $exEntryID
+     */
     public function action_view_express_entity($exEntryID = null)
     {
-        $entry = $this->entityManager->find(Entity::class, $exEntryID);
-        if (is_object($entry)) {
-            $entity = $this->entityManager->find('Concrete\Core\Entity\Express\Entity', $this->exEntityID);
+        $entry = $exEntryID ? $this->entityManager->find(Entry::class, $exEntryID) : null;
+        if ($entry) {
+            $entity = $this->entityManager->find(Entity::class, $this->exEntityID);
             if ($entry->getEntity()->getID() == $entity->getID()) {
                 /** @var Seo $seo */
                 $seo = $this->app->make('helper/seo');


### PR DESCRIPTION
There's a bug in the `action_view_express_entity()` method of the express_entry_detail controller introduced by [a commit of mine](https://github.com/concretecms/concretecms/commit/a498a28cebb06da891dcd5d50eabeb04b90d1aaa#diff-cee9f985e5af51f04731fef2fffb3a89a0a7e7059b0f3c82c1ec883e673bc5a4R19-R152).

This PR should fix it.

Reported on the forums - see https://forums.concretecms.org/t/express-front-end-detail-block-not-returning-results/9374