### PR TITLE
Add "Early 404 - Page Not Found" responses for selected request paths

### DIFF
--- a/concrete/config/app.php
+++ b/concrete/config/app.php
@@ -893,6 +893,10 @@ return [
             'priority' => 1,
             'class' => \Concrete\Core\Http\Middleware\ApplicationMiddleware::class,
         ],
+        [
+            'priority' => 3,
+            'class' => \Concrete\Core\Http\Middleware\Early404Middleware::class,
+        ],
         'core_cookie' => \Concrete\Core\Http\Middleware\CookieMiddleware::class,
         'core_csp' => \Concrete\Core\Http\Middleware\ContentSecurityPolicyMiddleware::class,
         'core_hsts' => \Concrete\Core\Http\Middleware\StrictTransportSecurityMiddleware::class,

--- a/concrete/config/concrete.php
+++ b/concrete/config/concrete.php
@@ -8,7 +8,7 @@ return [
      */
     'version' => '9.5.0RC2',
     'version_installed' => '9.5.0RC2',
-    'version_db' => '20260203004500', // the key of the latest database migration
+    'version_db' => '20260415000000', // the key of the latest database migration 
 
     /*
      * Installation status
@@ -1525,5 +1525,10 @@ return [
 
     'file_chooser' => [
         'results' => 20,
-    ]
+    ],
+
+    'early404' => [
+        'enabled' => false,
+        'regexes' => "#/wp-(admin|content|login|temp)#\n#/wp-\w+\.php#i\n#/\.env#\n#/\.git#\n#/\.ht#",
+    ],
 ];

--- a/concrete/config/install/base/single_pages/dashboard.xml
+++ b/concrete/config/install/base/single_pages/dashboard.xml
@@ -1249,6 +1249,14 @@
                 </attributekey>
             </attributes>
         </page>
+        <page name="Early Page Not Found" path="/dashboard/system/permissions/early_page_not_found"
+              filename="/dashboard/system/permissions/early_404.php" pagetype="" description="" package="">
+            <attributes>
+                <attributekey handle="meta_keywords">
+                    <value>404, crawler, hack, crack, spy, wp-admin, wp-login, found</value>
+                </attributekey>
+            </attributes>
+        </page>
 
         <page name="Login &amp; Registration" path="/dashboard/system/registration"
               filename="/dashboard/system/registration/view.php" pagetype=""

--- a/concrete/controllers/single_page/dashboard/system/permissions/early_page_not_found.php
+++ b/concrete/controllers/single_page/dashboard/system/permissions/early_page_not_found.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\Controller\SinglePage\Dashboard\System\Permissions;
+
+use Concrete\Core\Config\Repository\Repository;
+use Concrete\Core\Database\Connection\Connection;
+use Concrete\Core\Database\Query\LikeBuilder;
+use Concrete\Core\Error\UserMessageException;
+use Concrete\Core\Http\ResponseFactory;
+use Concrete\Core\Page\Controller\DashboardPageController;
+use Concrete\Core\Routing\RouterInterface;
+use Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface;
+use Concrete\Core\Utility\RegexParser;
+use Concrete\Core\Utility\RegexParser\ParsedRegex;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+class EarlyPageNotFound extends DashboardPageController
+{
+    public function view(): ?Response
+    {
+        $config = $this->app->make(Repository::class);
+        $this->set('rootUrl', (string) $this->app->make(ResolverManagerInterface::class)->resolve(['/']));
+        $this->set('early404Enabled', (bool) $config->get('concrete.early404.enabled'));
+        $parser = $this->app->make(RegexParser::class);
+        $this->set('early404Rules', array_map(
+            function ($regex) use ($parser) {
+                try {
+                    $parsedRegex = $parser->parseRegEx($regex);
+                } catch (\RuntimeException $x) {
+                    return (new ParsedRegex(ParsedRegex::TYPE_REGEX, $regex))->jsonSerialize() + ['error' => $x->getMessage()];
+                }
+                try {
+                    $this->checkRegex($parsedRegex);
+                } catch (UserMessageException $x) {
+                    return $parsedRegex->jsonSerialize() + ['error' => $x->getMessage()];
+                }
+                return $parsedRegex->jsonSerialize() + ['error' => ''];
+            },
+            preg_split('/[\r\n]+/', (string) $config->get('concrete.early404.regexes'), -1, \PREG_SPLIT_NO_EMPTY)
+        ));
+
+        return null;
+    }
+
+    public function test_rule(): JsonResponse
+    {
+        if (!$this->token->validate('e404-tr')) {
+            throw new UserMessageException($this->token->getErrorMessage());
+        }
+        $parsedRegex = $this->extractParsedRegexFromArray($this->request->request->all());
+        $this->checkRegex($parsedRegex);
+        $rf = $this->app->make(ResponseFactory::class);
+
+        return $rf->json(true);
+    }
+
+    public function test_url(): JsonResponse
+    {
+        if (!$this->token->validate('e404-tu')) {
+            throw new UserMessageException($this->token->getErrorMessage());
+        }
+        $url = trim((string) $this->request->request->get('url'));
+        if ($url === '') {
+            throw new UserMessageException(t('Please specify the URL'));
+        }
+        $url = '/' . $url;
+        $parsedRegexes = $this->extractParsedRegexesFromPost();
+        $result = [
+            'class' => 'text-muted',
+            'text' => t('No rules match the specified URL'),
+        ];
+        foreach ($parsedRegexes as $index => $parsedRegex) {
+            if (preg_match($parsedRegex->asRegex(), $url)) {
+                $result['class'] = 'text-success';
+                $result['text'] = t('The rule #%1$s matches the URL %2$s', $index + 1, $url);
+                break;
+            }
+        }
+        $rf = $this->app->make(ResponseFactory::class);
+
+        return $rf->json($result);
+    }
+
+    public function set_rules_enabled(): JsonResponse
+    {
+        if (!$this->token->validate('e404-e')) {
+            throw new UserMessageException($this->token->getErrorMessage());
+        }
+        $enabled = $this->request->request->getBoolean('enabled');
+        $config = $this->app->make(Repository::class);
+        $config->save('concrete.early404.enabled', $enabled);
+        $rf = $this->app->make(ResponseFactory::class);
+
+        return $rf->json($enabled);
+    }
+
+    public function save(): JsonResponse
+    {
+        if (!$this->token->validate('e404-s')) {
+            throw new UserMessageException($this->token->getErrorMessage());
+        }
+        $serialized = [];
+        $parsedRegexes = $this->extractParsedRegexesFromPost();
+        foreach ($parsedRegexes as $parsedRegex) {
+            $this->checkRegex($parsedRegex);
+            $serialized[] = $parsedRegex->asRegex();
+        }
+        $config = $this->app->make(Repository::class);
+        $config->save('concrete.early404.regexes', implode("\n", array_unique($serialized)));
+        $this->flash('success', t('Settings Saved.'));
+        $rf = $this->app->make(ResponseFactory::class);
+
+        return $rf->json(true);
+    }
+
+    private function extractParsedRegexesFromPost(): array
+    {
+        $result = [];
+        $all = $this->request->request->all();
+        for ($index = 0;; $index++) {
+            if (!isset($all['rules'][$index]['type']) && !isset($all['rules'][$index]['text'])) {
+                break;
+            }
+            $result[] = $this->extractParsedRegexFromArray($all['rules'][$index]);
+        }
+
+        return $result;
+    }
+
+    private function extractParsedRegexFromArray(array $data): ParsedRegex
+    {
+        $type = $data['type'] ?? null;
+        if (!in_array($type, [
+            ParsedRegex::TYPE_REGEX,
+            ParsedRegex::TYPE_EQUALS,
+            ParsedRegex::TYPE_STARTSWITH,
+            ParsedRegex::TYPE_ENDSWITH,
+            ParsedRegex::TYPE_CONTAINS,
+        ], true)) {
+            throw new UserMessageException(t('Invalid parameter received: %s', 'type'));
+        }
+
+        return new ParsedRegex($type, $data['text'] ?? '', $data['delimiter'] ?? '', $data['modifiers'] ?? '');
+    }
+
+    /**
+     * @throws \Concrete\Core\Error\UserMessageException
+     */
+    private function checkRegex(ParsedRegex $parsedRegex): void
+    {
+        if ($parsedRegex->getText() === '') {
+            throw new UserMessageException(t('Please specify the text'));
+        }
+        $parser = $this->app->make(RegexParser::class);
+        try {
+            $parser->parseRegEx($parsedRegex->asRegex());
+        } catch (\RuntimeException $x) {
+            throw new UserMessageException($x->getMessage());
+        }
+        switch ($parsedRegex->getType()) {
+            case ParsedRegex::TYPE_STARTSWITH:
+            case ParsedRegex::TYPE_EQUALS:
+                if (!str_starts_with($parsedRegex->getText(), '/')) {
+                    throw new UserMessageException(t('Requests will always start with the character "%s"', '/'));
+                }
+                break;
+            case ParsedRegex::TYPE_REGEX:
+                if (str_starts_with($parsedRegex->getText(), '^') && !str_starts_with($parsedRegex->getText(), '^/')) {
+                    throw new UserMessageException(t('Requests will always start with the character "%s"', '/'));
+                }
+                break;
+        }
+        if (preg_match($parsedRegex->asRegex(), '/')) {
+            throw new UserMessageException(t('This rule would prevent accessing the homepage'));
+        }
+        if (preg_match($parsedRegex->asRegex(), '/' . DISPATCHER_FILENAME) || preg_match($parsedRegex->asRegex(), '/' . DISPATCHER_FILENAME . '/')) {
+            throw new UserMessageException(t('This rule would prevent accessing the website with %s', DISPATCHER_FILENAME));
+        }
+        // We can't use Doctrine ORM queries, since when using REGEXP/RLIKE (see \Doctrine\DBAL\Platforms\AbstractPlatform::getRegexpExpression()) we have a Syntax Error (it seemd ORM doesn't support regexes)
+        $cn = $this->app->make(Connection::class);
+        $qb = $cn->createQueryBuilder()
+            ->from('PagePaths', 'pp')
+            ->select('pp.cPath')
+            ->orderBy('pp.cPath')
+            ->setMaxResults(1)
+        ;
+        if ($parsedRegex->getType() === ParsedRegex::TYPE_REGEX) {
+            $qb
+                ->andWhere('pp.cPath ' . $cn->getDatabasePlatform()->getRegexpExpression() . ' :rx')
+                ->setParameter('rx', $parsedRegex->getText())
+            ;
+        } else {
+            $lb = $this->app->make(LikeBuilder::class);
+            $qb
+                ->andWhere('pp.cPath LIKE :like')
+                ->setParameter(
+                    'like',
+                    $lb->escapeForLike(
+                        $parsedRegex->getText(),
+                        in_array($parsedRegex->getType(), [ParsedRegex::TYPE_EQUALS, ParsedRegex::TYPE_STARTSWITH], true) ? false : true,
+                        in_array($parsedRegex->getType(), [ParsedRegex::TYPE_EQUALS, ParsedRegex::TYPE_ENDSWITH], true) ? false : true
+                    )
+                )
+            ;
+        }
+        $pagePath = $qb->execute()->fetchOne();
+        if ($pagePath !== false) {
+            throw new UserMessageException(t('This rule would prevent accessing the existing page at path %s', $pagePath));
+        }
+        $router = $this->app->make(RouterInterface::class);
+        $regex = $parsedRegex->asRegex();
+        foreach ($router->getRoutes() as $route) {
+            $routePath = $route->getPath();
+            if (preg_match($regex, $routePath)) {
+                throw new UserMessageException(t('This rule would prevent accessing the route with path %s', $routePath));
+            }
+        }
+    }
+}

