### PR TITLE
Fix: A new draft page added on the dashboard sitemap page can goes to wrong sitemap

### DIFF
--- a/concrete/controllers/backend/page.php
+++ b/concrete/controllers/backend/page.php
@@ -6,6 +6,7 @@ use Concrete\Core\Controller\Controller;
 use Concrete\Core\Cookie\ResponseCookieJar;
 use Concrete\Core\Error\UserMessageException;
 use Concrete\Core\Http\ResponseFactoryInterface;
+use Concrete\Core\Page\DraftService;
 use Concrete\Core\Page\EditResponse;
 use Concrete\Core\Page\Page as ConcretePage;
 use Concrete\Core\Page\Type\Type as PageType;
@@ -34,7 +35,9 @@ class Page extends Controller
             }
             if ($proceed) {
                 $pt = $pagetype->getPageTypeDefaultPageTemplateObject();
-                $d = $pagetype->createDraft($pt);
+                /** @var DraftService $service */
+                $service = $this->app->make(DraftService::class);
+                $d = $service->createDraft($pagetype, $pt);
                 if ($parent !== null) {
                     $d->setPageDraftTargetParentPageID($parent->getCollectionID());
                 }

--- a/concrete/controllers/dialog/page/add/compose.php
+++ b/concrete/controllers/dialog/page/add/compose.php
@@ -3,6 +3,7 @@ namespace Concrete\Controller\Dialog\Page\Add;
 
 use Concrete\Core\Controller\Controller;
 use Concrete\Core\Form\Service\Widget\DateTime;
+use Concrete\Core\Page\DraftService;
 use Concrete\Core\Page\EditResponse;
 use Concrete\Core\Page\Template;
 use Concrete\Core\Page\Type\Type;
@@ -87,7 +88,9 @@ class Compose extends Controller
         $pr->setError($e);
 
         if (!$e->has()) {
-            $d = $pagetype->createDraft($template);
+            /** @var DraftService $draftService */
+            $draftService = $this->app->make(DraftService::class);
+            $d = $draftService->createDraft($pagetype, $template, $parent->getSite());
             $d->setPageDraftTargetParentPageID($cParentID);
             $saver = $pagetype->getPageTypeSaverObject();
             $saver->saveForm($d);

--- a/concrete/src/Page/DraftService.php
+++ b/concrete/src/Page/DraftService.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Concrete\Core\Page;
+
+use Concrete\Core\Entity\Page\Template;
+use Concrete\Core\Entity\Site\Site;
+use Concrete\Core\Page\Type\Composer\Control\Control as PageTypeComposerControl;
+use Concrete\Core\Page\Type\Type;
+
+class DraftService
+{
+    public function createDraft(Type $type, Template $template, ?Site $site = null): Page
+    {
+        $parent = Page::getDraftsParentPage($site);
+        $data = ['cvIsApproved' => 0, 'cIsDraft' => 1, 'cIsActive' => false, 'cAcquireComposerOutputControls' => true];
+        $p = $parent->add($type, $data, $template);
+
+        // now we setup in the initial configurated page target
+        $target = $type->getPageTypePublishTargetObject();
+        $cParentID = $target->getDefaultParentPageID();
+        if ($cParentID > 0) {
+            $p->setPageDraftTargetParentPageID($cParentID);
+        }
+
+        $controls = PageTypeComposerControl::getList($type);
+        foreach ($controls as $cn) {
+            $cn->onPageDraftCreate($p);
+        }
+
+        return $p;
+    }
+}

--- a/concrete/src/Page/PageServiceProvider.php
+++ b/concrete/src/Page/PageServiceProvider.php
@@ -9,6 +9,5 @@ class PageServiceProvider extends Provider
     public function register()
     {
         $this->app->singleton(HandleGenerator::class);
-        $this->app->bind(DraftService::class);
     }
 }

--- a/concrete/src/Page/PageServiceProvider.php
+++ b/concrete/src/Page/PageServiceProvider.php
@@ -9,5 +9,6 @@ class PageServiceProvider extends Provider
     public function register()
     {
         $this->app->singleton(HandleGenerator::class);
+        $this->app->bind(DraftService::class);
     }
 }

--- a/concrete/src/Page/Type/Type.php
+++ b/concrete/src/Page/Type/Type.php
@@ -1,6 +1,7 @@
 <?php
 namespace Concrete\Core\Page\Type;
 
+use Concrete\Core\Page\DraftService;
 use Concrete\Core\Page\Theme\Theme;
 use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\Attribute\Key\CollectionKey;
@@ -1207,31 +1208,19 @@ class Type extends ConcreteObject implements \Concrete\Core\Permission\ObjectInt
     }
 
 
+    /**
+     * @deprecated Use \Concrete\Core\Page\DraftService::createDraft instead
+     * @param \Concrete\Core\Entity\Page\Template $pt
+     * @param $u
+     * @return \Concrete\Core\Page\Page
+     */
     public function createDraft(\Concrete\Core\Entity\Page\Template $pt, $u = false)
     {
         $app = Application::getFacadeApplication();
-        if (!is_object($u)) {
-            $u = $app->make(User::class);
-        }
-        $db = Loader::db();
-        $ptID = $this->getPageTypeID();
-        $parent = Page::getDraftsParentPage();
-        $data = array('cvIsApproved' => 0, 'cIsDraft' => 1, 'cIsActive' => false, 'cAcquireComposerOutputControls' => true);
-        $p = $parent->add($this, $data, $pt);
+        /** @var DraftService $service */
+        $service = $app->make(DraftService::class);
 
-        // now we setup in the initial configurated page target
-        $target = $this->getPageTypePublishTargetObject();
-        $cParentID = $target->getDefaultParentPageID();
-        if ($cParentID > 0) {
-            $p->setPageDraftTargetParentPageID($cParentID);
-        }
-
-        $controls = PageTypeComposerControl::getList($this);
-        foreach ($controls as $cn) {
-            $cn->onPageDraftCreate($p);
-        }
-
-        return $p;
+        return $service->createDraft($this, $pt);
     }
 
     public function renderComposerOutputForm($page = null, $targetPage = null)


### PR DESCRIPTION
Fix #12725

* Introduced a new service class to create a draft for providing flexibility to the developers
* When adding a new draft page from the dashboard sitemap, we shouldn't detect a current site by domain. Let's do it by getting a site from the parent page.