### PR TITLE
Improve removal of old page versions by batching and handling edge cases

### DIFF
--- a/concrete/src/Command/Task/Controller/RemoveOldPageVersionsController.php
+++ b/concrete/src/Command/Task/Controller/RemoveOldPageVersionsController.php
@@ -56,8 +56,9 @@ class RemoveOldPageVersionsController extends AbstractController
         $query->orderBy('p.cID', 'asc');
 
         $batch = Batch::create();
-        foreach($query->execute()->fetchAll() as $result) {
-            $batch->add(new RemoveOldPageVersionsTaskCommand($result['cID']));
+        $result = $query->execute();
+        foreach ($result->iterateColumn() as $cID) {
+            $batch->add(new RemoveOldPageVersionsTaskCommand((int) $cID));
         }
 
         return new BatchProcessTaskRunner($task, $batch, $input, t('Page version removal beginning...'));

--- a/concrete/src/Page/Command/RemoveOldPageVersionsTaskCommandHandler.php
+++ b/concrete/src/Page/Command/RemoveOldPageVersionsTaskCommandHandler.php
@@ -20,17 +20,37 @@ class RemoveOldPageVersionsTaskCommandHandler implements OutputAwareInterface
     {
         $versionCount = 0;
         $page = Page::getByID($command->getPageID());
+        if (!($page && !$page->isError())) {
+            $this->output->write(t('Skipped invalid page ID: %s', $command->getPageID()));
+            return;
+        }
         $pvl = new VersionList($page);
-        foreach (array_slice($pvl->get(), 10) as $v) {
-            if ($v instanceof Version && !$v->isApproved() && !$v->isMostRecent()) {
-                $v->delete();
-                ++$versionCount;
+        $batchSize = 100;
+        $offset = 10; // keep the 10 most recent versions intact
+        while (true) {
+            $versions = $pvl->get($batchSize, $offset);
+            if (empty($versions)) {
+                break;
+            }
+            $deletedInPass = 0;
+            foreach ($versions as $v) {
+                if ($v instanceof Version && !$v->isApproved() && !$v->isMostRecent()) {
+                    try {
+                        $v->delete();
+                        ++$versionCount;
+                        ++$deletedInPass;
+                    } catch (\Throwable $e) {
+                        // Swallow exception to continue processing other versions
+                    }
+                }
+            }
+            unset($versions);
+            if ($deletedInPass === 0) {
+                // Nothing deletable left beyond the 10 most recent
+                break;
             }
         }
 
         $this->output->write(t('Scanned page ID: %s, removed versions: %s', $command->getPageID(), $versionCount));
-
     }
-
-
 }


### PR DESCRIPTION
There was a situation where our client had more than 10,000 pages and multiple versions of a page, leading to the task being halted due to insufficient memory. 
This pull request enhances memory management. I tested it with over 10,000 pages and numerous versions, and everything worked smoothly.