### PR TITLE
Fix: prevent select element from breaking if site name contains special characters

### DIFF
--- a/concrete/src/Site/Menu/Item/SiteListController.php
+++ b/concrete/src/Site/Menu/Item/SiteListController.php
@@ -66,7 +66,7 @@ class SiteListController extends Controller
                 }
             }
             $select = new Element('concrete-toolbar-site-list', null, [
-                ':sites' => htmlspecialchars(json_encode($sites), ENT_QUOTES, 'UTF-8'),
+                ':sites' => htmlspecialchars(json_encode($sites), ENT_QUOTES, APP_CHARSET),
                 'token' => $token,
                 'uri' => $request->getRequestURI(),
                 'selected-site' => $this->service->getActiveSiteForEditing()->getSiteID(),

--- a/concrete/src/Site/Menu/Item/SiteListController.php
+++ b/concrete/src/Site/Menu/Item/SiteListController.php
@@ -66,7 +66,7 @@ class SiteListController extends Controller
                 }
             }
             $select = new Element('concrete-toolbar-site-list', null, [
-                ':sites' => json_encode($sites),
+                ':sites' => htmlspecialchars(json_encode($sites), ENT_QUOTES, 'UTF-8'),
                 'token' => $token,
                 'uri' => $request->getRequestURI(),
                 'selected-site' => $this->service->getActiveSiteForEditing()->getSiteID(),


### PR DESCRIPTION
Fixes #12781 

Problem: when Site Name contains an apostrophe (e.g. "John's"), the dashboard toolbar's select element to switch sites in a multi-site environment breaks, printing part of the json string to the toolbar, see screenshot:
<img width="657" height="96" alt="image" src="https://github.com/user-attachments/assets/ad72f054-b133-4c9c-bb4c-9e96c19cdf21" />

Fix: HTML-escape the JSON-encoded sites string before injecting it into the select element, ensuring special characters such as apostrophes do not break the rendered markup.