### PR TITLE
Accept the case where getFileDetails returns null

### DIFF
--- a/concrete/blocks/image_slider/form_setup_html.php
+++ b/concrete/blocks/image_slider/form_setup_html.php
@@ -182,6 +182,9 @@ echo $userInterface->tabs([
                 ConcreteFileManager.launchDialog(function (data) {
                     ConcreteFileManager.getFileDetails(data.fID, function (r) {
                         jQuery.fn.dialog.hideLoader();
+                        if (!r) {
+                            return;
+                        }
                         let file = r.files[0];
                         oldLauncher.html(file.resultsThumbnailImg);
                         oldLauncher.next('.image-fID').val(file.fID);


### PR DESCRIPTION
See https://github.com/concretecms/bedrock/pull/393: in future `getFileDetails()` will invoke the callback with `null` in case of errors (let's be ready for that).