### PR TITLE
Make it possible to send a Page object to the buildredirect() method

### DIFF
--- a/concrete/src/Controller/AbstractController.php
+++ b/concrete/src/Controller/AbstractController.php
@@ -9,7 +9,6 @@ use Concrete\Core\Command\Process\ProcessFactory;
 use Concrete\Core\Command\Process\ProcessResponseFactory;
 use Concrete\Core\Http\ResponseAssetGroup;
 use Concrete\Core\Http\ResponseFactoryInterface;
-use Concrete\Core\Page\Page;
 use Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface;
 use Core;
 use League\Url\UrlInterface;
@@ -277,7 +276,7 @@ abstract class AbstractController implements ApplicationAwareInterface
     /**
      * Build a response that redirects clients to a specific URL/page (specify path(s) as argument(s) of $args).
      *
-     * @param array|string|\League\Url\UrlInterface|\Concrete\Core\Page\Page $destination use an Url object to specify the destination URL, or a Page object or string/array of strings to build the URL with the resolver
+     * @param array|string|\League\Url\UrlInterface|\Concrete\Core\Page\Page $destination use an Url object to specify the destination URL, or a Page object, or string/array of strings to build the URL with the resolver
      * @param int $httpResponseCode the HTTP response code
      *
      * @return \Symfony\Component\HttpFoundation\RedirectResponse
@@ -285,8 +284,11 @@ abstract class AbstractController implements ApplicationAwareInterface
     public function buildRedirect($destination, $httpResponseCode = Response::HTTP_FOUND)
     {
         if (!$destination instanceof UrlInterface) {
-            $destination = $destination instanceof Page ? [$destination] : (array)$destination;
-            $destination = $this->app->make(ResolverManagerInterface::class)->resolve((array) $destination);
+            if (!is_array($destination)) {
+                $destination = [$destination];
+            }
+            
+            $destination = $this->app->make(ResolverManagerInterface::class)->resolve($destination);
         }
 
         return $this->app->make(ResponseFactoryInterface::class)->redirect((string) $destination, Response::HTTP_FOUND);

--- a/concrete/src/Controller/AbstractController.php
+++ b/concrete/src/Controller/AbstractController.php
@@ -9,6 +9,7 @@ use Concrete\Core\Command\Process\ProcessFactory;
 use Concrete\Core\Command\Process\ProcessResponseFactory;
 use Concrete\Core\Http\ResponseAssetGroup;
 use Concrete\Core\Http\ResponseFactoryInterface;
+use Concrete\Core\Page\Page;
 use Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface;
 use Core;
 use League\Url\UrlInterface;
@@ -276,7 +277,7 @@ abstract class AbstractController implements ApplicationAwareInterface
     /**
      * Build a response that redirects clients to a specific URL/page (specify path(s) as argument(s) of $args).
      *
-     * @param array|string|\League\Url\UrlInterface $destination use an Url object to specify the destination URL, or a string/array of strings to build the URL with the resolver
+     * @param array|string|\League\Url\UrlInterface|\Concrete\Core\Page\Page $destination use an Url object to specify the destination URL, or a Page object or string/array of strings to build the URL with the resolver
      * @param int $httpResponseCode the HTTP response code
      *
      * @return \Symfony\Component\HttpFoundation\RedirectResponse
@@ -284,6 +285,7 @@ abstract class AbstractController implements ApplicationAwareInterface
     public function buildRedirect($destination, $httpResponseCode = Response::HTTP_FOUND)
     {
         if (!$destination instanceof UrlInterface) {
+            $destination = $destination instanceof Page ? [$destination] : (array)$destination;
             $destination = $this->app->make(ResolverManagerInterface::class)->resolve((array) $destination);
         }
 


### PR DESCRIPTION
The buildRedirect method is useful in dashboard single pages after flashing an error or success message. It will reload the page and show the message

The easiest way to use it is to send it the returned result of ``$this->getPageObject()``, which is a ``\Concrete\Core\Page\Page`` object for the current single page.

This commit allows the use of Page objects in the ``buildRedirectmethod``

So in a dashboard single page, for instance, I can do:

````
$this->flash("success", "my success message");
return $this->buildredirect($this->getPageObject());
````

It is simpler than having to get a Url Object or the actual Url.

Edit, I didn't notice that it would actually work with a Page object as long as it was in an array. So let's say this makes it just a tiny bit simpler by making sure, if a Page object is used directly, it doesn't break.