### PR TITLE
Fix missing registration for Survey Block feature dependency  

### DIFF
--- a/concrete/config/app.php
+++ b/concrete/config/app.php
@@ -572,6 +572,10 @@ return [
             ['css', 'css/features/maps/frontend.css', ['minify' => false]],
         ],
 
+        'feature/polls/frontend' => [
+            ['css', 'css/features/polls/frontend.css', ['minify' => false]],
+        ],
+
         'feature/multilingual/frontend' => [
             ['javascript', 'js/features/multilingual/frontend.js', ['minify' => false]],
             ['css', 'css/features/multilingual/frontend.css', ['minify' => false]],
@@ -789,6 +793,12 @@ return [
             [
                 ['javascript', 'feature/maps/frontend'],
                 ['css', 'feature/maps/frontend'],
+            ],
+        ],
+
+        'feature/polls/frontend' => [
+            [
+                ['css', 'feature/polls/frontend'],
             ],
         ],
 


### PR DESCRIPTION
This PR fixes the following warning-

```
Block type requested required feature 'feature/polls/frontend' but it was not registered.
```
