### PR TITLE
Switch to html-object fork that has some fixes

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -7,52 +7,6 @@
     "content-hash": "0db635001fd90701cd46808e68f9e47c",
     "packages": [
         {
-            "name": "anahkiasen/html-object",
-            "version": "1.4.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Anahkiasen/html-object.git",
-                "reference": "45bb54b91112c064d3906c207259d5c8dcba798f"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Anahkiasen/html-object/zipball/45bb54b91112c064d3906c207259d5c8dcba798f",
-                "reference": "45bb54b91112c064d3906c207259d5c8dcba798f",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.3.0"
-            },
-            "require-dev": {
-                "madewithlove/php-cs-fixer-config": "^1.3",
-                "phpunit/phpunit": "^4.8",
-                "phpunit/phpunit-dom-assertions": "^0.1.0",
-                "symfony/css-selector": "^2.6"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "HtmlObject\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Anahkiasen",
-                    "email": "ehtnam6@gmail.com"
-                }
-            ],
-            "description": "A set of classes to create and manipulate HTML objects abstractions",
-            "support": {
-                "issues": "https://github.com/Anahkiasen/html-object/issues",
-                "source": "https://github.com/Anahkiasen/html-object/tree/master"
-            },
-            "time": "2017-05-31T07:52:45+00:00"
-        },
-        {
             "name": "carbonphp/carbon-doctrine-types",
             "version": "1.0.0",
             "source": {
@@ -3162,6 +3116,72 @@
                 "source": "https://github.com/jbroadway/urlify/tree/1.2.3-stable"
             },
             "time": "2021-12-29T21:23:40+00:00"
+        },
+        {
+            "name": "kylekatarnls/html-object",
+            "version": "1.5.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/kylekatarnls/html-object.git",
+                "reference": "7e06624fa9aac2a33e683491abea163089087a88"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/kylekatarnls/html-object/zipball/7e06624fa9aac2a33e683491abea163089087a88",
+                "reference": "7e06624fa9aac2a33e683491abea163089087a88",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "replace": {
+                "anahkiasen/html-object": "self.version"
+            },
+            "require-dev": {
+                "madewithlove/php-cs-fixer-config": "^1.3",
+                "phpunit/phpunit": "^4.8.36 || ^5.7.27 || ^6.5.14 || ^7.5.20 || ^8.5.32 || ^9.6.3 || ^10.0.11",
+                "phpunit/phpunit-dom-assertions": "^0.1.0 || ^2.6.0",
+                "symfony/css-selector": "^2.6 || ^4.4.27 || ^5.4.0 || ^6.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "HtmlObject\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Anahkiasen",
+                    "email": "ehtnam6@gmail.com"
+                },
+                {
+                    "name": "kylekatanls",
+                    "homepage": "https://github.com/kylekatarnls"
+                }
+            ],
+            "description": "A set of classes to create and manipulate HTML objects abstractions",
+            "support": {
+                "source": "https://github.com/kylekatarnls/html-object/tree/1.5.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kylekatarnls",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/Carbon",
+                    "type": "open_collective"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/nesbot/carbon",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-03-02T15:22:44+00:00"
         },
         {
             "name": "laminas/laminas-cache",
@@ -13784,5 +13804,5 @@
     "platform-overrides": {
         "php": "7.3"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/concrete/composer.json
+++ b/concrete/composer.json
@@ -82,7 +82,7 @@
     "sunra/php-simple-html-dom-parser": "^1.5.2",
     "jbroadway/urlify": "^1.2.2-stable",
     "dapphp/securimage": "3.*",
-    "anahkiasen/html-object": "~1.4",
+    "kylekatarnls/html-object": "^1.5.2",
     "primal/color": "1.0.*",
     "nesbot/carbon": "^2.1",
     "punic/punic": "^3.0.1",


### PR DESCRIPTION
Relates to #12472 

This PR replaces `anahkiasen/html-object` with the updated (but still old) `kylekatarnls/html-object`. See the differences here: https://github.com/kylekatarnls/html-object/compare/1.4.4...master

A short summary of the benefits / changes that effect us:
- Better support, Kyle Katarn is still active in the PHP community
- Avoids errors when `declare(strict_types=1);` is used
- Supports running `->removeClass()` with classes that aren't already included
