### PR TITLE
Respect concrete.updates.skip_core

### DIFF
--- a/concrete/controllers/single_page/dashboard/system/update/update.php
+++ b/concrete/controllers/single_page/dashboard/system/update/update.php
@@ -36,6 +36,8 @@ class Update extends DashboardPageController
 
             return null;
         }
+        $config = $this->app->make('config');
+        $this->set('skipCoreUpdates', (bool) $config->get('concrete.updates.skip_core'));
         $upd = $this->app->make(UpdateService::class);
         $updates = $upd->getLocalAvailableUpdates();
         if (count($updates) === 1) {
@@ -44,7 +46,7 @@ class Update extends DashboardPageController
             return;
         }
         $this->set('dh', $this->app->make('date'));
-        $this->set('currentVersion', $this->app->make('config')->get('concrete.version'));
+        $this->set('currentVersion', $config->get('concrete.version'));
         $this->set('updates', $updates);
         $remote = $upd->getApplicationUpdateInformation();
         if ($remote instanceof RemoteApplicationUpdate && version_compare($remote->getVersion(), APP_VERSION, '>')) {
@@ -96,11 +98,11 @@ class Update extends DashboardPageController
         if (!$this->userHasUpgradePermission()) {
             return $this->buildRedirect($this->action());
         }
-
         if (!$this->token->validate('download_update')) {
             $this->error->add($this->token->getErrorMessage());
-        }
-        if (!is_dir(DIR_CORE_UPDATES)) {
+        } elseif ($this->app->make('config')->get('concrete.updates.skip_core')) {
+            $this->error->add(t('Updates are currently disabled via your site configuration.'));
+        } elseif (!is_dir(DIR_CORE_UPDATES)) {
             $this->error->add(t('The directory %s does not exist.', DIR_CORE_UPDATES));
         } elseif (!is_writable(DIR_CORE_UPDATES)) {
             $this->error->add(t('The directory %s must be writable by the web server.', DIR_CORE_UPDATES));
@@ -158,18 +160,22 @@ class Update extends DashboardPageController
         if (!$this->userHasUpgradePermission()) {
             return $this->buildRedirect($this->action());
         }
-        $updateVersion = (string) $this->request->request->get('version', '');
-        if ($updateVersion === '') {
-            $this->error->add(t('Invalid version'));
+        if ($this->app->make('config')->get('concrete.updates.skip_core')) {
+            $this->error->add(t('Updates are currently disabled via your site configuration.'));
         } else {
-            $upd = ApplicationUpdate::getByVersionNumber($updateVersion);
-            if ($upd == null) {
+            $updateVersion = (string) $this->request->request->get('version', '');
+            if ($updateVersion === '') {
                 $this->error->add(t('Invalid version'));
             } else {
-                if (version_compare($upd->getUpdateVersion(), APP_VERSION, '<=')) {
-                    $this->error->add(
-                        t('You may only apply updates with a greater version number than the version you are currently running.')
-                    );
+                $upd = ApplicationUpdate::getByVersionNumber($updateVersion);
+                if ($upd == null) {
+                    $this->error->add(t('Invalid version'));
+                } else {
+                    if (version_compare($upd->getUpdateVersion(), APP_VERSION, '<=')) {
+                        $this->error->add(
+                            t('You may only apply updates with a greater version number than the version you are currently running.')
+                        );
+                    }
                 }
             }
         }

--- a/concrete/single_pages/dashboard/system/update/update.php
+++ b/concrete/single_pages/dashboard/system/update/update.php
@@ -13,9 +13,19 @@ defined('C5_EXECUTE') or die('Access Denied.');
  * @var string $currentVersion
  * @var Concrete\Core\Updater\ApplicationUpdate[] $updates
  * @var Concrete\Core\Updater\RemoteApplicationUpdate|null $remoteUpdate
+ * @var bool $skipCoreUpdates
  */
 ?>
 
+<?php
+if ($skipCoreUpdates) {
+    ?>
+    <div class="alert alert-danger">
+        <?= t('Updates are currently disabled via your site configuration.') ?>
+    </div>
+    <?php
+}
+?>
 <fieldset class="mb-3">
     <legend><?= t('Current Version') ?></legend>
     <?= t('You are currently running Concrete version %s', '<strong>' . h($currentVersion) . '</strong>') ?>
@@ -24,7 +34,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
 <?php
 if ($remoteUpdate !== null) {
     ?>
-    <form method="POST" action="<?= $controller->action('download_update') ?>" class="mb-3">
+    <form method="POST" action="<?= $controller->action('download_update') ?>" class="mb-3" <?= $skipCoreUpdates ? ' onsubmit="return false"' : '' ?>>
         <?php $token->output('download_update') ?>
         <input type="submit" id="ccm-update-download-submit" class="d-none" />
         <fieldset>
@@ -63,17 +73,21 @@ if ($remoteUpdate !== null) {
             </div>
         </fieldset>
     </form>
-    <script>
-        $('#ccm-update-download-submit').closest('form').on('submit', function(e) {
-            var $form = $(this);
-            ConcreteAlert.confirm(<?= json_encode(t('Note: Downloading an update will NOT automatically install it.')) ?>, function() {
-                $form.off('submit').submit().on('submit', function(e) { e.preventDefault(); return false; });
-            });
-            e.preventDefault();
-            return false;
-        });
-    </script>
     <?php
+    if (!$skipCoreUpdates) {
+        ?>
+        <script>
+            $('#ccm-update-download-submit').closest('form').on('submit', function(e) {
+                var $form = $(this);
+                ConcreteAlert.confirm(<?= json_encode(t('Note: Downloading an update will NOT automatically install it.')) ?>, function() {
+                    $form.off('submit').submit().on('submit', function(e) { e.preventDefault(); return false; });
+                });
+                e.preventDefault();
+                return false;
+            });
+        </script>
+        <?php
+    }
 }
 ?>
 
@@ -123,7 +137,7 @@ if ($remoteUpdate !== null) {
             <?php
             if ($remoteUpdate !== null) {
                 ?>
-                <label for="ccm-update-download-submit" class="btn btn-success mb-0"><?= t('Download v.%s', h($remoteUpdate->getVersion())) ?></label>
+                <label <?= $skipCoreUpdates ? '' : ' for="ccm-update-download-submit"' ?> class="btn btn-success mb-0<?= $skipCoreUpdates ? ' disabled' : '' ?>"><?= t('Download v.%s', h($remoteUpdate->getVersion())) ?></label>
                 <?php
             }
             if ($updates !== []) {

--- a/concrete/single_pages/dashboard/system/update/update/local_available_update.php
+++ b/concrete/single_pages/dashboard/system/update/update/local_available_update.php
@@ -13,6 +13,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
  * @var Concrete\Core\Updater\ApplicationUpdate $update
  * @var Concrete\Core\Url\UrlImmutable $updatePackagesUrl
  * @var Concrete\Core\Entity\Package[] $installedPackages
+ * @var bool $skipCoreUpdates
  */
 
 ?>
@@ -21,10 +22,21 @@ defined('C5_EXECUTE') or die('Access Denied.');
     <?php $token->output('do_update') ?>
     <input type="hidden" name="version" value="<?= h($update->getVersion()) ?>" />
 
-    <div class="alert alert-warning">
-        <?= t('Before updating, it is highly recommended to make a full site backup. A full site backup consists of site files and site database export. Please consult your hosting provider for guidance on backup processes.') ?>
-    </div>
-
+    <?php
+    if ($skipCoreUpdates) {
+        ?>
+        <div class="alert alert-danger">
+            <?= t('Updates are currently disabled via your site configuration.') ?>
+        </div>
+        <?php
+    } else {
+        ?>
+        <div class="alert alert-warning">
+            <?= t('Before updating, it is highly recommended to make a full site backup. A full site backup consists of site files and site database export. Please consult your hosting provider for guidance on backup processes.') ?>
+        </div>
+        <?php
+    }
+    ?>
     <div class="ccm-dashboard-update-details">
         <div class="ccm-dashboard-update-thumbnail"><img src="<?= ASSETS_URL_IMAGES ?>/logo.svg" /></div>
         <h2><?= t('Version %s', $update->getVersion()) ?></h2>
@@ -236,10 +248,19 @@ $(document).ready(function() {
                     return result;
                 },
                 handleSubmit: function(e) {
-                    if (this.state === my.STATE.LOADING) {
+                    if (this.state === this.STATE.LOADING) {
                         e.preventDefault();
                         return false;
                     }
+                    <?php
+                    if ($skipCoreUpdates) {
+                        ?>
+                        ConcreteAlert.error({message: <?= json_encode(t('Updates are currently disabled via your site configuration.')) ?>});
+                        e.preventDefault();
+                        return false;
+                        <?php
+                    }
+                    ?>
                 }
             },
             mounted: function() {


### PR DESCRIPTION
ConcreteCMS can be installed either via zip file or via Composer.

In the first case, having the ability to update Concrete from a dashboard page is very useful.

In the second case, it is not: a client of mine just broke their Composer-based website by upgrading the core via the dashboard.

```
Compile Error: Cannot redeclare class Concrete\Core\Entity\Board\Designer\CustomElement
(previously declared in .../concrete/src/Entity/Board/Designer/CustomElement.php:15

at .../updates/concrete-cms-9.4.7-remote-updater/concrete/src/Entity/Board/Designer/CustomElement.php:15 
```

To avoid such problems, in #7790 we introduced the possibility to disable manual core updates by setting the `concrete.updates.skip_core` configuration key.

And I did set that configuration key... However, in 1d74e7b8723e2d86ad83c1841c9c51d60ac00cc4 we somehow lost this respecting this setting.

What about restoring it?

In this PR I've improved the original approach: in #7790 we simply disabled the check for new versions.
Here we now allow that check (so that system administrators can be informed that an update is available), but we disable downloading and installing updates.
