### PR TITLE
Express entry manager logging fix

### DIFF
--- a/concrete/src/Express/Controller/StandardController.php
+++ b/concrete/src/Express/Controller/StandardController.php
@@ -6,8 +6,6 @@ use Concrete\Core\Express\Entry\Manager as EntryManager;
 use Concrete\Core\Express\Entry\Notifier\NotificationProviderInterface;
 use Concrete\Core\Express\Entry\Notifier\StandardNotifier;
 use Concrete\Core\Express\Form\Processor\StandardProcessor;
-use Concrete\Core\Logging\Channels;
-use Concrete\Core\Logging\LoggerFactory;
 use Doctrine\ORM\EntityManager;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -32,11 +30,7 @@ class StandardController implements ControllerInterface
 
     public function getEntryManager(Request $request)
     {
-        $manager = $this->app->make(EntryManager::class, ['request' => $request]);
-        $manager->setLogger(
-            $this->app->make(LoggerFactory::class)->createLogger(Channels::CHANNEL_EXPRESS)
-        );
-        return $manager;
+        return $this->app->make(EntryManager::class, ['request' => $request]);
     }
 
     public function getNotifier(?NotificationProviderInterface $provider = null)

--- a/concrete/src/Express/Controller/StandardController.php
+++ b/concrete/src/Express/Controller/StandardController.php
@@ -6,6 +6,8 @@ use Concrete\Core\Express\Entry\Manager as EntryManager;
 use Concrete\Core\Express\Entry\Notifier\NotificationProviderInterface;
 use Concrete\Core\Express\Entry\Notifier\StandardNotifier;
 use Concrete\Core\Express\Form\Processor\StandardProcessor;
+use Concrete\Core\Logging\Channels;
+use Concrete\Core\Logging\LoggerFactory;
 use Doctrine\ORM\EntityManager;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -30,7 +32,11 @@ class StandardController implements ControllerInterface
 
     public function getEntryManager(Request $request)
     {
-        return $this->app->make(EntryManager::class, ['request' => $request]);
+        $manager = $this->app->make(EntryManager::class, ['request' => $request]);
+        $manager->setLogger(
+            $this->app->make(LoggerFactory::class)->createLogger(Channels::CHANNEL_EXPRESS)
+        );
+        return $manager;
     }
 
     public function getNotifier(?NotificationProviderInterface $provider = null)

--- a/concrete/src/Express/Entry/Manager.php
+++ b/concrete/src/Express/Entry/Manager.php
@@ -15,6 +15,7 @@ use Concrete\Core\Express\Form\Control\SaveHandler\SaveHandlerInterface;
 use Concrete\Core\Logging\Channels;
 use Concrete\Core\Logging\LoggerAwareInterface;
 use Concrete\Core\Logging\LoggerAwareTrait;
+use Concrete\Core\Logging\LoggerFactory;
 use Concrete\Core\User\User;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query;
@@ -37,6 +38,7 @@ class Manager implements EntryManagerInterface, LoggerAwareInterface
         $this->request = $request;
         $this->entityManager = $entityManager;
         $this->app = $app;
+        $this->logger = $app->make(LoggerFactory::class)->createLogger(Channels::CHANNEL_EXPRESS);     
     }
 
     public function getLoggerChannel()

--- a/concrete/src/Express/Entry/Manager.php
+++ b/concrete/src/Express/Entry/Manager.php
@@ -15,7 +15,6 @@ use Concrete\Core\Express\Form\Control\SaveHandler\SaveHandlerInterface;
 use Concrete\Core\Logging\Channels;
 use Concrete\Core\Logging\LoggerAwareInterface;
 use Concrete\Core\Logging\LoggerAwareTrait;
-use Concrete\Core\Logging\LoggerFactory;
 use Concrete\Core\User\User;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Query;
@@ -38,7 +37,6 @@ class Manager implements EntryManagerInterface, LoggerAwareInterface
         $this->request = $request;
         $this->entityManager = $entityManager;
         $this->app = $app;
-        $this->logger = $app->make(LoggerFactory::class)->createLogger(Channels::CHANNEL_EXPRESS);     
     }
 
     public function getLoggerChannel()

--- a/concrete/src/Express/Entry/Manager.php
+++ b/concrete/src/Express/Entry/Manager.php
@@ -103,7 +103,7 @@ class Manager implements EntryManagerInterface, LoggerAwareInterface
         $this->entityManager->persist($entry);
         $this->entityManager->flush();
 
-        $this->logger->info(t('Created new Express entry %s', $entry->getID()));
+        $this->logger?->info(t('Created new Express entry %s', $entry->getID()));
 
         return $entry;
     }
@@ -132,7 +132,7 @@ class Manager implements EntryManagerInterface, LoggerAwareInterface
 
         $this->entityManager->refresh($entry);
 
-        $this->logger->info(t('Saved Express entry attributes for %s (%s)', $entry->getLabel(), $entry->getID()));
+        $this->logger?->info(t('Saved Express entry attributes for %s (%s)', $entry->getLabel(), $entry->getID()));
         return $ev->getEntry();
     }
 


### PR DESCRIPTION
Manager seems to get instantiated somewhere that bypasses the container in some cases such as custom classes extending this one, so let's not assume the logger will be set

Fix #12857