### PR TITLE
Fix: Unable to get group info via API

### DIFF
--- a/concrete/src/Api/Controller/Groups.php
+++ b/concrete/src/Api/Controller/Groups.php
@@ -66,7 +66,7 @@ class Groups extends ApiController
             return $this->error(t('Group not found.'), 404);
         } else {
             $permissions = new Checker($group);
-            if (!$permissions->canSearchUserGroup()) {
+            if (!$permissions->canSearchUsersInGroup()) {
                 return $this->error(t('You do not have access to get information about this group.'), 401);
             }
         }


### PR DESCRIPTION
This PR fixes the error I reported in #12736 , but I wonder if this is the correct permission key.