### PR TITLE
Update block type description for tags controller

### DIFF
--- a/concrete/blocks/tags/controller.php
+++ b/concrete/blocks/tags/controller.php
@@ -55,7 +55,7 @@ class Controller extends BlockController implements UsesFeatureInterface
      */
     public function getBlockTypeDescription()
     {
-        return t("List pages based on type, area.");
+        return t("List tags for a page.");
     }
 
     public function getBlockTypeName()


### PR DESCRIPTION
This text must have been sitting incorrect since this block controller was originally created by copying a page list block controller.
