### PR TITLE
Fix/file version event dispatch

### DIFF
--- a/concrete/src/Entity/File/File.php
+++ b/concrete/src/Entity/File/File.php
@@ -461,7 +461,7 @@ class File implements \Concrete\Core\Permission\ObjectInterface, AttributeObject
      *
      * @return Version
      */
-    public function getVersionToModify($forceCreateNew = false)
+    public function getVersionToModify($newFilename = null, $newPrefix = null)
     {
         $u = Core::make(User::class);
         $createNew = false;
@@ -480,12 +480,19 @@ class File implements \Concrete\Core\Permission\ObjectInterface, AttributeObject
             $createNew = true;
         }
 
-        if ($forceCreateNew) {
+        if ($newFilename) {
             $createNew = true;
         }
 
         if ($createNew) {
             $fv2 = $fv->duplicate();
+
+            if ($newFilename && $newPrefix) {
+                $fv2->updateFile(
+                    $newFilename,
+                    $newPrefix
+                );
+            }
 
             // Are the recent and active versions the same? If so, we approve this new version we just made
             if ($fv->getFileVersionID() == $fav->getFileVersionID()) {

--- a/concrete/src/Entity/File/Version.php
+++ b/concrete/src/Entity/File/Version.php
@@ -1273,6 +1273,9 @@ class Version implements ObjectInterface
         $em->remove($this);
         $em->flush();
 
+        $fve = new FileVersionEvent($this);
+        $app->make(EventDispatcher::class)->dispatch('on_file_version_delete', $fve);
+
         try {
             $logger->notice(t('Version %1$s of file %2$s successfully deleted.', $this->getFileVersionID(), $this->getFileName()));
         } catch (Exception $err) {

--- a/concrete/src/File/Import/FileImporter.php
+++ b/concrete/src/File/Import/FileImporter.php
@@ -290,11 +290,7 @@ class FileImporter implements LoggerAwareInterface
         $file = $options->getAddNewVersionTo();
         if ($file !== null) {
             // We get a new version to modify
-            $fileVersion = $file->getVersionToModify(true);
-            $fileVersion->updateFile(
-                $importingFile->getConcreteFilenameSanitized(),
-                $prefix
-            );
+            $fileVersion = $file->getVersionToModify($importingFile->getConcreteFilenameSanitized(), $prefix);
             $this->logger->notice(t("Added new version %s to existing file %s (%s).", $fileVersion->getFileVersionID(), $file->getFileName(), $file->getFileID()));
         } else {
             // We create a new File instance


### PR DESCRIPTION
- add missing event for file version delete (`on_file_version_delete`)
- fix file id passed to `on_file_version_approve `. due to the event fired in getVersionToModify before updateFile happens, the file version passed to the event was the previous.