### PR TITLE
Fix Express Form block crash when configured upload folder was deleted

### DIFF
--- a/concrete/blocks/express_form/controller.php
+++ b/concrete/blocks/express_form/controller.php
@@ -916,7 +916,7 @@ class Controller extends BlockController implements NotificationProviderInterfac
 
         if ($this->addFilesToFolder) {
             $filesystem = new Filesystem();
-            $addFilesToFolder = $filesystem->getFolder($this->addFilesToFolder);
+            $addFilesToFolder = $filesystem->getFolder($this->addFilesToFolder)?:$filesystem->getRootFolder();
             $fp = new Checker($addFilesToFolder);
             if ($fp->canSearchFiles()) {
                 $this->set('addFilesToFolder', $addFilesToFolder);


### PR DESCRIPTION
### Problem
If an Express Form block is configured to save uploaded files into a specific folder, and that folder is later deleted, editing the block can fail with an exception similar to:

> `Unable to get permission key for search_files`

This prevents editors from opening the block configuration UI (and effectively “bricks” the block until the folder is recreated or the config is reset).

## How to reproduce
1. Configure an Express Form block to store uploads in a specific folder.
2. Delete that folder in File Manager.
3. Try to edit the block → exception / configuration UI fails.

### Root cause
`Filesystem::getFolder($folderId)` returns `null` when the stored folder ID no longer resolves to an existing file folder (e.g. the folder was deleted). The block controller then instantiates a permission `Checker` with a `null` object and calls `$fp->canSearchFiles()`.

When `Checker` has no permission object/response, it falls back to deriving a permission handle from the method name (e.g. `canSearchFiles` → `search_files`). There is no permission key with handle `search_files` (the folder permission is `search_file_folder`), so the permission lookup fails and throws.

### Solution
Gracefully handle the “folder was deleted” case by falling back to the root folder:

```php
$folder = $filesystem->getFolder($this->addFilesToFolder) ?: $filesystem->getRootFolder();
```

This ensures we always pass a valid folder object into `Checker`, and the permission check behaves as intended instead of triggering the fallback-to-nonexistent-handle path.
