### PR TITLE
ensure logo exists when editing a top nav bar

### DIFF
--- a/concrete/blocks/top_navigation_bar/controller.php
+++ b/concrete/blocks/top_navigation_bar/controller.php
@@ -155,6 +155,10 @@ class Controller extends BlockController implements UsesFeatureInterface, FileTr
 
     public function edit()
     {
+        $logo = File::getByID($this->brandingLogo);
+        if ($logo === null) {
+            $this->set('brandingLogo', null);
+        }
         $this->set('fileManager', new FileManager());
         $this->set('editor', $this->app->make('editor'));
         /** @var Detector $detector */


### PR DESCRIPTION
if not, set `$brandingLogo` to null to prevent the file selector from trying to load a non-existent image.

closes #12706

I'm not sure if there would be a different approach which would be preferred to handle this scenario
