### PR TITLE
Allow slashes in custom template filenames

### DIFF
--- a/concrete/src/Block/Block.php
+++ b/concrete/src/Block/Block.php
@@ -1539,7 +1539,7 @@ EOT
                     $bFilenameToCheck = $bFilename; // We just check the entirety of what's passed in.
                 }
 
-                if (!preg_match('/^[A-Za-z0-9_-]+$/i', $bFilenameToCheck)) {
+                if (!preg_match('/^[A-Za-z0-9\/_-]+$/i', $bFilenameToCheck)) {
                     $bFilename = null;
                     throw new \RuntimeException(
                         t('Custom templates may only contain letters, numbers, dashes and underscores.')


### PR DESCRIPTION
The existing comment mentions slashes are permitted but they are not. This causes problems when templates live in a folder as $bFilenameToCheck can look like "templatest/file_name" which breaks due to the slash. This was discovered after upgrading from 8.5.19 to 8.5.21 and then adding a new Block Developer block to a page.