### PR TITLE
Fix multiple issues

### DIFF
--- a/concrete/blocks/document_library/controller.php
+++ b/concrete/blocks/document_library/controller.php
@@ -877,8 +877,6 @@ class Controller extends BlockController implements UsesFeatureInterface
 
     public function view()
     {
-        $this->loadData();
-
         $list = new FolderItemList();
         $list = $this->setupFolderFileSetFilter($list);
         $list = $this->setupFolderFileFolderFilter($list);

--- a/concrete/blocks/page_attribute_display/controller.php
+++ b/concrete/blocks/page_attribute_display/controller.php
@@ -378,7 +378,7 @@ class Controller extends BlockController implements UsesFeatureInterface
             $template->setBlockCustomTemplate("templates/" . $this->attributeHandle . '.php');
             $info = pathinfo($template->getTemplate());
 
-            if ($info['basename'] != 'view.php') {
+            if ($info['basename'] != 'view.php' && file_exists($template->getTemplate())) {
                 $this->render('templates/' . $info['filename'] );
             }
         }

--- a/concrete/controllers/dialog/page/drag_request.php
+++ b/concrete/controllers/dialog/page/drag_request.php
@@ -138,7 +138,7 @@ class DragRequest extends UserInterfaceController
         $successMessages = [];
         $destipationPage = $dragRequestData->getDestinationPage();
         foreach ($dragRequestData->getOriginalPages() as $originalPage) {
-            if ($originalPage->isAlias()) {
+            if ($originalPage->isAliasPage() && !$originalPage->isExternalLink()) {
                 $newPageID = $originalPage->addCollectionAlias($destipationPage);
                 $newPage = Page::getByID($newPageID);
             } else {

--- a/concrete/src/Filesystem/TemplateService.php
+++ b/concrete/src/Filesystem/TemplateService.php
@@ -37,7 +37,7 @@ class TemplateService
         };
 
         if ($bindTo) {
-            $include = $include->bindTo($bindTo);
+            $include = $include->bindTo($bindTo, get_class($bindTo));
         }
 
         ob_start();

--- a/concrete/src/Page/Sitemap/DragRequestData.php
+++ b/concrete/src/Page/Sitemap/DragRequestData.php
@@ -406,6 +406,10 @@ class DragRequestData
      */
     protected function whyCantMove()
     {
+        $error = $this->whyCantReparentSystemPages();
+        if ($error !== '') {
+            return $error;
+        }
         $destinationPageChecker = new Checker($this->getDestinationPage());
         $destinationPageID = $this->getDestinationPage()->getCollectionID();
         foreach ($this->getOriginalPages() as $originalPage) {
@@ -438,6 +442,10 @@ class DragRequestData
      */
     protected function whyCantAlias()
     {
+        $error = $this->whyCantReparentSystemPages();
+        if ($error !== '') {
+            return $error;
+        }
         if ($this->isSomeOriginalPageAnAlias()) {
             return t('It\'s not possible to create aliases of aliases.');
         }
@@ -466,6 +474,10 @@ class DragRequestData
      */
     protected function whyCantCopy()
     {
+        $error = $this->whyCantReparentSystemPages();
+        if ($error !== '') {
+            return $error;
+        }
         $destinationPageChecker = new Checker($this->getDestinationPage());
         foreach ($this->getOriginalPages() as $originalPage) {
             $originalPageChecker = new Checker($originalPage);
@@ -519,6 +531,10 @@ class DragRequestData
      */
     protected function whyCantCopyVersion()
     {
+        $error = $this->whyCantReparentSystemPages();
+        if ($error !== '') {
+            return $error;
+        }
         $originalPage = $this->getSingleOriginalPage();
         if ($originalPage === null) {
             return t("It's possible to copy just one page version at a time.");
@@ -536,6 +552,23 @@ class DragRequestData
         $pc = new Checker($destinationPage);
         if (!$pc->canWrite()) {
             return t('You don\'t have the permission to edit the contents of "%s".', $destinationPage->getCollectionName());
+        }
+
+        return '';
+    }
+
+    /**
+     * Get the reason why system pages can't be dragged to a different parent.
+     *
+     * @return string empty string if the drag request CAN be performed
+     */
+    protected function whyCantReparentSystemPages()
+    {
+        $destinationPageID = $this->getDestinationPage()->getCollectionID();
+        foreach ($this->getOriginalPages() as $originalPage) {
+            if ($originalPage->isSystemPage() && $originalPage->getCollectionParentID() != $destinationPageID) {
+                return t("System pages can be reordered, but they can't be dragged beneath another page.");
+            }
         }
 
         return '';


### PR DESCRIPTION
This pull request introduces several important improvements and fixes related to page handling, template rendering, and file/folder filtering. The main focus is on enhancing the restrictions and error handling for system pages during drag-and-drop operations, improving template selection logic, and refining file/folder filtering.

### Page Drag-and-Drop Restrictions and Error Handling

* Added a new method `whyCantReparentSystemPages()` in `DragRequestData` to prevent system pages from being dragged beneath other pages, and integrated this check into all relevant drag-and-drop validation methods (`whyCantMove`, `whyCantAlias`, `whyCantCopy`, `whyCantCopyVersion`). This ensures consistent error messaging and restriction enforcement for system pages. [[1]](diffhunk://#diff-1a82eed2e04c6f2e999b8cdc84bbe0389ed66f5fe78384f78888db74954826ecR409-R412) [[2]](diffhunk://#diff-1a82eed2e04c6f2e999b8cdc84bbe0389ed66f5fe78384f78888db74954826ecR445-R448) [[3]](diffhunk://#diff-1a82eed2e04c6f2e999b8cdc84bbe0389ed66f5fe78384f78888db74954826ecR477-R480) [[4]](diffhunk://#diff-1a82eed2e04c6f2e999b8cdc84bbe0389ed66f5fe78384f78888db74954826ecR534-R537) [[5]](diffhunk://#diff-1a82eed2e04c6f2e999b8cdc84bbe0389ed66f5fe78384f78888db74954826ecR559-R575)
* Updated the copy logic in the page drag request controller to only allow aliasing for pages that are actual aliases and not external links, improving the accuracy of page operations.

### Template Rendering and Selection

* Improved PHP template rendering in `TemplateService` by binding the closure to the correct class scope, increasing compatibility and reliability when including templates.
* Enhanced template selection logic in the page attribute display block to check for file existence before rendering, preventing errors if a template file is missing.

### File/Folder Filtering

* Removed unnecessary data loading in the document library block controller, streamlining the view logic and potentially improving performance.