### PR TITLE
Mail Service - adds suport for bodyHTML in template and adds support to return eception

### DIFF
--- a/concrete/src/Calendar/Event/EventService.php
+++ b/concrete/src/Calendar/Event/EventService.php
@@ -145,11 +145,11 @@ class EventService implements ApplicationAwareInterface, LoggerAwareInterface
         }
 
         if (!$event->getID()) {
-            $this->logger->info(t('Creating new event %s', $version->getName()));
+            $this->logger->info(t('Creating new event %s', $version->getName()));            
         }
 
         $this->logger->info(t('Adding new version %s to event %s', $version->getID(), $version->getName()));
-
+        
         $this->entityManager->persist($version);
         $event->getVersions()->add($version);
         $event->setCalendar($calendar);

--- a/concrete/src/Entity/Calendar/CalendarEventVersion.php
+++ b/concrete/src/Entity/Calendar/CalendarEventVersion.php
@@ -283,6 +283,38 @@ class CalendarEventVersion implements ObjectInterface, \JsonSerializable
     }
 
     /**
+     * Returns json object with basic event details
+     * 
+     * @param  bool $getAttributes - Optional parameter, True if attrbitues should be included in the object, false otherwise.  Defaults to false.  
+     * @param  mixed $displayMode - Optional parameter, if set to 'display' will return the display value, or, set to false will return the value.  Defaults to false.  If getAttributes=false, this paramter has no impact.
+     * @return object
+     */
+    public function getJSONobject(bool $getAttributes=false, mixed $displayMode=false):object
+    {
+        
+        $o=new \stdClass();
+        $o->id = $this->event->getID();
+        $o->name = $this->getName();
+        $o->versionId = $this->getID();
+        $o->description = $this->getDescription();        
+
+        if($getAttributes){
+            foreach(EventKey::getList() AS $attribute){
+                $handle=$attribute->getAttributeKeyHandle();                        
+                if($displayMode && $av=$this->getAttributeValueObject($attribute)){
+                    $value=$av->getDisplayValue();
+                }else{
+                    $value=$this->getAttribute($handle);
+                }                
+                $o->$handle=$value;
+            }
+        }
+
+        return $o;
+        
+    }
+    
+    /**
      * @return array
      */
     #[\ReturnTypeWillChange]

--- a/concrete/src/Entity/Calendar/CalendarEventVersionOccurrence.php
+++ b/concrete/src/Entity/Calendar/CalendarEventVersionOccurrence.php
@@ -60,14 +60,21 @@ class CalendarEventVersionOccurrence implements ObjectInterface, CategoryMemberI
      */
     protected $occurrence;
 
-    public function getJSONObject()
+    /**
+     * Returns json object with basic event details.  Includes data from this occurence and the current event version.
+     * 
+     * @param  bool $getAttributes - Optional parameter, True if attrbitues should be included in the object, false otherwise.  Defaults to false.  
+     * @param  mixed $displayMode - Optional parameter, if set to 'display' will return the display value, or, set to false will return the value.  Defaults to false.  If getAttributes=false, this paramter has no impact.
+     * @return object
+     */
+    public function getJSONObject($getAttributes=false,$displayMode=false)
     {
         $ev = $this->getEvent();
         $r = array();
         $r['start'] = $this->occurrence->getStart();
         $r['end'] = $this->occurrence->getEnd();
 
-        return (object) array_merge($r, (array) $ev->getJSONObject());
+        return (object) array_merge($r, (array) $ev->getJSONObject($getAttributes,$displayMode));
     }
 
     public function __construct(CalendarEventVersion $version, CalendarEventRepetition $repetition, $start, $end, $cancelled = false)

--- a/concrete/src/Mail/Service.php
+++ b/concrete/src/Mail/Service.php
@@ -74,6 +74,13 @@ class Service implements LoggerAwareInterface
      */
     protected $throwOnFailure;
 
+    /**
+     * Contains excpetion thrown during sending process, null otherwise
+     *
+     * @var \Exception|null
+     */
+    protected ?\Exception $sendError;
+
     const LOG_MAILS_NONE = '';
     const LOG_MAILS_ONLY_METADATA = 'metadata';
     const LOG_MAILS_METADATA_AND_BODY = 'metadata_and_body';
@@ -594,21 +601,21 @@ class Service implements LoggerAwareInterface
             $headers->addIdHeader('Message-ID', $this->email->generateMessageId());
         }
 
-        $sendError = null;
+        $this->sendError = null;
         if ($config->get('concrete.email.enabled')) {
             try {
                 $this->mailer->send($this->email);
             } catch (Throwable $x) {
-                $sendError = $x;
+                $this->sendError = $x;
             }
         }
