### PR TITLE
Check if it's safe to remove index.php from URLs in /dashboard/system/seo/urls

### DIFF
--- a/concrete/controllers/single_page/dashboard/system/seo/urls.php
+++ b/concrete/controllers/single_page/dashboard/system/seo/urls.php
@@ -2,11 +2,15 @@
 
 namespace Concrete\Controller\SinglePage\Dashboard\System\Seo;
 
+use Concrete\Core\Error\UserMessageException;
 use Concrete\Core\Form\Service\Form;
+use Concrete\Core\Http\ResponseFactoryInterface;
 use Concrete\Core\Page\Controller\DashboardSitePageController;
 use Concrete\Core\Service\Manager\ServiceManager;
+use Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface;
 use Concrete\Core\Url\UrlImmutable;
 use Punic\Misc;
+use Symfony\Component\HttpFoundation\JsonResponse;
 
 class Urls extends DashboardSitePageController
 {
@@ -30,6 +34,21 @@ class Urls extends DashboardSitePageController
         $this->set('redirectToCanonicalUrl', (bool) $globalConfig->get('concrete.seo.redirect_to_canonical_url'));
         $this->set('urlRewriting', (bool) $globalConfig->get('concrete.seo.url_rewriting'));
         $this->set('canonicalTag', (bool) $siteConfig->get('seo.canonical_tag.enabled'));
+        $checkPrettyUrlsAction = $globalConfig->withKey('concrete.seo.url_rewriting', true, function () use ($globalConfig): string {
+            return $globalConfig->withKey('concrete.seo.url_rewriting_all', true, function () use ($globalConfig): string {
+                return (string) $this->action('check_pretty_urls');
+            });
+        });
+        $this->set('checkPrettyUrlsAction', $checkPrettyUrlsAction);
+    }
+
+    public function check_pretty_urls(): JsonResponse
+    {
+        if (!$this->token->validate(__FUNCTION__)) {
+            throw new UserMessageException($this->token->getErrorMessage());
+        }
+
+        return $this->app->make(ResponseFactoryInterface::class)->json(['it' => 'works!']);
     }
 
     public function save_urls()

--- a/concrete/single_pages/dashboard/system/seo/urls.php
+++ b/concrete/single_pages/dashboard/system/seo/urls.php
@@ -21,6 +21,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
  * @var string $canonicalUrlAlternative
  * @var bool $urlRewriting
  * @var bool $canonicalTag
+ * @var string $checkPrettyUrlsAction
  */
 ?>
 
@@ -30,7 +31,12 @@ defined('C5_EXECUTE') or die('Access Denied.');
         <legend><?= t('Pretty URLs') ?></legend>
         <div class="form-check">
             <?= $form->checkbox('url_rewriting', '1', $urlRewriting) ?>
-            <label class="form-check-label" for="url_rewriting"><?= t('Remove index.php from URLs') ?></label>
+            <label class="form-check-label" for="url_rewriting">
+                <?= t('Remove index.php from URLs') ?>
+                <span id="url_rewriting_works" class="ms-1">
+                    <i class="fas fa-spinner fa-spin"></i>
+                </span>
+            </label>
         </div>
     </fieldset>
     <fieldset>
@@ -75,6 +81,10 @@ $(function () {
         content: <?= json_encode('<h3>' . t('Pretty URLs') . '</h3>' . t('Check this checkbox to remove index.php from your URLs.<br/>You will be given code to place in a file named .htaccess in your web root. Concrete will try and place this code in the file for you.')) ?>,
         placement: 'bottom',
     },{
+        element: '#url_rewriting_works',
+        content: <?= json_encode('<h3>' . t('Pretty URLs') . '</h3>' . t('This icon tells you if ConcreteCMS should work when index.php is removed from URLs.')) ?>,
+        placement: 'right',
+    },{
         element: 'input[name=canonical_url]',
         content: <?= json_encode('<h3>' . t('Canonical URL') . '</h3>' . t('If you are running a site at multiple domains, enter the canonical domain here. This will be used for sitemap generation, any other purposes that require a specific domain. You can usually leave this blank.')) ?>,
         placement: 'bottom',
@@ -113,5 +123,46 @@ $(function () {
         }
     });
     ConcreteHelpGuideManager.register('dashboard-system-urls', tour);
+
+    function setUrlRewritingWorks(works) {
+        const icon = document.querySelector('#url_rewriting_works');
+        if (works === true) {
+            icon.innerHTML = '<i class="fas fa-check text-success" title="' + <?= json_encode(h(t('ConcreteCMS should work when index.php is removed from URLs.'))) ?> + '"></i>';
+        } else if (works === false) {
+            icon.innerHTML = '<i class="fas fa-ban text-danger" title="' + <?= json_encode(h(t('ConcreteCMS should NOT work when index.php is removed from URLs.'))) ?> + '"></i>';
+            const checkbox = document.querySelector('#url_rewriting');
+            checkbox.addEventListener('click', (e) => {
+                if (!checkbox.checked) {
+                    return;
+                }
+                e.preventDefault();
+                ConcreteAlert.confirm(
+                    <?= json_encode(t('ConcreteCMS should NOT work when index.php is removed from URLs.')) ?> + '<br/>' + <?= json_encode(t('Are you sure you want to do it anyway?')) ?>,
+                    () => {
+                        jQuery.fn.dialog.closeTop();
+                        checkbox.checked = true;
+                    },
+                    'btn-danger',
+                    <?= json_encode(t('Procced Anyway')) ?>
+                );
+            });
+        } else {
+            icon.innerHTML = '<i class="far fa-question-circle text-warning" title="' + <?= json_encode(h(t('Unable to determine if ConcreteCMS works when index.php is removed from the URLs.'))) ?> + '"></i>';
+        }
+        new bootstrap.Tooltip(icon.firstChild, {container: '#ccm-tooltip-holder'});
+    }
+
+    new ConcreteAjaxRequest({
+        url: <?=json_encode($checkPrettyUrlsAction) ?>,
+        data: {
+            <?= json_encode($token::DEFAULT_TOKEN_NAME) ?>: <?= json_encode($token->generate('check_pretty_urls')) ?>,
+        },
+        success(r) {
+            setUrlRewritingWorks(r?.it === 'works!' ? true : null);
+        },
+        error(r) {
+            setUrlRewritingWorks(r.status === 404 ? false : null);
+        },
+    });
 });
 </script>


### PR DESCRIPTION
- When it works:
   <img width="460" height="179" alt="image" src="https://github.com/user-attachments/assets/6149f639-d02d-499f-88a5-96f0c0edd74c" />
- When it doesn't work;
  <img width="462" height="182" alt="image" src="https://github.com/user-attachments/assets/52f1a295-cd59-4ec4-97c1-14f006f75be3" />
  and, if we click the checkbox anyway:
  <img width="601" height="389" alt="image" src="https://github.com/user-attachments/assets/2e363fb7-15f9-4a0f-90d9-70c2de25bcce" />

That way people won't break their websites 😉 