### PR TITLE
Proposal: Shows note "Logs stored in files are not displayed."

### DIFF
--- a/concrete/single_pages/dashboard/reports/logs.php
+++ b/concrete/single_pages/dashboard/reports/logs.php
@@ -13,7 +13,24 @@ use Concrete\Core\Logging\Search\Result\Column;
 use Concrete\Core\Logging\Search\Result\Item;
 use Concrete\Core\Logging\Search\Result\ItemColumn;
 use Concrete\Core\Logging\Search\Result\Result;
+use Concrete\Core\Support\Facade\Application;
+?>
+<?php
+$app = Application::getFacadeApplication();
+$config = app('config');
+$handler = $config->get('concrete.log.configuration.simple.handler');
 
+if ($handler === 'file') :
+?>
+    <div class="alert alert-info">
+        <?php
+        echo t('Note: Logs stored in files are not displayed. Only database logs are shown.');
+        ?>
+    </div>
+<?php
+endif;
+?>
+<?php
 // @var MenuInterface $menu
 // @var Result $result
 // @var DropdownMenu $resultsBulkMenu


### PR DESCRIPTION
I propose a notification message.
When the logging handler is set to file, a notification message saying “Logs stored in files are not displayed.” is shown.

<img width="771" height="327" alt="log-message" src="https://github.com/user-attachments/assets/3c00d29f-a94a-40c6-bcba-ef2abe3023fa" />
