### PR TITLE
Fix #11201 - layout delete confirmation says "remove" but means "orphan"

### DIFF
--- a/concrete/controllers/dialog/block/delete.php
+++ b/concrete/controllers/dialog/block/delete.php
@@ -26,7 +26,7 @@ class Delete extends BackendInterfaceBlockController
             }
         }
         if ($this->block->getBlockTypeHandle() == BLOCK_HANDLE_LAYOUT_PROXY) {
-            $this->set('message', t('Are you sure you wish to delete this layout? It will remove the blocks that are contained within it.'));
+            $this->set('message', t('Are you sure you wish to delete this layout? It will orphan the blocks that are contained within it.'));
         } else {
             $this->set('message', t('Are you sure you wish to delete this %s block?', $this->block->getBlockTypeObject()->getBlockTypeName()));
         }


### PR DESCRIPTION
The "Are you sure?" dialog shown when deleting a layout in the page editor reads:

> Are you sure you wish to delete this layout? It will remove the blocks that are contained within it.

But the actual behavior is that the inner blocks are *orphaned*, not removed. They stay in `CollectionVersionBlocks` with arHandles whose enclosing layout is gone, they keep showing up in site search, and the only way to actually clean them up is the Orphan Blocks panel. The bug reporter on #11201 caught this when search results kept surfacing content that was no longer visible on the page.

This PR is just the wording fix — change "remove" to "orphan" so the dialog matches behavior.

Deleting a layout parallels deleting a container — both orphan their inner blocks rather than removing them, leaving cleanup to the Orphan Blocks panel. That's the right behavior. And like containers, layouts hit the related bug from #11381, fixed by #12872: the per-row Delete in the Orphan Blocks panel silently no-op'd. With both PRs merged, an editor who reads the corrected dialog and goes on to clean up the orphans afterward will actually succeed.

Fixes #11201