--- a/concrete/single_pages/dashboard/system/permissions/early_page_not_found.php
+++ b/concrete/single_pages/dashboard/system/permissions/early_page_not_found.php
@@ -1,0 +1,398 @@
+<?php
+
+declare(strict_types=1);
+
+use Concrete\Core\Utility\RegexParser\ParsedRegex;
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+/**
+ * @var Concrete\Controller\SinglePage\Dashboard\System\Permissions\EarlyPageNotFound $controller
+ * @var Concrete\Core\Application\Service\Dashboard $dashboard
+ * @var Concrete\Core\Form\Service\Form $form
+ * @var Concrete\Core\Html\Service\Html $html
+ * @var Concrete\Core\Application\Service\UserInterface $interface
+ * @var Concrete\Core\Validation\CSRF\Token $token
+ * @var Concrete\Core\Page\View\PageView $view
+ *
+ * @var string $rootUrl
+ * @var bool $early404Enabled
+ * @var array[] $early404Rules
+ */
+
+?>
+<div class="ccm-dashboard-header-buttons">
+    <div id="ccm-e404-tools" v-cloak>
+        <button class="btn" v-bind:class="rulesEnabled ? 'btn-success' : 'btn-danger'" v-bind:disabled="busy" v-on:click.prevent="toggleRulesEnabled()">
+            <template v-if="rulesEnabled"><?= t('Rules Enabled') ?></template>
+            <template v-else><?= t('Rules Disabled') ?></template>
+        </button>
+    </div>
+</div>
+<div id="ccm-e404-main" v-cloak>
+    <fieldset>
+        <legend><?= t('Rules') ?></legend>
+        <table class="table table-hover">
+            <thead>
+                <tr>
+                    <th style="width: 1px"></th>
+                    <th style="width: 1px"><?= t('Type') ?></th>
+                    <th><?= t('Text') ?></th>
+                    <th style="width: 1px"><?= t('Options') ?></th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr v-for="(rule, index) in rules">
+                    <td>
+                        <button class="btn btn-sm btn-danger" v-on:click.prevent="deleteRule(rule)" v-bind:disabled="busy">&times;</button>
+                    </td>
+                    <td>
+                        <select class="form-control form-control-sm" v-model="rule.type" style="width: auto; min-width: max-content" v-bind:disabled="busy">
+                            <option v-bind:value="TYPE.EQUALS"><?= t('Equals') ?></option>
+                            <option v-bind:value="TYPE.CONTAINS"><?= t('Contains') ?></option>
+                            <option v-bind:value="TYPE.STARTSWITH"><?= t('Starts With') ?></option>
+                            <option v-bind:value="TYPE.ENDSWITH"><?= t('Ends With') ?></option>
+                            <option v-bind:value="TYPE.REGEX"><?= t('Regular Expression') ?></option>
+                        </select>
+                    </td>
+                    <td>
+                        <div class="input-group input-group-sm">
+                            <input type="text" class="form-control font-monospace" v-model.trim="rule.text" v-bind:readonly="busy" />
+                            <span v-if="rule.type === TYPE.REGEX" class="input-group-text">
+                                <?= t('Delimiter: %s', '&nbsp;<code>{{ rule.delimiter }}</code>') ?>
+                            </span>
+                        </div>
+                        <div class="text-danger" style="white-space: pre-wrap" v-if="rule.error">{{ rule.error }}</div>
+                    </td>
+                    <td class="text-nowrap">
+                        <div class="form-check mb-0">
+                            <input class="form-check-input" type="checkbox" value="" v-bind:id="`ccm-e404-ci${index}`" v-bind:value="MODIFIER.CASE_INSENSITIVE" v-model="rule.modifiers" v-bind:disabled="busy" />
+                            <label class="form-check-label" v-bind:for="`ccm-e404-ci${index}`">
+                                <?= t('Case Insensitive') ?>
+                            </label>
+                        </div>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </fieldset>
+    <fieldset>
+        <legend><?= t('Test') ?></legend>
+        <div class="input-group input-group-sm">
+            <span class="input-group-text"><?= h($rootUrl) ?></span>
+            <input type="text" class="form-control font-monospace" v-model.trim="test.url" v-bind:readonly="busy" />
+        </div>
+        <div v-bind:class="test.resultClass">{{ test.resultText }}</div>
+    </fieldset>
+    <div class="ccm-dashboard-form-actions-wrapper">
+        <div class="ccm-dashboard-form-actions">
+            <div class="float-end">
+                <button class="btn btn-primary" v-bind:disabled="busy" v-on:click.prevent="save()"><?= t('Save Rules') ?></button>
+            </div>
+        </div>
+    </div>
+</div>
+<script>$(document).ready(async function() {
+
+const {Vue} = await Concrete.Vue.activateContextAsync('cms');
+
+const tools = new Vue({
+    el: '#ccm-e404-tools',
+    data() {
+        return {
+            busy: false,
+            rulesEnabled: <?= json_encode($early404Enabled) ?>,
+            storedRulesHaveErrors: <?= json_encode(
+                array_filter(
+                    $early404Rules,
+                    static function (array $rule): bool {
+                        return $rule['error'] !== '';
+                    }
+                ) !== []
+            ) ?>,
+        };
+    },
+    methods: {
+        async toggleRulesEnabled() {
+            if (this.busy) {
+                return;
+            }
+            this.busy = true;
+            try {
+                if (!this.rulesEnabled && this.storedRulesHaveErrors) {
+                    throw new Error(<?= json_encode(t('Please fix the rule errors and save the rules before activating them')) ?>);
+                }
+                this.rulesEnabled = await $.ajax({
+                    type: 'POST',
+                    url: <?= json_encode($view->action('set_rules_enabled')); ?>,
+                    data: {
+                        <?= json_encode($token::DEFAULT_TOKEN_NAME); ?>: <?= json_encode($token->generate('e404-e')); ?>,
+                        enabled: !this.rulesEnabled
+                    },
+                    dataType: 'json'
+                });
+            } catch (e) {
+                let error;
+                if (e?.responseJSON?.errors?.length) {
+                    error = e?.responseJSON.errors.join('\n');
+                } else {
+                    error = e?.responseText || e?.message || <?= json_encode(t('Unknown error')) ?>;
+                }
+                ConcreteAlert.error({message: error, plainTextMessage: true});
+            } finally {
+                this.busy = false;
+            }
+        },
+    },
+});
+
+const main = new Vue({
+    el: '#ccm-e404-main',
+    data() {
+        return {
+            busy: false,
+            askBeforeUnload: true,
+            rules: <?= json_encode($early404Rules) ?>.map(rule => this.unserializeRule(rule)),
+            TYPE: <?= json_encode([
+                'REGEX' => ParsedRegex::TYPE_REGEX,
+                'EQUALS' => ParsedRegex::TYPE_EQUALS,
+                'STARTSWITH' => ParsedRegex::TYPE_STARTSWITH,
+                'ENDSWITH' => ParsedRegex::TYPE_ENDSWITH,
+                'CONTAINS' => ParsedRegex::TYPE_CONTAINS,
+            ]) ?>,
+            MODIFIER: <?= json_encode([
+                'CASE_INSENSITIVE' => ParsedRegex::MODIFIER_CASELESS,
+            ]) ?>,
+            WATCH_DELAY: 250,
+            rulesWatchTimer: null,
+            testUrlWatchTimer: null,
+            test: {
+                url: '',
+                resultClass: '',
+                resultText: '',
+                _checkKey: '',
+            },
+        };
+    },
+    created() {
+        this.checkRules();
+        this.updateTestUrlResult();
+    },
+    mounted() {
+        window.addEventListener('beforeunload', (e) => {
+            if (this.busy && this.askBeforeUnload) {
+                return e.returnValue = 'confirm';
+            }
+        });
+    },
+    methods: {
+        unserializeRule(rule) {
+            rule.modifiers = rule.modifiers.split('');
+            rule._checkKey = this.buildCheckKey(rule);
+            return rule;
+        },
+        serializeRule(rule) {
+            return {
+                type: rule.type,
+                text: rule.text,
+                delimiter: rule.delimiter,
+                modifiers: rule.modifiers.join(''),
+            };
+        },
+        buildCheckKey(rule) {
+            return [rule.type, rule.text, rule.delimiter, rule.modifiers.join('\x01')].join('\x02');
+        },
+        checkEmptyRules() {
+            if (!this.rules.some(rule => rule.text === '')) {
+                this.addRule();
+            }
+        },
+        checkRules() {
+            this.checkEmptyRules();
+            this.rules.forEach((rule) => {
+                if (rule._checkKey !== this.buildCheckKey(rule)) {
+                    this.checkRule(rule);
+                }
+            });
+        },
+        async checkRule(rule) {
+            const checkKey = this.buildCheckKey(rule);
+            if (rule.text === '') {
+                rule._checkKey = checkKey;
+                rule.error = '';
+                return;
+            }
+            if (rule._checkingKey === checkKey) {
+                return;
+            }
+            rule._checkingKey = checkKey;
+            try {
+                await $.ajax({
+                    type: 'POST',
+                    url: <?= json_encode($view->action('test_rule')); ?>,
+                    data: $.extend(
+                        {
+                            <?= json_encode($token::DEFAULT_TOKEN_NAME); ?>: <?= json_encode($token->generate('e404-tr')); ?>,
+                        },
+                        this.serializeRule(rule),
+                    ),
+                    dataType: 'json'
+                });
+                if (rule._checkingKey !== checkKey) {
+                    return;
+                }
+                delete rule._checkingKey;
+                rule._checkKey = checkKey;
+                rule.error = '';
+            } catch (e) {
+                if (rule._checkingKey !== checkKey) {
+                    return;
+                }
+                delete rule._checkingKey;
+                rule._checkKey = checkKey;
+                if (e?.responseJSON?.errors?.length) {
+                    rule.error = e?.responseJSON.errors.join('\n');
+                } else {
+                    rule.error = e?.responseText || e?.message || <?= json_encode(t('Unknown error')) ?>;
+                }
+            }
+        },
+        addRule() {
+            this.rules.push(this.unserializeRule({
+                type: this.TYPE.CONTAINS,
+                text: '',
+                delimiter: '#',
+                modifiers: this.MODIFIER.CASE_INSENSITIVE,
+                error: '',
+            }));
+        },
+        deleteRule(rule) {
+            const index = this.rules.indexOf(rule);
+            if (index >= 0) {
+                this.rules.splice(index, 1);
+            }
+        },
+        async updateTestUrlResult() {
+            if (this.test.url === '') {
+                this.test.resultClass = 'text-muted';
+                this.test.resultText = <?= json_encode(t('Specify a URL to check if the rules match')) ?>;
+                return;
+            }
+            const rules = this.rules.filter(rule => rule.text !== '');
+            if (rules.length === 0) {
+                this.test.resultClass = 'text-muted';
+                this.test.resultText = <?= json_encode(t('Specify at least one rule')) ?>;
+                return;
+            }
+            const checkKey = [this.test.url, ...rules.map(rule => rule._checkKey)].join('\x03');
+            if (this.test._checkKey === checkKey) {
+                return;
+            }
+            this.test.resultClass = 'text-muted';
+            this.test.resultText = '...';
+            try {
+                const response = await $.ajax({
+                    type: 'POST',
+                    url: <?= json_encode($view->action('test_url')); ?>,
+                    data: {
+                        <?= json_encode($token::DEFAULT_TOKEN_NAME); ?>: <?= json_encode($token->generate('e404-tu')); ?>,
+                        rules: rules.map(rule => this.serializeRule(rule)),
+                        url: this.test.url,
+                    },
+                    dataType: 'json'
+                });
+                console.log(response);
+                this.test.resultClass = response.class;
+                this.test.resultText = response.text;
+            } catch (e) {
+                this.test.resultClass = 'text-danger';
+                if (e?.responseJSON?.errors?.length) {
+                    this.test.resultText =e?.responseJSON.errors.join('\n');
+                } else {
+                    this.test.resultText =e?.responseText || e?.message || <?= json_encode(t('Unknown error')) ?>;
+                }
+            }
+        },
+        async save() {
+            if (this.busy) {
+                return;
+            }
+            const someErrors = this.rules.some((rule) => {
+                if (!rule.error) {
+                    return false;
+                }
+                ConcreteAlert.error({message: <?= json_encode(t('Please fix the errors')) ?>});
+                return true;
+            });
+            if (someErrors) {
+                return;
+            }
+            this.busy = true;
+            try {
+                await $.ajax({
+                    type: 'POST',
+                    url: <?= json_encode($view->action('save')); ?>,
+                    data: {
+                        <?= json_encode($token::DEFAULT_TOKEN_NAME); ?>: <?= json_encode($token->generate('e404-s')); ?>,
+                        rules: this.rules
+                            .filter(rule => rule.text !== '')
+                            .map(rule => this.serializeRule(rule))
+                        ,
+                    },
+                    dataType: 'json'
+                });
+                this.askBeforeUnload = false;
+                window.location.reload();
+            } catch (e) {
+                this.busy = false;
+                let error;
+                if (e?.responseJSON?.errors?.length) {
+                    error = e?.responseJSON.errors.join('\n');
+                } else {
+                    error = e?.responseText || e?.message || <?= json_encode(t('Unknown error')) ?>;
+                }
+                ConcreteAlert.error({message: error, plainTextMessage: true});
+            }
+        },
+    },
+    watch: {
+        rules: {
+            deep: true,
+            handler() {
+                this.checkEmptyRules();
+                this.rules.forEach(rule => {
+                    if (rule.text === '') {
+                        this.checkRule(rule);
+                    }
+                });
+                if (this.rulesWatchTimer) {
+                    clearTimeout(this.rulesWatchTimer);
+                }
+                this.rulesWatchTimer = setTimeout(
+                    () => {
+                        clearTimeout(this.rulesWatchTimer);
+                        this.rulesWatchTimer = null;
+                        this.checkRules();
+                        this.updateTestUrlResult();
+                    },
+                    this.WATCH_DELAY
+                );
+            }
+        },
+        'test.url'() {
+            if (this.testUrlWatchTimer) {
+                clearTimeout(this.testUrlWatchTimer);
+            }
+            this.testUrlWatchTimer = setTimeout(
+                () => {
+                    clearTimeout(this.testUrlWatchTimer);
+                    this.testUrlWatchTimer = null;
+                    this.updateTestUrlResult();
+                },
+                this.WATCH_DELAY
+            );
+        },
+    },
+});
+
+});</script>

