### PR TITLE
Allow turning on pretty URLs when installing Concrete

### DIFF
--- a/concrete/config/install.php
+++ b/concrete/config/install.php
@@ -20,6 +20,7 @@ return [
         'memory_limit' => Concrete\Core\Install\Preconditions\MemoryLimit::class,
         'remote_file_importing' => Concrete\Core\Install\Preconditions\RemoteFileImporting::class,
         'zip_support' => Concrete\Core\Install\Preconditions\ZipSupport::class,
+        'pretty_urls' => Concrete\Core\Install\Preconditions\PrettyUrls::class,
         // OptionsPreconditionInterface
         'canonical_urls' => Concrete\Core\Install\Preconditions\CanonicalUrls::class,
         'database_timezone' => Concrete\Core\Install\Preconditions\DatabaseTimeZone::class,

--- a/concrete/controllers/install.php
+++ b/concrete/controllers/install.php
@@ -229,6 +229,7 @@ class Install extends Controller
         $this->set('canonicalUrlAlternativeChecked', $canonicalUrlAlternativeChecked);
         $this->set('SERVER_TIMEZONE', @date_default_timezone_get() ?: 'UTC');
         $this->set('availableTimezones', $this->app->make('date')->getGroupedTimezones());
+        $this->set('prettyURLsSupported', filter_var($this->request->request->get('prettyURLsSupported'), FILTER_VALIDATE_BOOLEAN)); 
         $this->setInstallStep();
     }
 
@@ -311,6 +312,7 @@ class Install extends Controller
                         ],
                     ],
                 ];
+                $configuration['pretty-urls'] = $post->get('enablePrettyURLs') === '1';
                 $configuration['canonical-url'] = $post->get('canonicalUrlChecked') === '1' ? $post->get('canonicalUrl') : '';
                 $configuration['canonical-url-alternative'] = $post->get('canonicalUrlAlternativeChecked') === '1' ? $post->get('canonicalUrlAlternative') : '';
                 $configuration['session-handler'] = $post->get('sessionHandler');

--- a/concrete/single_pages/dashboard/system/seo/urls.php
+++ b/concrete/single_pages/dashboard/system/seo/urls.php
@@ -32,7 +32,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
         <div class="form-check">
             <?= $form->checkbox('url_rewriting', '1', $urlRewriting) ?>
             <label class="form-check-label" for="url_rewriting">
-                <?= t('Remove index.php from URLs') ?>
+                <?= t(/* i18n: %s is index.php */ 'Remove %s from URLs', '<code>' . DISPATCHER_FILENAME . '</code>') ?>
                 <span id="url_rewriting_works" class="ms-1">
                     <i class="fas fa-spinner fa-spin"></i>
                 </span>

