### PR TITLE
Support twig in authentication types

### DIFF
--- a/concrete/src/Authentication/AuthenticationType.php
+++ b/concrete/src/Authentication/AuthenticationType.php
@@ -4,8 +4,11 @@ namespace Concrete\Core\Authentication;
 use Concrete\Authentication\Concrete\Controller;
 use Concrete\Core\Backup\ContentImporter;
 use Concrete\Core\Database\Schema\Schema;
+use Concrete\Core\Filesystem\FileLocator;
+use Concrete\Core\Filesystem\TemplateService;
 use Concrete\Core\Foundation\ConcreteObject;
 use Concrete\Core\Package\PackageList;
+use Concrete\Core\Support\Facade\Application;
 use Core;
 use Environment;
 use Exception;
@@ -22,6 +25,20 @@ class AuthenticationType extends ConcreteObject
     protected $authTypeDisplayOrder;
     protected $authTypeIsEnabled;
     protected $pkgID;
+
+    /** @var FileLocator */
+    protected $locator;
+
+    /** @var TemplateService */
+    protected $templateService;
+
+    protected $addedPackageLocator = false;
+
+    public function __construct(FileLocator $locator, TemplateService $templateService)
+    {
+        $this->locator = $locator;
+        $this->templateService = $templateService;
+    }
 
     public static function getListSorted()
     {
@@ -77,7 +94,7 @@ class AuthenticationType extends ConcreteObject
             'authTypeIsEnabled',
             'pkgID',
         ];
