### PR TITLE
[REST API] Define operation ids for api endpoints

### DIFF
--- a/concrete/src/Api/Controller/Account.php
+++ b/concrete/src/Api/Controller/Account.php
@@ -27,6 +27,7 @@ class Account implements ApplicationAwareInterface
     /**
      * @OA\Get(
      *     path="/ccm/api/1.0/account",
+     *     operationId="getAccount",
      *     tags={"account"},
      *     security={
      *         {"authorization": {"account:read"}}

--- a/concrete/src/Api/Controller/Areas.php
+++ b/concrete/src/Api/Controller/Areas.php
@@ -33,6 +33,7 @@ class Areas extends ApiController implements ApplicationAwareInterface
      * @OA\Post(
      *     path="/ccm/api/1.0/pages/{pageID}/{areaHandle}",
      *     tags={"areas"},
+     *     operationId="addBlockToPageArea",
      *     summary="Adds a block to a page area.",
      *     security={
      *         {"authorization": {"pages:areas:add_blocks"}}
@@ -99,6 +100,7 @@ class Areas extends ApiController implements ApplicationAwareInterface
      * @OA\Delete(
      *     path="/ccm/api/1.0/pages/{pageID}/{areaHandle}/{blockID}",
      *     tags={"areas"},
+     *     operationId="deleteBlockFromPageArea",
      *     summary="Deletes a block from a page area.",
      *     security={
      *         {"authorization": {"pages:areas:delete_blocks"}}
@@ -185,6 +187,7 @@ class Areas extends ApiController implements ApplicationAwareInterface
      * @OA\Put(
      *     path="/ccm/api/1.0/pages/{pageID}/{areaHandle}/{blockID}",
      *     tags={"areas"},
+     *     operationId="updateBlockInPageArea",
      *     summary="Updates a block within a page area.",
      *     security={
      *         {"authorization": {"pages:areas:update_blocks"}}

--- a/concrete/src/Api/Controller/Blocks.php
+++ b/concrete/src/Api/Controller/Blocks.php
@@ -15,6 +15,7 @@ class Blocks extends ApiController
      * @OA\Get(
      *     path="/ccm/api/1.0/blocks/{blockID}",
      *     tags={"blocks"},
+     *     operationId="getBlockById",
      *     summary="Find a block by its ID",
      *     security={
      *         {"authorization": {"blocks:read"}}
@@ -72,6 +73,7 @@ class Blocks extends ApiController
      * @OA\Delete(
      *     path="/ccm/api/1.0/blocks/{blockID}",
      *     tags={"blocks"},
+     *     operationId="deleteBlockById",
      *     summary="Delete a block by its ID",
      *     security={
      *         {"authorization": {"blocks:delete"}}

--- a/concrete/src/Api/Controller/Files.php
+++ b/concrete/src/Api/Controller/Files.php
@@ -34,6 +34,7 @@ class Files extends ApiController
      * @OA\Get(
      *     path="/ccm/api/1.0/files/{fileID}",
      *     tags={"files"},
+     *     operationId="getFileById",
      *     summary="Find a file by its ID",
      *     security={
      *         {"authorization": {"files:read"}}
@@ -87,6 +88,7 @@ class Files extends ApiController
      * @OA\Get(
      *     path="/ccm/api/1.0/files",
      *     tags={"files"},
+     *     operationId="getFiles",
      *     summary="Returns a list of file objects, sorted by last updated descending. The most recent file objects appear first.",
      *     security={
      *         {"authorization": {"files:read"}}
@@ -166,6 +168,7 @@ class Files extends ApiController
      * @OA\Post(
      *     path="/ccm/api/1.0/files",
      *     tags={"files"},
+     *     operationId="addFile",
      *     summary="Adds a file object.",
      *     security={
      *         {"authorization": {"files:add"}}
@@ -228,6 +231,7 @@ class Files extends ApiController
      * @OA\Delete(
      *     path="/ccm/api/1.0/files/{fileID}",
      *     tags={"files"},
+     *     operationId="deleteFileById",
      *     summary="Delete a file by its ID",
      *     security={
      *         {"authorization": {"files:delete"}}
@@ -274,6 +278,7 @@ class Files extends ApiController
      * @OA\Put(
      *     path="/ccm/api/1.0/files/{fileID}",
      *     tags={"files"},
+     *     operationId="updateFileById",
      *     summary="Update a file by its ID",
      *     security={
      *         {"authorization": {"files:update"}}
@@ -340,6 +345,7 @@ class Files extends ApiController
      * @OA\Post(
      *     path="/ccm/api/1.0/files/{fileID}/move",
      *     tags={"files"},
+     *     operationId="moveFileToLocation",
      *     summary="Move a file to a new location",
      *     security={
      *         {"authorization": {"files:update"}}

--- a/concrete/src/Api/Controller/Groups.php
+++ b/concrete/src/Api/Controller/Groups.php
@@ -28,6 +28,7 @@ class Groups extends ApiController
      * @OA\Get(
      *     path="/ccm/api/1.0/groups/{groupID}",
      *     tags={"groups"},
+     *     operationId="getGroupById",
      *     summary="Find a user group by its ID",
      *     security={
      *         {"authorization": {"groups:read"}}
@@ -78,6 +79,7 @@ class Groups extends ApiController
      * @OA\Get(
      *     path="/ccm/api/1.0/groups",
      *     tags={"groups"},
+     *     operationId="getGroups",
      *     summary="Returns a list of Group objects, sorted by ID ascending.",
      *     security={
      *         {"authorization": {"groups:read"}}
@@ -136,6 +138,7 @@ class Groups extends ApiController
      * @OA\Post(
      *     path="/ccm/api/1.0/groups",
      *     tags={"groups"},
+     *     operationId="addGroup",
      *     summary="Adds a Group object.",
      *     security={
      *         {"authorization": {"groups:add"}}

--- a/concrete/src/Api/Controller/Pages.php
+++ b/concrete/src/Api/Controller/Pages.php
@@ -33,6 +33,7 @@ class Pages extends ApiController
      * @OA\Get(
      *     path="/ccm/api/1.0/pages/{pageID}",
      *     tags={"pages"},
+     *     operationId="getPageById",
      *     summary="Find a page by its ID",
      *     security={
      *         {"authorization": {"pages:read"}}
@@ -109,6 +110,7 @@ class Pages extends ApiController
      * @OA\Get(
      *     path="/ccm/api/1.0/pages",
      *     tags={"pages"},
+     *     operationId="getPages",
      *     summary="Returns a list of page objects, sorted by last updated descending. The most recent Page objects appear first.",
      *     security={
      *         {"authorization": {"pages:read"}}
@@ -192,6 +194,7 @@ class Pages extends ApiController
      * @OA\Get(
      *     path="/ccm/api/1.0/pages/{pageID}/children",
      *     tags={"pages"},
+     *     operationId="getChildPages",
      *     summary="Allows the traversal of the sitemap by showing child pages of a particular page.",
      *     security={
      *         {"authorization": {"pages:read"}}
@@ -260,6 +263,7 @@ class Pages extends ApiController
      * @OA\Post(
      *     path="/ccm/api/1.0/pages",
      *     tags={"pages"},
+     *     operationId="addPage",
      *     summary="Adds a page object.",
      *     security={
      *         {"authorization": {"pages:add"}}
@@ -339,6 +343,7 @@ class Pages extends ApiController
      * @OA\Put(
      *     path="/ccm/api/1.0/pages/{pageID}",
      *     tags={"pages"},
+     *     operationId="updatePageById",
      *     summary="Update a page by its ID",
      *     security={
      *         {"authorization": {"pages:update"}}
@@ -440,6 +445,7 @@ class Pages extends ApiController
      * @OA\Delete(
      *     path="/ccm/api/1.0/pages/{pageID}",
      *     tags={"pages"},
+     *     operationId="deletePageById",
      *     summary="Delete a page by its ID",
      *     security={
      *         {"authorization": {"pages:delete"}}

--- a/concrete/src/Api/Controller/Sites.php
+++ b/concrete/src/Api/Controller/Sites.php
@@ -28,6 +28,7 @@ class Sites extends ApiController
      * @OA\Get(
      *     path="/ccm/api/1.0/sites/{siteID}",
      *     tags={"sites"},
+     *     operationId="getSiteById",
      *     summary="Find a site by its ID",
      *     security={
      *         {"clientCredentials": {"sites:read"}}
@@ -67,6 +68,7 @@ class Sites extends ApiController
      * @OA\Get(
      *     path="/ccm/api/1.0/sites",
      *     tags={"sites"},
+     *     operationId="getSites",
      *     summary="Returns a list of site objects, sorted by date added ascending.",
      *     security={
      *         {"clientCredentials": {"sites:read"}}
@@ -104,6 +106,7 @@ class Sites extends ApiController
      * @OA\Get(
      *     path="/ccm/api/1.0/sites/default",
      *     tags={"sites"},
+     *     operationId="getDefaultSite",
      *     summary="Retrieve the default site for your Concrete installation",
      *     security={
      *         {"clientCredentials": {"sites:read"}}

--- a/concrete/src/Api/Controller/System.php
+++ b/concrete/src/Api/Controller/System.php
@@ -13,6 +13,7 @@ class System
      * @OA\Get(
      *     path="/ccm/api/1.0/system/info",
      *     tags={"system"},
+     *     operationId="getSystemInfo",
      *     security={
      *         {"clientCredentials": {"system:info:read"}}
      *     },

--- a/concrete/src/Api/Controller/Users.php
+++ b/concrete/src/Api/Controller/Users.php
@@ -27,6 +27,7 @@ class Users extends ApiController
      * @OA\Get(
      *     path="/ccm/api/1.0/users/{userID}",
      *     tags={"users"},
+     *     operationId="getUserById",
      *     summary="Find a user by its ID",
      *     security={
      *         {"authorization": {"users:read"}}
@@ -82,6 +83,7 @@ class Users extends ApiController
      * @OA\Get(
      *     path="/ccm/api/1.0/users",
      *     tags={"users"},
+     *     operationId="getUsers",
      *     summary="Returns a list of user objects, sorted by date added descending. The most recent user objects appear first.",
      *     security={
      *         {"authorization": {"users:read"}}
@@ -160,6 +162,7 @@ class Users extends ApiController
      * @OA\Post(
      *     path="/ccm/api/1.0/users",
      *     tags={"users"},
+     *     operationId="addUser",
      *     summary="Adds a user object.",
      *     security={
      *         {"authorization": {"users:add"}}
@@ -199,6 +202,7 @@ class Users extends ApiController
      * @OA\Delete(
      *     path="/ccm/api/1.0/users/{userID}",
      *     tags={"users"},
+     *     operationId="deleteUserById",
      *     summary="Delete a user by its ID",
      *     security={
      *         {"authorization": {"users:delete"}}
@@ -253,6 +257,7 @@ class Users extends ApiController
      * @OA\Put(
      *     path="/ccm/api/1.0/users/{userID}",
      *     tags={"users"},
+     *     operationId="updateUserById",
      *     summary="Update a user by its ID",
      *     security={
      *         {"authorization": {"users:update"}}
@@ -339,6 +344,7 @@ class Users extends ApiController
      * @OA\Post(
      *     path="/ccm/api/1.0/users/{userID}/change_password",
      *     tags={"users"},
+     *     operationId="changeUserPassword",
      *     summary="Change a user's password",
      *     security={
      *         {"authorization": {"users:update"}}

--- a/concrete/src/Api/Controller/Versions.php
+++ b/concrete/src/Api/Controller/Versions.php
@@ -21,6 +21,7 @@ class Versions extends ApiController
      * @OA\Get(
      *     path="/ccm/api/1.0/page_versions/{pageID}/{versionID}",
      *     tags={"page_versions"},
+     *     operationId="getPageVersionByPageIdAndVersionId",
      *     summary="Find a page version by its ID and the ID of its page.",
      *     security={
      *         {"authorization": {"pages:versions:read"}}
@@ -81,6 +82,7 @@ class Versions extends ApiController
      * @OA\Get(
      *     path="/ccm/api/1.0/page_versions/{pageID}",
      *     tags={"page_versions"},
+     *     operationId="getPageVersionsByPageId",
      *     summary="Returns a list of page version objects for a given page ID, sorted by date created descending.",
      *     security={
      *         {"authorization": {"pages:versions:read"}}
@@ -145,6 +147,7 @@ class Versions extends ApiController
      * @OA\Delete(
      *     path="/ccm/api/1.0/page_versions/{pageID}/{versionID}",
      *     tags={"page_versions"},
+     *     operationId="deletePageVersionByPageIdAndVersionId",
      *     summary="Delete a page version.",
      *     security={
      *         {"authorization": {"pages:versions:delete"}}
@@ -211,6 +214,7 @@ class Versions extends ApiController
      * @OA\Put(
      *     path="/ccm/api/1.0/page_versions/{pageID}/{versionID}",
      *     tags={"page_versions"},
+     *     operationId="updatePageVersionByPageIdAndVersionId",
      *     summary="Update a page version",
      *     security={
      *         {"authorization": {"pages:versions:update"}}


### PR DESCRIPTION
Currently, operation IDs are generated as UUIDs, which is a bad pattern. Let's define a human-readable, descriptive name for it!

> Best Practices for operationId
> 1. Descriptive Naming:
> Always use descriptive names that give an idea of what the operation does. For instance, getPets, createPet, and deletePet are more informative compared to ambiguous names like p1, p2.
> 
> 2. Consistency:
> Follow a consistent naming convention across your API. For instance, if you name a GET operation as getPets, the corresponding POST operation should ideally be named createPets, maintaining the correlation and readability.
> 3. Avoiding Collisions:
> Ensure that each operationId is unique within the context of the entire API specification. Using a pattern such as verbNoun (e.g., getPet, updatePet) can be beneficial.

https://openapispec.com/docs/what/what-is-the-operationid-in-openapi/

Now I'm trying to create a MCP server for Concrete CMS by parsing it. I'll publish it with MIT license soon.
This fix is crucial for generating 3rd-party libraries using the openapi spec, so please accept this change. Thanks