### PR TITLE
Update page list xml files to include "excludeCanonicalPaging" element

### DIFF
--- a/tests/assets/Block/cif/page_list/all-other-filters.xml
+++ b/tests/assets/Block/cif/page_list/all-other-filters.xml
@@ -12,6 +12,7 @@
       <displaySystemPages>1</displaySystemPages>
       <displayThumbnail>0</displayThumbnail>
       <enableExternalFiltering>1</enableExternalFiltering>
+      <excludeCanonicalPaging>0</excludeCanonicalPaging>
       <excludeCurrentPage>1</excludeCurrentPage>
       <filterByCustomTopic>0</filterByCustomTopic>
       <filterByRelated>0</filterByRelated>

--- a/tests/assets/Block/cif/page_list/custom-topic.xml
+++ b/tests/assets/Block/cif/page_list/custom-topic.xml
@@ -12,6 +12,7 @@
       <displaySystemPages>0</displaySystemPages>
       <displayThumbnail>0</displayThumbnail>
       <enableExternalFiltering>0</enableExternalFiltering>
+      <excludeCanonicalPaging>0</excludeCanonicalPaging>
       <excludeCurrentPage>0</excludeCurrentPage>
       <filterByCustomTopic>1</filterByCustomTopic>
       <filterByRelated>0</filterByRelated>

--- a/tests/assets/Block/cif/page_list/date-3-days-ago.xml
+++ b/tests/assets/Block/cif/page_list/date-3-days-ago.xml
@@ -12,6 +12,7 @@
       <displaySystemPages>0</displaySystemPages>
       <displayThumbnail>0</displayThumbnail>
       <enableExternalFiltering>0</enableExternalFiltering>
+      <excludeCanonicalPaging>0</excludeCanonicalPaging>
       <excludeCurrentPage>0</excludeCurrentPage>
       <filterByCustomTopic>0</filterByCustomTopic>
       <filterByRelated>0</filterByRelated>

--- a/tests/assets/Block/cif/page_list/date-4-days-future.xml
+++ b/tests/assets/Block/cif/page_list/date-4-days-future.xml
@@ -12,6 +12,7 @@
       <displaySystemPages>0</displaySystemPages>
       <displayThumbnail>0</displayThumbnail>
       <enableExternalFiltering>0</enableExternalFiltering>
+      <excludeCanonicalPaging>0</excludeCanonicalPaging>
       <excludeCurrentPage>0</excludeCurrentPage>
       <filterByCustomTopic>0</filterByCustomTopic>
       <filterByRelated>0</filterByRelated>

--- a/tests/assets/Block/cif/page_list/date-between-dates.xml
+++ b/tests/assets/Block/cif/page_list/date-between-dates.xml
@@ -12,6 +12,7 @@
       <displaySystemPages>0</displaySystemPages>
       <displayThumbnail>0</displayThumbnail>
       <enableExternalFiltering>0</enableExternalFiltering>
+      <excludeCanonicalPaging>0</excludeCanonicalPaging>
       <excludeCurrentPage>0</excludeCurrentPage>
       <filterByCustomTopic>0</filterByCustomTopic>
       <filterByRelated>0</filterByRelated>

--- a/tests/assets/Block/cif/page_list/date-today.xml
+++ b/tests/assets/Block/cif/page_list/date-today.xml
@@ -12,6 +12,7 @@
       <displaySystemPages>0</displaySystemPages>
       <displayThumbnail>0</displayThumbnail>
       <enableExternalFiltering>0</enableExternalFiltering>
+      <excludeCanonicalPaging>0</excludeCanonicalPaging>
       <excludeCurrentPage>0</excludeCurrentPage>
       <filterByCustomTopic>0</filterByCustomTopic>
       <filterByRelated>0</filterByRelated>

--- a/tests/assets/Block/cif/page_list/feed-existing.xml
+++ b/tests/assets/Block/cif/page_list/feed-existing.xml
@@ -12,6 +12,7 @@
       <displaySystemPages>0</displaySystemPages>
       <displayThumbnail>0</displayThumbnail>
       <enableExternalFiltering>0</enableExternalFiltering>
+      <excludeCanonicalPaging>0</excludeCanonicalPaging>
       <excludeCurrentPage>0</excludeCurrentPage>
       <filterByCustomTopic>0</filterByCustomTopic>
       <filterByRelated>0</filterByRelated>

--- a/tests/assets/Block/cif/page_list/feed-new.xml
+++ b/tests/assets/Block/cif/page_list/feed-new.xml
@@ -12,6 +12,7 @@
       <displaySystemPages>0</displaySystemPages>
       <displayThumbnail>0</displayThumbnail>
       <enableExternalFiltering>0</enableExternalFiltering>
+      <excludeCanonicalPaging>0</excludeCanonicalPaging>
       <excludeCurrentPage>0</excludeCurrentPage>
       <filterByCustomTopic>0</filterByCustomTopic>
       <filterByRelated>0</filterByRelated>

--- a/tests/assets/Block/cif/page_list/location-beneath-other.xml
+++ b/tests/assets/Block/cif/page_list/location-beneath-other.xml
@@ -12,6 +12,7 @@
       <displaySystemPages>0</displaySystemPages>
       <displayThumbnail>0</displayThumbnail>
       <enableExternalFiltering>0</enableExternalFiltering>