--- a/concrete/src/Application/Service/UserInterface/Help/DashboardManager.php
+++ b/concrete/src/Application/Service/UserInterface/Help/DashboardManager.php
@@ -202,6 +202,9 @@ class DashboardManager extends AbstractManager
             '/dashboard/system/files/image_uploading' => implode('', [
                 '<p>' . t('Control maximum dimensions for all images uploaded to your website. Ensures that enormous images will be resized.') . ' ' . t('Auto-rotate images accordingly to EXIF metadata.') . '<br />' . t('Set PNG and JPEG compression options.') . '</p>',
             ]),
+            '/dashboard/system/permissions/early_page_not_found' => 
+                '<p>' . t("Use this page to define patterns for request paths that should return an immediate 404 (Page Not Found) response.") . ' ' . t('This reduces server load by fast-tracking requests likely performed by bots or hackers, preventing unnecessary processing by Concrete CMS.') . '</p>'
+            ,
         ]);
     }
 }

--- a/concrete/src/Http/Middleware/Early404Middleware.php
+++ b/concrete/src/Http/Middleware/Early404Middleware.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Concrete\Core\Http\Middleware;
+
+use Concrete\Core\Application\Application;
+use Concrete\Core\Config\Repository\Repository;
+use Concrete\Core\Http\Response;
+use Concrete\Core\Http\ResponseFactoryInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+class Early404Middleware implements MiddlewareInterface
+{
+    /**
+     * @var \Concrete\Core\Application\Application
+     */
+    private $app;
+
+    /**
+     * @var \Concrete\Core\Config\Repository\Repository
+     */
+    private $config;
+
+    public function __construct(Application $app, Repository $config)
+    {
+        $this->app = $app;
+        $this->config = $config;
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Http\Middleware\MiddlewareInterface::process()
+     */
+    public function process(Request $request, DelegateInterface $frame)
+    {
+        return $this->handle($request) ?? $frame->next($request);
+    }
+
+    private function handle(Request $request): ?Response
+    {
+        if (!$this->app->isInstalled()) {
+            return null;
+        }
+        if (!$this->config->get('concrete.early404.enabled')) {
+            return null;
+        }
+        $regexes = (string) $this->config->get('concrete.early404.regexes');
+        if (!$regexes) {
+            return null;
+        }
+        $pi = $request->getPathInfo();
+        foreach (preg_split('/[\r\n]+/', $regexes, -1, \PREG_SPLIT_NO_EMPTY) as $regex) {
+            if (preg_match($regex, $pi)) {
+                return $this->buildEarly404Response($request);
+            }
+        }
+
+        return null;
+    }
+
+    private function buildEarly404Response(Request $request): Response
+    {
+        return $this->app->make(ResponseFactoryInterface::class)->create('404', Response::HTTP_NOT_FOUND, ['Content-Type' => 'text/plain']);
+    }
+}

--- a/concrete/src/Updater/Migrations/Migrations/Version20260415000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20260415000000.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Concrete\Core\Updater\Migrations\Migrations;
+
+use Concrete\Core\Updater\Migrations\AbstractMigration;
+use Concrete\Core\Updater\Migrations\RepeatableMigrationInterface;
+
+class Version20260415000000 extends AbstractMigration implements RepeatableMigrationInterface
+{
+    public function upgradeDatabase()
+    {
+        $this->createSinglePage('/dashboard/system/permissions/early_page_not_found', 'Early Page Not Found', ['meta_keywords' => '404, crawler, hack, crack, spy, wp-admin, wp-login, found']);
+    }
+}

--- a/concrete/src/Utility/RegexParser.php
+++ b/concrete/src/Utility/RegexParser.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\Core\Utility;
+
+use Concrete\Core\Utility\RegexParser\ParsedRegex;
+
+class RegexParser
+{
+    /**
+     * @see https://www.php.net/manual/en/regexp.reference.meta.php
+     */
+    private const META_CHARS = ['\\', '^', '$', '.', '[', ']', '|', '(', ')', '?', '*', '+', '{', '}'];
+
+    /**
+     * preg_quote() also escaped these chars ('#' since PHP 7.3, '-' since PHP 5.3)
+     */
+    private const ADDITIONAL_ESCAPED_CHARS = ['!', '#', '-', ':', '<', '=', '>'];
+
+    /**
+     * @throws \RuntimeException
+     */
+    public function parseRegEx(string $regex): ParsedRegex
+    {
+        $result = new ParsedRegex(ParsedRegex::TYPE_REGEX, $regex);
+        $parts = $this->splitRegex($regex);
+        if ($parts === null) {
+            throw new \RuntimeException(t('Invalid regular expression'));
+        }
+        $result = $result
+            ->withText($parts['pattern'])
+            ->withDelimiter($parts['delimiter'])
+            ->withModifiers($parts['modifiers'])
+        ;
+        $hasStart = $this->patternStartsWithCaret($parts['pattern']);
+        $hasEnd = $this->patternEndsWithDollar($parts['pattern']);
+        $cleanPattern = $parts['pattern'];
+        if ($hasStart) {
+            $cleanPattern = substr($cleanPattern, 1);
+        }
+        if ($hasEnd) {
+            $cleanPattern = substr($cleanPattern, 0, -1);
+        }
+        if ($this->isConvertibleToTextSearch($cleanPattern, $result->getDelimiter())) {
+            $result = $result->withText($this->unescapeSimplePattern($cleanPattern, $result->getDelimiter()));
+            if ($hasStart && $hasEnd) {
+                $result = $result->withType(ParsedRegex::TYPE_EQUALS);
+            } elseif ($hasStart) {
+                $result = $result->withType(ParsedRegex::TYPE_STARTSWITH);
+            } elseif ($hasEnd) {
+                $result = $result->withType(ParsedRegex::TYPE_ENDSWITH);
+            } else {
+                $result = $result->withType(ParsedRegex::TYPE_CONTAINS);
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return array{'delimiter': string, 'pattern': string, 'modifiers': string}
+     */
+    private function splitRegex(string $regex): ?array
+    {
+        set_error_handler(static function () { }, -1);
+        try {
+            if (preg_match($regex, '') === false) {
+                return null;
+            }
+        } finally {
+            restore_error_handler();
+        }
+        $matches = null;
+        if (!preg_match(
+            '/^(?<delimiter1>[^A-Za-z0-9\s\\\\])(?<pattern>.*)(?<delimiter2>[^A-Za-z0-9\s\\\\])(?<modifiers>[' . implode('', ParsedRegex::getAllModifiers()) . ']*)$/D',
+            $regex,
+            $matches
+        )) {
+            return null;
+        }
+        $expectedDelimiter2 = ParsedRegex::DELIMITER_COUPLES[$matches['delimiter1']] ?? $matches['delimiter1'];
+        if ($matches['delimiter2'] !== $expectedDelimiter2) {
+            return null;
+        }
+
+        return [
+            'delimiter' => $matches['delimiter1'],
+            'pattern' => $matches['pattern'],
+            'modifiers' => $matches['modifiers'],
+        ];
+    }
+
+    private function patternStartsWithCaret(string $pattern): bool
+    {
+        return $pattern !== '' && $pattern[0] === '^';
+    }
+
+    private function patternEndsWithDollar(string $pattern): bool
+    {
+        // Read it as:
+        // - '\\$$': the string ends with a $
+        // - '(?:\\\\\\\\)*': before the trailing $ we may have 0, 2, 4, 6, ... an even number of '\'
+        // - '(?<!\\\\)': the character immediately before the whole trailing sequence must not be a '\'
+        // In short: the string ends with a '$' which is not escaped by an odd number of backslashes
+        return (bool) preg_match('/(?<!\\\\)(?:\\\\\\\\)*\\$$/D', $pattern);
+    }
+
+    private function isConvertibleToTextSearch(string $pattern, string $delimiter): bool
+    {
+        $charsAfterBackslash = implode('', self::META_CHARS) . implode('', self::ADDITIONAL_ESCAPED_CHARS) . $delimiter;
+        $i = 0;
+        $len = strlen($pattern);
+        while ($i < $len) {
+            $char = $pattern[$i];
+            if ($char === '\\') {
+                if ($i + 1 < $len) {
+                    $nextChar = $pattern[$i + 1];
+                    if (strpos($charsAfterBackslash, $nextChar) === false) {
+                        return false;
+                    }
+                    $i += 2;
+                    continue;
+                }
+                return false;
+            }
+            if (in_array($char, self::META_CHARS, true)) {
+                // Unescaped meta character: not a simple regex
+                return false;
+            }
+            $i++;
+        }
+
+        return true;
+    }
+
+    private function unescapeSimplePattern(string $pattern, string $delimiter): string
+    {
+        return preg_replace('/\\\\(.)/', '$1', $pattern);
+    }
+}

--- a/concrete/src/Utility/RegexParser/ParsedRegex.php
+++ b/concrete/src/Utility/RegexParser/ParsedRegex.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\Core\Utility\RegexParser;
+
+final class ParsedRegex implements \JsonSerializable
+{
+    public const TYPE_REGEX = 'regex';
+
+    public const TYPE_EQUALS = 'equals';
+
+    public const TYPE_STARTSWITH = 'startsWith';
+
+    public const TYPE_ENDSWITH = 'endsWith';
+
+    public const TYPE_CONTAINS = 'contains';
+
+    /**
+     * @see https://www.php.net/manual/en/reference.pcre.pattern.modifiers.php
+     */
+    public const MODIFIER_CASELESS = 'i';
+
+    public const MODIFIER_MULTILINE = 'm';
+
+    public const MODIFIER_DOTALL = 's';
+
+    public const MODIFIER_EXTENDED = 'x';
+
+    public const MODIFIER_ANCHORED = 'A';
+
+    public const MODIFIER_DOLLAR_ENDONLY = 'D';
+
+    public const MODIFIER_UNGREEDY = 'U';
+
+    public const MODIFIER_EXTRA = 'X';
+
+    public const MODIFIER_INFO_JCHANGED = 'J';
+
+    public const MODIFIER_UTF8 = 'u';
+
+    /**
+     * @since PHP 8.2
+     */
+    public const MODIFIER_NO_AUTO_CAPTURE = 'n';
+
+    /**
+     * @since PHP 8.3
+     */
+    public const MODIFIER_EXTRA_CASELESS_RESTRICT = 'r';
+
+    /**
+     * @see https://www.php.net/manual/en/regexp.reference.delimiters.php
+     */
+    public const DELIMITER_COUPLES = [
+        '(' => ')',
+        '{' => '}',
+        '[' => ']',
+        '<' => '>',
+    ];
+
+    /**
+     * @var string
+     */
+    private $type;
+
+    /**
+     * @var string
+     */
+    private $text;
+
+    /**
+     * @var string
+     */
+    private $delimiter;
+
+    /**
+     * @var string
+     */
+    private $modifiers;
+
+    public function __construct(string $type, string $text, string $delimiter = '/', string $modifiers = '')
+    {
+        $this->type = $type;
+        $this->text = $text;
+        $this->delimiter = $delimiter;
+        $this->modifiers = $modifiers;
+    }
+
+    public function getType(): string
+    {
+        return $this->type;
+    }
+
+    public function withType(string $newType): self
+    {
+        $result = clone $this;
+        $result->type = $newType;
+
+        return $result;
+    }
+
+    public function getText(): string
+    {
+        return $this->text;
+    }
+
+    public function withText(string $newText): self
+    {
+        $result = clone $this;
+        $result->text = $newText;
+
+        return $result;
+    }
+
+    public function getDelimiter(): string
+    {
+        return $this->delimiter;
+    }
+
+    public function withDelimiter(string $newDelimiter): self
+    {
+        $result = clone $this;
+        $result->delimiter = $newDelimiter;
+
+        return $result;
+    }
+
+    public function getModifiers(): string
+    {
+        return $this->modifiers;
+    }
+
+    public function withModifiers(string $newModifiers): self
+    {
+        $result = clone $this;
+        $result->modifiers = $newModifiers;
+
+        return $result;
+    }
+
+    public function asRegex(): string
+    {
+        $result = $this->delimiter;
+        if ($this->type === self::TYPE_REGEX) {
+            $result .= $this->text;
+        } else {
+            if (in_array($this->type, [self::TYPE_STARTSWITH, self::TYPE_EQUALS], true)) {
+                $result .= '^';
+            }
+            $result .= preg_quote($this->text, $this->delimiter);
+            if (in_array($this->type, [self::TYPE_ENDSWITH, self::TYPE_EQUALS], true)) {
+                $result .= '$';
+            }
+        }
+        $result .= self::DELIMITER_COUPLES[$this->delimiter] ?? $this->delimiter;
+        $result .= $this->modifiers;
+
+        return $result;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'type' => $this->type,
+            'text' => $this->text,
+            'delimiter' => $this->delimiter,
+            'modifiers' => $this->modifiers,
+        ];
+    }
+
+    /**
+     * @return string[]
+     */
+    public static function getAllModifiers(): array
+    {
+        static $result;
+        if ($result === null) {
+            $result = [];
+            $ref = new \ReflectionClass(self::class);
+            foreach ($ref->getConstants() as $name => $value) {
+                if (!str_starts_with($name, 'MODIFIER_')) {
+                    continue;
+                }
+                if ($name === 'MODIFIER_NO_AUTO_CAPTURE' && PHP_VERSION_ID < 80200) {
+                    continue;
+                }
+                if ($name === 'MODIFIER_EXTRA_CASELESS_RESTRICT' && PHP_VERSION_ID < 80400) {
+                    continue;
+                }
+                $result[] = $value;
+            }
+        }
+
+        return $result;
+    }
+}

--- a/tests/tests/Utility/RegexParserTest.php
+++ b/tests/tests/Utility/RegexParserTest.php
@@ -1,0 +1,425 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\Tests\Utility;
+
+use Concrete\Core\Utility\RegexParser;
+use Concrete\Core\Utility\RegexParser\ParsedRegex;
+use Concrete\Tests\TestCase;
+
+class RegexParserTest extends TestCase
+{
+    /**
+     * @var \Concrete\Core\Utility\RegexParser
+     */
+    private static $parser;
+
+    /**
+     * @var array<string, \ReflectionMethod>
+     */
+    private static $parserPrivateMethods;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$parser = new RegexParser();
+        self::$parserPrivateMethods = [];
+        $class = new \ReflectionClass(self::$parser);
+        foreach ($class->getMethods(\ReflectionMethod::IS_PROTECTED | \ReflectionMethod::IS_PRIVATE) as $method) {
+            if (PHP_VERSION < 80500) {
+                $method->setAccessible(true);
+            }
+            self::$parserPrivateMethods[$method->name] = $method;
+        }
+    }
+
+    /**
+     * @dataProvider splitRegexProvider
+     */
+    public function testSplitRegex(string $regex, ?array $expected = null): void
+    {
+        $actual = self::$parserPrivateMethods['splitRegex']->invoke(self::$parser, $regex);
+        self::assertSame($expected, $actual);
+    }
+
+    public static function splitRegexProvider(): array
+    {
+        return [
+            [''],
+            ['^$'],
+            ['a.a'],
+            ['<.>#'],
+            ['//', ['delimiter' => '/', 'pattern' => '', 'modifiers' => '']],
+            ['//i', ['delimiter' => '/', 'pattern' => '', 'modifiers' => 'i']],
+            ['//imsxADUXJu', ['delimiter' => '/', 'pattern' => '', 'modifiers' => 'imsxADUXJu']],
+            ['#.#', ['delimiter' => '#', 'pattern' => '.', 'modifiers' => '']],
+            ['[.]', ['delimiter' => '[', 'pattern' => '.', 'modifiers' => '']],
+            ['{.}', ['delimiter' => '{', 'pattern' => '.', 'modifiers' => '']],
+            ['(.)', ['delimiter' => '(', 'pattern' => '.', 'modifiers' => '']],
+        ];
+    }
+
+    /**
+     * @dataProvider patternStartsWithCaretProvider
+     */
+    public function testPatternStartsWithCaret(string $pattern, bool $expected): void
+    {
+        $actual = self::$parserPrivateMethods['patternStartsWithCaret']->invoke(self::$parser, $pattern);
+
+        self::assertSame($expected, $actual);
+    }
+
+    public static function patternStartsWithCaretProvider(): array
+    {
+        return [
+            ['', false],
+            ['$', false],
+            ['^', true],
+            ['^.', true],
+        ];
+    }
+
+    /**
+     * @dataProvider patternEndsWithDollarProvider
+     */
+    public function testPatternEndsWithDollar(string $pattern, bool $expected): void
+    {
+        $actual = self::$parserPrivateMethods['patternEndsWithDollar']->invoke(self::$parser, $pattern);
+
+        self::assertSame($expected, $actual);
+    }
+
+    public static function patternEndsWithDollarProvider(): \Generator
+    {
+        yield ['', false];
+        yield ['^', false];
+        for ($numBackSlashes = 0; $numBackSlashes < 6; $numBackSlashes++) {
+            $isEscaped = ($numBackSlashes % 2) === 1;
+            $trailing = str_repeat('\\', $numBackSlashes) . '$';
+            yield [$trailing, $isEscaped ? false : true];
+            yield [".{$trailing}", $isEscaped ? false : true];
+        }
+    }
+
+    /**
+     * @dataProvider isConvertibleToTextSearchProvider
+     */
+    public function testIsConvertibleToTextSearch(string $pattern, string $delimiter, bool $expected): void
+    {
+        $actual = self::$parserPrivateMethods['isConvertibleToTextSearch']->invoke(self::$parser, $pattern, $delimiter);
+
+        self::assertSame($expected, $actual);
+    }
+
+    public static function isConvertibleToTextSearchProvider(): \Generator
+    {
+        foreach (self::listConvertibleToText() as $key => [$pattern, $delimiter, $convertedToText]) {
+            yield $key => [$pattern, $delimiter, $convertedToText !== null];
+        }
+    }
+
+    /**
+     * @dataProvider unescapeSimplePatternProvider
+     */
+    public function testUnescapeSimplePattern(string $pattern, string $delimiter, string $expected): void
+    {
+        $actual = self::$parserPrivateMethods['unescapeSimplePattern']->invoke(self::$parser, $pattern, $delimiter);
+
+        self::assertSame($expected, $actual);
+    }
+
+    public static function unescapeSimplePatternProvider(): \Generator
+    {
+        foreach (self::listConvertibleToText() as $key => [$pattern, $delimiter, $convertedToText]) {
+            if ($convertedToText !== null) {
+                yield $key => [$pattern, $delimiter, $convertedToText];
+            }
+        }
+    }
+
+    private static function listConvertibleToText(): \Generator
+    {
+        // base cases
+        yield 'empty string' => ['', '/', ''];
+        yield 'simple text' => ['foo', '/', 'foo'];
+
+        // metacharacters (non escaped)
+        yield 'dot not escaped' => ['foo.', '/', null];
+        yield 'dot in middle' => ['foo.bar', '/', null];
+        yield 'plus' => ['foo+bar', '/', null];
+        yield 'star' => ['foo*bar', '/', null];
+        yield 'question mark' => ['foo?bar', '/', null];
+        yield 'pipe' => ['foo|bar', '/', null];
+        yield 'grouping' => ['foo(bar)', '/', null];
+        yield 'brackets' => ['foo[bar]', '/', null];
+        yield 'braces' => ['foo{1,2}', '/', null];
+
+        // escaped literals
+        yield 'escaped dot' => ['foo\\.bar', '/', 'foo.bar'];
+        yield 'escaped slash' => ['foo\\/bar', '/', 'foo/bar'];
+        yield 'escaped plus' => ['foo\\+bar', '/', 'foo+bar'];
+        yield 'escaped star' => ['foo\\*bar', '/', 'foo*bar'];
+        yield 'escaped question' => ['foo\\?bar', '/', 'foo?bar'];
+        yield 'escaped pipe' => ['foo\\|bar', '/', 'foo|bar'];
+        yield 'escaped bracket open' => ['foo\\[bar', '/', 'foo[bar'];
+        yield 'escaped bracket close' => ['foo\\]bar', '/', 'foo]bar'];
+
+        // anchors
+        yield 'caret at start invalid' => ['^foo', '/', null];
+        yield 'dollar at end invalid' => ['foo$', '/', null];
+        yield 'both anchors' => ['^foo$', '/', null];
+
+        // special classes (always regex)
+        yield 'digit class' => ['foo\\dbar', '/', null];
+        yield 'word class' => ['foo\\wbar', '/', null];
+        yield 'space class' => ['foo\\sbar', '/', null];
+        yield 'digit class uppercase' => ['foo\\Dbar', '/', null];
+
+        // delimiter handling
+        yield 'escaped delimiter / allowed' => ['foo\\/bar', '/', 'foo/bar'];
+        yield 'escaped delimiter # allowed' => ['foo\\#bar', '#', 'foo#bar'];
+
+        // mixed cases
+        yield 'mixed escaped and literal dot' => ['foo\\.bar.baz', '/', null];
+        yield 'multiple escaped literals only' => ['a\\.b\\+c\\\\_d', '/', 'a.b+c\\_d'];
+
+        // edge case
+        yield 'trailing backslash invalid' => ['foo\\', '/', null];
+    }
+
+    /**
+     * @dataProvider parseRegexProvider
+     */
+    public function testParseRegex(string $regex, string $expectedType, string $expectedText, string $expectedDelimiter, string $expectedModifiers, string $normalizedRegex = ''): void
+    {
+        if ($normalizedRegex === '') {
+            $normalizedRegex = $regex;
+        }
+        $result = self::$parser->parseRegEx($regex);
+
+        self::assertSame($expectedType, $result->getType());
+        self::assertSame($expectedText, $result->getText());
+        self::assertSame($expectedDelimiter, $result->getDelimiter());
+        self::assertSame($expectedModifiers, $result->getModifiers());
+        self::assertSame($normalizedRegex, $result->asRegex());
+    }
+
+    public static function parseRegExProvider(): \Generator
+    {
+        yield 'simple regex with dot' => [
+            '/foo.bar/',
+            ParsedRegex::TYPE_REGEX,
+            'foo.bar',
+            '/',
+            '',
+        ];
+
+        yield 'regex with caseless modifier' => [
+            '/foo.bar/i',
+            ParsedRegex::TYPE_REGEX,
+            'foo.bar',
+            '/',
+            'i',
+        ];
+
+        yield 'equals type - both anchors' => [
+            '/^exact match$/i',
+            ParsedRegex::TYPE_EQUALS,
+            'exact match',
+            '/',
+            'i',
+        ];
+
+        yield 'startsWith type - caret anchor' => [
+            '/^starts with/',
+            ParsedRegex::TYPE_STARTSWITH,
+            'starts with',
+            '/',
+            '',
+        ];
+
+        yield 'endsWith type - dollar anchor' => [
+            '/ends with$/',
+            ParsedRegex::TYPE_ENDSWITH,
+            'ends with',
+            '/',
+            '',
+        ];
+
+        yield 'contains type - no anchors' => [
+            '/contains text/',
+            ParsedRegex::TYPE_CONTAINS,
+            'contains text',
+            '/',
+            '',
+        ];
+
+        yield 'hash delimiter equals' => [
+            '#^exact#',
+            ParsedRegex::TYPE_STARTSWITH,
+            'exact',
+            '#',
+            '',
+        ];
+
+        yield 'bracket delimiter' => [
+            '[^test$]',
+            ParsedRegex::TYPE_EQUALS,
+            'test',
+            '[',
+            '',
+        ];
+
+        yield 'brace delimiter' => [
+            '{pattern}m',
+            ParsedRegex::TYPE_CONTAINS,
+            'pattern',
+            '{',
+            'm',
+        ];
+
+        yield 'parenthesis delimiter' => [
+            '(^text$)im',
+            ParsedRegex::TYPE_EQUALS,
+            'text',
+            '(',
+            'im',
+        ];
+
+        yield 'escaped dot converts to text' => [
+            '/^foo\\.bar$/',
+            ParsedRegex::TYPE_EQUALS,
+            'foo.bar',
+            '/',
+            '',
+        ];
+
+        yield 'escaped special chars' => [
+            '/^foo\\+bar\\|baz$/',
+            ParsedRegex::TYPE_EQUALS,
+            'foo+bar|baz',
+            '/',
+            '',
+        ];
+
+        yield 'escaped delimiter' => [
+            '/^\\/path\\/to\\/file$/',
+            ParsedRegex::TYPE_EQUALS,
+            '/path/to/file',
+            '/',
+            '',
+        ];
+
+        yield 'multiple modifiers' => [
+            '/^multiline$/imsx',
+            ParsedRegex::TYPE_EQUALS,
+            'multiline',
+            '/',
+            'imsx',
+        ];
+
+        yield 'metachar pipe cannot convert' => [
+            '/foo|bar/',
+            ParsedRegex::TYPE_REGEX,
+            'foo|bar',
+            '/',
+            '',
+        ];
+
+        yield 'metachar plus cannot convert' => [
+            '/^pattern+$/',
+            ParsedRegex::TYPE_REGEX,
+            '^pattern+$',
+            '/',
+            '',
+        ];
+
+        yield 'character class cannot convert' => [
+            '/[a-z]+/',
+            ParsedRegex::TYPE_REGEX,
+            '[a-z]+',
+            '/',
+            '',
+        ];
+
+        yield 'grouping cannot convert' => [
+            '/(foo)(bar)/',
+            ParsedRegex::TYPE_REGEX,
+            '(foo)(bar)',
+            '/',
+            '',
+        ];
+
+        yield 'empty pattern' => [
+            '//',
+            ParsedRegex::TYPE_CONTAINS,
+            '',
+            '/',
+            '',
+        ];
+
+        yield 'empty pattern with anchors' => [
+            '/^$/',
+            ParsedRegex::TYPE_EQUALS,
+            '',
+            '/',
+            '',
+        ];
+
+        yield 'escaped backslash before dollar' => [
+            '/text\\\\$/',
+            ParsedRegex::TYPE_ENDSWITH,
+            'text\\',
+            '/',
+            '',
+        ];
+
+        yield 'multiple escaped chars' => [
+            '/^\\.\\+\\*\\?$/',
+            ParsedRegex::TYPE_EQUALS,
+            '.+*?',
+            '/',
+            '',
+        ];
+
+        yield 'all modifiers' => [
+            '/^test$/imsxADUXJu',
+            ParsedRegex::TYPE_EQUALS,
+            'test',
+            '/',
+            'imsxADUXJu',
+        ];
+
+        yield 'text with spaces equals' => [
+            '/^  spaces  $/',
+            ParsedRegex::TYPE_EQUALS,
+            '  spaces  ',
+            '/',
+            '',
+        ];
+
+        yield 'text with spaces contains' => [
+            '/text with spaces/',
+            ParsedRegex::TYPE_CONTAINS,
+            'text with spaces',
+            '/',
+            '',
+        ];
+
+        yield 'escaped hash delimiter' => [
+            '#^foo\\#bar$#',
+            ParsedRegex::TYPE_EQUALS,
+            'foo#bar',
+            '#',
+            '',
+        ];
+
+        yield 'escaped space' => [
+            '/foo\ bar/Di',
+            ParsedRegex::TYPE_REGEX,
+            'foo\ bar',
+            '/',
+            'Di',
+        ];
+    }
+}


### PR DESCRIPTION
We often see a lot of traffic from hackers trying to crack (or otherwise extract information from) our sites.

For example:

```sh
$ grep '/wp-.* 404 ' /var/log/nginx/website-access.log
<ip> - - [17/Apr/2026:12:25:52 +0000] "GET /wp-content/plugins/hellopress/wp_filemanager.php HTTP/1.1" 404 29498 "-" "-"
<ip> - - [17/Apr/2026:12:25:53 +0000] "GET /wp-admin/network/users.php HTTP/1.1" 404 29498 "-" "-"
<ip> - - [17/Apr/2026:12:25:54 +0000] "GET /wp-blog-header.php HTTP/1.1" 404 29498 "-" "-"
<ip> - - [17/Apr/2026:12:25:59 +0000] "GET /wp-blogs.php HTTP/1.1" 404 29498 "-" "-"
<ip> - - [17/Apr/2026:12:26:02 +0000] "GET /wp-good.php HTTP/1.1" 404 29498 "-" "-"
<ip> - - [17/Apr/2026:12:26:04 +0000] "GET /wp-png.php HTTP/1.1" 404 29498 "-" "-"
<ip> - - [17/Apr/2026:12:26:05 +0000] "GET //wp-links-opml.php HTTP/1.1" 404 29498 "-" "-"
<ip> - - [17/Apr/2026:12:26:07 +0000] "GET /wp-content/radio.php HTTP/1.1" 404 29498 "-" "-"
<ip> - - [17/Apr/2026:12:26:07 +0000] "GET /wp-access.php HTTP/1.1" 404 29498 "-" "-"
<ip> - - [17/Apr/2026:12:26:08 +0000] "GET /wp-admin/css/bolt.php HTTP/1.1" 404 29498 "-" "-"
<ip> - - [17/Apr/2026:12:26:12 +0000] "GET /wp-admin/network/edit.php HTTP/1.1" 404 29498 "-" "-"
<ip> - - [17/Apr/2026:12:26:13 +0000] "GET /wp-the.php HTTP/1.1" 404 29498 "-" "-"
<ip> - - [17/Apr/2026:12:26:13 +0000] "GET /wp-content/plugins/hellopress/wp_filemanager.php HTTP/1.1" 404 29498 "-" "-"
<ip> - - [17/Apr/2026:12:26:14 +0000] "GET /wp-p2r3q9c8k4.php HTTP/1.1" 404 29498 "-" "-"
```

This causes unnecessary use of system resources.

How about adding a middleware that intercepts these requests early enough and terminates execution with a quick 404? There's no need to load the theme, localization, blocks, etc., since the response will only be for bots.

In this PR we have:
1. a configuration key `concrete.early404.enabled` that tells if this feature is enabled (default: disabled)
2. a configuration key with some regular expressions intercepting common paths used by hackers (`concrete.early404.regexes` )
3. the new `Early404Middleware` middleware that uses these regular expressions to determine if responsing with an empty 404 response
4. a dashboard page where users can:
   - enable/disable this new feature
   - define the regular expressions
   - test if these regular expressions are correct or not
   - test if these regular expressions match for existing Concrete pages
   - test if the regular expressions match a test URL
   - specify the regular expressions in an easier way (instead of regular expressions, users may define "paths starting with",  "paths ending with", ..). Under the hood, everything is stored as regular expressions, so that we have less overhead as possible in the middleware (it's executed for every request)

Here's a sample screenshot of the new dashboard page:

<img width="954" height="789" alt="Early Page Not Found dashboard page" src="https://github.com/user-attachments/assets/254d3fe9-f0c0-4f47-9709-3d7bee483f28" />


IMHO this PR may close https://github.com/concretecms/concretecms/issues/10165
