### PR TITLE
Use native datepicker instead of jQuery UI for date time attribute search function

### DIFF
--- a/concrete/attributes/date_time/controller.php
+++ b/concrete/attributes/date_time/controller.php
@@ -135,10 +135,10 @@ class Controller extends AttributeTypeController implements SimpleTextExportable
 
     public function search()
     {
-        $dt = $this->app->make('helper/form/date_time');
-        $html = $dt->date($this->field('from'), $this->request('from'), true);
+        $form = $this->app->make('helper/form');
+        $html = $form->date($this->field('from'));
         $html .= ' ' . t('to') . ' ';
-        $html .= $dt->date($this->field('to'), $this->request('to'), true);
+        $html .= $form->date($this->field('to'));
         echo $html;
     }
 


### PR DESCRIPTION
fixes #12679

<img width="839" height="606" alt="Screenshot 2025-08-28 at 18 24 58" src="https://github.com/user-attachments/assets/74c812e1-9dc0-4da2-b342-9b95aa87e5a9" />
