### PR TITLE
Fix warnings in Text::encodePath()

### DIFF
--- a/concrete/src/Utility/Service/Text.php
+++ b/concrete/src/Utility/Service/Text.php
@@ -24,22 +24,19 @@ class Text
     /**
      * URL-encodes collection path.
      *
-     * @param string $path
+     * @param string|null $path
      *
      * @return string $path
      */
     public static function encodePath($path)
     {
+        $path = (string) $path;
         if (mb_strpos($path, '/') !== false) {
             $path = explode('/', $path);
             $path = array_map('rawurlencode', $path);
             $newPath = implode('/', $path);
         } else {
-            if (is_null($path)) {
-                $newPath = null;
-            } else {
-                $newPath = rawurlencode($path);
-            }
+            $newPath = rawurlencode($path);
         }
         $path = str_replace('%21', '!', $newPath);
 


### PR DESCRIPTION
Let's fix these two warnings:

```
Deprecated: mb_strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated
Deprecated: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated
```