### PR TITLE
Fix #11381 - orphaned block deletion silently no-ops

### DIFF
--- a/concrete/controllers/panel/add.php
+++ b/concrete/controllers/panel/add.php
@@ -262,24 +262,21 @@ class Add extends BackendInterfacePageController
                         } else {
                             $orphanedBlockFound = false;
 
-                            foreach ($this->getOrphanedBlockIds($usedAreas) as $arrOrphanedBlock) {
+                            foreach ($arrOrphanedBlocks as $arrOrphanedBlock) {
                                 if ($blockId === (int)$arrOrphanedBlock["bID"]) {
                                     $orphanedBlockFound = true;
+                                    $block = Block::getByID($blockId, $this->page, $arrOrphanedBlock["arHandle"]);
+                                    if (!$block instanceof Block) {
+                                        $errorList->add(t("Error while removing orphaned block."));
+                                    } else {
+                                        $block->deleteBlock();
+                                    }
+                                    break;
                                 }
                             }
 
                             if (!$orphanedBlockFound) {
                                 $errorList->add(t("The given block is not orphaned."));
-                            } else {
-                                $arID = $request->request->get('arId');
-                                $areaHandle = Area::getAreaHandleFromID($arID);
-                                $block = Block::getByID($blockId, $this->page, $areaHandle);
-                                if (!$block instanceof Block) {
-                                    //$errorList->add(t("Error while removing orphaned block."));
-                                } else {
-                                    // returns false because the area no longer exists in the theme.
-                                    $block->deleteBlock();
-                                }
                             }
                         }
                     }

--- a/concrete/src/Block/Block.php
+++ b/concrete/src/Block/Block.php
@@ -1950,6 +1950,27 @@ EOT
         }
         $arHandle = $this->getAreaHandle();
 
+        // Caller may have loaded this block by bID alone (no specific placement). Recover
+        // cID/cvID/arHandle from CollectionVersionBlocks so the targeted deletes below have
+        // values that can match -- otherwise they filter on NULL and remove nothing.
+        if (!$cID || !$arHandle) {
+            $row = $db->fetchAssociative(
+                'select cID, cvID, arHandle from CollectionVersionBlocks where bID = ? order by isOriginal desc limit 1',
+                [$bID]
+            );
+            if ($row) {
+                if (!$cID) {
+                    $cID = (int) $row['cID'];
+                }
+                if (!$cvID) {
+                    $cvID = (int) $row['cvID'];
+                }
+                if (!$arHandle) {
+                    $arHandle = $row['arHandle'];
+                }
+            }
+        }
+
         // if this block is located in a master collection, we're going to delete all the instances of the block,
         // regardless
         if (($c instanceof Page && $c->isMasterCollection() && !$this->isAlias()) || $forceDelete) {


### PR DESCRIPTION
Two related paths cause the "deletion is reported as successful, but nothing has been deleted" symptom in #11381. Fixing both.

**Single-delete button in the Orphan Blocks panel**

The per-row Delete button hits `removeOrphanedBlock` in `controllers/panel/add.php`. That code reads `arId` from the request and resolves it to an arHandle via `Area::getAreaHandleFromID`. But the panel's JS in `views/panels/add.php` doesn't send `arId` — it only sends `blockId`, `usedAreas`, `task`, and the token. So the controller calls `Block::getByID($blockId, $this->page, null)`, which falls through to a `WHERE arHandle = ''` lookup that matches nothing and returns null. The error message in the controller was commented out, so the response shipped a "success" with no errors, the JS showed the success toast, and the orphan stayed in the database.

Refactored to walk the orphan list once for both validation and arHandle lookup, and to surface the error if `Block::getByID` still can't find it. Same shape as the bulk path right below it.

**`Block::deleteBlock` silently no-op'ing on bID-only loads**

When `Block::getByID` is called with only a bID (no page, no area handle), the returned object has `cID = null` and `arHandle = null`, but `getBlockCollectionObject()` still finds *a* page via `getOriginalCollection()` — so the existing `is_object($c)` guard added in #11949 passes, the master-collection branch is skipped, and the else branch runs the targeted deletes with `NULL` cID and `NULL` arHandle. `WHERE cID = NULL AND arHandle = NULL` matches nothing in MySQL, so the row stays. JeRoNZ's comment on #11381 describes this exactly: "the area and collection are still null, thus the SQL selects nothing for deletion."

Recover the placement from `CollectionVersionBlocks` (preferring the `isOriginal=1` row) before running the delete statements, so they have something to match. This keeps the existing single-row delete semantics — not falling back to `forceDelete` and clobbering aliases, just using the values the database already knows about.

**Testing**

Tested both ways the inner blocks can end up orphaned, on a local 9.5.x checkout:

1. **Container deleted from the page.** Added two content blocks inside a container, then chose **Delete Container** in the page edit UI to orphan them. Deleted one orphan via the per-row Delete button in the panel — the row in `CollectionVersionBlocks` for the current page version is gone after the fix, only older-version copies remain (matches how non-`cbIncludeAll` deletes behave elsewhere).

2. **Container template deleted from the dashboard.** Added a Highlight Stripe container instance to a page, dropped a content block into the body sub-area, deleted the Highlight Stripe template from Dashboard → Pages & Themes → Containers, returned to the page in edit mode, opened Orphan Blocks, hit the per-row Delete button on the inner block. The template row in `PageContainers` is gone, the `CollectionVersionBlocks` row for the orphan is gone, and because the block only existed in this one page version the cascade also cleared the `Blocks` and `btContentLocal` rows. All clean.

Fixes #11381