### PR TITLE
Fix Image block tooltip of Image Hover

### DIFF
--- a/concrete/blocks/image/form.php
+++ b/concrete/blocks/image/form.php
@@ -51,8 +51,7 @@ $thumbnailTypes['0'] = t('Full Size');
             </small>
         </label>
 
-        <i class="fas fa-question-circle launch-tooltip" title=""
-           data-original-title="<?php echo t('The image hover effect requires constraining the image size.'); ?>"></i>
+        <i class="launch-tooltip fa fa-question-circle" title="<?php echo t('The image hover effect requires constraining the image size.'); ?>"></i>
 
         <?php echo $fileManager->image('ccm-b-image-onstate', 'fOnstateID', t('Choose Image On-State'), $bfo); ?>
     </div>


### PR DESCRIPTION
When you hover over the tooltip icon near Image hover of Image Block, the tooltip does not appear. 
<img width="453" height="700" alt="image" src="https://github.com/user-attachments/assets/28febe09-30b3-4d95-b89c-42d3f8daf691" />
Tip was inside ` data-original-title` instead of `title`

<img width="462" height="696" alt="image" src="https://github.com/user-attachments/assets/0bbc28ea-9e9c-40e7-bae9-38bdea28e0ae" />
