### PR TITLE
Avoid multiline comments in i18n comments

### DIFF
--- a/concrete/src/Permission/Access/Entity/GroupCombinationEntity.php
+++ b/concrete/src/Permission/Access/Entity/GroupCombinationEntity.php
@@ -207,8 +207,7 @@ class GroupCombinationEntity extends Entity
                     $this->label .= $g->getGroupDisplayName();
                     if ($i + 1 < count($gIDs)) {
                         $this->label .= t(
-                            /*i18n: used for combining Group Display Names,
-                             eg GroupName1 + GroupName2 */
+                            /*i18n: used for combining Group Display Names, eg GroupName1 + GroupName2 */
                             ' + '
                         );
                     }


### PR DESCRIPTION
The version of Gettext we are using doesn't handle well multiline translation comments.

For example, we'd have:

```po
#. used for combining Group Display Names,
                             eg GroupName1 + GroupName2
#: concrete/src/Permission/Access/Entity/GroupCombinationEntity.php:209
msgid " + "
msgstr ""
```

which is not valid for gettext