### PR TITLE
Fix null version ID handling in CustomStyleRepository methods

### DIFF
--- a/concrete/src/Area/CustomStyleRepository.php
+++ b/concrete/src/Area/CustomStyleRepository.php
@@ -77,8 +77,14 @@ class CustomStyleRepository
         return $styles;
     }
 
-    protected function loadCollectionVersionAreaStyleRecords(int $collectionID, int $versionID): void
+    protected function loadCollectionVersionAreaStyleRecords(int $collectionID, ?int $versionID): void
     {
+        if ($versionID === null) {
+            $this->styles[$collectionID] = [];
+
+            return;
+        }
+
         if (!isset($this->styles[$collectionID])) {
             $qb = $this->connection->createQueryBuilder();
             $qb->select('arHandle', 'issID')

--- a/concrete/src/Block/CustomStyleRepository.php
+++ b/concrete/src/Block/CustomStyleRepository.php
@@ -105,8 +105,14 @@ class CustomStyleRepository
         return null;
     }
 
-    protected function loadCollectionVersionBlockStyleRecords(int $collectionID, int $versionID)
+    protected function loadCollectionVersionBlockStyleRecords(int $collectionID, ?int $versionID)
     {
+        if ($versionID === null) {
+            $this->styles[$collectionID] = [];
+
+            return;
+        }
+
         if (!isset($this->styles[$collectionID])) {
             $qb = $this->connection->createQueryBuilder();
             $qb->select('bID', 'arHandle', 'issID')


### PR DESCRIPTION
The following exception happens for non-logged-in users when a global area stack does not have an "ACTIVE" version.

```
Concrete\Core\Block\CustomStyleRepository::loadCollectionVersionBlockStyleRecords(): Argument #2 ($versionID) must be of type int, null given, called in concrete/src/Block/CustomStyleRepository.php on line 60
```

This PR fixes the issue.