### PR TITLE
Fix/file version event dispatch

### DIFF
--- a/concrete/controllers/dialog/file/properties.php
+++ b/concrete/controllers/dialog/file/properties.php
@@ -77,11 +77,15 @@ class Properties extends BackendInterfaceFileController
     public function submit()
     {
         if ($this->validateAction()) {
+            $shouldApprove = ($this->file->getRecentVersion()->getFileVersionID() == $this->file->getApprovedVersion()->getFileVersionID());
             $fv = $this->file->getVersionToModify();
             $fv->updateTitle($this->request->request->get('title'));
             $fv->updateDescription($this->request->request->get('description'));
             $fv->updateTags($this->request->request->get('tags'));
             $attributesResponse = $this->saveAttributes();
+            if (!$fv->isApproved() && $shouldApprove) {
+                $fv->approve();
+            }
             $sr = new EditResponse();
             $sr->setFile($this->file);
             if ($attributesResponse instanceof ErrorList) {

--- a/concrete/controllers/dialog/file/thumbnails/edit.php
+++ b/concrete/controllers/dialog/file/thumbnails/edit.php
@@ -52,6 +52,7 @@ class Edit extends BackendInterfaceFileController
         if ($this->validateAction()) {
             $fp = new Checker($this->file);
             if ($fp->canEditFileProperties()) {
+                $shouldApprove = ($this->file->getRecentVersion()->getFileVersionID() == $this->file->getApprovedVersion()->getFileVersionID());
                 $fileVersion = $this->file->getVersionToModify();
                 $uploadedFile = $this->request->files->get('file');
                 $typeVersion = $this->getThumbnailTypeVersionFromRequest();
@@ -61,6 +62,9 @@ class Edit extends BackendInterfaceFileController
                  * @var $uploadedFile UploadedFile
                  */
                 $filesystem->update($typeVersion->getFilePath($fileVersion), $uploadedFile->getContent());
+                if (!$fileVersion->isApproved() && $shouldApprove) {
+                    $fileVersion->approve();
+                }
 
                 $sr = new FileEditResponse();
                 $sr->setFile($this->file);

--- a/concrete/src/Api/Controller/Files.php
+++ b/concrete/src/Api/Controller/Files.php
@@ -322,6 +322,7 @@ class Files extends ApiController
         }
 
         $body = json_decode($this->request->getContent(), true);
+        $shouldApprove = ($file->getRecentVersion()->getFileVersionID() == $file->getApprovedVersion()->getFileVersionID());
         $version = $file->getVersionToModify();
         if (isset($body['title'])) {
             $version->updateTitle($body['title']);
@@ -340,6 +341,9 @@ class Files extends ApiController
             foreach ($attributeMap->getEntries() as $entry) {
                 $version->setAttribute($entry->getAttributeKey(), $entry->getAttributeValue());
             }
+        }
+        if (!$version->isApproved() && $shouldApprove) {
+            $version->approve();
         }
 
         return $this->transform($version->getFile(), new FileTransformer(), Resources::RESOURCE_FILES);

--- a/concrete/src/Entity/File/File.php
+++ b/concrete/src/Entity/File/File.php
@@ -461,13 +461,12 @@ class File implements \Concrete\Core\Permission\ObjectInterface, AttributeObject
      *
      * @return Version
      */
-    public function getVersionToModify($newFilename = null, $newPrefix = null)
+    public function getVersionToModify($forceCreateNew = false)
     {
         $u = Core::make(User::class);
         $createNew = false;
 
         $fv = $this->getRecentVersion();
-        $fav = $this->getApprovedVersion();
 
         // first test. Does the user ID of the most recent version match ours? If not, then we create new
         if ($u->getUserID() != $fv->getAuthorUserID()) {
@@ -480,27 +479,12 @@ class File implements \Concrete\Core\Permission\ObjectInterface, AttributeObject
             $createNew = true;
         }
 
-        if ($newFilename) {
+        if ($forceCreateNew) {
             $createNew = true;
         }
 
         if ($createNew) {
-            $fv2 = $fv->duplicate();
-
-
-            if ($newFilename && $newPrefix) {
-                $fv2->updateFile(
-                    $newFilename,
-                    $newPrefix
-                );
-            }
-
-            // Are the recent and active versions the same? If so, we approve this new version we just made
-            if ($fv->getFileVersionID() == $fav->getFileVersionID()) {
-                $fv2->approve();
-            }
-
-            return $fv2;
+            return $fv->duplicate();
         }
 
         return $fv;

--- a/concrete/src/Entity/File/File.php
+++ b/concrete/src/Entity/File/File.php
@@ -461,7 +461,7 @@ class File implements \Concrete\Core\Permission\ObjectInterface, AttributeObject
      *
      * @return Version
      */
-    public function getVersionToModify($forceCreateNew = false)
+    public function getVersionToModify($newFilename = null, $newPrefix = null)
     {
         $u = Core::make(User::class);
         $createNew = false;
@@ -480,12 +480,20 @@ class File implements \Concrete\Core\Permission\ObjectInterface, AttributeObject
             $createNew = true;
         }
 
-        if ($forceCreateNew) {
+        if ($newFilename) {
             $createNew = true;
         }
 
         if ($createNew) {
             $fv2 = $fv->duplicate();
+
+
+            if ($newFilename && $newPrefix) {
+                $fv2->updateFile(
+                    $newFilename,
+                    $newPrefix
+                );
+            }
 
             // Are the recent and active versions the same? If so, we approve this new version we just made
             if ($fv->getFileVersionID() == $fav->getFileVersionID()) {

--- a/concrete/src/Entity/File/Version.php
+++ b/concrete/src/Entity/File/Version.php
@@ -560,8 +560,9 @@ class Version implements ObjectInterface
     {
         $app = Application::getFacadeApplication();
         foreach ($this->file->getFileVersions() as $fv) {
-            $fv->fvIsApproved = false;
-            $fv->save(false);
+            if ($fv->isApproved()) {
+                $fv->deny();
+            }
         }
 
         $this->fvIsApproved = true;
@@ -1179,8 +1180,6 @@ class Version implements ObjectInterface
         }
 
         $em->persist($fv);
-
-        $this->deny();
 
         foreach ($this->getAttributes() as $value) {
             $value = clone $value;

--- a/concrete/src/Entity/File/Version.php
+++ b/concrete/src/Entity/File/Version.php
@@ -1273,6 +1273,9 @@ class Version implements ObjectInterface
         $em->remove($this);
         $em->flush();
 
+        $fve = new FileVersionEvent($this);
+        $app->make(EventDispatcher::class)->dispatch('on_file_version_delete', $fve);
+
         try {
             $logger->notice(t('Version %1$s of file %2$s successfully deleted.', $this->getFileVersionID(), $this->getFileName()));
         } catch (Exception $err) {

--- a/concrete/src/File/Import/FileImporter.php
+++ b/concrete/src/File/Import/FileImporter.php
@@ -290,8 +290,12 @@ class FileImporter implements LoggerAwareInterface
         $file = $options->getAddNewVersionTo();
         if ($file !== null) {
             // We get a new version to modify
-            $fileVersion = $file->getVersionToModify($importingFile->getConcreteFilenameSanitized(), $prefix);
-
+            $fileVersion = $file->getVersionToModify(true);
+            $fileVersion->updateFile(
+                $importingFile->getConcreteFilenameSanitized(),
+                $prefix
+            );
+            $fileVersion->approve();
             $this->logger->notice(t("Added new version %s to existing file %s (%s).", $fileVersion->getFileVersionID(), $file->getFileName(), $file->getFileID()));
         } else {
             // We create a new File instance

--- a/concrete/src/File/Import/FileImporter.php
+++ b/concrete/src/File/Import/FileImporter.php
@@ -290,11 +290,8 @@ class FileImporter implements LoggerAwareInterface
         $file = $options->getAddNewVersionTo();
         if ($file !== null) {
             // We get a new version to modify
-            $fileVersion = $file->getVersionToModify(true);
-            $fileVersion->updateFile(
-                $importingFile->getConcreteFilenameSanitized(),
-                $prefix
-            );
+            $fileVersion = $file->getVersionToModify($importingFile->getConcreteFilenameSanitized(), $prefix);
+
             $this->logger->notice(t("Added new version %s to existing file %s (%s).", $fileVersion->getFileVersionID(), $file->getFileName(), $file->getFileID()));
         } else {
             // We create a new File instance


### PR DESCRIPTION
- add new event for file version deletion: `on_file_version_delete`
- update file name and prefix before dispatching `on_file_version_approve`

If I swap a file in the file manager, a new version is created in the `save()` method of `concrete/src/File/Import/FileImporter.php`. In there the `getVersionToModify()` executes `duplicate()` on the existing file version and then `approve()` on the duplicated file version (`concrete/src/Entity/File/Version.php`). In `approve()` the event `on_file_version_approve` is fired. But unless `updateFile()` is called, the duplicated file has the old name and prefix but already the new file version id. This leads to a file version passed to the event with inconsistent data. So I moved `updateFile()` to `getVersionToModify()` between `duplicate()` and `approve()`. For `updateFile()` I need the new file name and the prefix. As the only call to `getVersionToModify()` which requests a `forceCreateNew` is from the file importer the impact of the change seemed reasonably small.