### PR TITLE
Mail Services, corrects bug #12845 regarding bodyHTML

### DIFF
--- a/concrete/src/Mail/Service.php
+++ b/concrete/src/Mail/Service.php
@@ -317,7 +317,7 @@ class Service implements LoggerAwareInterface
         }
 
         $this->setBody($body ?? null);
-        $this->setBodyHTML($bodyHtml ?? null);
+        $this->setBodyHTML($bodyHTML ?? null);
     }
 
     /**


### PR DESCRIPTION
Somewhere along the lines the case on $bodyHTML was changed to $bodyHtml.  This is incorrect.  All templates currently are using $bodyHTML which should remain.