-        $obj = new self();
+        $obj = Application::make(self::class);
         foreach ($extract as $key) {
             if (!isset($arr[$key])) {
                 return false;
@@ -159,8 +176,8 @@ class AuthenticationType extends ConcreteObject
         }
         $db = Loader::db();
         $db->Execute(
-           'INSERT INTO AuthenticationTypes (authTypeHandle, authTypeName, authTypeIsEnabled, authTypeDisplayOrder, pkgID) values (?, ?, ?, ?, ?)',
-           [$atHandle, $atName, 1, intval($order), $pkgID]);
+            'INSERT INTO AuthenticationTypes (authTypeHandle, authTypeName, authTypeIsEnabled, authTypeDisplayOrder, pkgID) values (?, ?, ?, ?, ?)',
+            [$atHandle, $atName, 1, intval($order), $pkgID]);
         $est = self::getByHandle($atHandle);
         $r = $est->mapAuthenticationTypeFilePath(FILENAME_AUTHENTICATION_DB);
         if ($r->exists()) {
@@ -266,8 +283,8 @@ class AuthenticationType extends ConcreteObject
     {
         $db = Loader::db();
         $db->Execute(
-           'UPDATE AuthenticationTypes SET authTypeName=? WHERE authTypeID=?',
-           [$authTypeName, $this->getAuthenticationTypeID()]);
+            'UPDATE AuthenticationTypes SET authTypeName=? WHERE authTypeID=?',
+            [$authTypeName, $this->getAuthenticationTypeID()]);
     }
 
     /**
@@ -280,8 +297,8 @@ class AuthenticationType extends ConcreteObject
     {
         $db = Loader::db();
         $db->Execute(
-           'UPDATE AuthenticationTypes SET authTypeDisplayOrder=? WHERE authTypeID=?',
-           [$order, $this->getAuthenticationTypeID()]);
+            'UPDATE AuthenticationTypes SET authTypeDisplayOrder=? WHERE authTypeID=?',
+            [$order, $this->getAuthenticationTypeID()]);
     }
 
     public function getAuthenticationTypeID()
@@ -319,8 +336,8 @@ class AuthenticationType extends ConcreteObject
         }
         $db = Loader::db();
         $db->Execute(
-           'UPDATE AuthenticationTypes SET authTypeIsEnabled=0 WHERE AuthTypeID=?',
-           [$this->getAuthenticationTypeID()]);
+            'UPDATE AuthenticationTypes SET authTypeIsEnabled=0 WHERE AuthTypeID=?',
+            [$this->getAuthenticationTypeID()]);
     }
 
     /**
@@ -331,8 +348,8 @@ class AuthenticationType extends ConcreteObject
     {
         $db = Loader::db();
         $db->Execute(
-           'UPDATE AuthenticationTypes SET authTypeIsEnabled=1 WHERE AuthTypeID=?',
-           [$this->getAuthenticationTypeID()]);
+            'UPDATE AuthenticationTypes SET authTypeIsEnabled=1 WHERE AuthTypeID=?',
+            [$this->getAuthenticationTypeID()]);
     }
 
     /**
@@ -397,21 +414,21 @@ class AuthenticationType extends ConcreteObject
      * Settings forms are expected to handle their own submissions and redirect to the appropriate page.
      * Otherwise, if the method exists, all $_REQUEST variables with the arrangement: HANDLE[]
      * in an array to the AuthenticationTypeController::saveTypeForm.
+     *
+     * @return void
      */
     public function renderTypeForm()
     {
-        $type_form = $this->mapAuthenticationTypeFilePath('type_form.php');
-        if ($type_form->exists()) {
-            ob_start();
-            $this->controller->edit();
-            extract($this->controller->getSets());
-            require_once $type_form->file; // We use the $this method to prevent extract overwrite.
-            $out = ob_get_contents();
-            ob_end_clean();
-            echo $out;
-        } else {
+        if (!$this->hasTemplate('type_form')) {
             echo '<p>' . t('This authentication type does not require any customization.') . '</p>';
+            return;
         }
+
+        if (method_exists($this->controller, 'edit')) {
+            $this->controller->edit();
+        }
+
+        echo $this->renderTemplate('type_form', []) ?? '';
     }
 
     /**
@@ -419,82 +436,48 @@ class AuthenticationType extends ConcreteObject
      *
      * @param string $element
      * @param array  $params
+     * @return void
      */
     public function renderForm($element = 'form', $params = [])
     {
-        $this->controller->requireAsset('javascript', 'backstretch');
-
-        $form_element = $this->mapAuthenticationTypeFilePath($element . '.php');
-        if (!$form_element->exists()) {
-            $form_element = $this->mapAuthenticationTypeFilePath('form.php');
-            if (method_exists($this->controller, 'form')) {
-                call_user_func_array([$this->controller, 'form'], $params);
-            }
+        if (str_contains($element, '.')) {
+            $element = explode('.', $element)[0];
         }
-        ob_start();
-        if (method_exists($this->controller, $element)) {
-            call_user_func_array([$this->controller, $element], array_values($params));
-        } else {
-            $this->controller->view();
+        if (in_array(strtolower($element), ['form', 'type_form', 'hook', 'hooked']) && !$this->hasTemplate($element)) {
+            echo $this->renderTemplate('form', $params, true) ?? '';
+            return;
         }
-        extract(array_merge($params, $this->controller->getSets()));
-        require $form_element->file;
-        $out = ob_get_contents();
-        ob_end_clean();
-        echo $out;
+        echo $this->renderTemplate($element, $params, true) ?? $this->renderTemplate('form', $params, true) ?? '';
     }
 
     /**
      * Render the hook form for saving the profile settings.
      * All settings are expected to be saved by each individual authentication type.
+     *
+     * @return void
      */
     public function renderHook()
     {
-        $form_hook = $this->mapAuthenticationTypeFilePath('hook.php');
-        if (method_exists($this->controller, 'hook') || $form_hook->exists()) {
-            ob_start();
-            if (method_exists($this->controller, 'hook')) {
-                $this->controller->hook();
-            }
-            if ($form_hook->exists()) {
-                $controller = $this->controller;
-                extract($this->controller->getSets());
-                require_once $form_hook->file;
-            }
-            $out = ob_get_contents();
-            ob_end_clean();
-            echo $out;
-        }
-    }
-
-    public function hasHook()
-    {
-        $form_hook = $this->mapAuthenticationTypeFilePath('hook.php');
-
-        return method_exists($this->controller, 'hook') || $form_hook->exists();
+        echo $this->renderTemplate('hook') ?? '';
     }
 
     /**
-     * Render the a form to be displayed when the authentication type is already hooked.
+     * @return bool
+     */
+    public function hasHook()
+    {
+        return $this->hasTemplate('hook');
+    }
+
+    /**
+     * Render a form to be displayed when the authentication type is already hooked.
      * All settings are expected to be saved by each individual authentication type.
+     *
+     * @return void
      */
     public function renderHooked()
     {
-        $form_hooked = $this->mapAuthenticationTypeFilePath('hooked.php');
-        if (method_exists($this->controller, 'hooked') || $form_hooked->exists()) {
-            ob_start();
-            if (method_exists($this->controller, 'hooked')) {
-                $this->controller->hooked();
-            }
-            if ($form_hooked->exists()) {
-                $controller = $this->controller;
-                extract($this->controller->getSets());
-                require_once $form_hooked->file;
-            }
-            $out = ob_get_contents();
-            ob_end_clean();
-            echo $out;
-        }
+        echo $this->renderTemplate('hooked') ?? '';
     }
 
     /**
@@ -504,9 +487,7 @@ class AuthenticationType extends ConcreteObject
      */
     public function hasHooked()
     {
-        $form_hooked = $this->mapAuthenticationTypeFilePath('hooked.php');
-
-        return method_exists($this->controller, 'hooked') || $form_hooked->exists();
+        return $this->hasTemplate('hooked');
     }
 
     /**
@@ -526,5 +507,61 @@ class AuthenticationType extends ConcreteObject
         }
 
         return $result;
+    }
+
+    protected function hasTemplate(string $handle): bool
+    {
+        $atHandle = $this->getAuthenticationTypeHandle();
+        $path = implode('/', [DIRNAME_AUTHENTICATION, $atHandle, $handle]);
+        $r = $this->getLocator()->getRecord($path, true);
+
+        return $r->exists();
+    }
+
+    /**
+     * Render the matching template for a given handle. The template can be either PHP or Twig
+     *
+     * @param string $handle
+     * @param array<string, mixed> $data
+     * @param bool $viewFallback
+     * @return string|null
+     */
+    protected function renderTemplate(string $handle, array $data = [], bool $viewFallback = false): ?string
+    {
+        if ($handle === '') {
+            return null;
+        }
+
+        $atHandle = $this->getAuthenticationTypeHandle();
+        $path = implode('/', [DIRNAME_AUTHENTICATION, $atHandle, $handle]);
+        $r = $this->getLocator()->getRecord($path, true);
+        if (!$r->exists()) {
+            return null;
+        }
+
+        if (method_exists($this->controller, $handle)) {
+            $this->controller->{$handle}();
+        } elseif ($viewFallback && method_exists($this->controller, 'view')) {
+            $this->controller->view();
+        }
+
+        $sets = $this->controller->getSets();
+        if (is_array($sets)) {
+            $data = array_merge($data, $this->controller->getSets());
+        }
+
+        return $this->templateService->renderTemplate($r->getFile(), $data, $this);
+    }
+
+    protected function getLocator(): FileLocator
+    {
+        if (!$this->addedPackageLocator) {
+            $this->addedPackageLocator = true;
+            $pkgHandle = $this->getPackageHandle();
+            if ($pkgHandle) {
+                $this->locator->addPackageLocation($pkgHandle);
+            }
+        }
+        return $this->locator;
     }
 }

--- a/concrete/src/Authentication/AuthenticationTypeController.php
+++ b/concrete/src/Authentication/AuthenticationTypeController.php
@@ -2,13 +2,13 @@
 
 namespace Concrete\Core\Authentication;
 
+use Concrete\Core\Controller\Controller;
 use Concrete\Core\Logging\Channels;
 use Concrete\Core\Logging\LoggerAwareInterface;
 use Concrete\Core\Logging\LoggerAwareTrait;
 use Concrete\Core\Http\Request;
 use Concrete\Core\User\User;
 use Page;
-use Controller;
 use Concrete\Core\Support\Facade\Application;
 
 abstract class AuthenticationTypeController extends Controller implements LoggerAwareInterface,

--- a/tests/tests/Authentication/AuthenticationTypeTest.php
+++ b/tests/tests/Authentication/AuthenticationTypeTest.php
@@ -1,0 +1,234 @@
+<?php
+
+namespace Concrete\Tests\Authentication;
+
+use Concrete\Core\Authentication\AuthenticationType;
+use Concrete\Core\Authentication\AuthenticationTypeController;
+use Concrete\Core\Filesystem\FileLocator;
+use Concrete\Core\Filesystem\TemplateService;
+use Concrete\Tests\TestCase;
+use Mockery;
+
+final class AuthenticationTypeTest extends TestCase
+{
+    /** @var string */
+    private $file;
+    /** @var bool */
+    private $exists;
+    /** @var FileLocator\Record&Mockery\MockInterface */
+    private $record;
+    /** @var FileLocator&Mockery\MockInterface */
+    private $fileLocator;
+    /** @var TemplateService&Mockery\MockInterface */
+    private $templateService;
+    /** @var AuthenticationType */
+    private $authenticationType;
+
+    /**
+     * @dataProvider basicRenderProvider
+     */
+    public function testRendersBasicEndpoints(string $method): void
+    {
+        $this->setFullyDefinedController();
+
+        $this->fileLocator->expects('getRecord')
+            ->with('authentication/test_auth_type/' . $method, true)
+            ->andReturn($this->record);
+        $this->templateService->expects('renderTemplate')
+            ->with($this->file, ['foo', $method], $this->authenticationType)
+            ->andReturn('foo');
+
+        ob_start();
+        $this->authenticationType->{'render' . camelcase($method)}();
+        $actual = ob_get_clean();
+        $this->assertEquals($actual, 'foo');
+    }
+
+    public function basicRenderProvider()
+    {
+        return [['hook'], ['hooked']];
+    }
+
+    public function testRendersForm(): void
+    {
+        $this->setFullyDefinedController();
+
+        $this->fileLocator->expects('getRecord')
+            ->times(2)
+            ->with('authentication/test_auth_type/form', true)
+            ->andReturn($this->record);
+        $this->templateService->expects('renderTemplate')
+            ->with($this->file, ['foo', 'form'], $this->authenticationType)
+            ->andReturn('foo');
+
+        ob_start();
+        $this->authenticationType->renderForm();
+        $actual = ob_get_clean();
+        $this->assertEquals($actual, 'foo');
+    }
+
+    public function testRendersTypeForm(): void
+    {
+        $this->setFullyDefinedController();
+
+        $this->fileLocator->expects('getRecord')
+            ->times(2)
+            ->with('authentication/test_auth_type/type_form', true)
+            ->andReturn($this->record);
+        $this->templateService->expects('renderTemplate')
+            ->with($this->file, ['foo', 'edit', 'type_form'], $this->authenticationType)
+            ->andReturn('foo');
+
+        ob_start();
+        $this->authenticationType->renderTypeForm();
+        $actual = ob_get_clean();
+        $this->assertEquals($actual, 'foo');
+    }
+
+    public function testRendersTypeFormWithEditMethod(): void
+    {
+        $this->setEditController();
+
+        $this->fileLocator->expects('getRecord')
+            ->times(2)
+            ->with('authentication/test_auth_type/type_form', true)
+            ->andReturn($this->record);
+        $this->templateService->expects('renderTemplate')
+            ->with($this->file, ['foo', 'edit'], $this->authenticationType)
+            ->andReturn('foo');
+
+        ob_start();
+        $this->authenticationType->renderTypeForm();
+        $actual = ob_get_clean();
+        $this->assertEquals($actual, 'foo');
+    }
+
+    public function testFallsBackToView(): void
+    {
+        $this->setViewController();
+
+        $this->fileLocator->expects('getRecord')
+            ->times(2)
+            ->with('authentication/test_auth_type/form', true)
+            ->andReturn($this->record);
+        $this->templateService->expects('renderTemplate')
+            ->with($this->file, ['foo', 'view'], $this->authenticationType)
+            ->andReturn('foo');
+
+        ob_start();
+        $this->authenticationType->renderForm();
+        $actual = ob_get_clean();
+        $this->assertEquals($actual, 'foo');
+    }
+
+    public function testAddsPackageLocation(): void
+    {
+        $this->setViewController();
+        $this->authenticationType->pkgHandle = 'fake_package';
+
+        $this->fileLocator->shouldReceive('getRecord')->andReturn($this->record);
+        $this->templateService->shouldReceive('renderTemplate')->andReturn('foo');
+
+        $this->fileLocator->expects('addPackageLocation')->with('fake_package');
+
+        ob_start();
+        $this->authenticationType->renderForm();
+        ob_end_clean();
+    }
+
+
+    public function setUp(): void
+    {
+        $this->file = 'test/file';
+        $this->exists = true;
+        $this->record = Mockery::mock(FileLocator\Record::class);
+        $this->record->shouldReceive('getFile')->andReturnUsing(function () {
+            return $this->file;
+        });
+        $this->record->shouldReceive('exists')->andReturnUsing(function () {
+            return $this->exists;
+        });
+        $this->fileLocator = Mockery::mock(FileLocator::class);
+        $this->templateService = Mockery::mock(TemplateService::class);
+
+        $this->authenticationType = new class($this->fileLocator, $this->templateService) extends AuthenticationType {
+            protected $authTypeHandle = 'test_auth_type';
+            /** @var string|false */
+            public $pkgHandle = false;
+            /** @return string|false */
+            public function getPackageHandle()
+            {
+                return $this->pkgHandle;
+            }
+        };
+    }
+
+    protected function setFullyDefinedController(): void
+    {
+        $this->authenticationType->controller = new Class() {
+            public $sets = ['foo'];
+            public function hook(): void
+            {
+                $this->sets[] = 'hook';
+            }
+            public function hooked(): void
+            {
+                $this->sets[] = 'hooked';
+            }
+            public function form(): void
+            {
+                $this->sets[] = 'form';
+            }
+            public function edit(): void
+            {
+                $this->sets[] = 'edit';
+            }
+            public function type_form(): void
+            {
+                $this->sets[] = 'type_form';
+            }
+            public function custom(): void
+            {
+                $this->sets[] = 'custom';
+            }
+            public function view(): void
+            {
+                $this->sets[] = 'view';
+            }
+            public function getSets(): array
+            {
+                return $this->sets;
+            }
+        };
+    }
+
+    protected function setEditController(): void
+    {
+        $this->authenticationType->controller = new Class() {
+            public $sets = ['foo'];
+            public function edit(): void
+            {
+                $this->sets[] = 'edit';
+            }
+            public function getSets(): array
+            {
+                return $this->sets;
+            }
+        };
+    }
+
+    protected function setViewController(): void
+    {
+        $this->authenticationType->controller = new Class() {
+            public $sets = ['foo'];
+            public function view(): void
+            {
+                $this->sets[] = 'view';
+            }
+            public function getSets(): array
+            {
+                return $this->sets;
+            }
+        };
+    }
+}


### PR DESCRIPTION
This PR adds support for twig templates in authentication types. It also updates the `AuthenticationTypeController` base class to extend the real `Controller` class rather than the `\Controller` alias.
