### PR TITLE
Show MySQL max_connections in environment details

### DIFF
--- a/concrete/controllers/single_page/dashboard/system/environment/info.php
+++ b/concrete/controllers/single_page/dashboard/system/environment/info.php
@@ -23,7 +23,8 @@ class Info extends DashboardPageController
         $dbInfos = '';
         if ($info->isInstalled()) {
             $dbInfos = "\n# Database Information\nVersion: {$info->getDBMSVersion()}\nSQL Mode: {$info->getDBMSSqlMode()}\n".
-                "Character Set: {$info->getDbCharset()}\nCollation: {$info->getDbCollation()}\n";
+                "Character Set: {$info->getDbCharset()}\nCollation: {$info->getDbCollation()}\n".
+                "Max Connections: {$info->getDBMSMaxConnections()}\n";
         }
 
         $packages = $info->getPackages() ?: 'None';

--- a/concrete/src/Console/Command/InfoCommand.php
+++ b/concrete/src/Console/Command/InfoCommand.php
@@ -54,6 +54,7 @@ EOT
             $output->writeln('SQL Mode - ' . $info->getDBMSSqlMode());
             $output->writeln('Character Set - ' . $info->getDbCharset());
             $output->writeln('Collation - ' . $info->getDbCollation());
+            $output->writeln('Max Connections - ' . $info->getDBMSMaxConnections());
         }
 
         $output->writeln('');

--- a/concrete/src/System/Info.php
+++ b/concrete/src/System/Info.php
@@ -94,7 +94,12 @@ class Info
      * @var string|null
      */
     private $dbmsSqlMode;
-    
+
+    /**
+     * @var int|null
+     */
+    private $dbmsMaxConnections;
+
     /**
      * @var string|null
      */
@@ -551,6 +556,21 @@ class Info
         }
 
         return $this->dbmsSqlMode;
+    }
+
+    public function getDBMSMaxConnections(): ?int
+    {
+        if ($this->dbmsMaxConnections === null) {
+            if ($this->installed) {
+                try {
+                    $cn = $this->app->make(Connection::class);
+                    $this->dbmsMaxConnections = (int) $cn->fetchColumn('select @@max_connections');
+                } catch (\Throwable $x) {
+                }
+            }
+        }
+
+        return $this->dbmsMaxConnections;
     }
 
     public function getHostname()


### PR DESCRIPTION
What about including the maximum number of database connections in the environment details?

CLI:

```sh
$ ./concrete/bin/concrete c5:info
[...]
# Database Information
Version - 5.7.40-log
SQL Mode - STRICT_TRANS_TABLES,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION
Character Set - utf8mb4
Collation - utf8mb4_unicode_ci
Max Connections - 151
[...]
```

Dashboard:

<img width="601" height="245" alt="image" src="https://github.com/user-attachments/assets/992a713d-4bb4-4d9a-8e62-6895980f71bd" />
