### PR TITLE
Return errors in JSON format when the expected response should be in JSON

### DIFF
--- a/concrete/src/Http/ResponseFactory.php
+++ b/concrete/src/Http/ResponseFactory.php
@@ -71,7 +71,7 @@ class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInter
      */
     public function notFound($content, $code = Response::HTTP_NOT_FOUND, $headers = [])
     {
-        if ($this->request->isXmlHttpRequest()) {
+        if ($this->request->isXmlHttpRequest() || in_array($this->request->getPreferredFormat(), ['json', 'jsonld'], true)) {
             $this->localization->pushActiveContext(Localization::CONTEXT_SITE);
             $responseData = [
                 'error' => t('Page not found'),

--- a/concrete/src/Http/Service/Ajax.php
+++ b/concrete/src/Http/Service/Ajax.php
@@ -13,11 +13,11 @@ class Ajax
      *
      * @return bool
      *
-     * @deprecated use the isXmlHttpRequest() method of the request object
+     * @deprecated use the isXmlHttpRequest() and/or the getPreferredFormat() methods of the request object
      */
     public function isAjaxRequest(Request $request)
     {
-        return $request->isXmlHttpRequest();
+        return $request->isXmlHttpRequest() || in_array($request->getPreferredFormat(), ['json', 'jsonld'], true);
     }
 
     /**

--- a/concrete/src/Validation/CSRF/Token.php
+++ b/concrete/src/Validation/CSRF/Token.php
@@ -31,7 +31,7 @@ class Token
     {
         $app = Application::getFacadeApplication();
         $request = $app->make(Request::class);
-        if ($request->isXmlHttpRequest()) {
+        if ($request->isXmlHttpRequest() || in_array($request->getPreferredFormat(), ['json', 'jsonld'], true)) {
             return t("Invalid token. Please reload the page and retry.");
         } else {
             return t("Invalid form token. Please reload this form and submit again.");


### PR DESCRIPTION
In order to determine if an HTTP response should be in JSON format, we sometimes only check if the `X-Requested-With` request header has the value `XMLHttpRequest`.

This is enough when we use [`$.ajax()`](https://api.jquery.com/jQuery.ajax/).

But nowadays we can also use [`window.fetch()`](https://developer.mozilla.org/en-US/docs/Web/API/Window/fetch), that doesn't set the `X-Requested-With` request header by default
(that's why in https://github.com/concretecms/bedrock/pull/394 I [added it](https://github.com/concretecms/bedrock/pull/394/changes#diff-bf70492bc72f8048823baec0109107372aa7b554b9e76b3f1f2bfb5361695f7eR91) to `window.ConcreteFetch` - not yet available in any GA Concrete release).

So, when we check if clients expect a JSON response, what about also checking if they send `Accept: application/json` (or `application/x-json` or `application/ld+json`)?
