### PR TITLE
fix(blocks/hero_image): change event to get immediate ui feedback

### DIFF
--- a/concrete/blocks/hero_image/edit.php
+++ b/concrete/blocks/hero_image/edit.php
@@ -22,7 +22,7 @@ $icon = $icon ?? '';
     </div>
     <div class="mb-3">
         <label class="form-label" for="image"><?=t('Height')?></label>
-        <input class="form-range" type="range" name="height" id="heroImageHeight" min="20" max="100" onchange="updateHeroImageHeight(this.value)" value="<?=$height?>">
+        <input class="form-range" type="range" name="height" id="heroImageHeight" min="20" max="100" oninput="updateHeroImageHeight(this.value)" value="<?=$height?>">
         <div class="alert alert-info">
             <?=t('Current Value:')?> <code><span data-value="height"></span></code>
         </div>


### PR DESCRIPTION
Changed `onchange` to `oninput` in `hero_image` edit form:

A single word changed, but it makes` hero_image` block more user friendly: Height value now immediately updates **while moving** the knob on the range field, making it much easier to adjust it so the preferred value.

