### PR TITLE
Handle array values in document library table

### DIFF
--- a/concrete/blocks/document_library/view.php
+++ b/concrete/blocks/document_library/view.php
@@ -34,8 +34,13 @@ $view->inc('view_header.php');
     $rowClass = 'ccm-block-document-library-row-a';
     foreach($results as $f) { ?>
         <tr class="<?=$rowClass?>">
-        <?php foreach($tableColumns as $column) { ?>
-            <td><?=$controller->getColumnValue($column, $f)?></td>
+        <?php foreach($tableColumns as $column) { 
+             $col_value = $controller->getColumnValue($column, $f);
+             if(is_array($col_value)) {
+                $col_value = implode(', ', $col_value);
+             }
+            ?>
+            <td><?= $col_value ?></td>
         <?php } ?>
         </tr>
         <?php


### PR DESCRIPTION
The default template for the document library fails when 'tags' are selected. The controller returns an array of tags and the view assumes a string. 

By convert array values to comma-separated strings we avoid such array issues.
