### PR TITLE
Use laravel's Arr class instead of array_first for PHP 8.5 support

### DIFF
--- a/concrete/blocks/express_entry_list/controller.php
+++ b/concrete/blocks/express_entry_list/controller.php
@@ -33,6 +33,7 @@ use Concrete\Core\Search\Result\ResultFactory;
 use Concrete\Core\Support\Facade\Facade;
 use Concrete\Core\Utility\Service\Xml;
 use Doctrine\ORM\EntityManagerInterface;
+use Illuminate\Support\Arr;
 use SimpleXMLElement;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
@@ -584,7 +585,7 @@ class Controller extends BlockController implements UsesFeatureInterface
             if ($linkedPropertyHandle === '') {
                 continue;
             }
-            $linkedProperty = array_first(
+            $linkedProperty = Arr::first(
                 $entityAttributes,
                 static function($attribute) use ($linkedPropertyHandle) {
                     return $linkedPropertyHandle === $attribute->getAttributeKeyHandle();
@@ -602,7 +603,7 @@ class Controller extends BlockController implements UsesFeatureInterface
             if ($searchPropertyHandle === '') {
                 continue;
             }
-            $searchProperty = array_first(
+            $searchProperty = Arr::first(
                 $entityAttributes,
                 static function($attribute) use ($searchPropertyHandle) {
                     return $searchPropertyHandle === $attribute->getAttributeKeyHandle();
@@ -618,7 +619,7 @@ class Controller extends BlockController implements UsesFeatureInterface
         $searchAssociations = [];
         foreach ($xRecord->searchAssociation as $xSearchAssociation) {
             $searchAssociationUUID = (string) $xSearchAssociation;
-            $association = array_first(
+            $association = Arr::first(
                 $entityAssociations,
                 static function ($association) use ($searchAssociationUUID): bool {
                     return $searchAssociationUUID !== '' && $association->getId() === $searchAssociationUUID;
@@ -626,7 +627,7 @@ class Controller extends BlockController implements UsesFeatureInterface
             );
             if ($association === null) {
                 $searchAssociationName = (string) $xSearchAssociation['target-property-name'];
-                $association = array_first(
+                $association = Arr::first(
                     $entityAssociations,
                     static function ($association) use ($searchAssociationName): bool {
                         return $searchAssociationName !== '' && $association->getTargetPropertyName() === $searchAssociationName;
@@ -658,7 +659,7 @@ class Controller extends BlockController implements UsesFeatureInterface
             $availableColumns = $provider->getAvailableColumnSet()->getColumns();
             $findColumn = static function(string $key, string $name) use ($availableColumns) {
                 if ($key !== '') {
-                    $column = array_first(
+                    $column = Arr::first(
                         $availableColumns,
                         static function ($column) use ($key) { return $column->getColumnKey() === $key; }
                     );
@@ -667,7 +668,7 @@ class Controller extends BlockController implements UsesFeatureInterface
                     }
                 }
                 if ($name !== '') {
-                    $column = array_first(
+                    $column = Arr::first(
                         $availableColumns,
                         static function ($column) use ($name) { return $column->getColumnName() === $name; }
                     );
@@ -723,7 +724,7 @@ class Controller extends BlockController implements UsesFeatureInterface
         unset($xRecord->linkedProperties[0]);
         $linkedPropertyIDs = array_map('intval', (array) json_decode($this->linkedProperties));
         foreach ($linkedPropertyIDs as $linkedPropertyID) {
-            $linkedProperty = array_first(
+            $linkedProperty = Arr::first(
                 $entityAttributes,
                 static function($attribute) use ($linkedPropertyID) {
                     return $linkedPropertyID === (int) $attribute->getAttributeKeyID();
@@ -737,7 +738,7 @@ class Controller extends BlockController implements UsesFeatureInterface
         unset($xRecord->searchProperties[0]);
         $searchPropertyIDs = array_map('intval', (array) json_decode($this->searchProperties));
         foreach ($searchPropertyIDs as $searchPropertyID) {
-            $searchProperty = array_first(
+            $searchProperty = Arr::first(
                 $entityAttributes,
                 static function($attribute) use ($searchPropertyID): bool {
                     return $searchPropertyID === (int) $attribute->getAttributeKeyID();
@@ -750,7 +751,7 @@ class Controller extends BlockController implements UsesFeatureInterface
 
         $searchAssociationUUIDs = (array) json_decode($this->searchAssociations);
         foreach ($searchAssociationUUIDs as $searchAssociationUUID) {
-            $association = array_first(
+            $association = Arr::first(
                 $entityAssociations,
                 static function ($association) use ($searchAssociationUUID): bool {
                     return $association->getId() === $searchAssociationUUID;

--- a/concrete/blocks/express_form/controller.php
+++ b/concrete/blocks/express_form/controller.php
@@ -43,6 +43,7 @@ use Concrete\Core\Utility\Service\Xml;
 use Concrete\Core\Validator\String\EmailValidator;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Id\UuidGenerator;
+use Illuminate\Support\Arr;
 use SimpleXMLElement;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Concrete\Core\Permission\Checker;
@@ -540,7 +541,7 @@ class Controller extends BlockController implements NotificationProviderInterfac
                         $entity = $entityHandle === '' ? null : $em->getRepository(Entity::class)->findOneBy(['handle' => $entityHandle]);
                     }
                     if ($entity !== null) {
-                        $form = array_first(
+                        $form = Arr::first(
                             $entity->getForms()->toArray(),
                             static function ($form) use ($formName) { return $form->getName() === $formName; }
                         );

--- a/concrete/single_pages/dashboard/extend/update.php
+++ b/concrete/single_pages/dashboard/extend/update.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Arr;
 use Michelf\Markdown;
 
 /** @var \Concrete\Core\Entity\Package[] $localUpdates */
@@ -36,7 +37,7 @@ if (!$tp->canInstallPackages()) {
         <table class="table update-addons-table">
 			<?php
             foreach ($remoteUpdates as $pkg) {
-                $remotePackage = array_first($remotePackages, function ($remote) use ($pkg) {
+                $remotePackage = Arr::first($remotePackages, function ($remote) use ($pkg) {
                     return $remote->handle === $pkg->getPackageHandle();
                 });
                 ?>

--- a/concrete/src/Console/Command/InstallPackageCommand.php
+++ b/concrete/src/Console/Command/InstallPackageCommand.php
@@ -10,6 +10,7 @@ use Concrete\Core\Marketplace\PackageRepositoryInterface;
 use Concrete\Core\Package\PackageService;
 use Concrete\Core\Support\Facade\Application;
 use Exception;
+use Illuminate\Support\Arr;
 use Symfony\Component\Console\Exception\InvalidOptionException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -68,7 +69,7 @@ EOT
                 break;
             case 'auto':
                 $associatedPackages = $connection ? $packageRepository->getPackages($connection) : [];
-                $getLanguages = (bool) array_first($associatedPackages, function ($pkg) use ($pkgHandle) {
+                $getLanguages = (bool) Arr::first($associatedPackages, function ($pkg) use ($pkgHandle) {
                     return $pkg->handle = $pkgHandle;
                 });
                 break;
@@ -77,7 +78,7 @@ EOT
         }
         $packageOptions = [];
         foreach ($input->getArgument('package-options') as $keyValuePair) {
-            list($key, $value) = explode('=', $keyValuePair, 2);
+            [$key, $value] = explode('=', $keyValuePair, 2);
             $key = trim($key);
             if (substr($key, -2) === '[]') {
                 $isArray = true;

--- a/concrete/src/Foundation/EnvironmentDetector.php
+++ b/concrete/src/Foundation/EnvironmentDetector.php
@@ -2,6 +2,7 @@
 namespace Concrete\Core\Foundation;
 
 use Closure;
+use Illuminate\Support\Arr;
 
 /**
  * Class EnvironmentDetector.
@@ -115,7 +116,7 @@ class EnvironmentDetector
      */
     protected function getEnvironmentArgument(array $args)
     {
-        return array_first($args, function ($v) {
+        return Arr::first($args, function ($v) {
             return starts_with($v, '--env');
         });
     }


### PR DESCRIPTION
PHP 8.5 adds an `array_first` function that doesn't support passing a closure https://www.php.net/manual/en/function.array-first.php
This PR switches to Laravel's `Arr` static `first` method, which is what powered the old `array_first`.