### PR TITLE
Fix attribute deletion- Add `onDelete="CASCADE"` to attribute key join column

### DIFF
--- a/concrete/src/Entity/Attribute/Key/Settings/Settings.php
+++ b/concrete/src/Entity/Attribute/Key/Settings/Settings.php
@@ -14,7 +14,7 @@ abstract class Settings
     /**
      * @ORM\Id
      * @ORM\OneToOne(targetEntity="\Concrete\Core\Entity\Attribute\Key\Key")
-     * @ORM\JoinColumn(name="akID", referencedColumnName="akID")
+     * @ORM\JoinColumn(name="akID", referencedColumnName="akID", onDelete="CASCADE")
      */
     protected $key;
 


### PR DESCRIPTION
This PR fixes the following issue.

```
Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException thrown with message "An exception occurred while executing 'DELETE FROM AttributeKeys WHERE akID = ?' with params [88]:

SQLSTATE[23000]: Integrity constraint violation: 1451 Cannot delete or update a parent row: a foreign key constraint fails (`hulft_c5`.`atEmptySettings`, CONSTRAINT `FK_ED1BF189B6561A7E` FOREIGN KEY (`akID`) REFERENCES `AttributeKeys` (`akID`))"
```

### Root cause
- The Doctrine mapping for attribute key settings (`Concrete\Core\Entity\Attribute\Key\Settings\Settings`) defined the `@ORM\JoinColumn` without `onDelete="CASCADE"`.
- As a result, Doctrine’s schema created (or had) a restrictive FK, and when the app attempted to delete the `AttributeKeys` row, the child row in `atEmptySettings` blocked it.

### Fix implemented (code)
- Updated the mapped superclass used by all attribute settings entities so the DB foreign key is created with cascading deletes.
