### PR TITLE
Check for GET method in handleURLSlashes

### DIFF
--- a/concrete/src/Application/Application.php
+++ b/concrete/src/Application/Application.php
@@ -318,7 +318,7 @@ class Application extends Container
     {
         $path = $request->getPathInfo();
         // If this isn't the homepage
-        if ($path && $path != '/') {
+        if ($path && $path != '/' && $request->isMethod('GET')) {
             $config = $this->make('config');
             $trailing_slashes = $config->get('concrete.seo.trailing_slash');
             // If the trailing slash doesn't match the config, return a redirect response


### PR DESCRIPTION
Add method check for GET requests in URL handling.

Fix https://github.com/concretecms/concretecms/issues/12742

concrete.seo.trailing_slash 301 redirect breaks POST. This implements suggestion (a), only redirect trailing_slash for GET requests, so POST and other verb payloads are not lost.