--- a/concrete/src/Install/Preconditions/Cookies.php
+++ b/concrete/src/Install/Preconditions/Cookies.php
@@ -66,6 +66,7 @@ class Cookies implements WebPreconditionInterface
     {
         $errorMessage = json_encode(t('Cookies must be enabled in your browser to install Concrete CMS.'));
         $myIdentifier = json_encode($this->getUniqueIdentifier());
+        $isOptional = json_encode($this->isOptional());
 
         return <<<EOT
 <script>
@@ -85,7 +86,7 @@ $(document).ready(function() {
     if (check()) {
         setWebPreconditionResult({$myIdentifier}, true);
     } else {
-        setWebPreconditionResult({$myIdentifier}, false, {$errorMessage});
+        setWebPreconditionResult({$myIdentifier}, false, {$errorMessage}, {$isOptional});
     }
 });
 </script>

--- a/concrete/src/Install/Preconditions/PrettyUrls.php
+++ b/concrete/src/Install/Preconditions/PrettyUrls.php
@@ -2,11 +2,12 @@
 
 namespace Concrete\Core\Install\Preconditions;
 
+use Concrete\Core\Config\Repository\Repository;
 use Concrete\Core\Error\UserMessageException;
 use Concrete\Core\Install\WebPreconditionInterface;
 use Concrete\Core\Url\Resolver\Manager\ResolverManager;
 
-class RequestUrls implements WebPreconditionInterface
+class PrettyUrls implements WebPreconditionInterface
 {
     /**
      * The URL resolver.
@@ -16,13 +17,19 @@ class RequestUrls implements WebPreconditionInterface
     protected $resolver;
 
     /**
+     * @var \Concrete\Core\Config\Repository\Repository
+     */
+    protected $config;
+
+    /**
      * Initialize the instance.
      *
      * @param ResolverManager $resolver The URL resolver
      */
-    public function __construct(ResolverManager $resolver)
+    public function __construct(ResolverManager $resolver, Repository $config)
     {
         $this->resolver = $resolver;
+        $this->config = $config;
     }
 
     /**
@@ -32,7 +39,7 @@ class RequestUrls implements WebPreconditionInterface
      */
     public function getName()
     {
-        return t('Supports Concrete request URLs');
+        return t(/* i18n: %s is "index.php" */'Support for URLs without %s ("pretty URLs")', \DISPATCHER_FILENAME);
     }
 
     /**
@@ -42,7 +49,7 @@ class RequestUrls implements WebPreconditionInterface
      */
     public function getUniqueIdentifier()
     {
-        return 'request_urls';
+        return 'pretty_urls';
     }
 
     /**
@@ -52,7 +59,7 @@ class RequestUrls implements WebPreconditionInterface
      */
     public function isOptional()
     {
-        return false;
+        return true;
     }
 
     /**
@@ -82,9 +89,13 @@ class RequestUrls implements WebPreconditionInterface
      */
     public function getHtml()
     {
-        $url = json_encode((string) $this->resolver->resolve(['/install', 'web_precondition', 'request_urls', '20']));
-        $errorMessage = json_encode(t('Concrete cannot parse the PATH_INFO or ORIG_PATH_INFO information provided by your server.'));
-        $ajaxFailErrorMessage = json_encode(t('Request failed: unable to verify support for request URLs'));
+        $url = $this->config->withKey('concrete.seo.url_rewriting', true, function (): string {
+            return $this->config->withKey('concrete.seo.url_rewriting_all', true, function (): string {
+                return (string) $this->resolver->resolve(['/install', 'web_precondition', $this->getUniqueIdentifier(), 'ping']);
+            });
+        });
+        $url = json_encode($url);
+        $errorMessage = json_encode(t('It seems seems your web server does not support pretty URLs.'));
         $myIdentifier = json_encode($this->getUniqueIdentifier());
         $isOptional = json_encode($this->isOptional());
 
@@ -98,14 +109,15 @@ $(document).ready(function() {
         url: {$url}
     })
     .done(function(data) {
-        if (data.response === 400) {
+        if (data && data.response === 'pong') {
+            $('form#continue-to-installation').append('<input type="hidden" name="prettyURLsSupported" value="1" />');
             setWebPreconditionResult({$myIdentifier}, true);
         } else {
             setWebPreconditionResult({$myIdentifier}, false, {$errorMessage}, {$isOptional});
         }
     })
     .fail(function(xhr, textStatus, errorThrown) {
-        setWebPreconditionResult({$myIdentifier}, false, {$ajaxFailErrorMessage}, {$isOptional});
+        setWebPreconditionResult({$myIdentifier}, false, {$errorMessage}, {$isOptional});
     });
 });
 </script>
@@ -130,10 +142,8 @@ EOT
      */
     public function getAjaxAnswer($argument)
     {
-        $i = is_int($argument) || is_string($argument) && is_numeric($argument) ? (int) $argument : null;
-
         return [
-            'response' => $i === null ? null : $i * $i,
+            'response' => $argument === 'ping' ? 'pong' : '',
         ];
     }
 }

--- a/concrete/src/Package/StartingPointPackage.php
+++ b/concrete/src/Package/StartingPointPackage.php
@@ -647,7 +647,10 @@ class StartingPointPackage extends Package
 
         $siteConfig = \Site::getDefault()->getConfigRepository();
         $siteConfig->save('name', $this->installerOptions->getSiteName());
-
+        if (isset($installConfiguration['pretty-urls'])) {
+            $config->save('concrete.seo.url_rewriting', $installConfiguration['pretty-urls'] ? true : false);
+        }
+        unset($installConfiguration['pretty-urls']);
         if (isset($installConfiguration['canonical-url']) && $installConfiguration['canonical-url']) {
             $siteConfig->save('seo.canonical_url', $installConfiguration['canonical-url']);
         }

--- a/concrete/views/frontend/install.php
+++ b/concrete/views/frontend/install.php
@@ -47,7 +47,6 @@ defined('C5_EXECUTE') or die('Access Denied.');
 $locale = $locale ?? Localization::BASE_LOCALE;
 
 $install_config = Config::get('install_overrides');
-$uh = Core::make('helper/concrete/urls');
 if ($install_config) {
     $_POST = $install_config;
 }

--- a/concrete/views/frontend/install.php
+++ b/concrete/views/frontend/install.php
@@ -36,6 +36,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
  * @var bool $canonicalUrlAlternativeChecked
  * @var string $SERVER_TIMEZONE
  * @var array $availableTimezones
+ * @var bool $prettyURLsSupported
  * @var Concrete\Core\Error\ErrorList\ErrorList $warnings
  * 
  * // When $installStep === $controller::STEP_INSTALL
@@ -86,23 +87,21 @@ if ($install_config) {
 
         <form method="post" id="ccm-install-language-form"
               action="<?= $urlResolver->resolve(['install', 'select_language']) ?>" class="w-100">
-            <div class="form-group">
-                <p class="lead"><?=t('Choose the language you want to run your website in.')?></p>
+            <p class="lead"><?=t('Choose the language you want to run your website in.')?></p>
 
-                <div class="input-group-lg input-group">
-                    <?php
-                    $selectOptions = $locales;
-                    if (!empty($onlineLocales)) {
-                        $selectOptions[t('Online Languages')] = $onlineLocales;
-                    }
-                    ?>
-                    <?= $form->select('wantedLocale', $selectOptions, Localization::BASE_LOCALE, [
-                        'class' => 'form-select'
-                    ]); ?>
-                    <button type="submit" class="btn btn-primary">
-                        <i class="fas fa-arrow-right"></i>
-                    </button>
-                </div>
+            <div class="input-group-lg input-group">
+                <?php
+                $selectOptions = $locales;
+                if (!empty($onlineLocales)) {
+                    $selectOptions[t('Online Languages')] = $onlineLocales;
+                }
+                ?>
+                <?= $form->select('wantedLocale', $selectOptions, Localization::BASE_LOCALE, [
+                    'class' => 'form-select'
+                ]); ?>
+                <button type="submit" class="btn btn-primary">
+                    <i class="fas fa-arrow-right"></i>
+                </button>
             </div>
         </form>
 
@@ -334,9 +333,16 @@ if ($install_config) {
                 $('#canonicalUrlChecked,#canonicalUrlAlternativeChecked').change(updateCanonicalURLState);
                 <?php
                 if ($setInitialState) {
-                ?>
-                $('#canonicalUrlChecked').prop('checked', <?=$canonicalUrlChecked ? 'true' : 'false'?>);
-                $('#canonicalUrlAlternativeChecked').prop('checked', <?=$canonicalUrlAlternativeChecked ? 'true' : 'false'?>);
+                    ?>
+                    <?php
+                    if ($prettyURLsSupported) {
+                        ?>
+                        $('#enablePrettyURLs').prop('checked', true);
+                        <?php
+                    }
+                    ?>
+                    $('#canonicalUrlChecked').prop('checked', <?=$canonicalUrlChecked ? 'true' : 'false'?>);
+                    $('#canonicalUrlAlternativeChecked').prop('checked', <?=$canonicalUrlAlternativeChecked ? 'true' : 'false'?>);
                 <?php
                 }
                 ?>
@@ -399,7 +405,7 @@ if ($install_config) {
                                 </div>
                             </div>
                             <div class="col-md-6">
-                                <div class="form-group">
+                                <div class="form-group mb-0">
                                     <div class="d-none">
                                         <input type="text" name="username" value="<?= h(USER_SUPER) ?>" autocomplete="username" readonly="readonly" />
                                     </div>
@@ -409,7 +415,7 @@ if ($install_config) {
                                 </div>
                             </div>
                             <div class="col-md-6">
-                                <div class="form-group">
+                                <div class="form-group mb-0">
                                     <label for="uPassword"
                                            class="control-label form-label"><?= t('Confirm Password') ?></label>
                                     <?= $form->password('uPasswordConfirm', $passwordAttributes) ?>
@@ -466,20 +472,68 @@ if ($install_config) {
                                 </div>
                             </div>
                             <div class="col-md-6">
-                                <div class="form-group">
+                                <div class="form-group mb-0">
                                     <label class="control-label form-label"
                                            for="DB_PASSWORD"><?= t('MySQL Password') ?></label>
                                     <?= $form->password('DB_PASSWORD', ['autocomplete' => 'off']) ?>
                                 </div>
                             </div>
                             <div class="col-md-6">
-                                <div class="form-group">
+                                <div class="form-group mb-0">
                                     <label class="control-label form-label"
                                            for="DB_DATABASE"><?= t('Database Name') ?></label>
                                     <?= $form->text('DB_DATABASE', ['required' => 'required']) ?>
                                 </div>
                             </div>
                         </div>
+                    </div>
+                </div>
+            </div>
+            <div class="card card-default mb-4">
+                <div class="card-header">
+                    <?= t('URLs') ?>
+                </div>
+                <div class="card-body">
+                    <div class="form-group">
+                        <div class="control-label form-label form-check">
+                            <?= $form->checkbox('enablePrettyURLs', 1, false, $prettyURLsSupported ? [] : ['disabled' => 'disabled']) ?>
+                            <label class="form-check-label" for="enablePrettyURLs">
+                                <?= t(/* i18n: %s is index.php */ 'Remove %s from URLs', '<code>' . DISPATCHER_FILENAME . '</code>') ?>
+                            </label>
+                            <?php
+                            if (!$prettyURLsSupported) {
+                                ?>
+                                <div class="small text-muted">
+                                    <?= t('It seems seems your web server does not support pretty URLs.') ?>
+                                </div>
+                                <?php
+                            }
+                            ?>
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <div class="control-label form-label form-check">
+                            <?= $form->checkbox('canonicalUrlChecked', '1') ?>
+                            <label class="form-check-label" for="canonicalUrlChecked">
+                                <?= t('Set main canonical URL') ?>:
+                            </label>
+                        </div>
+                        <?= $form->url('canonicalUrl', h($canonicalUrl), [
+                            'pattern' => 'https?:.+',
+                            'placeholder' => t('%s or %s', 'http://...', 'https://...')
+                        ]) ?>
+                    </div>
+                    <div class="form-group mb-0">
+                        <div class="control-label form-label form-check">
+                            <?= $form->checkbox('canonicalUrlAlternativeChecked', '1') ?>
+                            <label class="form-check-label" for="canonicalUrlAlternativeChecked">
+                                <?= t('Set alternative canonical URL') ?>:
+                            </label>
+                        </div>
+                        <?= $form->url('canonicalUrlAlternative', h($canonicalUrlAlternative), [
+                            'pattern' => 'https?:.+',
+                            'placeholder' => t('%s or %s', 'http://...', 'https://...')
+                        ]) ?>
                     </div>
                 </div>
             </div>
@@ -507,49 +561,6 @@ if ($install_config) {
                     <div class="card-body container">
 
                         <div class="row">
-
-                            <div class="col-sm-6">
-                                <h4><?= t('URLs & Session') ?></h4>
-
-                                <div class="form-group">
-                                    <label class="control-label form-label">
-                                        <div class="form-check">
-                                            <?= $form->checkbox('canonicalUrlChecked', '1') ?>
-                                            <label class="form-check-label" for="canonicalUrlChecked">
-                                                <?= t('Set main canonical URL') ?>:
-                                            </label>
-                                        </div>
-                                    </label>
-                                    <?= $form->url('canonicalUrl', h($canonicalUrl), [
-                                        'pattern' => 'https?:.+',
-                                        'placeholder' => t('%s or %s', 'http://...', 'https://...')
-                                    ]) ?>
-                                </div>
-
-                                <div class="form-group">
-                                    <label class="control-label form-label">
-                                        <div class="form-check">
-                                            <?= $form->checkbox('canonicalUrlAlternativeChecked', '1') ?>
-                                            <label class="form-check-label" for="canonicalUrlAlternativeChecked">
-                                                <?= t('Set alternative canonical URL') ?>:
-                                            </label>
-                                        </div>
-                                    </label>
-                                    <?= $form->url('canonicalUrlAlternative', h($canonicalUrlAlternative), [
-                                        'pattern' => 'https?:.+',
-                                        'placeholder' => t('%s or %s', 'http://...', 'https://...')
-                                    ]) ?>
-                                </div>
-                                <div class="form-group">
-                                    <label class="control-label form-label"
-                                           for="sessionHandler"><?= t('Session Handler') ?></label>
-                                    <?= $form->select('sessionHandler', [
-                                        '' => t('Default Handler (Recommended)'),
-                                        'database' => t('Database')
-                                    ]) ?>
-                                </div>
-
-                            </div>
                             <div class="col-sm-6">
                                 <h4><?= t('Locale') ?></h4>
 
@@ -567,7 +578,7 @@ if ($install_config) {
                                         $computedSiteLocaleCountry) ?>
                                 </div>
 
-                                <div class="form-group">
+                                <div class="form-group mb-0">
                                     <label class="control-label form-label"
                                            for="SERVER_TIMEZONE"><?= t('System Time Zone') ?></label>
                                     <?= $form->select('SERVER_TIMEZONE', $availableTimezones,
@@ -591,6 +602,16 @@ if ($install_config) {
                                             });
                                     });
                                 </script>
+                            </div>
+                            <div class="col-sm-6">
+                                <h4><?= t('Session') ?></h4>
+                                <div class="form-group mb-0">
+                                    <label class="control-label form-label" for="sessionHandler"><?= t('Session Handler') ?></label>
+                                    <?= $form->select('sessionHandler', [
+                                        '' => t('Default Handler (Recommended)'),
+                                        'database' => t('Database')
+                                    ]) ?>
+                                </div>
                             </div>
                         </div>
                     </div>

--- a/concrete/views/frontend/install.php
+++ b/concrete/views/frontend/install.php
@@ -7,21 +7,42 @@ use Concrete\Core\Localization\Localization;
 
 defined('C5_EXECUTE') or die('Access Denied.');
 
-/* @var Concrete\Controller\Install $controller */
-/* @var Concrete\Core\Form\Service\Form $form */
-/* @var Concrete\Core\Html\Service\Html $html */
-/* @var Concrete\Core\View\View $this */
-/* @var Concrete\Core\View\View $view */
-/* @var Concrete\Core\Url\Resolver\UrlResolverInterface $urlResolver */
-/* @var Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface $urlResolver */
-
-/* @var int $backgroundFade */
-/* @var string $pageTitle */
-/* @var string $image */
-/* @var string $imagePath */
-/* @var string $concreteVersion */
-
-/* @var int $installStep */
+/**
+ * @var Concrete\Controller\Install $controller
+ * @var Concrete\Core\Form\Service\Form $form
+ * @var Concrete\Core\Html\Service\Html $html
+ * @var Concrete\Core\View\View $this
+ * @var Concrete\Core\View\View $view
+ * @var Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface $urlResolver
+ * @var string $pageTitle
+ * @var string $concreteVersion
+ * @var string|null $locale (may be unset)
+ * @var int $installStep
+ *
+ * // When $installStep === $controller::STEP_CHOOSELOCALE
+ * @var array $locales
+ * @var array $onlineLocales
+ * 
+ * // When $installStep === $controller::STEP_CONFIGURATION
+ * @var array $passwordAttributes
+ * @var array $languages
+ * @var array $countries
+ * @var string $computedSiteLocaleLanguage
+ * @var string $computedSiteLocaleCountry
+ * @var bool $setInitialState
+ * @var string $canonicalUrl
+ * @var bool $canonicalUrlChecked
+ * @var string $canonicalUrlAlternative
+ * @var bool $canonicalUrlAlternativeChecked
+ * @var string $SERVER_TIMEZONE
+ * @var array $availableTimezones
+ * @var Concrete\Core\Error\ErrorList\ErrorList $warnings
+ * 
+ * // When $installStep === $controller::STEP_INSTALL
+ * @var string $installPackage
+ * @var Concrete\Core\Package\StartingPointInstallRoutine[] $installRoutines
+ * @var string $successMessage
+ */
 
 $locale = $locale ?? Localization::BASE_LOCALE;
 


### PR DESCRIPTION
What about allowing users to enable pretty URLs when they install Concrete?

Here are some screenshots:

## Before

* Checks screen
   <img width="942" height="139" alt="before-1" src="https://github.com/user-attachments/assets/580243f5-efb8-4287-8009-84725e74d63e" />
* Options screen
  <img width="943" height="405" alt="before-2" src="https://github.com/user-attachments/assets/ee382ed3-aa18-4ca6-b925-709b7fe73d5b" />

## After - pretty URLs supported

* Checks screen
   <img width="945" height="179" alt="after-ok-1" src="https://github.com/user-attachments/assets/29c15576-f271-49ea-9ff4-5acf6c7caeb0" />
* Options screen
  <img width="945" height="673" alt="after-ok-2" src="https://github.com/user-attachments/assets/55730e44-9b8c-4bc5-818b-54a0d56cd88e" />

## After - pretty URLs not supported

* Checks screen
   <img width="944" height="180" alt="after-ko-1" src="https://github.com/user-attachments/assets/4f9dc3ba-8ab8-406e-ad52-a9b4c04bcd9c" />
* Options screen
  <img width="945" height="694" alt="after-ko-2" src="https://github.com/user-attachments/assets/e072bb87-bceb-428e-ae83-5754e3768c5c" />
