### PR TITLE
Early page not found middleware based solely on page path.

### DIFF
--- a/concrete/config/app.php
+++ b/concrete/config/app.php
@@ -896,7 +896,8 @@ return [
         'core_cookie' => \Concrete\Core\Http\Middleware\CookieMiddleware::class,
         'core_csp' => \Concrete\Core\Http\Middleware\ContentSecurityPolicyMiddleware::class,
         'core_hsts' => \Concrete\Core\Http\Middleware\StrictTransportSecurityMiddleware::class,
-        'core_xframeoptions' => \Concrete\Core\Http\Middleware\FrameOptionsMiddleware::class
+        'core_xframeoptions' => \Concrete\Core\Http\Middleware\FrameOptionsMiddleware::class,
+        'core_early_404' => \Concrete\Core\Http\Middleware\Early404Middleware::class,
     ],
 
     'command_handlers' => [

--- a/concrete/controllers/single_page/page_not_found.php
+++ b/concrete/controllers/single_page/page_not_found.php
@@ -18,8 +18,6 @@ class PageNotFound extends PageController
         $view = $this->getViewObject();
         $contents = $view->render();
 
-        Events::dispatch('on_page_not_found');
-
         return new Response($contents, 404);
     }
 

--- a/concrete/src/Http/DefaultDispatcher.php
+++ b/concrete/src/Http/DefaultDispatcher.php
@@ -45,13 +45,6 @@ class DefaultDispatcher implements DispatcherInterface
      */
     public function dispatch(SymfonyRequest $request)
     {
-        $path = rawurldecode($request->getPathInfo());
-
-        if (substr($path, 0, 3) == '../' || substr($path, -3) == '/..' || strpos($path, '/../') ||
-            substr($path, 0, 3) == '..\\' || substr($path, -3) == '\\..' || strpos($path, '\\..\\')) {
-            throw new UserMessageException(t('Invalid path traversal. Please make this request with a valid HTTP client.'));
-        }
-
         $response = null;
         if ($this->app->isInstalled()) {
             $response = $this->getEarlyDispatchResponse();

--- a/concrete/src/Http/Middleware/Early404Middleware.php
+++ b/concrete/src/Http/Middleware/Early404Middleware.php
@@ -61,7 +61,7 @@ class Early404Middleware implements MiddlewareInterface, ApplicationAwareInterfa
         // Note: I would love to typehint the ResponseFactoryInterface into this class,
         // but doing so causes problems because it builds this class too early, and
         // for some reason doesn't include the header/footer when outputting the 404 (?!?)
-        return $this->app->make(ResponseFactoryInterface::class)->cachedNotFound('');
+        return $this->app->make(ResponseFactoryInterface::class)->cachedNotFound();
     }
 
     private function containsPathTraversal(string $path): bool

--- a/concrete/src/Http/Middleware/Early404Middleware.php
+++ b/concrete/src/Http/Middleware/Early404Middleware.php
@@ -40,22 +40,19 @@ class Early404Middleware implements MiddlewareInterface, ApplicationAwareInterfa
     public function process(Request $request, DelegateInterface $frame)
     {
         $pathInfo = rawurldecode($request->getPathInfo());
-        if ($this->containsPathTraversal($pathInfo)) {
-            return $frame->next($request);
-        }
+        if (!$this->containsPathTraversal($pathInfo)) {
+            $firstSegment = $this->getFirstSegment($pathInfo);
+            if ($firstSegment === null) {
+                return $frame->next($request);
+            }
 
-        $firstSegment = $this->getFirstSegment($pathInfo);
-        if ($firstSegment === null) {
-            return $frame->next($request);
-        }
+            if ($this->hasPotentialRouteForFirstSegment($firstSegment)) {
+                return $frame->next($request);
+            }
 
-        if ($this->hasPotentialRouteForFirstSegment($firstSegment)) {
-            return $frame->next($request);
-        }
-
-        if ($this->hasPotentialPagePathForFirstSegment($firstSegment)) {
-            return $frame->next($request);
-
+            if ($this->hasPotentialPagePathForFirstSegment($firstSegment)) {
+                return $frame->next($request);
+            }
         }
 
         // Note: I would love to typehint the ResponseFactoryInterface into this class,

--- a/concrete/src/Http/Middleware/Early404Middleware.php
+++ b/concrete/src/Http/Middleware/Early404Middleware.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Concrete\Core\Http\Middleware;
+
+use Concrete\Core\Application\ApplicationAwareInterface;
+use Concrete\Core\Application\ApplicationAwareTrait;
+use Concrete\Core\Cache\Level\ExpensiveCache;
+use Concrete\Core\Database\Connection\Connection;
+use Concrete\Core\Http\ResponseFactoryInterface;
+use Concrete\Core\Routing\Router;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class Early404Middleware implements MiddlewareInterface, ApplicationAwareInterface
+{
+    use ApplicationAwareTrait;
+
+    /**
+     * @var \Concrete\Core\Routing\Router
+     */
+    private $router;
+
+    /**
+     * @var \Concrete\Core\Database\Connection\Connection
+     */
+    private $connection;
+
+    /**
+     * @var ExpensiveCache
+     */
+    private $cache;
+
+    public function __construct(ExpensiveCache $cache, Router $router, Connection $connection)
+    {
+        $this->cache = $cache;
+        $this->router = $router;
+        $this->connection = $connection;
+    }
+
+    public function process(Request $request, DelegateInterface $frame)
+    {
+        $pathInfo = rawurldecode($request->getPathInfo());
+        if ($this->containsPathTraversal($pathInfo)) {
+            return $frame->next($request);
+        }
+
+        $firstSegment = $this->getFirstSegment($pathInfo);
+        if ($firstSegment === null) {
+            return $frame->next($request);
+        }
+
+        if ($this->hasPotentialRouteForFirstSegment($firstSegment)) {
+            return $frame->next($request);
+        }
+
+        if ($this->hasPotentialPagePathForFirstSegment($firstSegment)) {
+            return $frame->next($request);
+
+        }
+
+        // Note: I would love to typehint the ResponseFactoryInterface into this class,
+        // but doing so causes problems because it builds this class too early, and
+        // for some reason doesn't include the header/footer when outputting the 404 (?!?)
+        return $this->app->make(ResponseFactoryInterface::class)->cachedNotFound('');
+    }
+
+    private function containsPathTraversal(string $path): bool
+    {
+        return substr($path, 0, 3) === '../'
+            || substr($path, -3) === '/..'
+            || strpos($path, '/../') !== false
+            || substr($path, 0, 3) === '..\\'
+            || substr($path, -3) === '\\..'
+            || strpos($path, '\\..\\') !== false;
+    }
+
+    private function getFirstSegment(string $pathInfo): ?string
+    {
+        $pathInfo = trim($pathInfo, '/');
+        if ($pathInfo === '') {
+            return null;
+        }
+
+        $segments = explode('/', $pathInfo, 2);
+
+        return '/' . $segments[0];
+    }
+
+    private function hasPotentialRouteForFirstSegment(string $firstSegment): bool
+    {
+        $pattern = '#^' . preg_quote($firstSegment, '#') . '(?:/|$)#';
+        foreach ($this->router->getRoutes()->all() as $route) {
+            $routePath = $route->getPath();
+            if (strpos($routePath, '/{') === 0) {
+                continue;
+            }
+            if (preg_match($pattern, $routePath) === 1) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function hasPotentialPagePathForFirstSegment(string $firstSegment): bool
+    {
+        $result = $this->connection->fetchOne(
+            'select 1 from PagePaths where cPath = ? or cPath like ? limit 1',
+            [$firstSegment, $firstSegment . '/%']
+        );
+
+        return $result !== false && $result !== null;
+    }
+}

--- a/concrete/src/Http/ResponseFactory.php
+++ b/concrete/src/Http/ResponseFactory.php
@@ -4,9 +4,11 @@ namespace Concrete\Core\Http;
 use Concrete\Controller\Frontend\PageForbidden;
 use Concrete\Core\Application\ApplicationAwareInterface;
 use Concrete\Core\Application\ApplicationAwareTrait;
+use Concrete\Core\Cache\Level\ExpensiveCache;
 use Concrete\Core\Command\Process\Menu\Item\RunningProcessesItem;
 use Concrete\Core\Config\Repository\Repository;
 use Concrete\Core\Controller\Controller;
+use Concrete\Core\Events\EventDispatcher;
 use Concrete\Core\Localization\Localization;
 use Concrete\Core\Page\Collection\Collection;
 use Concrete\Core\Page\Controller\PageController;
@@ -43,8 +45,20 @@ class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInter
      */
     private $config;
 
-    public function __construct(Request $request, Localization $localization, Repository $config)
+    /**
+     * @var EventDispatcher
+     */
+    private $eventDispatcher;
+
+    /**
+     * @var ExpensiveCache
+     */
+    private $cache;
+
+    public function __construct(ExpensiveCache $cache, EventDispatcher $eventDispatcher, Request $request, Localization $localization, Repository $config)
     {
+        $this->cache = $cache;
+        $this->eventDispatcher = $eventDispatcher;
         $this->request = $request;
         $this->localization = $localization;
         $this->config = $config;
@@ -66,11 +80,45 @@ class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInter
         return new JsonResponse($data, $code, $headers);
     }
 
+    public function cachedNotFound($content, $code = Response::HTTP_NOT_FOUND, $headers = [])
+    {
+        $this->eventDispatcher->dispatch('on_page_not_found');
+        if ($this->request->isXmlHttpRequest() || in_array($this->request->getPreferredFormat(), ['json', 'jsonld'], true)) {
+            $this->localization->pushActiveContext(Localization::CONTEXT_SITE);
+            $responseData = [
+                'error' => t('Page not found'),
+                'errors' => [t('Page not found')],
+            ];
+            $this->localization->popActiveContext();
+
+            return $this->json($responseData, $code, $headers);
+        }
+
+        $record = $this->cache->getItem('page_not_found');
+        if ($record->isHit()) {
+            /** @var Response */
+            return $record->get();
+        }
+
+        $item = '/page_not_found';
+        $c = Page::getByPath($item, 'APPROVED');
+        if (is_object($c) && !$c->isError()) {
+            $this->request->setCurrentPage($c);
+            $response = $this->controller($c->getPageController(), $code, $headers);
+        } else {
+            $cnt = $this->app->make(PageForbidden::class);
+            $response = $this->controller($cnt, $code, $headers);
+        }
+        $record->set($response)->expiresAfter(1800)->save();
+        return $response;
+    }
+
     /**
      * {@inheritdoc}
      */
     public function notFound($content, $code = Response::HTTP_NOT_FOUND, $headers = [])
     {
+        $this->eventDispatcher->dispatch('on_page_not_found');
         if ($this->request->isXmlHttpRequest() || in_array($this->request->getPreferredFormat(), ['json', 'jsonld'], true)) {
             $this->localization->pushActiveContext(Localization::CONTEXT_SITE);
             $responseData = [

--- a/concrete/src/Http/ResponseFactory.php
+++ b/concrete/src/Http/ResponseFactory.php
@@ -80,28 +80,17 @@ class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInter
         return new JsonResponse($data, $code, $headers);
     }
 
-    public function cachedNotFound($content, $code = Response::HTTP_NOT_FOUND, $headers = [])
+
+    public function cachedNotFound($code = Response::HTTP_NOT_FOUND, $headers = [])
     {
         $this->eventDispatcher->dispatch('on_page_not_found');
-        if ($this->request->isXmlHttpRequest() || in_array($this->request->getPreferredFormat(), ['json', 'jsonld'], true)) {
-            $this->localization->pushActiveContext(Localization::CONTEXT_SITE);
-            $responseData = [
-                'error' => t('Page not found'),
-                'errors' => [t('Page not found')],
-            ];
-            $this->localization->popActiveContext();
-
-            return $this->json($responseData, $code, $headers);
-        }
-
         $record = $this->cache->getItem('page_not_found');
         if ($record->isHit()) {
             /** @var Response */
             return $record->get();
         }
-
         $item = '/page_not_found';
-        $c = Page::getByPath($item, 'APPROVED');
+        $c = Page::getByPath($item);
         if (is_object($c) && !$c->isError()) {
             $this->request->setCurrentPage($c);
             $response = $this->controller($c->getPageController(), $code, $headers);

--- a/concrete/src/Http/ResponseFactory.php
+++ b/concrete/src/Http/ResponseFactory.php
@@ -21,6 +21,7 @@ use Concrete\Core\Permission\Key\Key;
 use Concrete\Core\Routing\RedirectResponse;
 use Concrete\Core\Session\SessionValidator;
 use Concrete\Core\Site\Menu\Item\SiteListItem;
+use Concrete\Core\User\Login\LoginCookieService;
 use Concrete\Core\User\PostLoginLocation;
 use Concrete\Core\User\User;
 use Concrete\Core\View\View;
@@ -55,9 +56,10 @@ class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInter
      */
     private $cache;
 
-    public function __construct(ExpensiveCache $cache, EventDispatcher $eventDispatcher, Request $request, Localization $localization, Repository $config)
+    public function __construct(LoginCookieService $loginCookieService, ExpensiveCache $cache, EventDispatcher $eventDispatcher, Request $request, Localization $localization, Repository $config)
     {
         $this->cache = $cache;
+        $this->loginCookieService = $loginCookieService;
         $this->eventDispatcher = $eventDispatcher;
         $this->request = $request;
         $this->localization = $localization;
@@ -85,10 +87,13 @@ class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInter
     {
         $this->eventDispatcher->dispatch('on_page_not_found');
         $record = $this->cache->getItem('page_not_found');
-        if ($record->isHit()) {
-            /** @var Response */
-            return $record->get();
+        if (!$this->loginCookieService->hasLoginCookie()) {
+            if ($record->isHit()) {
+                /** @var Response */
+                return $record->get();
+            }
         }
+
         $item = '/page_not_found';
         $c = Page::getByPath($item);
         if (is_object($c) && !$c->isError()) {
@@ -98,7 +103,11 @@ class ResponseFactory implements ResponseFactoryInterface, ApplicationAwareInter
             $cnt = $this->app->make(PageForbidden::class);
             $response = $this->controller($cnt, $code, $headers);
         }
-        $record->set($response)->expiresAfter(1800)->save();
+
+        if (!$this->loginCookieService->hasLoginCookie()) {
+            $record->set($response)->expiresAfter(1800)->save();
+        }
+
         return $response;
     }
 

--- a/concrete/src/User/Login/LoginCookieService.php
+++ b/concrete/src/User/Login/LoginCookieService.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Concrete\Core\User\Login;
+
+use Concrete\Core\Config\Repository\Repository;
+use Concrete\Core\Cookie\CookieJar;
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+class LoginCookieService
+{
+
+    /**
+     * @var Repository
+     */
+    protected $config;
+
+    /**
+     * @var CookieJar
+     */
+    protected $cookieJar;
+
+    public function __construct(CookieJar $cookieJar, Repository $config)
+    {
+        $this->cookieJar = $cookieJar;
+        $this->config = $config;
+    }
+
+    public function hasLoginCookie(): bool
+    {
+        $loginCookie = sprintf('%s_LOGIN', $this->config->get('concrete.session.name'));
+        return $this->cookieJar->has($loginCookie) && $this->cookieJar->get($loginCookie) === '1';
+    }
+
+}

--- a/tests/tests/Http/Early404MiddlewareTest.php
+++ b/tests/tests/Http/Early404MiddlewareTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace Concrete\Tests\Http;
+
+use Concrete\Core\Database\Connection\Connection;
+use Concrete\Core\Http\Middleware\DelegateInterface;
+use Concrete\Core\Http\Middleware\Early404Middleware;
+use Concrete\Core\Http\Request;
+use Concrete\Core\Http\ResponseFactoryInterface;
+use Concrete\Core\Routing\RouteActionFactory;
+use Concrete\Core\Routing\Router;
+use Concrete\Tests\TestCase;
+use Mockery;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\RouteCollection;
+
+class Early404MiddlewareTest extends TestCase
+{
+    public function testMatchingRoutePrefixDelegatesRequest(): void
+    {
+        $router = new Router(new RouteCollection(), new RouteActionFactory());
+        $router->get('/ccm/system/page/{id}', static function () {
+        });
+        $connection = Mockery::mock(Connection::class);
+        $responseFactory = Mockery::mock(ResponseFactoryInterface::class);
+        $delegate = Mockery::mock(DelegateInterface::class);
+        $request = Request::create('https://www.concretecms.org/ccm/system/page/42');
+        $response = new Response('ok');
+
+        $delegate->shouldReceive('next')->once()->with($request)->andReturn($response);
+        $connection->shouldNotReceive('fetchOne');
+        $responseFactory->shouldNotReceive('notFound');
+
+        $middleware = new Early404Middleware($router, $connection, $responseFactory);
+
+        $this->assertSame($response, $middleware->process($request, $delegate));
+    }
+
+    public function testMatchingPagePathPrefixDelegatesRequest(): void
+    {
+        $router = new Router(new RouteCollection(), new RouteActionFactory());
+        $connection = Mockery::mock(Connection::class);
+        $responseFactory = Mockery::mock(ResponseFactoryInterface::class);
+        $delegate = Mockery::mock(DelegateInterface::class);
+        $request = Request::create('https://www.concretecms.org/blog/article/example');
+        $response = new Response('ok');
+
+        $connection->shouldReceive('fetchOne')
+            ->once()
+            ->with('select 1 from PagePaths where cPath = ? or cPath like ? limit 1', ['/blog', '/blog/%'])
+            ->andReturn(1);
+        $delegate->shouldReceive('next')->once()->with($request)->andReturn($response);
+        $responseFactory->shouldNotReceive('notFound');
+
+        $middleware = new Early404Middleware($router, $connection, $responseFactory);
+
+        $this->assertSame($response, $middleware->process($request, $delegate));
+    }
+
+    public function testMissingRouteAndPagePathReturnsNotFound(): void
+    {
+        $router = new Router(new RouteCollection(), new RouteActionFactory());
+        $router->get('/{slug}', static function () {
+        });
+        $connection = Mockery::mock(Connection::class);
+        $responseFactory = Mockery::mock(ResponseFactoryInterface::class);
+        $delegate = Mockery::mock(DelegateInterface::class);
+        $request = Request::create('https://www.concretecms.org/wp-login.php');
+        $response = new Response('missing', 404);
+
+        $connection->shouldReceive('fetchOne')
+            ->once()
+            ->with('select 1 from PagePaths where cPath = ? or cPath like ? limit 1', ['/wp-login.php', '/wp-login.php/%'])
+            ->andReturn(false);
+        $delegate->shouldNotReceive('next');
+        $responseFactory->shouldReceive('notFound')->once()->with('')->andReturn($response);
+
+        $middleware = new Early404Middleware($router, $connection, $responseFactory);
+
+        $this->assertSame($response, $middleware->process($request, $delegate));
+    }
+}

--- a/tests/tests/Http/Early404MiddlewareTest.php
+++ b/tests/tests/Http/Early404MiddlewareTest.php
@@ -2,6 +2,8 @@
 
 namespace Concrete\Tests\Http;
 
+use Concrete\Core\Application\Application;
+use Concrete\Core\Cache\Level\ExpensiveCache;
 use Concrete\Core\Database\Connection\Connection;
 use Concrete\Core\Http\Middleware\DelegateInterface;
 use Concrete\Core\Http\Middleware\Early404Middleware;
@@ -21,17 +23,16 @@ class Early404MiddlewareTest extends TestCase
         $router = new Router(new RouteCollection(), new RouteActionFactory());
         $router->get('/ccm/system/page/{id}', static function () {
         });
+        $cache = Mockery::mock(ExpensiveCache::class);
         $connection = Mockery::mock(Connection::class);
-        $responseFactory = Mockery::mock(ResponseFactoryInterface::class);
         $delegate = Mockery::mock(DelegateInterface::class);
         $request = Request::create('https://www.concretecms.org/ccm/system/page/42');
         $response = new Response('ok');
 
         $delegate->shouldReceive('next')->once()->with($request)->andReturn($response);
         $connection->shouldNotReceive('fetchOne');
-        $responseFactory->shouldNotReceive('notFound');
 
-        $middleware = new Early404Middleware($router, $connection, $responseFactory);
+        $middleware = new Early404Middleware($cache, $router, $connection);
 
         $this->assertSame($response, $middleware->process($request, $delegate));
     }
@@ -39,8 +40,8 @@ class Early404MiddlewareTest extends TestCase
     public function testMatchingPagePathPrefixDelegatesRequest(): void
     {
         $router = new Router(new RouteCollection(), new RouteActionFactory());
+        $cache = Mockery::mock(ExpensiveCache::class);
         $connection = Mockery::mock(Connection::class);
-        $responseFactory = Mockery::mock(ResponseFactoryInterface::class);
         $delegate = Mockery::mock(DelegateInterface::class);
         $request = Request::create('https://www.concretecms.org/blog/article/example');
         $response = new Response('ok');
@@ -50,9 +51,8 @@ class Early404MiddlewareTest extends TestCase
             ->with('select 1 from PagePaths where cPath = ? or cPath like ? limit 1', ['/blog', '/blog/%'])
             ->andReturn(1);
         $delegate->shouldReceive('next')->once()->with($request)->andReturn($response);
-        $responseFactory->shouldNotReceive('notFound');
 
-        $middleware = new Early404Middleware($router, $connection, $responseFactory);
+        $middleware = new Early404Middleware($cache, $router, $connection);
 
         $this->assertSame($response, $middleware->process($request, $delegate));
     }
@@ -62,8 +62,10 @@ class Early404MiddlewareTest extends TestCase
         $router = new Router(new RouteCollection(), new RouteActionFactory());
         $router->get('/{slug}', static function () {
         });
+        $cache = Mockery::mock(ExpensiveCache::class);
         $connection = Mockery::mock(Connection::class);
         $responseFactory = Mockery::mock(ResponseFactoryInterface::class);
+        $app = Mockery::mock(Application::class);
         $delegate = Mockery::mock(DelegateInterface::class);
         $request = Request::create('https://www.concretecms.org/wp-login.php');
         $response = new Response('missing', 404);
@@ -73,9 +75,11 @@ class Early404MiddlewareTest extends TestCase
             ->with('select 1 from PagePaths where cPath = ? or cPath like ? limit 1', ['/wp-login.php', '/wp-login.php/%'])
             ->andReturn(false);
         $delegate->shouldNotReceive('next');
-        $responseFactory->shouldReceive('notFound')->once()->with('')->andReturn($response);
+        $responseFactory->shouldReceive('cachedNotFound')->once()->withNoArgs()->andReturn($response);
+        $app->shouldReceive('make')->once()->with(ResponseFactoryInterface::class)->andReturn($responseFactory);
 
-        $middleware = new Early404Middleware($router, $connection, $responseFactory);
+        $middleware = new Early404Middleware($cache, $router, $connection);
+        $middleware->setApplication($app);
 
         $this->assertSame($response, $middleware->process($request, $delegate));
     }


### PR DESCRIPTION
This pull request introduces a new `Early404Middleware` to optimize 404 handling by quickly returning cached 404 responses for requests that do not match any route or page path, reducing unnecessary processing. It also updates the `ResponseFactory` to support cached 404 responses and ensures the `on_page_not_found` event is dispatched in both cached and standard 404 scenarios. The changes are covered by new unit tests for the middleware.

This is a zero-configuration, simpler version of #12867 