+      <excludeCanonicalPaging>0</excludeCanonicalPaging>
       <excludeCurrentPage>0</excludeCurrentPage>
       <filterByCustomTopic>0</filterByCustomTopic>
       <filterByRelated>0</filterByRelated>

--- a/tests/assets/Block/cif/page_list/location-beneath-other2.xml
+++ b/tests/assets/Block/cif/page_list/location-beneath-other2.xml
@@ -12,6 +12,7 @@
       <displaySystemPages>0</displaySystemPages>
       <displayThumbnail>0</displayThumbnail>
       <enableExternalFiltering>0</enableExternalFiltering>
+      <excludeCanonicalPaging>0</excludeCanonicalPaging>
       <excludeCurrentPage>0</excludeCurrentPage>
       <filterByCustomTopic>0</filterByCustomTopic>
       <filterByRelated>0</filterByRelated>

--- a/tests/assets/Block/cif/page_list/location-beneath-this.xml
+++ b/tests/assets/Block/cif/page_list/location-beneath-this.xml
@@ -12,6 +12,7 @@
       <displaySystemPages>0</displaySystemPages>
       <displayThumbnail>0</displayThumbnail>
       <enableExternalFiltering>0</enableExternalFiltering>
+      <excludeCanonicalPaging>0</excludeCanonicalPaging>
       <excludeCurrentPage>0</excludeCurrentPage>
       <filterByCustomTopic>0</filterByCustomTopic>
       <filterByRelated>0</filterByRelated>

--- a/tests/assets/Block/cif/page_list/location-beneath-this2.xml
+++ b/tests/assets/Block/cif/page_list/location-beneath-this2.xml
@@ -12,6 +12,7 @@
       <displaySystemPages>0</displaySystemPages>
       <displayThumbnail>0</displayThumbnail>
       <enableExternalFiltering>0</enableExternalFiltering>
+      <excludeCanonicalPaging>0</excludeCanonicalPaging>
       <excludeCurrentPage>0</excludeCurrentPage>
       <filterByCustomTopic>0</filterByCustomTopic>
       <filterByRelated>0</filterByRelated>

--- a/tests/assets/Block/cif/page_list/location-current-level.xml
+++ b/tests/assets/Block/cif/page_list/location-current-level.xml
@@ -12,6 +12,7 @@
       <displaySystemPages>0</displaySystemPages>
       <displayThumbnail>0</displayThumbnail>
       <enableExternalFiltering>0</enableExternalFiltering>
+      <excludeCanonicalPaging>0</excludeCanonicalPaging>
       <excludeCurrentPage>0</excludeCurrentPage>
       <filterByCustomTopic>0</filterByCustomTopic>
       <filterByRelated>0</filterByRelated>

--- a/tests/assets/Block/cif/page_list/location-everywhere.xml
+++ b/tests/assets/Block/cif/page_list/location-everywhere.xml
@@ -12,6 +12,7 @@
       <displaySystemPages>0</displaySystemPages>
       <displayThumbnail>0</displayThumbnail>
       <enableExternalFiltering>0</enableExternalFiltering>
+      <excludeCanonicalPaging>0</excludeCanonicalPaging>
       <excludeCurrentPage>0</excludeCurrentPage>
       <filterByCustomTopic>0</filterByCustomTopic>
       <filterByRelated>0</filterByRelated>

--- a/tests/assets/Block/cif/page_list/misc.xml
+++ b/tests/assets/Block/cif/page_list/misc.xml
@@ -12,6 +12,7 @@
       <displaySystemPages>0</displaySystemPages>
       <displayThumbnail>1</displayThumbnail>
       <enableExternalFiltering>0</enableExternalFiltering>
+      <excludeCanonicalPaging>0</excludeCanonicalPaging>
       <excludeCurrentPage>0</excludeCurrentPage>
       <filterByCustomTopic>0</filterByCustomTopic>
       <filterByRelated>0</filterByRelated>

--- a/tests/assets/Block/cif/page_list/page-type.xml
+++ b/tests/assets/Block/cif/page_list/page-type.xml
@@ -12,6 +12,7 @@
       <displaySystemPages>0</displaySystemPages>
       <displayThumbnail>0</displayThumbnail>
       <enableExternalFiltering>0</enableExternalFiltering>
+      <excludeCanonicalPaging>0</excludeCanonicalPaging>
       <excludeCurrentPage>0</excludeCurrentPage>
       <filterByCustomTopic>0</filterByCustomTopic>
       <filterByRelated>0</filterByRelated>

--- a/tests/assets/Block/cif/page_list/related-topic.xml
+++ b/tests/assets/Block/cif/page_list/related-topic.xml
@@ -12,6 +12,7 @@
       <displaySystemPages>0</displaySystemPages>
       <displayThumbnail>0</displayThumbnail>
       <enableExternalFiltering>0</enableExternalFiltering>
+      <excludeCanonicalPaging>0</excludeCanonicalPaging>
       <excludeCurrentPage>0</excludeCurrentPage>
       <filterByCustomTopic>0</filterByCustomTopic>
       <filterByRelated>1</filterByRelated>


### PR DESCRIPTION
The `page_list` block database [includes this field](https://github.com/concretecms/concretecms/blob/9.4.x/concrete/blocks/page_list/db.xml#L85-L87) so the expected xml output from export should also include it