### PR TITLE
Delete request cache after saving attribute value instead of before

### DIFF
--- a/concrete/src/Attribute/ObjectTrait.php
+++ b/concrete/src/Attribute/ObjectTrait.php
@@ -73,16 +73,6 @@ trait ObjectTrait
      */
     public function setAttribute($ak, $value, $doReindexImmediately = true)
     {
-        $app = Application::getFacadeApplication();
-        /** @var RequestCache $cache */
-        $cache = $app->make('cache/request');
-        if (is_object($ak)) {
-            $akHandle = $ak->getAttributeKeyHandle();
-        } else {
-            $akHandle = $ak;
-        }
-        $cache->delete('attribute/value/' . $akHandle);
-
         $orm = \Database::connection()->getEntityManager();
 
         $this->clearAttribute($ak, $doReindexImmediately);
@@ -135,6 +125,16 @@ trait ObjectTrait
                 $indexer->indexEntry($category, $attributeValue, $this);
             }
         }
+
+        $app = Application::getFacadeApplication();
+        /** @var RequestCache $cache */
+        $cache = $app->make('cache/request');
+        if (is_object($ak)) {
+            $akHandle = $ak->getAttributeKeyHandle();
+        } else {
+            $akHandle = $ak;
+        }
+        $cache->delete('attribute/value/' . $akHandle);
 
         return $attributeValue;
     }

--- a/tests/helpers/Attribute/AttributeTestCase.php
+++ b/tests/helpers/Attribute/AttributeTestCase.php
@@ -106,6 +106,7 @@ abstract class AttributeTestCase extends ConcreteDatabaseTestCase
      */
     public function testSetAttribute($handle, $first, $second, $firstStatic = null, $secondStatic = null)
     {
+        app('cache/request')->enable();
         $this->getAttributeObjectForSet()->setAttribute($handle, $first);
         $attribute = $this->getAttributeObjectForGet()->getAttribute($handle);
         if ($firstStatic != null) {


### PR DESCRIPTION
I'd added to caching attribute values to improve performance on #10546 before.
I deleted the values on save attribute values to avoid any issues related to cache, but it has never worked as expected since that PR.
I've fixed it and updated a test to catch the same issue in the future.