### PR TITLE
Preload hero image to improve LCP value

### DIFF
--- a/concrete/blocks/hero_image/controller.php
+++ b/concrete/blocks/hero_image/controller.php
@@ -10,6 +10,7 @@ use Concrete\Core\File\File;
 use Concrete\Core\File\Tracker\FileTrackableInterface;
 use Concrete\Core\File\Tracker\RichTextExtractor;
 use Concrete\Core\Form\Service\DestinationPicker\DestinationPicker;
+use Concrete\Core\Html\Object\HeadLink;
 use Concrete\Core\Html\Service\FontAwesomeIcon;
 use Concrete\Core\Page\Page;
 use Concrete\Core\Page\Theme\Theme;
@@ -202,7 +203,13 @@ class Controller extends BlockController implements FileTrackableInterface, Uses
 
     public function view()
     {
-        $this->set('image', File::getByID($this->image));
+        $f = File::getByID($this->image);
+        $this->set('image', $f);
+        if ($f) {
+            $link = new HeadLink($f->getURL(), 'preload', $f->getMimeType());
+            $link->setAttribute('as', 'image');
+            $this->addHeaderItem($link);
+        }
 
         if ($this->buttonText || $this->getLinkURL()) {
             $button = new Link($this->getLinkURL(), $this->buttonText);


### PR DESCRIPTION
Performance value has increased by more than 10 points after applying this patch.

Before fix:
<img width="1624" height="1056" alt="Screenshot 2025-09-01 at 18 11 13" src="https://github.com/user-attachments/assets/2aec67fc-b303-4504-a61d-dd6ab2b88333" />
<img width="1624" height="1056" alt="Screenshot 2025-09-01 at 18 11 19" src="https://github.com/user-attachments/assets/585e1912-142d-4357-895e-1358bc438e45" />

After fix:
<img width="1624" height="1056" alt="Screenshot 2025-09-01 at 18 11 54" src="https://github.com/user-attachments/assets/75077b82-70fe-4145-9286-27d024dd6062" />
<img width="1624" height="1056" alt="Screenshot 2025-09-01 at 18 12 16" src="https://github.com/user-attachments/assets/2ddc08be-1f33-4c3e-a829-3c473260124a" />
