### PR TITLE
composer.json enshrined/svg-sanitize CVE-2025-55166

### DIFF
--- a/concrete/composer.json
+++ b/concrete/composer.json
@@ -116,7 +116,7 @@
     "dragonmantank/cron-expression": "^3.1",
     "symfony/polyfill-uuid": "^1.20",
     "predis/predis": "^1.1",
-    "enshrined/svg-sanitize": "^0.15.4",
+    "enshrined/svg-sanitize": "^0.22.0",
     "laminas/laminas-feed": "^2.16",
     "laminas/laminas-mail": "^2.16",
     "laminas/laminas-cache": "^3.1.2",


### PR DESCRIPTION
Increase version of enshrined/svg-sanitize from 0.15.4 to 0.22.0 https://www.cve.org/CVERecord?id=CVE-2025-55166