### PR TITLE
Fix duplicated render bug while searching for S&P in the File Manager

### DIFF
--- a/concrete/src/File/Search/ColumnSet/Column/NameColumn.php
+++ b/concrete/src/File/Search/ColumnSet/Column/NameColumn.php
@@ -33,8 +33,8 @@ class NameColumn extends Column implements PagerColumnInterface
         $query = $itemList->getQueryObject();
         $sort = $this->getColumnSortDirection() == 'desc' ? '<' : '>';
         $name = '';
-        if ($mixed->getTreeNodeDisplayName()) {
-            $name = $mixed->getTreeNodeDisplayName();
+        if ($mixed->getTreeNodeDisplayName('text')) {
+            $name = $mixed->getTreeNodeDisplayName('text');
         }
         $config = Application::getFacadeApplication()->make('config');
         if ($config->get('concrete.file_manager.keep_folders_on_top')) {


### PR DESCRIPTION
Fixes https://github.com/concretecms/concretecms/issues/12786

Problem: When searching for **S&P** in the File Manager this can cause a duplicated render bug.