### PR TITLE
Fix console php 8

### DIFF
--- a/concrete/src/Console/Application.php
+++ b/concrete/src/Console/Application.php
@@ -17,7 +17,7 @@ class Application extends SymfonyApplication
         $this->app = $app;
         parent::__construct('concrete', $this->app->make('config')->get('concrete.version'));
     }
-    
+
     /**
      * @deprecated
      */
@@ -27,7 +27,8 @@ class Application extends SymfonyApplication
     }
 
     /**
-     * Get the concrete5 application instance
+     * Get the concrete5 application instance.
+     *
      * @return \Concrete\Core\Application\Application
      */
     public function getConcrete()

--- a/concrete/src/Console/Command.php
+++ b/concrete/src/Console/Command.php
@@ -103,7 +103,7 @@ abstract class Command extends SymfonyCommand
      *
      * @var string
      */
-    protected $signature;
+    protected $signature = null;
 
     /**
      * Can this command be executed as root?
@@ -117,7 +117,7 @@ abstract class Command extends SymfonyCommand
      */
     protected $canRunAsRoot = true;
 
-    public function __construct($name = null)
+    public function __construct(?string $name = null)
     {
         if ($this->signature) {
             $this->configureUsingFluentDefinition();
@@ -158,7 +158,7 @@ abstract class Command extends SymfonyCommand
      *
      * @return int
      */
-    public function call($command, array $arguments = [])
+    public function call(string $command, array $arguments = []): int
     {
         $arguments['command'] = $command;
 
@@ -176,7 +176,7 @@ abstract class Command extends SymfonyCommand
      *
      * @return int
      */
-    public function callSilent($command, array $arguments = [])
+    public function callSilent(string $command, array $arguments = []): int
     {
         $arguments['command'] = $command;
 
@@ -193,7 +193,7 @@ abstract class Command extends SymfonyCommand
      *
      * @return bool
      */
-    public function hasArgument($name)
+    public function hasArgument($name): bool
     {
         return $this->input->hasArgument($name);
     }
@@ -205,7 +205,7 @@ abstract class Command extends SymfonyCommand
      *
      * @return string|array
      */
-    public function argument($key = null)
+    public function argument(?string $key = null)
     {
         if ($key === null) {
             return $this->input->getArguments();
@@ -219,7 +219,7 @@ abstract class Command extends SymfonyCommand
      *
      * @return array
      */
-    public function arguments()
+    public function arguments(): array
     {
         return $this->argument();
     }
@@ -231,7 +231,7 @@ abstract class Command extends SymfonyCommand
      *
      * @return bool
      */
-    public function hasOption($name)
+    public function hasOption(string $name): bool
     {
         return $this->input->hasOption($name);
     }
@@ -243,7 +243,7 @@ abstract class Command extends SymfonyCommand
      *
      * @return string|array
      */
-    public function option($key = null)
+    public function option(?string $key = null)
     {
         if ($key === null) {
             return $this->input->getOptions();
@@ -257,7 +257,7 @@ abstract class Command extends SymfonyCommand
      *
      * @return array
      */
-    public function options()
+    public function options(): array
     {
         return $this->option();
     }
@@ -270,7 +270,7 @@ abstract class Command extends SymfonyCommand
      *
      * @return bool
      */
-    public function confirm($question, $default = false)
+    public function confirm(string $question, bool $default = false): bool
     {
         return $this->output->confirm($question, $default);
     }
@@ -283,7 +283,7 @@ abstract class Command extends SymfonyCommand
      *
      * @return string
      */
-    public function ask($question, $default = null)
+    public function ask(string $question, ?string $default = null): string
     {
         return $this->output->ask($question, $default);
     }
@@ -299,7 +299,7 @@ abstract class Command extends SymfonyCommand
      *
      * @return string
      */
-    public function askWithCompletion($question, array $choices, $default = null, $attempts = null, $strict = null)
+    public function askWithCompletion(string $question, array $choices, ?string $default = null, ?int $attempts = null, ?bool $strict = null): string
     {
         return $this->output->askWithCompletion($question, $choices, $default, $attempts, $strict);
     }
@@ -312,7 +312,7 @@ abstract class Command extends SymfonyCommand
      *
      * @return string
      */
-    public function secret($question, $fallback = true)
+    public function secret(string $question, bool $fallback = true): string
     {
         return $this->output->secret($question, $fallback);
     }
@@ -328,7 +328,7 @@ abstract class Command extends SymfonyCommand
      *
      * @return string
      */
-    public function choice($question, array $choices, $default = null, $attempts = null, $multiple = null)
+    public function choice(string $question, array $choices, ?string $default = null, $attempts = null, ?bool $multiple = null): string
     {
         return $this->output->choice($question, $choices, $default, $attempts, $multiple);
     }
@@ -343,7 +343,7 @@ abstract class Command extends SymfonyCommand
      *
      * @return void
      */
-    public function table(array $headers, array $rows, $tableStyle = 'default', array $columnStyles = [])
+    public function table(array $headers, array $rows, string $tableStyle = 'default', array $columnStyles = []): void
     {
         $this->output->table($headers, $rows, $tableStyle, $columnStyles);
     }
@@ -353,7 +353,7 @@ abstract class Command extends SymfonyCommand
      *
      * @return \Symfony\Component\Console\Application|\Concrete\Core\Console\Application
      */
-    public function getApplication()
+    public function getApplication(): Application
     {
         return parent::getApplication();
     }
@@ -363,7 +363,7 @@ abstract class Command extends SymfonyCommand
      *
      * @return void
      */
-    protected function configureUsingFluentDefinition()
+    protected function configureUsingFluentDefinition(): void
     {
         list($name, $arguments, $options) = Parser::parse($this->signature);
         parent::__construct($this->name = $name);
@@ -383,7 +383,7 @@ abstract class Command extends SymfonyCommand
      *
      * @return void
      */
-    protected function specifyParameters()
+    protected function specifyParameters(): void
     {
         // We will loop through all of the arguments and options for the command and
         // set them all on the base command instance. This specifies what can get
@@ -403,7 +403,7 @@ abstract class Command extends SymfonyCommand
      *
      * @return array [[$name, $mode = null, $description = '', $default = null], ...]
      */
-    protected function getArguments()
+    protected function getArguments(): array
     {
         return [];
     }
@@ -415,7 +415,7 @@ abstract class Command extends SymfonyCommand
      *
      * @return array [[$name, $shortcut = null, $mode = null, $description = '', $default = null], ...]
      */
-    protected function getOptions()
+    protected function getOptions(): array
     {
         return [];
     }
@@ -425,7 +425,7 @@ abstract class Command extends SymfonyCommand
      *
      * @see \Symfony\Component\Console\Command\Command::initialize()
      */
-    protected function initialize(InputInterface $input, OutputInterface $output)
+    protected function initialize(InputInterface $input, OutputInterface $output): void
     {
         if (!$this->canRunAsRoot && $this->isRunningAsRoot() === true) {
             $this->confirmRunningAsRoot($input, $output);
@@ -441,7 +441,7 @@ abstract class Command extends SymfonyCommand
      * @deprecated Use $this->output to manage your output
      * @see OutputStyle::error()
      */
-    protected function writeError(OutputInterface $output, $error)
+    protected function writeError(OutputInterface $output, $error): void
     {
         $result = [trim($error->getMessage())];
 
@@ -468,7 +468,7 @@ abstract class Command extends SymfonyCommand
      *
      * @return Command
      */
-    protected function addEnvOption()
+    protected function addEnvOption(): static
     {
         $this->addOption(
             'env',
@@ -491,7 +491,7 @@ abstract class Command extends SymfonyCommand
      *
      * @return $this
      */
-    protected function setCanRunAsRoot($canRunAsRoot)
+    protected function setCanRunAsRoot(bool $canRunAsRoot): static
     {
         $canRunAsRoot = (bool) $canRunAsRoot;
         if ($canRunAsRoot !== $this->canRunAsRoot) {
@@ -518,7 +518,7 @@ abstract class Command extends SymfonyCommand
      *
      * @return bool|null NULL if unknown, or boolean if determined
      */
-    protected function isRunningAsRoot()
+    protected function isRunningAsRoot(): ?bool
     {
         $app = ApplicationFacade::getFacadeApplication();
 
@@ -531,7 +531,7 @@ abstract class Command extends SymfonyCommand
      *
      * @throws UserMessageException
      */
-    protected function confirmRunningAsRoot(InputInterface $input, OutputInterface $output)
+    protected function confirmRunningAsRoot(InputInterface $input, OutputInterface $output): void
     {
         if (!($input->hasOption(static::ALLOWASROOT_OPTION) && $input->getOption(static::ALLOWASROOT_OPTION)) && !@getenv(static::ALLOWASROOT_ENV)) {
             if (!$input->isInteractive()) {
@@ -558,7 +558,7 @@ abstract class Command extends SymfonyCommand
      *
      * @see \Symfony\Component\Console\Command\Command::execute()
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if (!method_exists($this, 'handle')) {
             throw new LogicException('You must define the public handle() method in the command implementation.');

--- a/concrete/src/Console/Command.php
+++ b/concrete/src/Console/Command.php
@@ -37,7 +37,7 @@ abstract class Command extends SymfonyCommand
     public const RETURN_CODE_ON_FAILURE = self::FAILURE;
 
     /**
-     * Concrete requires symfony/console ^5.2, and the INVALID constant has been introduced in symfony/console 5.3.0
+     * Concrete requires symfony/console ^5.2, and the INVALID constant has been introduced in symfony/console 5.3.0.
      *
      * @var int
      */
@@ -103,7 +103,7 @@ abstract class Command extends SymfonyCommand
      *
      * @var string
      */
-    protected $signature = null;
+    protected $signature;
 
     /**
      * Can this command be executed as root?
@@ -365,7 +365,7 @@ abstract class Command extends SymfonyCommand
      */
     protected function configureUsingFluentDefinition(): void
     {
-        list($name, $arguments, $options) = Parser::parse($this->signature);
+        [$name, $arguments, $options] = Parser::parse($this->signature);
         parent::__construct($this->name = $name);
         // After parsing the signature we will spin through the arguments and options
         // and set them on this command. These will already be changed into proper

--- a/concrete/src/Console/Command/ActivateThemeCommand.php
+++ b/concrete/src/Console/Command/ActivateThemeCommand.php
@@ -6,7 +6,6 @@ use Concrete\Core\Console\Command;
 use Concrete\Core\Page\Theme\Theme;
 use Concrete\Core\Site\Service;
 use Concrete\Core\Support\Facade\Application;
-use Doctrine\ORM\EntityManager;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -25,7 +24,8 @@ class ActivateThemeCommand extends Command
                 null
             )
             ->setDescription('Activate a theme.')
-            ->addArgument('theme', InputArgument::REQUIRED, 'The name of the theme.');
+            ->addArgument('theme', InputArgument::REQUIRED, 'The name of the theme.')
+        ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -41,6 +41,7 @@ class ActivateThemeCommand extends Command
         }
         if (!$site) {
             $output->writeln('<fg=red>' . t('Invalid site.') . '</>');
+
             return static::FAILURE;
         }
 
@@ -52,6 +53,7 @@ class ActivateThemeCommand extends Command
                 $availableThemeIdentifiers[] = $availableTheme->getThemeHandle();
             }
             $output->writeln('<fg=red>' . t('No theme found with the handle "%s"! Available themes include: %s.', $themeIdentifier, implode(', ', $availableThemeIdentifiers)) . '</>');
+
             return static::FAILURE;
         }
 
@@ -59,6 +61,7 @@ class ActivateThemeCommand extends Command
         $theme->applyToSite($site);
 
         $output->writeln('<fg=green>' . t('Theme activation complete!') . '</>');
+
         return static::SUCCESS;
     }
 }

--- a/concrete/src/Console/Command/ActivateThemeSkinCommand.php
+++ b/concrete/src/Console/Command/ActivateThemeSkinCommand.php
@@ -25,7 +25,8 @@ class ActivateThemeSkinCommand extends Command
                 null
             )
             ->setDescription('Activate a theme skin.')
-            ->addArgument('skin', InputArgument::REQUIRED, 'The name of the skin.');
+            ->addArgument('skin', InputArgument::REQUIRED, 'The name of the skin.')
+        ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -42,12 +43,14 @@ class ActivateThemeSkinCommand extends Command
         }
         if (!$site) {
             $output->writeln('<fg=red>' . t('Invalid site.') . '</>');
+
             return static::FAILURE;
         }
 
         $theme = Theme::getByID($site->getThemeID());
         if (!$theme) {
             $output->writeln('<fg=red>' . t('Site has no active theme!') . '</>');
+
             return static::FAILURE;
         }
 
@@ -60,6 +63,7 @@ class ActivateThemeSkinCommand extends Command
                 $availableSkinIdentifiers[] = $availableSkin->getIdentifier();
             }
             $output->writeln('<fg=red>' . t('There is no skin named "%s" found in this theme. Active skins include: %s.', $skinIdentifier, implode(', ', $availableSkinIdentifiers)) . '</>');
+
             return static::FAILURE;
         }
 
@@ -68,6 +72,7 @@ class ActivateThemeSkinCommand extends Command
         $entityManager->persist($site);
         $entityManager->flush();
         $output->writeln('<fg=green>' . t('Theme skin activation complete!') . '</>');
+
         return static::SUCCESS;
     }
 }

--- a/concrete/src/Console/Command/BulkUserAssignCommand.php
+++ b/concrete/src/Console/Command/BulkUserAssignCommand.php
@@ -11,10 +11,10 @@ use Concrete\Core\User\Group\Group;
 use Concrete\Core\User\Group\GroupRepository;
 use Concrete\Core\User\UserInfo;
 use Concrete\Core\User\UserInfoRepository;
+use Exception;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Exception;
 
 class BulkUserAssignCommand extends Command
 {
@@ -26,14 +26,17 @@ class BulkUserAssignCommand extends Command
             ->addOption('csv-file', 'c', InputOption::VALUE_REQUIRED, 'Path to CSV file.')
             ->addOption('group-id', 'g', InputOption::VALUE_REQUIRED, 'The id of the target group.')
             ->addOption('remove-unlisted-users', 'r', InputOption::VALUE_OPTIONAL, 'Remove users from this group if they don\'t appear in CSV.')
-            ->addOption('dry-run', 'd', InputOption::VALUE_OPTIONAL, 'Perform a dry run.');
+            ->addOption('dry-run', 'd', InputOption::VALUE_OPTIONAL, 'Perform a dry run.')
+        ;
     }
 
     /**
      * @param InputInterface $input
      * @param OutputInterface $output
-     * @return int
+     *
      * @throws Exception
+     *
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
@@ -58,13 +61,10 @@ class BulkUserAssignCommand extends Command
         $targetGroup = $groupRepository->getGroupByID($groupId);
 
         if ($targetGroup instanceof Group) {
-
             if (strtolower(pathinfo($csvFile, PATHINFO_EXTENSION)) === 'csv') {
                 $csvData = $fileHelper->getContents($csvFile);
 
-                /*
-                 * Validate the CSV and extract all mail addresses.
-                 */
+                // Validate the CSV and extract all mail addresses.
 
                 foreach (explode(PHP_EOL, $csvData) as $line) {
                     $rows = str_getcsv($line);
@@ -72,7 +72,7 @@ class BulkUserAssignCommand extends Command
                     if (count($rows) === 1) {
                         if (filter_var($rows[0], FILTER_VALIDATE_EMAIL)) {
                             $mailAddresses[] = $rows[0];
-                        } else if ($rows[0] !== null) {
+                        } elseif ($rows[0] !== null) {
                             throw new Exception('The given CSV contains invalid mail addresses.');
                         }
                     } else {
@@ -90,9 +90,7 @@ class BulkUserAssignCommand extends Command
         $totalUsersAddedToTargetGroup = 0;
         $totalUsersRemovedFromTargetGroup = 0;
 
-        /*
-         * Add the given users to the target group.
-         */
+        // Add the given users to the target group.
 
         foreach ($mailAddresses as $mailAddress) {
             $userInfo = $userInfoRepository->getByEmail($mailAddress);
@@ -110,9 +108,7 @@ class BulkUserAssignCommand extends Command
             }
         }
 
-        /*
-         * Remove all users from the target group that are not part of the given CSV file if this option is selected.
-         */
+        // Remove all users from the target group that are not part of the given CSV file if this option is selected.
 
         if ($removeUnlistedUsers) {
             foreach ($targetGroup->getGroupMembers() as $groupMember) {
@@ -129,7 +125,8 @@ class BulkUserAssignCommand extends Command
             }
         }
 
-        $output->writeln(sprintf('<info>Done! %s user records are found in the given CSV. %s users were added to the target group and %s users were removed from target group. For further details please check the logs.</info>',
+        $output->writeln(sprintf(
+            '<info>Done! %s user records are found in the given CSV. %s users were added to the target group and %s users were removed from target group. For further details please check the logs.</info>',
             $totalUsersProvided,
             $totalUsersAddedToTargetGroup,
             $totalUsersRemovedFromTargetGroup
@@ -137,5 +134,4 @@ class BulkUserAssignCommand extends Command
 
         return static::SUCCESS;
     }
-
 }

--- a/concrete/src/Console/Command/ClearCacheCommand.php
+++ b/concrete/src/Console/Command/ClearCacheCommand.php
@@ -1,14 +1,15 @@
 <?php
+
 namespace Concrete\Core\Console\Command;
 
+use Concrete\Core\Cache\Command\ClearCacheCommand as ClearCacheCommandCommand;
 use Concrete\Core\Config\Repository\Repository;
 use Concrete\Core\Console\Command;
+use Core;
+use Exception;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Core;
-use Exception;
-use Concrete\Core\Cache\Command\ClearCacheCommand as ClearCacheCommandCommand;
 
 class ClearCacheCommand extends Command
 {
@@ -19,15 +20,16 @@ class ClearCacheCommand extends Command
         $this
             ->setName('c5:clear-cache')
             ->setDescription('Clear the cache')
-            ->addOption('thumbnails', 't', InputOption::VALUE_REQUIRED, "Should the thumbnails be removed from the cache? [Y/N]")
+            ->addOption('thumbnails', 't', InputOption::VALUE_REQUIRED, 'Should the thumbnails be removed from the cache? [Y/N]')
             ->addEnvOption()
             ->setCanRunAsRoot(false)
-            ->setHelp(<<<EOT
+            ->setHelp(
+                <<<EOT
 If the --thumbnails options is not specified, we'll use the last value set in the dashboard.
 
 Returns codes:
-  $okExitCode operation completed successfully
-  $errExitCode errors occurred
+  {$okExitCode} operation completed successfully
+  {$errExitCode} errors occurred
 
 More info at https://documentation.concretecms.org/9-x/developers/security/cli-jobs#c5-clear-cache
 EOT

--- a/concrete/src/Console/Command/CompareSchemaCommand.php
+++ b/concrete/src/Console/Command/CompareSchemaCommand.php
@@ -22,10 +22,11 @@ class CompareSchemaCommand extends Command
             ->setName('c5:compare-schema')
             ->setDescription('Compares db.xml in Concrete XML schema, Concrete entities, and all installed package schemas and entities with the contents of the database and prints the difference.')
             ->addEnvOption()
-            ->setHelp(<<<EOT
+            ->setHelp(
+                <<<EOT
 Returns codes:
-  $okExitCode operation completed successfully
-  $errExitCode errors occurred
+  {$okExitCode} operation completed successfully
+  {$errExitCode} errors occurred
 EOT
             )
         ;
@@ -89,7 +90,7 @@ EOT
             $i = 1;
             foreach ($saveQueries as $query) {
                 $output->writeln(sprintf('%s: %s', $i, $query));
-                ++$i;
+                $i++;
             }
         } else {
             $output->writeln(t('No differences found between schema and database.'));

--- a/concrete/src/Console/Command/ConfigCommand.php
+++ b/concrete/src/Console/Command/ConfigCommand.php
@@ -38,6 +38,7 @@ class ConfigCommand extends Command
                 return $this->doSetAction($repository, $item);
             default:
                 $this->output->error('Invalid action specified, please specify either "set" or "get"');
+
                 return static::FAILURE;
         }
     }

--- a/concrete/src/Console/Command/DenylistClear.php
+++ b/concrete/src/Console/Command/DenylistClear.php
@@ -22,14 +22,14 @@ class DenylistClear extends Command
      *
      * @var string
      */
-    const DELETE_AUTOMATIC_BANS_ALL = 'all';
+    public const DELETE_AUTOMATIC_BANS_ALL = 'all';
 
     /**
      * Value for the '--automatic-bans' option: expired bans.
      *
      * @var string
      */
-    const DELETE_AUTOMATIC_BANS_EXPIRED = 'expired';
+    public const DELETE_AUTOMATIC_BANS_EXPIRED = 'expired';
 
     protected function configure()
     {
@@ -46,15 +46,16 @@ class DenylistClear extends Command
             ->addOption('automatic-bans', 'b', InputOption::VALUE_REQUIRED, "Clear automatic bans (\"{$automaticBansExpired}\" to only delete expired bans, \"{$automaticBansAll}\" to delete the current bans too)")
             ->addOption('list', 'l', InputOption::VALUE_NONE, 'List the available IP Access Control Category handles')
             ->addOption('failed-login-age', 'f', InputOption::VALUE_REQUIRED, '*DEPRECATED* use --min-age')
-            ->setHelp(<<<EOT
+            ->setHelp(
+                <<<EOT
 You can use this command to clear the data related to IP address denylist.
 
 To clear the events data, use the --min-age option.
 To clear the automatic bans, use the --automatic-bans option.
 
 Returns codes:
-  $okExitCode operation completed successfully
-  $errExitCode errors occurred
+  {$okExitCode} operation completed successfully
+  {$errExitCode} errors occurred
 
 More info at https://documentation.concretecms.org/9-x/developers/security/cli-jobs#c5-denylist-clear
 EOT

--- a/concrete/src/Console/Command/ExecCommand.php
+++ b/concrete/src/Console/Command/ExecCommand.php
@@ -37,7 +37,7 @@ EOT
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if (!is_file($input->getArgument('script'))) {
             throw new Exception(sprintf('Unable to find the file %s', $input->getArgument('script')));

--- a/concrete/src/Console/Command/Express/ExportCommand.php
+++ b/concrete/src/Console/Command/Express/ExportCommand.php
@@ -14,23 +14,22 @@ use SplFileObject;
 
 class ExportCommand extends Command
 {
-
     /**
-     * Our command description
+     * Our command description.
      *
      * @var string
      */
     protected $description = 'Export express entries';
 
     /**
-     * The signature for this command
+     * The signature for this command.
      *
      * @var string
      */
     protected $signature = 'c5:express:export {entity : Which entity to export entries from}';
 
     /**
-     * Handle processing calls to this command
+     * Handle processing calls to this command.
      *
      * @param \Doctrine\ORM\EntityManagerInterface $entityManager
      * @param \Concrete\Core\Application\Application $app
@@ -51,12 +50,13 @@ class ExportCommand extends Command
         $repository = $entityManager->getRepository(Entity::class);
         /** @var Entity $entity */
         $entity = $repository->findOneBy([
-            'handle' => $entityHandle
+            'handle' => $entityHandle,
         ]);
 
         // Make sure we found a proper entity
         if (!$entity) {
             $this->output->error('Invalid entity handle.');
+
             return static::INVALID;
         }
 
@@ -64,7 +64,7 @@ class ExportCommand extends Command
     }
 
     /**
-     * Output the entries as CSV
+     * Output the entries as CSV.
      *
      * @param \Concrete\Core\Entity\Express\Entity $entity
      * @param \Concrete\Core\Application\Application $app
@@ -81,7 +81,7 @@ class ExportCommand extends Command
         $file = new SplFileObject('php://output', 'w');
         $csv = $factory->createFromFileObject($file);
         $writer = $app->make(CsvWriter::class, [
-            'writer' => $csv
+            'writer' => $csv,
         ]);
 
         // Insert BOM if needed
@@ -91,7 +91,7 @@ class ExportCommand extends Command
 
         // Write out data
         $entryList = $app->make(EntryList::class, [
-            'entity' => $entity
+            'entity' => $entity,
         ]);
         $entryList->ignorePermissions();
         $writer->insertHeaders($entity);
@@ -100,5 +100,4 @@ class ExportCommand extends Command
         // Success
         return static::SUCCESS;
     }
-
 }

--- a/concrete/src/Console/Command/GenerateFileIdentifiersCommand.php
+++ b/concrete/src/Console/Command/GenerateFileIdentifiersCommand.php
@@ -18,13 +18,19 @@ class GenerateFileIdentifiersCommand extends Command
         $this
             ->setName('c5:files:generate-identifiers')
             ->setDescription('Create unique identifiers for existing files.')
-            ->addOption('reset', 'a', InputOption::VALUE_NONE,
-                "Reset all generated unique identifiers.")
-            ->setHelp(<<<EOT
+            ->addOption(
+                'reset',
+                'a',
+                InputOption::VALUE_NONE,
+                'Reset all generated unique identifiers.'
+            )
+            ->setHelp(
+                <<<'EOT'
 This command will create unique identifiers for existing files. This is required for enabling
 the secure download feature.
 EOT
-            );
+            )
+        ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -51,7 +57,7 @@ EOT
 
         $entityManager->flush();
 
-        $output->writeln(sprintf("Unique identifier has been successfully changed for %s files.", $fileList->getTotalResults()));
+        $output->writeln(sprintf('Unique identifier has been successfully changed for %s files.', $fileList->getTotalResults()));
 
         return static::SUCCESS;
     }

--- a/concrete/src/Console/Command/GenerateIDESymbolsCommand.php
+++ b/concrete/src/Console/Command/GenerateIDESymbolsCommand.php
@@ -33,7 +33,7 @@ EOT
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $rc = static::SUCCESS;
         $what = $input->getArgument('generate-what');

--- a/concrete/src/Console/Command/GenerateIDESymbolsCommand.php
+++ b/concrete/src/Console/Command/GenerateIDESymbolsCommand.php
@@ -1,14 +1,14 @@
 <?php
+
 namespace Concrete\Core\Console\Command;
 
+use Concrete\Core\Console\Command;
 use Concrete\Core\Support\Symbol\ClassSymbol\ClassSymbol;
 use Concrete\Core\Support\Symbol\ClassSymbol\MethodSymbol\MethodSymbol;
-use Concrete\Core\Console\Command;
+use Exception;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Input\InputArgument;
-use Exception;
-use Core;
 
 class GenerateIDESymbolsCommand extends Command
 {
@@ -22,10 +22,11 @@ class GenerateIDESymbolsCommand extends Command
             ->addEnvOption()
             ->setCanRunAsRoot(false)
             ->addArgument('generate-what', InputArgument::IS_ARRAY, 'Elements to generate [all|ide-classes|phpstorm]', ['all'])
-            ->setHelp(<<<EOT
+            ->setHelp(
+                <<<EOT
 Returns codes:
-  $okExitCode operation completed successfully
-  $errExitCode errors occurred
+  {$okExitCode} operation completed successfully
+  {$errExitCode} errors occurred
 
 More info at https://documentation.concretecms.org/9-x/developers/security/cli-jobs#c5-ide-symbols
 EOT

--- a/concrete/src/Console/Command/GenerateSitemapCommand.php
+++ b/concrete/src/Console/Command/GenerateSitemapCommand.php
@@ -28,12 +28,13 @@ class GenerateSitemapCommand extends Command
             ->addOption('url', 'u', InputOption::VALUE_REQUIRED, 'The canonical URL of the site (required if no canonical URL is defined for the site).')
             ->addOption('output', 'o', InputOption::VALUE_REQUIRED, 'The full path of the file where the sitemap will be saved')
         ;
-        $this->setHelp(<<<EOT
+        $this->setHelp(
+            <<<EOT
 Returns codes:
   {$okExitCode} operation completed successfully
   {$errExitCode} errors occurred
 EOT
-            );
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -74,7 +75,7 @@ EOT
         $writer->generate(function (SitemapElement $element) use ($progressBar, &$numPages) {
             if ($element instanceof SitemapPage) {
                 $progressBar->advance();
-                ++$numPages;
+                $numPages++;
             }
         });
         $progressBar->clear();

--- a/concrete/src/Console/Command/InfoCommand.php
+++ b/concrete/src/Console/Command/InfoCommand.php
@@ -28,7 +28,7 @@ EOT
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $app = app();
         $info = $app->make(Info::class);

--- a/concrete/src/Console/Command/InfoCommand.php
+++ b/concrete/src/Console/Command/InfoCommand.php
@@ -1,11 +1,12 @@
 <?php
+
 namespace Concrete\Core\Console\Command;
 
 use Concrete\Core\Console\Command;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 use Concrete\Core\System\Info;
 use Concrete\Core\System\SystemUser;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class InfoCommand extends Command
 {
@@ -17,10 +18,11 @@ class InfoCommand extends Command
             ->setName('c5:info')
             ->setDescription('Get detailed information about this installation.')
             ->addEnvOption()
-            ->setHelp(<<<EOT
+            ->setHelp(
+                <<<EOT
 Returns codes:
-  $okExitCode operation completed successfully
-  $errExitCode errors occurred
+  {$okExitCode} operation completed successfully
+  {$errExitCode} errors occurred
 
 More info at https://documentation.concretecms.org/9-x/developers/security/cli-jobs#c5-info
 EOT

--- a/concrete/src/Console/Command/InstallCommand.php
+++ b/concrete/src/Console/Command/InstallCommand.php
@@ -97,7 +97,7 @@ EOT
             );
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $app = Application::getFacadeApplication();
         if ($app->isInstalled()) {

--- a/concrete/src/Console/Command/InstallCommand.php
+++ b/concrete/src/Console/Command/InstallCommand.php
@@ -28,31 +28,28 @@ class InstallCommand extends Command
 {
     /**
      * @var int
-     * @access private
      */
-    const OPTIONPRECONDITIONS_ERROR = 1;
+    public const OPTIONPRECONDITIONS_ERROR = 1;
 
     /**
      * @var int
-     * @access private
      */
-    const OPTIONPRECONDITIONS_WARNINGS = 2;
+    public const OPTIONPRECONDITIONS_WARNINGS = 2;
 
     /**
      * @var int
-     * @access private
      */
-    const OPTIONPRECONDITIONS_SUCCESS = 3;
+    public const OPTIONPRECONDITIONS_SUCCESS = 3;
 
     /**
      * @var bool|null
      */
-    private $preconditionsPassed = null;
+    private $preconditionsPassed;
 
     /**
      * @var Installer|null
      */
-    private $configuredInstaller = null;
+    private $configuredInstaller;
 
     protected function configure()
     {
@@ -87,14 +84,16 @@ class InstallCommand extends Command
             ->addOption('disable-marketplace-connect', null, InputOption::VALUE_NONE, 'Do not automatically connect site to marketplace')
             ->addOption('defer-installation', null, InputOption::VALUE_NONE, 'Defer installation to a later point; do not write the final configuration files necessary to complete installation')
             ->addOption('ignore-warnings', null, InputOption::VALUE_NONE, 'Ignore warnings')
-            ->setHelp(<<<EOT
+            ->setHelp(
+                <<<EOT
 Returns codes:
-  $okExitCode operation completed successfully
-  $errExitCode errors occurred
+  {$okExitCode} operation completed successfully
+  {$errExitCode} errors occurred
 
 More info at https://documentation.concretecms.org/9-x/developers/security/cli-jobs#c5-install
 EOT
-            );
+            )
+        ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -174,7 +173,7 @@ EOT
             throw $ex;
         }
         if (
-            isset($options['demo-username']) && isset($options['demo-password']) && isset($options['demo-email'])
+            isset($options['demo-username'], $options['demo-password'], $options['demo-email'])
             &&
             ((string) $options['demo-username'] !== '') && ((string) $options['demo-password'] !== '') && ((string) $options['demo-email'] !== '')
         ) {
@@ -206,9 +205,9 @@ EOT
         if ($input->getOption('interactive')) {
             $app = Application::getFacadeApplication();
             $helper = $this->getHelper('question');
-            /* @var \Symfony\Component\Console\Helper\QuestionHelper $helper */
+            // @var \Symfony\Component\Console\Helper\QuestionHelper $helper
 
-            for (; ;) {
+            for (;;) {
                 // Get the wizard generator
                 $wizard = $this->getWizard($input, $output);
                 $hidden = [];
@@ -414,7 +413,7 @@ EOT
                 $firstKey = null;
             }
 
-            if (in_array($question[0], ['demo-password', 'demo-email'], true) && '' === (string) $input->getOption('demo-username')) {
+            if (in_array($question[0], ['demo-password', 'demo-email'], true) && (string) $input->getOption('demo-username') === '') {
                 continue;
             }
 
@@ -439,7 +438,7 @@ EOT
      */
     private function getQuestionString(InputOption $option, $default)
     {
-        if ('' !== (string) $default) {
+        if ((string) $default !== '') {
             if (stripos($option->getName(), 'password') !== false) {
                 return sprintf('%s? [<options=bold>HIDDEN</>]: ', $option->getDescription(), $default);
             }
@@ -523,7 +522,7 @@ EOT
                 'starting-point',
                 'atomik_blank',
                 function (Question $question, InputInterface $input) {
-                    $available = array_map(function($item) { return $item->getPackageHandle(); }, StartingPointPackage::getAvailableList());
+                    $available = array_map(function ($item) { return $item->getPackageHandle(); }, StartingPointPackage::getAvailableList());
                     $available = array_unique(array_merge($available, ['atomik_blank', 'elemental_full', 'atomik_full']));
 
                     return new ChoiceQuestion($question->getQuestion(), $available, $question->getDefault());
@@ -618,7 +617,7 @@ EOT
     {
         $result = true;
         $service = $app->make(PreconditionService::class);
-        /* @var PreconditionService $service */
+        // @var PreconditionService $service
         $requiredPreconditions = [];
         $optionalPreconditions = [];
         foreach ($service->getPreconditions(false) as $precondition) {
@@ -698,7 +697,7 @@ EOT
                 throw new Exception('The configuration file did not returned an array.');
             }
             foreach ($configOptions as $k => $v) {
-                if (!$input->hasParameterOption("--$k")) {
+                if (!$input->hasParameterOption("--{$k}")) {
                     $options[$k] = $v;
                 }
             }
@@ -744,8 +743,8 @@ EOT
                 'canonical-url' => $options['canonical-url'] ?: '',
                 'canonical-url-alternative' => $options['canonical-url-alternative'] ?: '',
             ])
-            ->setSiteLocaleId(isset($options['site-locale']) ? $options['site-locale'] : Localization::BASE_LOCALE)
-            ->setUiLocaleId(isset($options['language']) ? $options['language'] : Localization::BASE_LOCALE)
+            ->setSiteLocaleId($options['site-locale'] ?? Localization::BASE_LOCALE)
+            ->setUiLocaleId($options['language'] ?? Localization::BASE_LOCALE)
             ->setAutoAttachEnabled($options['auto_attach'])
             ->setStartingPointHandle($options['starting-point'])
             ->setSiteName($options['site'])
@@ -753,7 +752,7 @@ EOT
             ->setUserPasswordHash($hasher->hashPassword($options['admin-password']))
             ->setServerTimeZoneId($options['timezone'])
             ->setIsConnectToMarketplaceEnabled($options['disable-marketplace-connect'] ? false : true)
-            ->setDeferInstallation($options['defer-installation'] ? true : false);
+            ->setDeferInstallation($options['defer-installation'] ? true : false)
         ;
 
         return $installer;
@@ -840,10 +839,11 @@ EOT
 
         if ($result === false) {
             return self::OPTIONPRECONDITIONS_ERROR;
-        } elseif ($someWarnings === true) {
-            return self::OPTIONPRECONDITIONS_WARNINGS;
-        } else {
-            return self::OPTIONPRECONDITIONS_SUCCESS;
         }
+        if ($someWarnings === true) {
+            return self::OPTIONPRECONDITIONS_WARNINGS;
+        }
+
+        return self::OPTIONPRECONDITIONS_SUCCESS;
     }
 }

--- a/concrete/src/Console/Command/InstallLanguageCommand.php
+++ b/concrete/src/Console/Command/InstallLanguageCommand.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\Console\Command;
 
 use Concrete\Core\Console\Command;
@@ -41,16 +42,17 @@ class InstallLanguageCommand extends Command
         $okExitCode = static::SUCCESS;
         $errExitCode = static::FAILURE;
         $this
-        ->setName('c5:language-install')
-        ->setAliases(['c5:install-language'])
-        ->setDescription('Install or update Concrete languages')
-        ->addEnvOption()
-        ->setCanRunAsRoot(false)
-        ->addOption('--update', 'u', InputOption::VALUE_NONE, 'Update any outdated language files')
-        ->addOption('--add', 'a', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Add new language files')
-        ->addOption('--core', 'c', InputOption::VALUE_NONE, 'Process only a the core')
-        ->addOption('--packages', 'p', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Process only packages (you can specify one or more package handle too)')
-        ->setHelp(<<<EOT
+            ->setName('c5:language-install')
+            ->setAliases(['c5:install-language'])
+            ->setDescription('Install or update Concrete languages')
+            ->addEnvOption()
+            ->setCanRunAsRoot(false)
+            ->addOption('--update', 'u', InputOption::VALUE_NONE, 'Update any outdated language files')
+            ->addOption('--add', 'a', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'Add new language files')
+            ->addOption('--core', 'c', InputOption::VALUE_NONE, 'Process only a the core')
+            ->addOption('--packages', 'p', InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Process only packages (you can specify one or more package handle too)')
+            ->setHelp(
+                <<<EOT
 Examples:
             
 # to update all the outdated language files (for the core and for all the packages)
@@ -72,12 +74,13 @@ $ concrete/bin/concrete c5:language-install --add it_IT --add de_DE
 $ concrete/bin/concrete c5:language-install --add it_IT --add de_DE --core
             
 Returns codes:
-  $okExitCode operation completed successfully
-  $errExitCode errors occurred
+  {$okExitCode} operation completed successfully
+  {$errExitCode} errors occurred
             
 More info at https://documentation.concretecms.org/9-x/developers/security/cli-jobs#c5-language-install
 EOT
-            );
+            )
+        ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -143,7 +146,7 @@ EOT
                 $pkgList = [];
             }
             $ps = $this->app->make(PackageService::class);
-            /* @var PackageService $ps */
+            // @var PackageService $ps
             $allPackages = $ps->getAvailablePackages(false);
             if (count($pkgList) === 0) {
                 $result = $allPackages;
@@ -246,7 +249,7 @@ EOT
                     $this->translationsInstaller->installPackageTranslations($package, $localeID);
                 }
                 $this->shouldClearLocalizationCache = true;
-                ++$result;
+                $result++;
                 if ($this->output->getVerbosity() > OutputInterface::VERBOSITY_NORMAL) {
                     $this->output->writeln('done.');
                 }
@@ -279,7 +282,7 @@ EOT
         $numAdded = 0;
         foreach ($data as $details) {
             if ($this->addLanguageFor($details->getOnlyRemote(), $localeID, ($details instanceof PackageLocaleStatus) ? $details->getPackage() : null)) {
-                ++$numAdded;
+                $numAdded++;
             }
         }
         if ($this->output->getVerbosity() >= OutputInterface::VERBOSITY_NORMAL) {

--- a/concrete/src/Console/Command/InstallLanguageCommand.php
+++ b/concrete/src/Console/Command/InstallLanguageCommand.php
@@ -32,11 +32,6 @@ class InstallLanguageCommand extends Command
     protected $translationsInstaller;
 
     /**
-     * @var OutputInterface|null
-     */
-    protected $output;
-
-    /**
      * @var bool|null
      */
     protected $shouldClearLocalizationCache;
@@ -85,7 +80,7 @@ EOT
             );
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if (!$input->getOption('update') && count($input->getOption('add')) === 0) {
             throw new Exception('Please specify at least the --update or the --add option');
@@ -94,7 +89,6 @@ EOT
         $this->app = Application::getFacadeApplication();
         $this->translationsChecker = $this->app->make(TranslationsChecker::class);
         $this->translationsInstaller = $this->app->make(TranslationsInstaller::class);
-        $this->output = $output;
         $this->shouldClearLocalizationCache = false;
 
         $processCore = $this->checkCoreFlag($input);

--- a/concrete/src/Console/Command/InstallPackageCommand.php
+++ b/concrete/src/Console/Command/InstallPackageCommand.php
@@ -37,10 +37,11 @@ class InstallPackageCommand extends Command
             ->setCanRunAsRoot(false)
             ->addArgument('package', InputArgument::REQUIRED, 'The handle of the package to be installed')
             ->addArgument('package-options', InputArgument::IS_ARRAY, 'List of key-value pairs to pass to the package install routine (example: foo=bar baz=foo)')
-            ->setHelp(<<<EOT
+            ->setHelp(
+                <<<EOT
 Returns codes:
-  $okExitCode operation completed successfully
-  $errExitCode errors occurred
+  {$okExitCode} operation completed successfully
+  {$errExitCode} errors occurred
 
 More info at https://documentation.concretecms.org/9-x/developers/security/cli-jobs#c5-package-install
 EOT
@@ -77,7 +78,7 @@ EOT
         }
         $packageOptions = [];
         foreach ($input->getArgument('package-options') as $keyValuePair) {
-            list($key, $value) = explode('=', $keyValuePair, 2);
+            [$key, $value] = explode('=', $keyValuePair, 2);
             $key = trim($key);
             if (substr($key, -2) === '[]') {
                 $isArray = true;
@@ -98,7 +99,7 @@ EOT
             }
         }
 
-        $output->write("Looking for package '$pkgHandle'... ");
+        $output->write("Looking for package '{$pkgHandle}'... ");
         foreach ($packageService->getInstalledList() as $installed) {
             if ($installed->getPackageHandle() === $pkgHandle) {
                 throw new Exception(sprintf("The package '%s' (%s) is already installed", $pkgHandle, $installed->getPackageName()));
@@ -149,7 +150,7 @@ EOT
                     } elseif ($result === false) {
                         $output->writeln(" - {$localeID}: <error>non available</error>");
                     } else {
-                        $output->writeln(" - $localeID: <error>" . ((string) $result) . '</error>');
+                        $output->writeln(" - {$localeID}: <error>" . ((string) $result) . '</error>');
                     }
                 }
             }
@@ -164,9 +165,9 @@ EOT
                 $contentSwapTemplateNames = [];
                 $index = 1;
 
-                foreach($pkg->getContentSwapFiles() as $contentSwapFile => $contentSwapTemplateName) {
+                foreach ($pkg->getContentSwapFiles() as $contentSwapFile => $contentSwapTemplateName) {
                     $contentSwapFiles[$index] = $contentSwapFile;
-                    $contentSwapTemplateNames[] = sprintf("%s: %s", $index, $contentSwapTemplateName);
+                    $contentSwapTemplateNames[] = sprintf('%s: %s', $index, $contentSwapTemplateName);
                     $index++;
                 }
                 $io = new SymfonyStyle($input, $output);
@@ -176,7 +177,7 @@ EOT
                 $selectedContentSwapFile = $helper->ask($input, $output, new Question('Select the number of the content swap file you want to install: ', 1));
 
                 if (isset($contentSwapFiles[$selectedContentSwapFile])) {
-                    $options["contentSwapFile"] = $contentSwapFiles[$selectedContentSwapFile];
+                    $options['contentSwapFile'] = $contentSwapFiles[$selectedContentSwapFile];
                 }
             }
 

--- a/concrete/src/Console/Command/InstallThemeCommand.php
+++ b/concrete/src/Console/Command/InstallThemeCommand.php
@@ -1,11 +1,12 @@
 <?php
+
 namespace Concrete\Core\Console\Command;
 
 use Concrete\Core\Console\Command;
-use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\Page\Theme\Theme;
-use Loader;
+use Concrete\Core\Support\Facade\Application;
 use Exception;
+use Loader;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -15,10 +16,11 @@ class InstallThemeCommand extends Command
     protected function configure()
     {
         $this->setName('c5:theme:install')
-        ->addOption('activate', 'a', InputOption::VALUE_NONE, 'Activate this theme after install', null)
-        ->setDescription('Install a Concrete Theme')
-        ->setCanRunAsRoot(false)
-        ->addArgument('theme-handle', null, InputOption::VALUE_REQUIRED, 'The handle name of the theme');
+            ->addOption('activate', 'a', InputOption::VALUE_NONE, 'Activate this theme after install', null)
+            ->setDescription('Install a Concrete Theme')
+            ->setCanRunAsRoot(false)
+            ->addArgument('theme-handle', null, InputOption::VALUE_REQUIRED, 'The handle name of the theme')
+        ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)

--- a/concrete/src/Console/Command/IsInstalledCommand.php
+++ b/concrete/src/Console/Command/IsInstalledCommand.php
@@ -10,9 +10,11 @@ use Throwable;
 
 class IsInstalledCommand extends Command
 {
-    const CONCRETE_IS_INSTALLED = self::SUCCESS;
-    const CONCRETE_IS_NOT_INSTALLED = 1;
-    const FAILURE = 2;
+    public const CONCRETE_IS_INSTALLED = self::SUCCESS;
+
+    public const CONCRETE_IS_NOT_INSTALLED = 1;
+
+    public const FAILURE = 2;
 
     protected function configure()
     {
@@ -24,13 +26,14 @@ class IsInstalledCommand extends Command
             ->setName('c5:is-installed')
             ->setDescription('Check if Concrete is already installed')
             ->addEnvOption()
-            ->setHelp(<<<EOT
+            ->setHelp(
+                <<<EOT
 This command will print out if Concrete CMS is already installed (unless the --quiet option is specified),
 and set the following return codes
 
-  $installedExitCode Concrete is installed
-  $notInstalledExitCode Concrete is not installed
-  $errExitCode errors occurred
+  {$installedExitCode} Concrete is installed
+  {$notInstalledExitCode} Concrete is not installed
+  {$errExitCode} errors occurred
 EOT
             )
         ;
@@ -48,6 +51,7 @@ EOT
             return $isInstalled ? static::CONCRETE_IS_INSTALLED : static::CONCRETE_IS_NOT_INSTALLED;
         } catch (Throwable $error) {
             $this->writeError($output, $error);
+
             return static::FAILURE;
         }
     }

--- a/concrete/src/Console/Command/IsInstalledCommand.php
+++ b/concrete/src/Console/Command/IsInstalledCommand.php
@@ -36,7 +36,7 @@ EOT
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         try {
             $app = Application::getFacadeApplication();

--- a/concrete/src/Console/Command/JobCommand.php
+++ b/concrete/src/Console/Command/JobCommand.php
@@ -1,11 +1,12 @@
 <?php
+
 namespace Concrete\Core\Console\Command;
 
+use Concrete\Core\Console\Command;
 use Concrete\Core\Console\ConsoleAwareInterface;
 use Job;
 use JobSet;
 use RuntimeException;
-use Concrete\Core\Console\Command;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -29,10 +30,11 @@ class JobCommand extends Command
                 InputArgument::IS_ARRAY,
                 t('Jobs to run (separate multiple jobs with a space)')
             )
-            ->setHelp(<<<EOT
+            ->setHelp(
+                <<<EOT
 Returns codes:
-  $okExitCode operation completed successfully
-  $errExitCode errors occurred
+  {$okExitCode} operation completed successfully
+  {$errExitCode} errors occurred
 
 More info at https://documentation.concretecms.org/9-x/developers/security/cli-jobs#c5-job
 EOT
@@ -119,7 +121,8 @@ EOT
                         if ($output->getVerbosity() >= OutputInterface::VERBOSITY_NORMAL) {
                             $output->writeln(
                                 $formatter->formatSection(
-                                    $job->getJobHandle(), '<error>' . t('Job Failed: %s', $result->getResultMessage()) . '</error>'
+                                    $job->getJobHandle(),
+                                    '<error>' . t('Job Failed: %s', $result->getResultMessage()) . '</error>'
                                 )
                             );
                         }

--- a/concrete/src/Console/Command/PackPackageCommand.php
+++ b/concrete/src/Console/Command/PackPackageCommand.php
@@ -28,98 +28,98 @@ final class PackPackageCommand extends Command
      *
      * @var string
      */
-    const SHORTTAGS_ALL = 'all';
+    public const SHORTTAGS_ALL = 'all';
 
     /**
      * Convert short PHP tags to long PHP tags (excluding short echo tags).
      *
      * @var string
      */
-    const SHORTTAGS_KEEPECHO = 'keep-echo';
+    public const SHORTTAGS_KEEPECHO = 'keep-echo';
 
     /**
      * Use SHORTTAGS_ALL for Concrete 5.x packages, SHORTTAGS_KEEPECHO for Concrete 8+ packages.
      *
      * @var string
      */
-    const SHORTTAGS_AUTO = 'auto';
+    public const SHORTTAGS_AUTO = 'auto';
 
     /**
      * Do not convert any short PHP tags.
      *
      * @var string
      */
-    const SHORTTAGS_NO = 'no';
+    public const SHORTTAGS_NO = 'no';
 
     /**
      * Keep files starting with a dot.
      *
      * @var string
      */
-    const KEEP_DOT = 'dot';
+    public const KEEP_DOT = 'dot';
 
     /**
      * Keep translation .po files and icon source .svg files.
      *
      * @var string
      */
-    const KEEP_SOURCES = 'sources';
+    public const KEEP_SOURCES = 'sources';
 
     /**
      * Keep composer.json files.
      *
      * @var string
      */
-    const KEEP_COMPOSER_JSON = 'composer-json';
+    public const KEEP_COMPOSER_JSON = 'composer-json';
 
     /**
      * Keep composer.json and composer.lock files.
      *
      * @var string
      */
-    const KEEP_COMPOSER_LOCK = 'composer-lock';
+    public const KEEP_COMPOSER_LOCK = 'composer-lock';
 
     /**
      * Keep tests directory.
      *
      * @var string
      */
-    const KEEP_TESTS = 'tests';
+    public const KEEP_TESTS = 'tests';
 
     /**
      * Keep phpunit.xml file.
      *
      * @var string
      */
-    const KEEP_PHPUNIT_XML = 'phpunitxml';
+    public const KEEP_PHPUNIT_XML = 'phpunitxml';
 
     /**
      * Option for boolean/automatic flags: yes.
      *
      * @var string
      */
-    const YNA_YES = 'yes';
+    public const YNA_YES = 'yes';
 
     /**
      * Option for boolean/automatic flags: automatic.
      *
      * @var string
      */
-    const YNA_AUTO = 'auto';
+    public const YNA_AUTO = 'auto';
 
     /**
      * Option for boolean/automatic flags: no.
      *
      * @var string
      */
-    const YNA_NO = 'no';
+    public const YNA_NO = 'no';
 
     /**
      * Value of the zip option to be used to automatically determine the .zip file name.
      *
      * @var string
      */
-    const ZIPOUT_AUTO = '-';
+    public const ZIPOUT_AUTO = '-';
 
     /**
      * Execute the command.
@@ -173,26 +173,27 @@ final class PackPackageCommand extends Command
             ->addOption('zip', 'z', InputOption::VALUE_OPTIONAL, 'Create a zip archive of the package (and optionally set its path)', self::ZIPOUT_AUTO)
             ->addOption('copy', 'c', InputOption::VALUE_REQUIRED, 'Copy the package files to another directory')
             ->addOption('overwrite', 'o', InputOption::VALUE_NONE, 'Copy the package files to another directory even if it already exists')
-            ->setHelp(<<<EOT
+            ->setHelp(
+                <<<EOT
 You have to specify at least the -z option (to create a zip file) and/or the -u option (to update the package directory).
 
 If the -u option is not specified, the package directory is not touched.
 
-If the -z option is specified without a value (or with a value of "$zipAuto"), the zip file will be created in the directory containing the package folder.
+If the -z option is specified without a value (or with a value of "{$zipAuto}"), the zip file will be created in the directory containing the package folder.
 If the -z option is set and the zip file already exists, it will be overwritten.
 
-To include in the zip archive the files and directories starting with a dot, use the "-k $keepDot" option.
-To include in the zip archive the source files for translations (.po files) and icons (.svg files) use the "-k $keepSources" option.
-To include in the zip archive the composer.json and composer.lock files, use the "-k $keepComposerLock" option.
-To include in the zip archive the composer.json file but not the composer.lock files, use the "-k $keepComposerJson" option.
-To include in the zip archive the tests directory, use the "-k $tests" option.
-To include in the zip archive the phpunit.xml file, use the "-k $phpunitxml" option.
+To include in the zip archive the files and directories starting with a dot, use the "-k {$keepDot}" option.
+To include in the zip archive the source files for translations (.po files) and icons (.svg files) use the "-k {$keepSources}" option.
+To include in the zip archive the composer.json and composer.lock files, use the "-k {$keepComposerLock}" option.
+To include in the zip archive the composer.json file but not the composer.lock files, use the "-k {$keepComposerJson}" option.
+To include in the zip archive the tests directory, use the "-k {$tests}" option.
+To include in the zip archive the phpunit.xml file, use the "-k {$phpunitxml}" option.
 
 Please remark that this command can also parse legacy (pre-5.7) packages.
 
 Returns codes:
-  $okExitCode operation completed successfully
-  $errExitCode errors occurred
+  {$okExitCode} operation completed successfully
+  {$errExitCode} errors occurred
 
 More info at https://documentation.concretecms.org/9-x/developers/security/cli-jobs#c5-package-pack
 EOT

--- a/concrete/src/Console/Command/PhpCodingStyleCommand.php
+++ b/concrete/src/Console/Command/PhpCodingStyleCommand.php
@@ -108,11 +108,11 @@ EOT
      *
      * @see \Concrete\Core\Console\Command::initialize()
      */
-    protected function initialize(InputInterface $input, OutputInterface $output)
+    protected function initialize(InputInterface $input, OutputInterface $output): void
     {
         $this->canRunAsRoot = $input->getArgument('action') !== 'fix';
 
-        return parent::initialize($input, $output);
+        parent::initialize($input, $output);
     }
 
     /**

--- a/concrete/src/Console/Command/PhpCodingStyleCommand.php
+++ b/concrete/src/Console/Command/PhpCodingStyleCommand.php
@@ -4,6 +4,7 @@ namespace Concrete\Core\Console\Command;
 
 use Concrete\Core\Console\Command;
 use Concrete\Core\Error\UserMessageException;
+use Concrete\Core\Events\EventDispatcher;
 use Concrete\Core\Support\CodingStyle\PhpFixer;
 use Concrete\Core\Support\CodingStyle\PhpFixerOptions;
 use PhpCsFixer\Error\ErrorsManager;
@@ -12,7 +13,6 @@ use RuntimeException;
 use SplFileInfo;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Concrete\Core\Events\EventDispatcher;
 
 class PhpCodingStyleCommand extends Command
 {
@@ -70,10 +70,10 @@ EOT
             ->setIsCacheDisabled($this->input->getOption('no-cache'))
             ->setMinimumPhpVersion($this->input->getOption('php'))
         ;
-        list($counters, $changes, $errors) = $fixer->fix($this->input, $this->output, $splFileInfos, $dryRun);
-        /* @var array $counters */
-        /* @var array $changes */
-        /* @var \PhpCsFixer\Error\ErrorsManager $errors */
+        [$counters, $changes, $errors] = $fixer->fix($this->input, $this->output, $splFileInfos, $dryRun);
+        // @var array $counters
+        // @var array $changes
+        // @var \PhpCsFixer\Error\ErrorsManager $errors
         $this->printChanges($changes, $dryRun);
         $this->printErrors($errors, $dryRun);
         $this->printCountersTable($counters, $dryRun);
@@ -89,7 +89,8 @@ EOT
         $okExitCode = static::SUCCESS;
         $errExitCode = static::FAILURE;
 
-        $this->setHelp(<<<EOT
+        $this->setHelp(
+            <<<EOT
 Check or fix the PHP coding style.
 
 Return values when checking the coding style:

--- a/concrete/src/Console/Command/RefreshBoardsCommand.php
+++ b/concrete/src/Console/Command/RefreshBoardsCommand.php
@@ -13,52 +13,13 @@ use Symfony\Component\Console\Input\InputOption;
 
 class RefreshBoardsCommand extends Command
 {
-    protected function configure()
-    {
-        $okExitCode = static::SUCCESS;
-        $errExitCode = static::FAILURE;
-
-        $this
-            ->setName('c5:boards:refresh')
-            ->setDescription('Add content to boards and board instances.')
-            ->addOption('--all',  'a',InputOption::VALUE_NONE,
-    'Refreshes and regenerates boards.')
-            ->addArgument('boardID', InputArgument::OPTIONAL)
-            ->setHelp(<<<EOT
-This command will add content to specified boards or board instances.
-
-  {$okExitCode} operation completed successfully
-  {$errExitCode} errors occurred
-EOT
-            )
-        ;
-    }
-
-    protected function refreshBoard(Application $app, EntityManager $em, int $boardID)
-    {
-        $board = $em->find(Board::class, $boardID); // we do this because em->clear() clears out the board.
-        $this->output->writeln(t('Retrieving instances from board: %s', $board->getBoardName()));
-        $instances = $board->getInstances();
-        foreach($instances as $instance) {
-            $this->refreshInstance($app, $instance);
-        }
-        $em->clear();
-    }
-
-    protected function refreshInstance(Application $app, Instance $instance)
-    {
-        $this->output->writeln(t('** Regenerating board instance: %s', $instance->getBoardInstanceName()));
-        $command = new RegenerateBoardInstanceCommand();
-        $command->setInstance($instance);
-        $app->executeCommand($command);
-    }
-
     public function handle(Application $app, EntityManager $em)
     {
         if ($this->input->getOption('all')) {
             $boards = $em->getRepository(Board::class)
-                ->findAll();
-            foreach($boards as $board) {
+                ->findAll()
+            ;
+            foreach ($boards as $board) {
                 $this->refreshBoard($app, $em, $board->getBoardID());
             }
         } else {
@@ -74,6 +35,52 @@ EOT
                 throw new \Exception(t('You must specify a board ID or use the --all option.'));
             }
         }
+
         return static::SUCCESS;
+    }
+
+    protected function configure()
+    {
+        $okExitCode = static::SUCCESS;
+        $errExitCode = static::FAILURE;
+
+        $this
+            ->setName('c5:boards:refresh')
+            ->setDescription('Add content to boards and board instances.')
+            ->addOption(
+                '--all',
+                'a',
+                InputOption::VALUE_NONE,
+                'Refreshes and regenerates boards.'
+            )
+            ->addArgument('boardID', InputArgument::OPTIONAL)
+            ->setHelp(
+                <<<EOT
+This command will add content to specified boards or board instances.
+
+  {$okExitCode} operation completed successfully
+  {$errExitCode} errors occurred
+EOT
+            )
+        ;
+    }
+
+    protected function refreshBoard(Application $app, EntityManager $em, int $boardID)
+    {
+        $board = $em->find(Board::class, $boardID); // we do this because em->clear() clears out the board.
+        $this->output->writeln(t('Retrieving instances from board: %s', $board->getBoardName()));
+        $instances = $board->getInstances();
+        foreach ($instances as $instance) {
+            $this->refreshInstance($app, $instance);
+        }
+        $em->clear();
+    }
+
+    protected function refreshInstance(Application $app, Instance $instance)
+    {
+        $this->output->writeln(t('** Regenerating board instance: %s', $instance->getBoardInstanceName()));
+        $command = new RegenerateBoardInstanceCommand();
+        $command->setInstance($instance);
+        $app->executeCommand($command);
     }
 }

--- a/concrete/src/Console/Command/RefreshEntitiesCommand.php
+++ b/concrete/src/Console/Command/RefreshEntitiesCommand.php
@@ -4,12 +4,12 @@ namespace Concrete\Core\Console\Command;
 
 use Concrete\Core\Console\Command;
 use Concrete\Core\Database\DatabaseStructureManager;
+use Concrete\Core\Events\EventDispatcher;
 use Concrete\Core\Package\Event\PackageEntities;
 use Concrete\Core\Support\Facade\Application;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Concrete\Core\Events\EventDispatcher;
 
 class RefreshEntitiesCommand extends Command
 {
@@ -23,7 +23,8 @@ class RefreshEntitiesCommand extends Command
             ->setDescription('Refresh the Doctrine database entities')
             ->addEnvOption()
             ->setCanRunAsRoot(false)
-            ->setHelp(<<<EOT
+            ->setHelp(
+                <<<EOT
 This command will refresh the Doctrine database entities and set the following return codes
 
   {$okExitCode} operation completed successfully

--- a/concrete/src/Console/Command/RescanFilesCommand.php
+++ b/concrete/src/Console/Command/RescanFilesCommand.php
@@ -4,20 +4,8 @@ namespace Concrete\Core\Console\Command;
 
 use Concrete\Core\Console\Command;
 use Concrete\Core\Database\Connection\Connection;
-use Concrete\Core\Entity\File\File;
 use Concrete\Core\File\Command\RescanFileCommand;
-use Concrete\Core\File\FileList;
-use Concrete\Core\File\Image\Thumbnail\Path\Resolver as ThumbnailPathResolver;
-use Concrete\Core\File\Image\Thumbnail\Type\Type as ThumbnailType;
-use Concrete\Core\File\Importer;
-use Concrete\Core\File\ImportProcessor\AutorotateImageProcessor;
-use Concrete\Core\File\ImportProcessor\ConstrainImageProcessor;
-use Concrete\Core\File\Type\Type as FileType;
-use Concrete\Core\Search\Pagination\PaginationFactory;
-use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\Support\Facade\Facade;
-use Doctrine\ORM\EntityManager;
-use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -29,8 +17,9 @@ class RescanFilesCommand extends Command
         $this
             ->setName('c5:rescan-files')
             ->setDescription('Rescans all files in the file manager.')
-            ->addOption('after',  'a',InputOption::VALUE_REQUIRED, 'Rescan files after a particular file ID.')
-            ->addOption('limit',  'l',InputOption::VALUE_REQUIRED, 'Limit the number of files to scan in this batch');
+            ->addOption('after', 'a', InputOption::VALUE_REQUIRED, 'Rescan files after a particular file ID.')
+            ->addOption('limit', 'l', InputOption::VALUE_REQUIRED, 'Limit the number of files to scan in this batch')
+        ;
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
@@ -39,7 +28,7 @@ class RescanFilesCommand extends Command
         $app = Facade::getFacadeApplication();
         $db = $app->make(Connection::class);
         /**
-         * @var $db Connection
+         * @var Connection $db
          */
         $query = $db->createQueryBuilder();
         $query->select('fID')->from('Files', 'f');
@@ -52,13 +41,14 @@ class RescanFilesCommand extends Command
             $query->setMaxResults($input->getOption('limit'));
         }
         $count = 0;
-        foreach($query->execute()->fetchAll() as $result) {
+        foreach ($query->execute()->fetchAll() as $result) {
             $command = new RescanFileCommand($result['fID']);
             $output->writeln(t('Rescanning file ID: %s', $result['fID']));
             $app->executeCommand($command);
             $count++;
         }
         $output->writeln("{$count} files rescanned.");
+
         return static::SUCCESS;
     }
 }

--- a/concrete/src/Console/Command/ResetCommand.php
+++ b/concrete/src/Console/Command/ResetCommand.php
@@ -33,7 +33,7 @@ EOT
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         if (!$input->getOption('force')) {
             if (!$input->isInteractive()) {

--- a/concrete/src/Console/Command/ResetCommand.php
+++ b/concrete/src/Console/Command/ResetCommand.php
@@ -1,13 +1,14 @@
 <?php
+
 namespace Concrete\Core\Console\Command;
 
 use Concrete\Core\Console\Command;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
-use Database;
 use Core;
+use Database;
 use Exception;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 class ResetCommand extends Command
@@ -22,10 +23,11 @@ class ResetCommand extends Command
             ->addEnvOption()
             ->setCanRunAsRoot(false)
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Force the reset')
-            ->setHelp(<<<EOT
+            ->setHelp(
+                <<<EOT
 Returns codes:
-  $okExitCode operation completed successfully
-  $errExitCode errors occurred
+  {$okExitCode} operation completed successfully
+  {$errExitCode} errors occurred
 
 More info at https://documentation.concretecms.org/9-x/developers/security/cli-jobs#c5-reset
 EOT
@@ -37,7 +39,7 @@ EOT
     {
         if (!$input->getOption('force')) {
             if (!$input->isInteractive()) {
-                throw new Exception("You have to specify the --force option in order to run this command");
+                throw new Exception('You have to specify the --force option in order to run this command');
             }
             $confirmQuestion = new ConfirmationQuestion(
                 'Are you sure you want to reset this Concrete installation? ' .
@@ -45,14 +47,14 @@ EOT
                 false
             );
             if (!$this->getHelper('question')->ask($input, $output, $confirmQuestion)) {
-                throw new Exception("Operation aborted.");
+                throw new Exception('Operation aborted.');
             }
         }
         $cn = Database::get();
         $cn->executeQuery('set foreign_key_checks = 0');
         if (Database::getDefaultConnection()) {
-            $output->write("Listing tables... ");
-            /* @var $cn \Concrete\Core\Database\Connection\Connection */
+            $output->write('Listing tables... ');
+            // @var $cn \Concrete\Core\Database\Connection\Connection
             $sm = $cn->getSchemaManager();
             $tables = $sm->listTables();
             $output->writeln('<info>done.</info>');
@@ -63,7 +65,7 @@ EOT
             }
         }
         $fh = Core::make('helper/file');
-        /* @var $fh \Concrete\Core\File\Service\File */
+        // @var $fh \Concrete\Core\File\Service\File
         $createEmptyDirs = [
             'application/files' => DIR_FILES_UPLOADED_STANDARD,
         ];
@@ -83,9 +85,9 @@ EOT
         ];
         foreach ($deleteFiles as $shownName => $fullpath) {
             if (is_file($fullpath)) {
-                $output->write("Deleting file $shownName... ");
+                $output->write("Deleting file {$shownName}... ");
                 if (@unlink($fullpath) === false) {
-                    throw new Exception("Failed to delete file $fullpath");
+                    throw new Exception("Failed to delete file {$fullpath}");
                 }
                 $output->writeln('<info>done.</info>');
             }
@@ -97,27 +99,27 @@ EOT
         ];
         foreach ($deleteDirs as $shownName => $fullpath) {
             if (is_dir($fullpath)) {
-                $output->write("Deleting directory $shownName... ");
+                $output->write("Deleting directory {$shownName}... ");
                 if ($fh->removeAll($fullpath, true) === false) {
-                    throw new Exception("Failed to delete directory $fullpath");
+                    throw new Exception("Failed to delete directory {$fullpath}");
                 }
                 $output->writeln('<info>done.</info>');
             }
         }
         foreach ($createEmptyDirs as $shownName => $fullpath) {
             if (!file_exists($fullpath)) {
-                $output->write("Creating directory $shownName... ");
+                $output->write("Creating directory {$shownName}... ");
                 if (@mkdir($fullpath, DIRECTORY_PERMISSIONS_MODE_COMPUTED) === false) {
-                    throw new Exception("Failed to create directory $fullpath");
+                    throw new Exception("Failed to create directory {$fullpath}");
                 }
                 $output->writeln('<info>done.</info>');
             }
         }
         foreach ($createEmptyFiles as $shownName => $fullpath) {
             if (!file_exists($fullpath)) {
-                $output->write("Creating empty file $shownName... ");
+                $output->write("Creating empty file {$shownName}... ");
                 if (@touch($fullpath) === false) {
-                    throw new Exception("Failed to create empty file $fullpath");
+                    throw new Exception("Failed to create empty file {$fullpath}");
                 }
                 $output->writeln('<info>done.</info>');
             }

--- a/concrete/src/Console/Command/RunSchedulerCommand.php
+++ b/concrete/src/Console/Command/RunSchedulerCommand.php
@@ -11,14 +11,6 @@ use Doctrine\ORM\EntityManager;
 
 class RunSchedulerCommand extends Command
 {
-    protected function configure()
-    {
-        $this
-            ->setName('concrete:scheduler:run')
-            ->setDescription('Runs the task scheduler, dispatching any tasks whose time has come.');
-        ;
-    }
-
     public function handle(Repository $config, EntityManager $em)
     {
         $timezone = new \DateTimeZone($config->get('app.server_timezone'));
@@ -26,15 +18,24 @@ class RunSchedulerCommand extends Command
         $schedules = $em->getRepository(ScheduledTask::class)->findAll();
         $app = Facade::getFacadeApplication();
         foreach ($schedules as $scheduledTask) {
-           if ($scheduledTask->getCronExpressionObject()->isDue($now->format('Y-m-d H:i:s'))) {
-               // Execute the task since it's the right time.
-               $input = $scheduledTask->getTaskInput();
-               $task = $scheduledTask->getTask();
+            if ($scheduledTask->getCronExpressionObject()->isDue($now->format('Y-m-d H:i:s'))) {
+                // Execute the task since it's the right time.
+                $input = $scheduledTask->getTaskInput();
+                $task = $scheduledTask->getTask();
 
-               $command = new ExecuteConsoleTaskCommand($task, $input, $this->output);
-               $app->executeCommand($command);
-           }
+                $command = new ExecuteConsoleTaskCommand($task, $input, $this->output);
+                $app->executeCommand($command);
+            }
         }
+
         return static::SUCCESS;
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setName('concrete:scheduler:run')
+            ->setDescription('Runs the task scheduler, dispatching any tasks whose time has come.')
+        ;
     }
 }

--- a/concrete/src/Console/Command/RunSchedulerInForegroundCommand.php
+++ b/concrete/src/Console/Command/RunSchedulerInForegroundCommand.php
@@ -3,22 +3,11 @@
 namespace Concrete\Core\Console\Command;
 
 use Carbon\Carbon;
-use Concrete\Core\Config\Repository\Repository;
 use Concrete\Core\Console\Command;
-use Concrete\Core\Entity\Command\ScheduledTask;
-use Doctrine\ORM\EntityManager;
 use Symfony\Component\Console\Input\ArgvInput;
 
 class RunSchedulerInForegroundCommand extends Command
 {
-    protected function configure()
-    {
-        $this
-            ->setName('concrete:scheduler:run-dev')
-            ->setDescription('Runs the task scheduler in the foreground every minute. Useful for development environments.');
-        ;
-    }
-
     public function handle()
     {
         $this->output->writeln('Running the worker every minute...');
@@ -32,6 +21,15 @@ class RunSchedulerInForegroundCommand extends Command
             }
             sleep(1);
         }
+
         return static::SUCCESS;
+    }
+
+    protected function configure()
+    {
+        $this
+            ->setName('concrete:scheduler:run-dev')
+            ->setDescription('Runs the task scheduler in the foreground every minute. Useful for development environments.')
+        ;
     }
 }

--- a/concrete/src/Console/Command/ServiceCommand.php
+++ b/concrete/src/Console/Command/ServiceCommand.php
@@ -67,7 +67,7 @@ EOT
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $rc = static::SUCCESS;
         $manager = Core::make('Concrete\Core\Service\Manager\ServiceManager');

--- a/concrete/src/Console/Command/ServiceCommand.php
+++ b/concrete/src/Console/Command/ServiceCommand.php
@@ -1,102 +1,20 @@
 <?php
+
 namespace Concrete\Core\Console\Command;
 
 use Concrete\Core\Console\Command;
-use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
-use Concrete\Core\Service\ServiceInterface;
-use Concrete\Core\Service\Rule\RuleInterface;
 use Concrete\Core\Service\Rule\ConfigurableRuleInterface;
+use Concrete\Core\Service\Rule\RuleInterface;
+use Concrete\Core\Service\ServiceInterface;
 use Core;
 use Exception;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 
 final class ServiceCommand extends Command
 {
-    protected function configure()
-    {
-        $okExitCode = static::SUCCESS;
-        $errExitCode = static::FAILURE;
-        $errInvalid = static::INVALID;
-        $serviceHandles = [];
-        $help = '';
-        $manager = Core::make('Concrete\Core\Service\Manager\ServiceManager');
-        /* @var \Concrete\Core\Service\Manager\ServiceManager $manager */
-        foreach ($manager->getAllServices() as $serviceHandle => $service) {
-            $serviceHandles[] = $serviceHandle;
-            foreach ($service->getGenerator()->getRules() as $ruleHandle => $rule) {
-                if ($rule instanceof ConfigurableRuleInterface) {
-                    /* @var ConfigurableRuleInterface $rule */
-                    foreach ($rule->getOptions() as $optionHandle => $option) {
-                        $help .= "Rule option for service $serviceHandle, rule $ruleHandle:\n";
-                        $help .= "  - $optionHandle: " . $option->getDescription();
-                        if ($option->isRequired()) {
-                            $help .= ' [required]';
-                        } else {
-                            $help .= ' [optional]';
-                        }
-                        $help .= "\n";
-                    }
-                }
-            }
-        }
-        $help .= <<<EOT
-
-Return codes for the check operation:
-  $okExitCode operation completed successfully
-  $errInvalid web server configuration is not aligned
-  $errExitCode errors occurred
-
-Return codes for the update operation:
-  $okExitCode operation completed successfully
-  $errExitCode errors occurred
-
-More info at https://documentation.concretecms.org/9-x/developers/security/cli-jobs#c5-service
-EOT
-        ;
-        $this
-            ->setName('c5:service')
-            ->setDescription('Check or update the web server configuration')
-            ->addEnvOption()
-            ->addOption('service-version', 'r', InputOption::VALUE_REQUIRED, 'The specific version of the web server software', '')
-            ->addArgument('service', InputArgument::REQUIRED, 'The web server to use (' . implode('|', $serviceHandles) . ')')
-            ->addArgument('operation', InputArgument::REQUIRED, 'The operation to perform (check|update)')
-            ->addArgument('rule-options', InputArgument::IS_ARRAY, 'List of key-value pairs to pass to the rules (example: foo=bar baz=foo)')
-            ->setHelp(trim($help))
-        ;
-    }
-
-    protected function execute(InputInterface $input, OutputInterface $output): int
-    {
-        $rc = static::SUCCESS;
-        $manager = Core::make('Concrete\Core\Service\Manager\ServiceManager');
-        /* @var \Concrete\Core\Service\Manager\ServiceManager $manager */
-        $service = $manager->getService($input->getArgument('service'), $input->getOption('service-version'));
-        if ($service === null) {
-            $msg = 'Unknown web server handle: ' . $input->getArgument('service');
-            $msg .= PHP_EOL;
-            $msg .= 'Valid handles: ' . implode(', ', $manager->getExtensions());
-            throw new Exception($msg);
-        }
-        $operation = $input->getArgument('operation');
-        $ruleOptions = $this->parseRuleOptions($input);
-        switch ($operation) {
-            case 'check':
-                if ($this->checkConfiguration($service, $ruleOptions, $output) === false) {
-                    $rc = static::INVALID;
-                }
-                break;
-            case 'update':
-                $this->updateConfiguration($service, $ruleOptions, $output);
-                break;
-            default:
-                throw new Exception('Invalid value of the operation argument (valid values: check or update');
-        }
-
-        return $rc;
-    }
-
     public function checkConfiguration(ServiceInterface $service, array $ruleOptions, OutputInterface $output)
     {
         $storage = $service->getStorage();
@@ -112,14 +30,14 @@ EOT
             $shouldHave = $rule->isEnabled();
             if ($shouldHave !== null) {
                 if ($shouldHave) {
-                    $output->write("Checking presence of rule $ruleHandle... ");
+                    $output->write("Checking presence of rule {$ruleHandle}... ");
                     if ($configurator->hasRule($configuration, $rule)) {
                         $output->writeln('<info>found (ok).</info>');
                     } else {
                         $output->writeln('<error>NOT FOUND!</error>');
                     }
                 } else {
-                    $output->write("Checking absence of rule $ruleHandle... ");
+                    $output->write("Checking absence of rule {$ruleHandle}... ");
                     if ($configurator->hasRule($configuration, $rule)) {
                         $output->writeln('<error>FOUND!</error>');
                     } else {
@@ -153,42 +71,125 @@ EOT
 
             if ($shouldHave === true) {
                 // This rule should be present in the configuration
-                $output->write("Checking presence of rule $ruleHandle... ");
+                $output->write("Checking presence of rule {$ruleHandle}... ");
                 if ($configurator->hasRule($configuration, $rule)) {
                     // The rule is already in the configuration
-                    $output->writeln("<info>already present.</info>");
+                    $output->writeln('<info>already present.</info>');
                 } else {
                     // The rule is not in the configuration: let's add it
-                    $output->write("not found. Adding it... ");
+                    $output->write('not found. Adding it... ');
                     $configuration = $configurator->addRule($configuration, $rule);
-                    $output->writeln("<info>done.</info>");
+                    $output->writeln('<info>done.</info>');
                     $configurationUpdated = true;
                 }
             } elseif ($shouldHave === false) {
                 // This rule should not be present in the configuration
-                $output->write("Checking absence of rule $ruleHandle... ");
+                $output->write("Checking absence of rule {$ruleHandle}... ");
                 if ($configurator->hasRule($configuration, $rule)) {
                     // The rule is in the configuration: let's remove it
-                    $output->write("found. Removing it... ");
+                    $output->write('found. Removing it... ');
                     $configuration = $configurator->removeRule($configuration, $rule);
-                    $output->writeln("<info>done.</info>");
+                    $output->writeln('<info>done.</info>');
                     $configurationUpdated = true;
                 } else {
                     // The rule is not in the configuration
-                    $output->writeln("<info>already absent.</info>");
+                    $output->writeln('<info>already absent.</info>');
                 }
             }
         }
 
         if ($configurationUpdated) {
             // Some rule has been added or removed from the configuration: let's save it
-            $output->write("Persisting new configuration... ");
+            $output->write('Persisting new configuration... ');
             if (!$storage->canWrite()) {
                 throw new Exception('Unable to write the current server configuration for ' . $service->getFullName());
             }
             $storage->write($configuration);
-            $output->writeln("<info>done.</info>");
+            $output->writeln('<info>done.</info>');
         }
+    }
+
+    protected function configure()
+    {
+        $okExitCode = static::SUCCESS;
+        $errExitCode = static::FAILURE;
+        $errInvalid = static::INVALID;
+        $serviceHandles = [];
+        $help = '';
+        $manager = Core::make('Concrete\Core\Service\Manager\ServiceManager');
+        // @var \Concrete\Core\Service\Manager\ServiceManager $manager
+        foreach ($manager->getAllServices() as $serviceHandle => $service) {
+            $serviceHandles[] = $serviceHandle;
+            foreach ($service->getGenerator()->getRules() as $ruleHandle => $rule) {
+                if ($rule instanceof ConfigurableRuleInterface) {
+                    // @var ConfigurableRuleInterface $rule
+                    foreach ($rule->getOptions() as $optionHandle => $option) {
+                        $help .= "Rule option for service {$serviceHandle}, rule {$ruleHandle}:\n";
+                        $help .= "  - {$optionHandle}: " . $option->getDescription();
+                        if ($option->isRequired()) {
+                            $help .= ' [required]';
+                        } else {
+                            $help .= ' [optional]';
+                        }
+                        $help .= "\n";
+                    }
+                }
+            }
+        }
+        $help .= <<<EOT
+
+Return codes for the check operation:
+  {$okExitCode} operation completed successfully
+  {$errInvalid} web server configuration is not aligned
+  {$errExitCode} errors occurred
+
+Return codes for the update operation:
+  {$okExitCode} operation completed successfully
+  {$errExitCode} errors occurred
+
+More info at https://documentation.concretecms.org/9-x/developers/security/cli-jobs#c5-service
+EOT
+        ;
+        $this
+            ->setName('c5:service')
+            ->setDescription('Check or update the web server configuration')
+            ->addEnvOption()
+            ->addOption('service-version', 'r', InputOption::VALUE_REQUIRED, 'The specific version of the web server software', '')
+            ->addArgument('service', InputArgument::REQUIRED, 'The web server to use (' . implode('|', $serviceHandles) . ')')
+            ->addArgument('operation', InputArgument::REQUIRED, 'The operation to perform (check|update)')
+            ->addArgument('rule-options', InputArgument::IS_ARRAY, 'List of key-value pairs to pass to the rules (example: foo=bar baz=foo)')
+            ->setHelp(trim($help))
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $rc = static::SUCCESS;
+        $manager = Core::make('Concrete\Core\Service\Manager\ServiceManager');
+        // @var \Concrete\Core\Service\Manager\ServiceManager $manager
+        $service = $manager->getService($input->getArgument('service'), $input->getOption('service-version'));
+        if ($service === null) {
+            $msg = 'Unknown web server handle: ' . $input->getArgument('service');
+            $msg .= PHP_EOL;
+            $msg .= 'Valid handles: ' . implode(', ', $manager->getExtensions());
+            throw new Exception($msg);
+        }
+        $operation = $input->getArgument('operation');
+        $ruleOptions = $this->parseRuleOptions($input);
+        switch ($operation) {
+            case 'check':
+                if ($this->checkConfiguration($service, $ruleOptions, $output) === false) {
+                    $rc = static::INVALID;
+                }
+                break;
+            case 'update':
+                $this->updateConfiguration($service, $ruleOptions, $output);
+                break;
+            default:
+                throw new Exception('Invalid value of the operation argument (valid values: check or update');
+        }
+
+        return $rc;
     }
 
     /**
@@ -204,7 +205,7 @@ EOT
     {
         $ruleOptions = [];
         foreach ($input->getArgument('rule-options') as $keyValuePair) {
-            list($key, $value) = explode('=', $keyValuePair, 2);
+            [$key, $value] = explode('=', $keyValuePair, 2);
             $key = trim($key);
             if (substr($key, -2) === '[]') {
                 $isArray = true;

--- a/concrete/src/Console/Command/SetDatabaseCharacterSetCommand.php
+++ b/concrete/src/Console/Command/SetDatabaseCharacterSetCommand.php
@@ -33,10 +33,10 @@ EOT
         }
         $connection = $databaseManager->connection($connectionName);
         try {
-            list($characterSet, $collation) = $resolver->setCharacterSet($this->argument('charset'))->setCollation('')->resolveCharacterSetAndCollation($connection);
+            [$characterSet, $collation] = $resolver->setCharacterSet($this->argument('charset'))->setCollation('')->resolveCharacterSetAndCollation($connection);
         } catch (UnsupportedCharacterSetException $x) {
             try {
-                list($characterSet, $collation) = $resolver->setCharacterSet('')->setCollation($this->argument('charset'))->resolveCharacterSetAndCollation($connection);
+                [$characterSet, $collation] = $resolver->setCharacterSet('')->setCollation($this->argument('charset'))->resolveCharacterSetAndCollation($connection);
             } catch (UnsupportedCollationException $x) {
                 $this->output->error(sprintf('"%s" is neither a valid character set nor a valid collation.', $this->argument('charset')));
 

--- a/concrete/src/Console/Command/TaskCommand.php
+++ b/concrete/src/Console/Command/TaskCommand.php
@@ -1,25 +1,17 @@
 <?php
+
 namespace Concrete\Core\Console\Command;
 
-use Concrete\Core\Command\Process\Command\ProcessMessageInterface;
-use Concrete\Core\Command\Process\ProcessUpdater;
 use Concrete\Core\Command\Task\Command\ExecuteConsoleTaskCommand;
 use Concrete\Core\Command\Task\Input\InputFactory;
-use Concrete\Core\Command\Task\Runner\ProcessTaskRunnerInterface;
-use Concrete\Core\Messenger\MessageBusAwareInterface;
-use Concrete\Core\Command\Task\Input\Input;
-use Concrete\Core\Command\Task\Output\OutputFactory;
 use Concrete\Core\Command\Task\TaskInterface;
-use Concrete\Core\Messenger\MessageBusManager;
 use Concrete\Core\Support\Facade\Facade;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class TaskCommand extends SymfonyCommand
 {
-
     /**
      * @var TaskInterface
      */

--- a/concrete/src/Console/Command/TranslatePackageCommand.php
+++ b/concrete/src/Console/Command/TranslatePackageCommand.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Concrete\Core\Console\Command;
 
 use Concrete\Core\Config\Repository\Repository;
@@ -16,6 +17,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class TranslatePackageCommand extends Command
 {
+    /**
+     * @var \Concrete\Core\Application\Application
+     */
+    protected $app;
+
     protected function configure()
     {
         $okExitCode = static::SUCCESS;
@@ -26,16 +32,17 @@ class TranslatePackageCommand extends Command
                 'c5:package-translate',
                 'c5:translate-package',
             ])
-        ->addArgument('package', InputArgument::REQUIRED, 'The handle of the package to be translated (or the path to a directory containing a Concrete package)')
-        ->addEnvOption()
-        ->setCanRunAsRoot(false)
-        ->addOption('locale', 'l', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'List of locale codes to handle')
-        ->addOption('contact', 'c', InputOption::VALUE_REQUIRED, 'Contact information to be put in the language files to report bugs to (eg the "Report-Msgid-Bugs-To" gettext header)', '')
-        ->addOption('translator', 't', InputOption::VALUE_REQUIRED, 'Translator to be put in the language files (eg the "Last-Translator" gettext header)', '')
-        ->addOption('exclude-3rdparty', 'x', InputOption::VALUE_NONE, 'Specify this option to avoid parsing 3rd party folders')
-        ->addOption('fill', 'f', InputOption::VALUE_NONE, 'Fill-in already known translations using an online service')
-        ->setDescription('Creates or updates translations of a Concrete package')
-        ->setHelp(<<<EOT
+            ->addArgument('package', InputArgument::REQUIRED, 'The handle of the package to be translated (or the path to a directory containing a Concrete package)')
+            ->addEnvOption()
+            ->setCanRunAsRoot(false)
+            ->addOption('locale', 'l', InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'List of locale codes to handle')
+            ->addOption('contact', 'c', InputOption::VALUE_REQUIRED, 'Contact information to be put in the language files to report bugs to (eg the "Report-Msgid-Bugs-To" gettext header)', '')
+            ->addOption('translator', 't', InputOption::VALUE_REQUIRED, 'Translator to be put in the language files (eg the "Last-Translator" gettext header)', '')
+            ->addOption('exclude-3rdparty', 'x', InputOption::VALUE_NONE, 'Specify this option to avoid parsing 3rd party folders')
+            ->addOption('fill', 'f', InputOption::VALUE_NONE, 'Fill-in already known translations using an online service')
+            ->setDescription('Creates or updates translations of a Concrete package')
+            ->setHelp(
+                <<<EOT
 If the locale option(s) is not specified, we'll generate/update translations for the currently defined locales for the package.
 If currently no locale is defined, we'll generate/update translations for all the currently installed locales of the core of Concrete.
 In order to don't generate the locale files but only the master translations file (.pot), specify "--locale=-" (or "-l-")
@@ -49,30 +56,25 @@ Examples:
 Please remark that this command can also parse legacy (pre-5.7) packages.
             
 Returns codes:
-  $okExitCode operation completed successfully
-  $errExitCode errors occurred
+  {$okExitCode} operation completed successfully
+  {$errExitCode} errors occurred
             
 More info at https://documentation.concretecms.org/9-x/developers/security/cli-jobs#c5-package-translate
 EOT
-        )
+            )
         ;
     }
-    
-    /**
-     * @var \Concrete\Core\Application\Application
-     */
-    protected $app;
-    
+
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->app = Application::getFacadeApplication();
         $config = $this->app->make(Repository::class);
-        
+
         $vsh = $this->app->make('helper/validation/strings');
-        /* @var \Concrete\Core\Utility\Service\Validation\Strings $vsh */
+        // @var \Concrete\Core\Utility\Service\Validation\Strings $vsh
         $fh = $this->app->make('helper/file');
-        /* @var \Concrete\Core\File\Service\File $fh */
-        
+        // @var \Concrete\Core\File\Service\File $fh
+
         // Let's determine the package handle, directory and version
         $packageHandle = null;
         $packageDirectory = null;
@@ -81,10 +83,10 @@ EOT
         if (is_dir($p) || !$vsh->handle($p)) {
             $packageDirectory = @realpath($p);
             if ($packageDirectory === false) {
-                throw new Exception("Unable to find the directory '$p'");
+                throw new Exception("Unable to find the directory '{$p}'");
             }
             $packageDirectory = str_replace(DIRECTORY_SEPARATOR, '/', $packageDirectory);
-            list($packageHandle, $packageVersion) = $this->guessPackageDetails($packageDirectory);
+            [$packageHandle, $packageVersion] = $this->guessPackageDetails($packageDirectory);
             if ($packageHandle === null) {
                 $packageHandle = basename($packageDirectory);
             }
@@ -98,11 +100,11 @@ EOT
                 }
             }
             if ($packageHandle === null) {
-                throw new Exception("Unable to find a package with handle '$p'");
+                throw new Exception("Unable to find a package with handle '{$p}'");
             }
         }
         $packageLanguagesDirectory = $packageDirectory . '/' . DIRNAME_LANGUAGES;
-        
+
         // Determine the locales to translate
         $locales = [];
         $localeOption = $input->getOption('locale');
@@ -111,7 +113,7 @@ EOT
         } elseif (empty($localeOption)) {
             // List the currently package locales
             foreach ($fh->getDirectoryContents($packageLanguagesDirectory) as $item) {
-                if (is_file("$packageLanguagesDirectory/$item/LC_MESSAGES/messages.mo") || is_file("$packageLanguagesDirectory/$item/LC_MESSAGES/messages.po")) {
+                if (is_file("{$packageLanguagesDirectory}/{$item}/LC_MESSAGES/messages.mo") || is_file("{$packageLanguagesDirectory}/{$item}/LC_MESSAGES/messages.po")) {
                     $locales[] = $item;
                 }
             }
@@ -138,14 +140,14 @@ EOT
                 $locales[] = implode('_', $chunks);
             }
         }
-        
+
         // Initialize the master translations file (.pot)
         $pot = new Translations();
-        $pot->setHeader('Project-Id-Version', "$packageHandle $packageVersion");
+        $pot->setHeader('Project-Id-Version', "{$packageHandle} {$packageVersion}");
         $pot->setLanguage(Localization::BASE_LOCALE);
         $pot->setHeader('Report-Msgid-Bugs-To', $input->getOption('contact'));
         $pot->setHeader('Last-Translator', $input->getOption('translator'));
-        
+
         // Parse the package directory
         $output->writeln('Parsing package contents');
         $parserFactory = $this->app->make(\C5TL\ParserFactory::class);
@@ -154,35 +156,35 @@ EOT
                 $output->write('- running parser "' . $parser->getParserName() . '"... ');
                 $parser->parseDirectory(
                     $packageDirectory,
-                    "packages/$packageHandle",
+                    "packages/{$packageHandle}",
                     $pot,
                     false,
                     $input->getOption('exclude-3rdparty')
-                    );
+                );
                 $output->writeln('<info>done.</info>');
             }
         }
-        
+
         // Save the pot file
         $output->write('Saving .pot file... ');
         if (!is_dir($packageLanguagesDirectory)) {
             @mkdir($packageLanguagesDirectory, $config->get('concrete.filesystem.permissions.directory'), true);
             if (!is_dir($packageLanguagesDirectory)) {
-                throw new Exception("Unable to create the directory $packageLanguagesDirectory");
+                throw new Exception("Unable to create the directory {$packageLanguagesDirectory}");
             }
         }
-        $potFilename = "$packageLanguagesDirectory/messages.pot";
+        $potFilename = "{$packageLanguagesDirectory}/messages.pot";
         if ($pot->toPoFile($potFilename) === false) {
-            throw new Exception("Unable to save the .pot file to $potFilename");
+            throw new Exception("Unable to save the .pot file to {$potFilename}");
         }
         $output->writeln('<info>done.</info>');
-        
+
         $remoteTranslationsProvider = $this->app->make(RemoteTranslationProvider::class);
-        /* @var RemoteTranslationProvider $remoteTranslationsProvider */
+        // @var RemoteTranslationProvider $remoteTranslationsProvider
         // Creating/updating the locale files
         foreach ($locales as $locale) {
-            $output->writeln("Working on locale $locale");
-            $poDirectory = "$packageLanguagesDirectory/$locale/LC_MESSAGES";
+            $output->writeln("Working on locale {$locale}");
+            $poDirectory = "{$packageLanguagesDirectory}/{$locale}/LC_MESSAGES";
             $po = clone $pot;
             $po->setLanguage($locale);
             if ($input->getOption('fill')) {
@@ -190,8 +192,8 @@ EOT
                 $po = $remoteTranslationsProvider->fillTranslations($po);
                 $output->writeln('<info>done.</info>');
             }
-            $poFile = "$poDirectory/messages.po";
-            $moFile = "$poDirectory/messages.mo";
+            $poFile = "{$poDirectory}/messages.po";
+            $moFile = "{$poDirectory}/messages.mo";
             if (is_file($poFile)) {
                 $output->write('- reading current .po file... ');
                 $oldPo = Translations::fromPoFile($poFile);
@@ -212,7 +214,7 @@ EOT
             if (!is_dir($poDirectory)) {
                 @mkdir($poDirectory, $config->get('concrete.filesystem.permissions.directory'), true);
                 if (!is_dir($poDirectory)) {
-                    throw new Exception("Unable to create the directory $poDirectory");
+                    throw new Exception("Unable to create the directory {$poDirectory}");
                 }
             }
             $po->toPoFile($poFile);
@@ -224,17 +226,17 @@ EOT
 
         return static::SUCCESS;
     }
-    
+
     private function guessPackageDetails($packageDirectory)
     {
         $packageHandle = null;
         $packageVersion = null;
         $controllerFile = $packageDirectory . '/' . FILENAME_CONTROLLER;
         if (!is_file($controllerFile)) {
-            throw new Exception("The directory '$packageDirectory' does not seems to contain a valid Concrete package");
+            throw new Exception("The directory '{$packageDirectory}' does not seems to contain a valid Concrete package");
         }
         $fh = $this->app->make('helper/file');
-        /* @var \Concrete\Core\File\Service\File $fh */
+        // @var \Concrete\Core\File\Service\File $fh
         $controllerContents = $fh->getContents($controllerFile);
         if ($controllerContents) {
             $allTokens = @token_get_all($controllerContents);
@@ -253,33 +255,33 @@ EOT
                                         break;
                                 }
                             }
-                            
+
                             return $keep;
                         }
                     )
                 );
                 // Look for package version
-                for ($i = 0; $i < count($tokens) - 2; ++$i) {
+                for ($i = 0; $i < count($tokens) - 2; $i++) {
                     if (
                         $packageHandle === null
                         && is_array($tokens[$i + 0]) && $tokens[$i + 0][0] === T_VARIABLE && $tokens[$i + 0][1] === '$pkgHandle'
                         && is_string($tokens[$i + 1]) && $tokens[$i + 1] === '='
                         && is_array($tokens[$i + 2]) && $tokens[$i + 2][0] === T_CONSTANT_ENCAPSED_STRING
                         ) {
-                            $packageHandle = @eval('return ' . $tokens[$i + 2][1] . ';');
-                        }
-                        if (
+                        $packageHandle = @eval('return ' . $tokens[$i + 2][1] . ';');
+                    }
+                    if (
                             $packageVersion === null
                             && is_array($tokens[$i + 0]) && $tokens[$i + 0][0] === T_VARIABLE && $tokens[$i + 0][1] === '$pkgVersion'
                             && is_string($tokens[$i + 1]) && $tokens[$i + 1] === '='
                             && is_array($tokens[$i + 2]) && $tokens[$i + 2][0] === T_CONSTANT_ENCAPSED_STRING
                             ) {
-                                $packageVersion = @eval('return ' . $tokens[$i + 2][1] . ';');
-                            }
+                        $packageVersion = @eval('return ' . $tokens[$i + 2][1] . ';');
+                    }
                 }
             }
         }
-        
+
         return [$packageHandle, $packageVersion];
     }
 }

--- a/concrete/src/Console/Command/TranslatePackageCommand.php
+++ b/concrete/src/Console/Command/TranslatePackageCommand.php
@@ -63,7 +63,7 @@ EOT
      */
     protected $app;
     
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $this->app = Application::getFacadeApplication();
         $config = $this->app->make(Repository::class);

--- a/concrete/src/Console/Command/UninstallPackageCommand.php
+++ b/concrete/src/Console/Command/UninstallPackageCommand.php
@@ -1,15 +1,16 @@
 <?php
+
 namespace Concrete\Core\Console\Command;
 
 use Concrete\Core\Console\Command;
 use Concrete\Core\Console\ConsoleAwareInterface;
 use Concrete\Core\Error\ErrorList\ErrorList;
-use Symfony\Component\Console\Input\InputInterface;
+use Exception;
+use Package;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Package;
-use Exception;
 
 class UninstallPackageCommand extends Command
 {
@@ -28,10 +29,11 @@ class UninstallPackageCommand extends Command
             ->addOption('trash', null, InputOption::VALUE_NONE, 'If this option is specified the package directory will be moved to the trash directory')
             ->addArgument('package', InputArgument::REQUIRED, 'The handle of the package to be uninstalled')
             ->setDescription('Uninstall a Concrete package')
-            ->setHelp(<<<EOT
+            ->setHelp(
+                <<<EOT
 Returns codes:
-  $okExitCode operation completed successfully
-  $errExitCode errors occurred
+  {$okExitCode} operation completed successfully
+  {$errExitCode} errors occurred
 
 More info at https://documentation.concretecms.org/9-x/developers/security/cli-jobs#c5-package-uninstall
 EOT
@@ -43,7 +45,7 @@ EOT
     {
         $pkgHandle = $input->getArgument('package');
 
-        $output->write("Looking for package '$pkgHandle'... ");
+        $output->write("Looking for package '{$pkgHandle}'... ");
         $pkg = null;
         foreach (Package::getInstalledList() as $installed) {
             if ($installed->getPackageHandle() === $pkgHandle) {
@@ -65,9 +67,7 @@ EOT
         $output->write('Checking preconditions... ');
         $test = $pkg->testForUninstall();
         if (is_object($test)) {
-            /*
-             * @var Error $test
-             */
+            // @var Error $test
             throw new Exception(implode("\n", $test->getList()));
         }
         $output->writeln('<info>good.</info>');

--- a/concrete/src/Console/Command/UpdateCommand.php
+++ b/concrete/src/Console/Command/UpdateCommand.php
@@ -27,7 +27,8 @@ class UpdateCommand extends Command
             ->addOption('rerun', null, InputOption::VALUE_NONE, '(Re)apply already executed migrations')
             ->addOption('after', 'a', InputOption::VALUE_REQUIRED, '(Re)apply migrations after a specific version or migration (requires --rerun)')
             ->addOption('since', 's', InputOption::VALUE_REQUIRED, '(Re)apply migrations starting from a specific version or migration (requires --rerun)')
-            ->setHelp(<<<EOT
+            ->setHelp(
+                <<<EOT
 Examples:
 
   ./concrete/bin/concrete c5:update
@@ -49,8 +50,8 @@ Examples:
     Execute the migrations starting from the 20171218000000 migration (even if they have already been marked as executed)
 
 Returns codes:
-  $okExitCode operation completed successfully
-  $errExitCode errors occurred
+  {$okExitCode} operation completed successfully
+  {$errExitCode} errors occurred
 EOT
             )
         ;

--- a/concrete/src/Console/Command/UpdatePackageCommand.php
+++ b/concrete/src/Console/Command/UpdatePackageCommand.php
@@ -1,14 +1,15 @@
 <?php
+
 namespace Concrete\Core\Console\Command;
 
 use Concrete\Core\Console\Command;
 use Concrete\Core\Console\ConsoleAwareInterface;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
-use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Output\OutputInterface;
 use Concrete\Core\Support\Facade\Package;
 use Exception;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class UpdatePackageCommand extends Command
 {
@@ -28,10 +29,11 @@ class UpdatePackageCommand extends Command
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'Force update even if the package is already at last version')
             ->addArgument('packages', InputArgument::IS_ARRAY, 'The handle of the package to be updated (multiple values allowed)')
             ->setDescription('Update a Concrete package')
-            ->setHelp(<<<EOT
+            ->setHelp(
+                <<<EOT
 Returns codes:
-  $okExitCode operation completed successfully
-  $errExitCode errors occurred
+  {$okExitCode} operation completed successfully
+  {$errExitCode} errors occurred
 
 More info at https://documentation.concretecms.org/9-x/developers/security/cli-jobs#c5-package-update
 EOT
@@ -53,14 +55,14 @@ EOT
                     $updatableHandles[] = $pkgHandle;
                 }
                 if (empty($updatableHandles)) {
-                    $output->writeln("No package has been found.");
+                    $output->writeln('No package has been found.');
                 }
             } else {
                 foreach (Package::getLocalUpgradeablePackages() as $pkg) {
                     $updatableHandles[] = $pkg->getPackageHandle();
                 }
                 if (empty($updatableHandles)) {
-                    $output->writeln("No package needs to be updated.");
+                    $output->writeln('No package needs to be updated.');
                 }
             }
         } else {
@@ -83,7 +85,7 @@ EOT
 
     protected function updatePackage($pkgHandle, OutputInterface $output, InputInterface $input, $force)
     {
-        $output->write("Looking for package '$pkgHandle'... ");
+        $output->write("Looking for package '{$pkgHandle}'... ");
         $pkg = null;
         foreach (Package::getInstalledList() as $installed) {
             if ($installed->getPackageHandle() === $pkgHandle) {
@@ -111,7 +113,7 @@ EOT
             }
         }
         if ($upPkg === null && $force !== true) {
-            $output->writeln(sprintf("<info>the package is already up-to-date (v%s)</info>", $pkg->getPackageVersion()));
+            $output->writeln(sprintf('<info>the package is already up-to-date (v%s)</info>', $pkg->getPackageVersion()));
         } else {
             $test = $pkg->testForUpgrade();
             if ($test !== true) {

--- a/concrete/src/Console/CommandRegistry.php
+++ b/concrete/src/Console/CommandRegistry.php
@@ -16,7 +16,7 @@ use Symfony\Component\Messenger\Command\FailedMessagesRetryCommand;
 use Symfony\Component\Messenger\Command\FailedMessagesShowCommand;
 
 /**
- * Adds commands to the console
+ * Adds commands to the console.
  *
  * Important note: this used to be a part of the Console service provider (which has been removed). We had to remove it
  * because it fired too early. Packages could not modify the dependencies passed to the command classes because they
@@ -24,7 +24,6 @@ use Symfony\Component\Messenger\Command\FailedMessagesShowCommand;
  */
 class CommandRegistry implements ApplicationAwareInterface
 {
-
     use ApplicationAwareTrait;
 
     /**
@@ -83,7 +82,7 @@ class CommandRegistry implements ApplicationAwareInterface
         FailedMessagesShowCommand::class,
         FailedMessagesRetryCommand::class,
         FailedMessagesRemoveCommand::class,
-        Command\BulkUserAssignCommand::class
+        Command\BulkUserAssignCommand::class,
     ];
 
     /**
@@ -102,6 +101,7 @@ class CommandRegistry implements ApplicationAwareInterface
 
     /**
      * CommandRegistry constructor.
+     *
      * @param Application $console
      */
     public function __construct(Application $console)
@@ -115,14 +115,6 @@ class CommandRegistry implements ApplicationAwareInterface
         $this->setupInstalledCommands();
         $this->setupDoctrineCommands();
         $this->setupTaskCommands();
-    }
-
-    protected function setupDefaultCommands(): void
-    {
-        // Add commands that always work
-        foreach($this->commands as $commandClass) {
-            $this->console->add($this->app->make($commandClass));
-        }
     }
 
     public function setupInstalledCommands(): void
@@ -161,12 +153,20 @@ class CommandRegistry implements ApplicationAwareInterface
         }
     }
 
+    protected function setupDefaultCommands(): void
+    {
+        // Add commands that always work
+        foreach ($this->commands as $commandClass) {
+            $this->console->add($this->app->make($commandClass));
+        }
+    }
+
     protected function setupTaskCommands(): void
     {
         if ($this->app->isInstalled()) {
             try {
                 $tasks = $this->app->make(TaskService::class)->getList();
-                foreach($tasks as $task) {
+                foreach ($tasks as $task) {
                     $this->console->add(new TaskCommand($task));
                 }
             } catch (\Throwable $e) {
@@ -189,8 +189,4 @@ class CommandRegistry implements ApplicationAwareInterface
 
         return $migrationsConfiguration;
     }
-
-
-
-
 }

--- a/concrete/src/Console/CommandRegistry.php
+++ b/concrete/src/Console/CommandRegistry.php
@@ -30,14 +30,14 @@ class CommandRegistry implements ApplicationAwareInterface
     /**
      * @var Application
      */
-    protected $console;
+    protected Application $console;
 
     /**
      * Commands that are always available.
      *
      * @var string[]
      */
-    protected $commands = [
+    protected array $commands = [
         Command\InfoCommand::class,
         Command\InstallCommand::class,
         Command\IsInstalledCommand::class,
@@ -57,7 +57,7 @@ class CommandRegistry implements ApplicationAwareInterface
      *
      * @var string[]
      */
-    protected $installedCommands = [
+    protected array $installedCommands = [
         Command\CompareSchemaCommand::class,
         Command\ClearCacheCommand::class,
         Command\InstallPackageCommand::class,
@@ -91,7 +91,7 @@ class CommandRegistry implements ApplicationAwareInterface
      *
      * @var string[]
      */
-    protected $migrationCommands = [
+    protected array $migrationCommands = [
         \Doctrine\Migrations\Tools\Console\Command\DiffCommand::class,
         \Doctrine\Migrations\Tools\Console\Command\ExecuteCommand::class,
         \Doctrine\Migrations\Tools\Console\Command\GenerateCommand::class,
@@ -109,7 +109,7 @@ class CommandRegistry implements ApplicationAwareInterface
         $this->console = $console;
     }
 
-    public function registerCommands()
+    public function registerCommands(): void
     {
         $this->setupDefaultCommands();
         $this->setupInstalledCommands();
@@ -117,7 +117,7 @@ class CommandRegistry implements ApplicationAwareInterface
         $this->setupTaskCommands();
     }
 
-    protected function setupDefaultCommands()
+    protected function setupDefaultCommands(): void
     {
         // Add commands that always work
         foreach($this->commands as $commandClass) {
@@ -125,7 +125,7 @@ class CommandRegistry implements ApplicationAwareInterface
         }
     }
 
-    public function setupInstalledCommands()
+    public function setupInstalledCommands(): void
     {
         if ($this->app->isInstalled()) {
             foreach ($this->installedCommands as $commandClass) {
@@ -134,7 +134,7 @@ class CommandRegistry implements ApplicationAwareInterface
         }
     }
 
-    public function setupDoctrineCommands()
+    public function setupDoctrineCommands(): void
     {
         if ($this->app->isInstalled()) {
             // Set the doctrine helperset to the CLI
@@ -161,7 +161,7 @@ class CommandRegistry implements ApplicationAwareInterface
         }
     }
 
-    protected function setupTaskCommands()
+    protected function setupTaskCommands(): void
     {
         if ($this->app->isInstalled()) {
             try {

--- a/concrete/src/Console/ConsoleAwareInterface.php
+++ b/concrete/src/Console/ConsoleAwareInterface.php
@@ -13,31 +13,32 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 interface ConsoleAwareInterface
 {
-
     /**
-     * Set the console object
+     * Set the console object.
      *
      * @param \Symfony\Component\Console\Application $console
      * @param \Symfony\Component\Console\Output\OutputInterface|null $output
      * @param \Symfony\Component\Console\Input\InputInterface|null $input
+     *
      * @return static Returns itself
      */
     public function setConsole(SymfonyApplication $console, ?OutputInterface $output = null, ?InputInterface $input = null): static;
 
     /**
-     * Set the output object to use
+     * Set the output object to use.
      *
      * @param \Symfony\Component\Console\Output\OutputInterface $output
+     *
      * @return static Returns itself
      */
     public function setOutput(OutputInterface $output): static;
 
     /**
-     * Set the input object to use
+     * Set the input object to use.
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input
+     *
      * @return static Returns itself
      */
     public function setInput(InputInterface $input): static;
-
 }

--- a/concrete/src/Console/ConsoleAwareInterface.php
+++ b/concrete/src/Console/ConsoleAwareInterface.php
@@ -22,7 +22,7 @@ interface ConsoleAwareInterface
      * @param \Symfony\Component\Console\Input\InputInterface|null $input
      * @return static Returns itself
      */
-    public function setConsole(SymfonyApplication $console, ?OutputInterface $output = null, ?InputInterface $input = null);
+    public function setConsole(SymfonyApplication $console, ?OutputInterface $output = null, ?InputInterface $input = null): static;
 
     /**
      * Set the output object to use
@@ -30,7 +30,7 @@ interface ConsoleAwareInterface
      * @param \Symfony\Component\Console\Output\OutputInterface $output
      * @return static Returns itself
      */
-    public function setOutput(OutputInterface $output);
+    public function setOutput(OutputInterface $output): static;
 
     /**
      * Set the input object to use
@@ -38,6 +38,6 @@ interface ConsoleAwareInterface
      * @param \Symfony\Component\Console\Input\InputInterface $input
      * @return static Returns itself
      */
-    public function setInput(InputInterface $input);
+    public function setInput(InputInterface $input): static;
 
 }

--- a/concrete/src/Console/ConsoleAwareTrait.php
+++ b/concrete/src/Console/ConsoleAwareTrait.php
@@ -9,26 +9,32 @@ use Symfony\Component\Console\Output\NullOutput;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
- * A trait that provides awareness of the console to objects
+ * A trait that provides awareness of the console to objects.
  */
 trait ConsoleAwareTrait
 {
-
-    /** @var SymfonyApplication|null */
+    /**
+     * @var SymfonyApplication|null
+     */
     protected ?SymfonyApplication $traitConsole;
 
-    /** @var OutputInterface|null */
+    /**
+     * @var OutputInterface|null
+     */
     protected ?OutputInterface $traitOutput;
 
-    /** @var InputInterface|null */
+    /**
+     * @var InputInterface|null
+     */
     protected ?InputInterface $traitInput;
 
     /**
-     * Set the console object
+     * Set the console object.
      *
      * @param \Symfony\Component\Console\Application $console
      * @param \Symfony\Component\Console\Output\OutputInterface|null $output
      * @param \Symfony\Component\Console\Input\InputInterface|null $input
+     *
      * @return static
      */
     public function setConsole(SymfonyApplication $console, ?OutputInterface $output = null, ?InputInterface $input = null)
@@ -45,31 +51,35 @@ trait ConsoleAwareTrait
     }
 
     /**
-     * Set the output object to use
+     * Set the output object to use.
      *
      * @param \Symfony\Component\Console\Output\OutputInterface $output
+     *
      * @return static
      */
     public function setOutput(OutputInterface $output)
     {
         $this->traitOutput = $output;
+
         return $this;
     }
 
     /**
-     * Set the input object to use
+     * Set the input object to use.
      *
      * @param \Symfony\Component\Console\Input\InputInterface $input
+     *
      * @return static
      */
     public function setInput(InputInterface $input)
     {
         $this->traitInput = $input;
+
         return $this;
     }
 
     /**
-     * Get an output object
+     * Get an output object.
      *
      * @return OutputInterface
      */
@@ -79,7 +89,7 @@ trait ConsoleAwareTrait
     }
 
     /**
-     * Get an input object
+     * Get an input object.
      *
      * @return InputInterface
      */
@@ -89,12 +99,12 @@ trait ConsoleAwareTrait
     }
 
     /**
-     * Find out if we are in console context
+     * Find out if we are in console context.
+     *
      * @return bool
      */
     protected function hasConsole(): bool
     {
         return $this->traitConsole !== null;
     }
-
 }

--- a/concrete/src/Console/ConsoleAwareTrait.php
+++ b/concrete/src/Console/ConsoleAwareTrait.php
@@ -15,13 +15,13 @@ trait ConsoleAwareTrait
 {
 
     /** @var SymfonyApplication|null */
-    protected $traitConsole;
+    protected ?SymfonyApplication $traitConsole;
 
     /** @var OutputInterface|null */
-    protected $traitOutput;
+    protected ?OutputInterface $traitOutput;
 
     /** @var InputInterface|null */
-    protected $traitInput;
+    protected ?InputInterface $traitInput;
 
     /**
      * Set the console object
@@ -73,7 +73,7 @@ trait ConsoleAwareTrait
      *
      * @return OutputInterface
      */
-    protected function getOutput()
+    protected function getOutput(): OutputInterface
     {
         return $this->traitOutput ?: new NullOutput();
     }
@@ -83,7 +83,7 @@ trait ConsoleAwareTrait
      *
      * @return InputInterface
      */
-    protected function getInput()
+    protected function getInput(): InputInterface
     {
         return $this->traitInput ?: new StringInput('');
     }
@@ -92,7 +92,7 @@ trait ConsoleAwareTrait
      * Find out if we are in console context
      * @return bool
      */
-    protected function hasConsole()
+    protected function hasConsole(): bool
     {
         return $this->traitConsole !== null;
     }

--- a/concrete/src/Console/OutputStyle.php
+++ b/concrete/src/Console/OutputStyle.php
@@ -12,19 +12,21 @@ use Symfony\Component\Console\Terminal;
 
 /**
  * Concrete's output style.
- * Inspiration goes to illuminate/console
+ * Inspiration goes to illuminate/console.
  */
 class OutputStyle extends SymfonyStyle
 {
-
-    /** @var \Symfony\Component\Console\Output\OutputInterface */
+    /**
+     * @var \Symfony\Component\Console\Output\OutputInterface
+     */
     private $output;
 
     /**
      * Create a new Console OutputStyle instance.
      *
-     * @param  \Symfony\Component\Console\Input\InputInterface  $input
-     * @param  \Symfony\Component\Console\Output\OutputInterface  $output
+     * @param \Symfony\Component\Console\Input\InputInterface $input
+     * @param \Symfony\Component\Console\Output\OutputInterface $output
+     *
      * @return void
      */
     public function __construct(InputInterface $input, OutputInterface $output)
@@ -34,13 +36,14 @@ class OutputStyle extends SymfonyStyle
     }
 
     /**
-     * Ask a question with autocompletion
+     * Ask a question with autocompletion.
      *
      * @param string $question
      * @param array $choices
      * @param null $default
      * @param null $attempts
      * @param bool $strict
+     *
      * @return string
      */
     public function askWithCompletion(string $question, array $choices, $default = null, $attempts = null, bool $strict = false): string
@@ -49,11 +52,12 @@ class OutputStyle extends SymfonyStyle
         $question->setMaxAttempts($attempts)->setAutocompleterValues($choices);
 
         if ($strict) {
-            $question->setValidator(function($result) use ($choices) {
+            $question->setValidator(function ($result) use ($choices) {
                 if (!in_array($result, $choices)) {
                     throw new \InvalidArgumentException(sprintf(
                         'The provided answer is ambiguous. Value should be one of %s',
-                        implode(' or ', $choices)));
+                        implode(' or ', $choices)
+                    ));
                 }
 
                 return $result;
@@ -72,40 +76,45 @@ class OutputStyle extends SymfonyStyle
     }
 
     /**
-     * Ask a question while hiding the response
+     * Ask a question while hiding the response.
      *
      * @param string $question
      * @param bool $fallback
+     *
      * @return string
      */
     public function askSecretQuestion(string $question, bool $fallback = true): string
     {
         $question = new Question($question);
         $question->setHidden(true)->setHiddenFallback($fallback);
+
         return $this->askQuestion($question);
     }
 
     /**
-     * Ask a question with a list of allowed answers
+     * Ask a question with a list of allowed answers.
      *
      * @param string $question
      * @param array $choices
      * @param null $default
      * @param null $attempts
      * @param null $multiple
+     *
      * @return mixed
      */
     public function choice(string $question, array $choices, $default = null, $attempts = null, $multiple = null)
     {
         $question = new ChoiceQuestion($question, $choices, $default);
         $question->setMaxAttempts($attempts)->setMultiselect($multiple);
+
         return $this->askQuestion($question);
     }
 
     /**
-     * Create a table instance
+     * Create a table instance.
      *
      * @see Table::initStyles()
+     *
      * @param array $headers
      * @param array $rows
      * @param string $tableStyle
@@ -124,7 +133,7 @@ class OutputStyle extends SymfonyStyle
     }
 
     /**
-     * Output in even width columns
+     * Output in even width columns.
      *
      * @param array $values
      * @param int $width

--- a/concrete/src/Console/OutputStyle.php
+++ b/concrete/src/Console/OutputStyle.php
@@ -36,14 +36,14 @@ class OutputStyle extends SymfonyStyle
     /**
      * Ask a question with autocompletion
      *
-     * @param $question
+     * @param string $question
      * @param array $choices
      * @param null $default
      * @param null $attempts
      * @param bool $strict
      * @return string
      */
-    public function askWithCompletion($question, array $choices, $default = null, $attempts = null, $strict = false)
+    public function askWithCompletion(string $question, array $choices, $default = null, $attempts = null, bool $strict = false): string
     {
         $question = new Question($question, $default);
         $question->setMaxAttempts($attempts)->setAutocompleterValues($choices);
@@ -66,7 +66,7 @@ class OutputStyle extends SymfonyStyle
     /**
      * @see askSecretQuestion
      */
-    public function secret($question, $fallback = true)
+    public function secret(string $question, bool $fallback = true): string
     {
         return $this->askSecretQuestion($question, $fallback);
     }
@@ -74,11 +74,11 @@ class OutputStyle extends SymfonyStyle
     /**
      * Ask a question while hiding the response
      *
-     * @param $question
+     * @param string $question
      * @param bool $fallback
      * @return string
      */
-    public function askSecretQuestion($question, $fallback = true)
+    public function askSecretQuestion(string $question, bool $fallback = true): string
     {
         $question = new Question($question);
         $question->setHidden(true)->setHiddenFallback($fallback);
@@ -95,7 +95,7 @@ class OutputStyle extends SymfonyStyle
      * @param null $multiple
      * @return mixed
      */
-    public function choice($question, array $choices, $default = null, $attempts = null, $multiple = null)
+    public function choice(string $question, array $choices, $default = null, $attempts = null, $multiple = null)
     {
         $question = new ChoiceQuestion($question, $choices, $default);
         $question->setMaxAttempts($attempts)->setMultiselect($multiple);
@@ -111,7 +111,7 @@ class OutputStyle extends SymfonyStyle
      * @param string $tableStyle
      * @param array $columnStyles
      */
-    public function table(array $headers, array $rows, $tableStyle = 'default', array $columnStyles = [])
+    public function table(array $headers, array $rows, string $tableStyle = 'default', array $columnStyles = []): void
     {
         $table = new Table($this);
         $table->setHeaders($headers)->setRows($rows)->setStyle($tableStyle);
@@ -131,7 +131,7 @@ class OutputStyle extends SymfonyStyle
      * @param string $tableStyle
      * @param array $columnStyles
      */
-    public function columns(array $values, $width = 5, $tableStyle = 'compact', array $columnStyles = [])
+    public function columns(array $values, int $width = 5, string $tableStyle = 'compact', array $columnStyles = []): void
     {
         $table = new Table($this);
         $table->setHeaders([])->setRows(iterator_to_array($this->chunk($values, $width)))->setStyle($tableStyle);
@@ -146,7 +146,7 @@ class OutputStyle extends SymfonyStyle
         $table->render();
     }
 
-    protected function chunk(array $values, $size)
+    protected function chunk(array $values, int $size)
     {
         $chunk = [];
         foreach ($values as $value) {
@@ -160,7 +160,7 @@ class OutputStyle extends SymfonyStyle
         yield $chunk;
     }
 
-    private function getColumnWidths($width)
+    private function getColumnWidths(int $width): array
     {
         $terminal = new Terminal();
         $totalWidth = $terminal->getWidth();

--- a/concrete/src/Console/Parser.php
+++ b/concrete/src/Console/Parser.php
@@ -4,22 +4,23 @@ namespace Concrete\Core\Console;
 
 use Illuminate\Support\Str;
 use InvalidArgumentException;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 
 /**
  * Console command parser
- * This was taken directly from illuminate/console
+ * This was taken directly from illuminate/console.
  */
 class Parser
 {
     /**
      * Parse the given console command definition into an array.
      *
-     * @param  string  $expression
-     * @return array
+     * @param string $expression
      *
      * @throws \InvalidArgumentException
+     *
+     * @return array
      */
     public static function parse(string $expression): array
     {
@@ -37,7 +38,8 @@ class Parser
     /**
      * Extract the name of the command from the expression.
      *
-     * @param  string  $expression
+     * @param string $expression
+     *
      * @return string
      */
     protected static function name(string $expression): string
@@ -46,7 +48,7 @@ class Parser
             throw new InvalidArgumentException('Console command definition is empty.');
         }
 
-        if (! preg_match('/[^\s]+/', $expression, $matches)) {
+        if (!preg_match('/[^\s]+/', $expression, $matches)) {
             throw new InvalidArgumentException('Unable to determine command name from signature.');
         }
 
@@ -56,7 +58,8 @@ class Parser
     /**
      * Extract all of the parameters from the tokens.
      *
-     * @param  array  $tokens
+     * @param array $tokens
+     *
      * @return array
      */
     protected static function parameters(array $tokens): array
@@ -79,12 +82,13 @@ class Parser
     /**
      * Parse an argument expression.
      *
-     * @param  string  $token
+     * @param string $token
+     *
      * @return \Symfony\Component\Console\Input\InputArgument
      */
     protected static function parseArgument(string $token): InputArgument
     {
-        list($token, $description) = static::extractDescription($token);
+        [$token, $description] = static::extractDescription($token);
 
         switch (true) {
             case Str::endsWith($token, '?*'):
@@ -105,12 +109,13 @@ class Parser
     /**
      * Parse an option expression.
      *
-     * @param  string  $token
+     * @param string $token
+     *
      * @return \Symfony\Component\Console\Input\InputOption
      */
     protected static function parseOption(string $token): InputOption
     {
-        list($token, $description) = static::extractDescription($token);
+        [$token, $description] = static::extractDescription($token);
 
         $matches = preg_split('/\s*\|\s*/', $token, 2);
 
@@ -138,7 +143,8 @@ class Parser
     /**
      * Parse the token into its token and description segments.
      *
-     * @param  string  $token
+     * @param string $token
+     *
      * @return array
      */
     protected static function extractDescription(string $token): array

--- a/concrete/src/Console/Parser.php
+++ b/concrete/src/Console/Parser.php
@@ -21,7 +21,7 @@ class Parser
      *
      * @throws \InvalidArgumentException
      */
-    public static function parse($expression)
+    public static function parse(string $expression): array
     {
         $name = static::name($expression);
 
@@ -40,7 +40,7 @@ class Parser
      * @param  string  $expression
      * @return string
      */
-    protected static function name($expression)
+    protected static function name(string $expression): string
     {
         if (trim($expression) === '') {
             throw new InvalidArgumentException('Console command definition is empty.');
@@ -59,7 +59,7 @@ class Parser
      * @param  array  $tokens
      * @return array
      */
-    protected static function parameters(array $tokens)
+    protected static function parameters(array $tokens): array
     {
         $arguments = [];
 
@@ -82,7 +82,7 @@ class Parser
      * @param  string  $token
      * @return \Symfony\Component\Console\Input\InputArgument
      */
-    protected static function parseArgument($token)
+    protected static function parseArgument(string $token): InputArgument
     {
         list($token, $description) = static::extractDescription($token);
 
@@ -108,7 +108,7 @@ class Parser
      * @param  string  $token
      * @return \Symfony\Component\Console\Input\InputOption
      */
-    protected static function parseOption($token)
+    protected static function parseOption(string $token): InputOption
     {
         list($token, $description) = static::extractDescription($token);
 
@@ -141,7 +141,7 @@ class Parser
      * @param  string  $token
      * @return array
      */
-    protected static function extractDescription($token)
+    protected static function extractDescription(string $token): array
     {
         $parts = preg_split('/\s+:\s+/', trim($token), 2);
 


### PR DESCRIPTION
Symfony\Component\Console\Command\Command::getApplication() declares a nullable
Application return type. Concrete\Core\Console\Command overrides this method
without a compatible signature, which causes a fatal compile error on PHP 8+:

Declaration of Concrete\Core\Console\Command::getApplication() must be compatible with …

This change updates the method signature to match Symfony while remaining compatible
with PHP 7.4+.

*Checklist before submitting:*

- [x] I read the guidelines for contributing.
- [x] My pull request conforms to the coding style guidelines described in the project.
- [x] The fix supports PHP 7.4 through PHP 8.2.

Fix issue: #12798

Thank you!
