### PR TITLE
Test minimum PHP version consistency

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -96,6 +96,7 @@ jobs:
       - name: "Install highest unlocked dependencies"
         if: ${{ matrix.dependencies == 'highest-unlocked' }}
         run: |
+          echo "CCM_TEST_SKIP_CHECKCOMPOSERPLATFORM=1" >>"$GITHUB_ENV"
           composer config --unset platform.php
           composer update --no-interaction --no-progress
 

--- a/tests/tests/System/MinPHPVersionTest.php
+++ b/tests/tests/System/MinPHPVersionTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\Tests\System;
+
+use Concrete\Core\Install\Preconditions\PhpVersion;
+use Concrete\Tests\TestCase;
+
+final class MinPHPVersionTest extends TestCase
+{
+    public function testInstallPreconditions(): void
+    {
+        $version = self::getMinPHPVersionFromInstallPreconditions();
+        self::assertNotNull($version, 'Unable to retrieve the minimum PHP version from the install preconditions');
+        self::assertMatchesRegularExpression('/^[1-9]\d*\.(0|[1-9]\d*)(\.(0|[1-9]\d*))?$/D', $version, "'{$version}' is not a valid PHP version");
+    }
+
+    public function testComposerPlatform(): void
+    {
+        if (getenv('CCM_TEST_SKIP_CHECKCOMPOSERPLATFORM')) {
+            self::markTestSkipped('Skipping because the CCM_TEST_SKIP_CHECKCOMPOSERPLATFORM environment variable is set');
+        }
+        $expectedVersion = self::getMinPHPVersionFromInstallPreconditions();
+        if ($expectedVersion === null) {
+            self::markTestSkipped('Unable to retrieve the minimum PHP version from the install preconditions');
+        }
+        $composerJsonFile = DIR_BASE . '/composer.json';
+        $composerJson = file_get_contents($composerJsonFile);
+        self::assertNotFalse($composerJson, "Failed to read the file {$composerJsonFile}");
+        $composerConfig = json_decode($composerJson, true);
+        self::assertIsArray($composerConfig, "Failed to parse the file {$composerJsonFile}");
+        $actualVersion = $composerConfig['config']['platform']['php'] ?? null;
+        self::assertIsString($actualVersion, "The file {$composerJsonFile} doesn't define config.platform.php");
+        self::assertSame($expectedVersion, $actualVersion, "The value of config.platform.php in the root composer.json file ({$actualVersion}) should be the same as the one defined in the install preconditions ({$expectedVersion})");
+    }
+
+    public function testComposerRequirements(): void
+    {
+        $expectedVersion = self::getMinPHPVersionFromInstallPreconditions();
+        if ($expectedVersion === null) {
+            self::markTestSkipped('Unable to retrieve the minimum PHP version from the install preconditions');
+        }
+        $expectedRequirementsRegex = '/^\s*(\^|~|>=)?' . preg_quote($expectedVersion) . '(\s|&|\||$)/';
+        $composerJsonFile = DIR_BASE_CORE . '/composer.json';
+        $composerJson = file_get_contents($composerJsonFile);
+        self::assertNotFalse($composerJson, "Failed to read the file {$composerJsonFile}");
+        $composerConfig = json_decode($composerJson, true);
+        self::assertIsArray($composerConfig, "Failed to parse the file {$composerJsonFile}");
+        $actualRequirements = $composerConfig['require']['php'] ?? null;
+        self::assertIsString($actualRequirements, "The file {$composerJsonFile} doesn't have 'php' in the 'require' section");
+        self::assertMatchesRegularExpression($expectedRequirementsRegex, $actualRequirements, "The value of require.php in the concrete/composer.json file ({$actualRequirements}) should have {$expectedVersion} as the minimum PHP version");
+    }
+
+    public function testDefaultPHPCSFixerPHPVersion(): void
+    {
+        $expectedVersion = self::getMinPHPVersionFromInstallPreconditions();
+        if ($expectedVersion === null) {
+            self::markTestSkipped('Unable to retrieve the minimum PHP version from the install preconditions');
+        }
+        $configFile = DIR_BASE . '/.php-cs-fixer.dist.php';
+        $phpCode = file_get_contents($configFile);
+        self::assertNotFalse($phpCode, "Failed to read the file {$configFile}");
+        $expectedAssignementRegex = '/^\s*\$minimumPHPVersion\s*=\s*["\']' . preg_quote($expectedVersion) . '["\']\s*;/m';
+        self::assertMatchesRegularExpression(
+            $expectedAssignementRegex,
+            $phpCode,
+            "The PHP CS Fixer configuration file ({$configFile}) should contain the line \$minimumPHPVersion = '{$expectedVersion}';"
+        );
+    }
+
+    private static function getMinPHPVersionFromInstallPreconditions(): ?string
+    {
+        if (!class_exists(PhpVersion::class)) {
+            return null;
+        }
+        if (!defined(PhpVersion::class . '::MINIMUM_PHP_VERSION')) {
+            return null;
+        }
+        return is_string(PhpVersion::MINIMUM_PHP_VERSION) ? PhpVersion::MINIMUM_PHP_VERSION : null;
+    }
+}


### PR DESCRIPTION
We currently define the minimum PHP version (7.3) in different places:

1. [in the PhpVersion install precondition](https://github.com/concretecms/concretecms/blob/9.4.7/concrete/src/Install/Preconditions/PhpVersion.php#L15)
2. [in the PHP version we tell composer to be assumed](https://github.com/concretecms/concretecms/blob/9.4.7/composer.json#L27)
3. [in the minimum PHP version concrete should run on for composer](https://github.com/concretecms/concretecms/blob/9.4.7/concrete/composer.json#L38)
4. [when defining the rules for PHP CS Fixer](https://github.com/concretecms/concretecms/blob/9.5.0RC2/.php-cs-fixer.dist.php#L17)

What about adding a test to be sure all these values match?