### PR TITLE
Update Version20211023155414.php - fixes font size migration

### DIFF
--- a/concrete/src/Updater/Migrations/Migrations/Version20211023155414.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20211023155414.php
@@ -108,7 +108,7 @@ final class Version20211023155414 extends AbstractMigration implements Repeatabl
         }
         if (is_array($legacyValueValueData['fontSize'])) {
             $sizeStyle = new SizeStyle();
-            $sizeStyle->setVariable($variable . '-type');
+            $sizeStyle->setVariable($variable . '-type-font');
             $sizeValue = $this->upgradeSizeValue($legacyValueValueData['fontSize']);
             $value->addSubStyleValue(new StyleValue($sizeStyle, $sizeValue));
         }


### PR DESCRIPTION
I noticed that for a theme I used which uses the legacy style system, the font sizes where not migrated from the customizer. After adding the -font to the variable and rerun the migration it worked.