-        if ($sendError !== null) {
+        if ($this->sendError !== null) {
             if ($this->getTesting()) {
-                throw $sendError;
+                throw $this->sendError;
             }
             $l = new GroupLogger(Channels::CHANNEL_EXCEPTIONS, Logger::CRITICAL);
-            $l->write(t('Mail Exception Occurred. Unable to send mail: ') . $sendError->getMessage());
-            $l->write($sendError->getTraceAsString());
+            $l->write(t('Mail Exception Occurred. Unable to send mail: ') . $this->sendError->getMessage());
+            $l->write($this->sendError->getTraceAsString());
             $l->close();
         }
 
@@ -616,7 +623,7 @@ class Service implements LoggerAwareInterface
             $l = new GroupLogger(Channels::CHANNEL_EMAIL, Logger::NOTICE);
 
             if ($config->get('concrete.email.enabled')) {
-                if ($sendError === null) {
+                if ($this->sendError === null) {
                     $l->write('**' . t('EMAILS ARE ENABLED. THIS EMAIL HAS BEEN SENT') . '**');
                 } else {
                     $l->write('**' . t('EMAILS ARE ENABLED. THIS EMAIL HAS NOT BEEN SENT') . '**');
@@ -650,11 +657,11 @@ class Service implements LoggerAwareInterface
             $l->close();
         }
 
-        if ($sendError !== null && $this->isThrowOnFailure()) {
+        if ($this->sendError !== null && $this->isThrowOnFailure()) {
             if ($resetData) {
                 $this->reset();
             }
-            throw $sendError;
+            throw $this->sendError;
         }
 
         // clear data if applicable
@@ -662,11 +669,23 @@ class Service implements LoggerAwareInterface
             $this->reset();
         }
 
-        return $sendError === null;
+        return $this->sendError === null;
     }
 
     public function getLoggerChannel(): string
     {
         return Channels::CHANNEL_EMAIL;
     }
+
+        
+    /**
+     * Returns exception encoutered during sending if one exists. 
+     *
+     * @return Exception or null if no excpetion
+     */
+    public function getSendErrorException(): ?\Exception
+    {
+        return $this->sendError;
+    }
+
 }

--- a/concrete/src/Mail/Service.php
+++ b/concrete/src/Mail/Service.php
@@ -74,13 +74,6 @@ class Service implements LoggerAwareInterface
      */
     protected $throwOnFailure;
 
-    /**
-     * Contains excpetion thrown during sending process, null otherwise
-     *
-     * @var \Exception|null
-     */
-    protected ?\Exception $sendError;
-
     const LOG_MAILS_NONE = '';
     const LOG_MAILS_ONLY_METADATA = 'metadata';
     const LOG_MAILS_METADATA_AND_BODY = 'metadata_and_body';
@@ -324,7 +317,7 @@ class Service implements LoggerAwareInterface
         }
 
         $this->setBody($body ?? null);
-        $this->setBodyHTML($bodyHtml ?? $bodyHTML ?? null); //added $bodyHTML to accomodate templates which specify as such
+        $this->setBodyHTML($bodyHTML ?? null); 
     }
 
     /**
@@ -601,21 +594,21 @@ class Service implements LoggerAwareInterface
             $headers->addIdHeader('Message-ID', $this->email->generateMessageId());
         }
 
-        $this->sendError = null;
+        $sendError = null;
         if ($config->get('concrete.email.enabled')) {
             try {
                 $this->mailer->send($this->email);
             } catch (Throwable $x) {
-                $this->sendError = $x;
+                $sendError = $x;
             }
         }
-        if ($this->sendError !== null) {
+        if ($sendError !== null) {
             if ($this->getTesting()) {
-                throw $this->sendError;
+                throw $sendError;
             }
             $l = new GroupLogger(Channels::CHANNEL_EXCEPTIONS, Logger::CRITICAL);
-            $l->write(t('Mail Exception Occurred. Unable to send mail: ') . $this->sendError->getMessage());
-            $l->write($this->sendError->getTraceAsString());
+            $l->write(t('Mail Exception Occurred. Unable to send mail: ') . $sendError->getMessage());
+            $l->write($sendError->getTraceAsString());
             $l->close();
         }
 
@@ -623,7 +616,7 @@ class Service implements LoggerAwareInterface
             $l = new GroupLogger(Channels::CHANNEL_EMAIL, Logger::NOTICE);
 
             if ($config->get('concrete.email.enabled')) {
-                if ($this->sendError === null) {
+                if ($sendError === null) {
                     $l->write('**' . t('EMAILS ARE ENABLED. THIS EMAIL HAS BEEN SENT') . '**');
                 } else {
                     $l->write('**' . t('EMAILS ARE ENABLED. THIS EMAIL HAS NOT BEEN SENT') . '**');
@@ -657,11 +650,11 @@ class Service implements LoggerAwareInterface
             $l->close();
         }
 
-        if ($this->sendError !== null && $this->isThrowOnFailure()) {
+        if ($sendError !== null && $this->isThrowOnFailure()) {
             if ($resetData) {
                 $this->reset();
             }
-            throw $this->sendError;
+            throw $sendError;
         }
 
         // clear data if applicable
@@ -669,7 +662,7 @@ class Service implements LoggerAwareInterface
             $this->reset();
         }
 
-        return $this->sendError === null;
+        return $sendError === null;
     }
 
     public function getLoggerChannel(): string
@@ -685,7 +678,7 @@ class Service implements LoggerAwareInterface
      */
     public function getSendErrorException(): ?\Exception
     {
-        return $this->sendError;
+        return $sendError;
     }
 
 }

--- a/concrete/src/Mail/Service.php
+++ b/concrete/src/Mail/Service.php
@@ -317,7 +317,7 @@ class Service implements LoggerAwareInterface
         }
 
         $this->setBody($body ?? null);
-        $this->setBodyHTML($bodyHtml ?? null);
+        $this->setBodyHTML($bodyHtml ?? $bodyHTML ?? null); //added $bodyHTML to accomodate templates which specify as such
     }
 
     /**


### PR DESCRIPTION
One issue and one minor new feature:
1. Somewhere along the line bodyHtml became the expected variable in templates despite bodyHTML being in documentation and existing templates . This simple mod adds support for both bodyHtml and bodyHTML as the variable name.

2. when running in quiet mode, if an exception is thrown, the send method returns false however there was no way to get the error other than to look at the log.  I needed the error programmatically. I converted the sendError variable to a class property and added a function to return it.  