### PR TITLE
Fixes Issue #12822 - missing getJSONObject method in CalendarEventVersion entity 

### DIFF
--- a/concrete/src/Calendar/Event/EventService.php
+++ b/concrete/src/Calendar/Event/EventService.php
@@ -145,11 +145,11 @@ class EventService implements ApplicationAwareInterface, LoggerAwareInterface
         }
 
         if (!$event->getID()) {
-            $this->logger->info(t('Creating new event %s', $version->getName()));
+            $this->logger->info(t('Creating new event %s', $version->getName()));            
         }
 
         $this->logger->info(t('Adding new version %s to event %s', $version->getID(), $version->getName()));
-
+        
         $this->entityManager->persist($version);
         $event->getVersions()->add($version);
         $event->setCalendar($calendar);

--- a/concrete/src/Entity/Calendar/CalendarEventVersion.php
+++ b/concrete/src/Entity/Calendar/CalendarEventVersion.php
@@ -283,6 +283,38 @@ class CalendarEventVersion implements ObjectInterface, \JsonSerializable
     }
 
     /**
+     * Returns json object with basic event details
+     * 
+     * @param  bool $getAttributes - Optional parameter, True if attrbitues should be included in the object, false otherwise.  Defaults to false.  
+     * @param  mixed $displayMode - Optional parameter, if set to 'display' will return the display value, or, set to false will return the value.  Defaults to false.  If getAttributes=false, this paramter has no impact.
+     * @return object
+     */
+    public function getJSONobject(bool $getAttributes=false, mixed $displayMode=false):object
+    {
+        
+        $o=new \stdClass();
+        $o->id = $this->event->getID();
+        $o->name = $this->getName();
+        $o->versionId = $this->getID();
+        $o->description = $this->getDescription();        
+
+        if($getAttributes){
+            foreach(EventKey::getList() AS $attribute){
+                $handle=$attribute->getAttributeKeyHandle();                        
+                if($displayMode && $av=$this->getAttributeValueObject($attribute)){
+                    $value=$av->getDisplayValue();
+                }else{
+                    $value=$this->getAttribute($handle);
+                }                
+                $o->$handle=$value;
+            }
+        }
+
+        return $o;
+        
+    }
+    
+    /**
      * @return array
      */
     #[\ReturnTypeWillChange]

--- a/concrete/src/Entity/Calendar/CalendarEventVersionOccurrence.php
+++ b/concrete/src/Entity/Calendar/CalendarEventVersionOccurrence.php
@@ -60,14 +60,21 @@ class CalendarEventVersionOccurrence implements ObjectInterface, CategoryMemberI
      */
     protected $occurrence;
 
-    public function getJSONObject()
+    /**
+     * Returns json object with basic event details.  Includes data from this occurence and the current event version.
+     * 
+     * @param  bool $getAttributes - Optional parameter, True if attrbitues should be included in the object, false otherwise.  Defaults to false.  
+     * @param  mixed $displayMode - Optional parameter, if set to 'display' will return the display value, or, set to false will return the value.  Defaults to false.  If getAttributes=false, this paramter has no impact.
+     * @return object
+     */
+    public function getJSONObject($getAttributes=false,$displayMode=false)
     {
         $ev = $this->getEvent();
         $r = array();
         $r['start'] = $this->occurrence->getStart();
         $r['end'] = $this->occurrence->getEnd();
 
-        return (object) array_merge($r, (array) $ev->getJSONObject());
+        return (object) array_merge($r, (array) $ev->getJSONObject($getAttributes,$displayMode));
     }
 
     public function __construct(CalendarEventVersion $version, CalendarEventRepetition $repetition, $start, $end, $cancelled = false)


### PR DESCRIPTION
Made two  changes:
1. Added missing getJSONObject method into CalendarEventVersion Entity
2. Added optional parameters into both getJSONObject methods in CalendarEventVersion and CalendarEventVersionOccurrence entities to include attributes from the event in the object.  This allows for return of a complete picture of the event in the object.

The attributes are included at the root level of the object which works out very well for what i'm doing.  I've seen other areas where they are included under a custom_attributes key in the object.  Not sure which is better inline with concrete architecture.  If the latter is more appropriate I'm happy to make the change just let me know.

The new signature of the methods:
```
/**
     * Returns json object with basic event details
     * 
     * @param  bool $getAttributes - Optional parameter, True if attrbitues should be included in the object, false otherwise.  Defaults to false.  
     * @param  mixed $displayMode - Optional parameter, if set to 'display' will return the display value, or, set to false will return the value.  Defaults to false.  If getAttributes=false, this paramter has no impact.
     * @return object
     */
    public function getJSONobject(bool $getAttributes=false, mixed $displayMode=false):object {...
```