### PR TITLE
Refactor Twig template variants and improve file locator tests

### DIFF
--- a/concrete/src/Authentication/AuthenticationType.php
+++ b/concrete/src/Authentication/AuthenticationType.php
@@ -6,6 +6,7 @@ use Concrete\Core\Backup\ContentImporter;
 use Concrete\Core\Database\Schema\Schema;
 use Concrete\Core\Filesystem\FileLocator;
 use Concrete\Core\Filesystem\TemplateService;
+use Concrete\Core\Filesystem\TemplateVariantLocator;
 use Concrete\Core\Foundation\ConcreteObject;
 use Concrete\Core\Package\PackageList;
 use Concrete\Core\Support\Facade\Application;
@@ -512,8 +513,8 @@ class AuthenticationType extends ConcreteObject
     protected function hasTemplate(string $handle): bool
     {
         $atHandle = $this->getAuthenticationTypeHandle();
-        $path = implode('/', [DIRNAME_AUTHENTICATION, $atHandle, $handle]);
-        $r = $this->getLocator()->getRecord($path, true);
+        $path = implode('/', [DIRNAME_AUTHENTICATION, $atHandle, $handle . '.php']);
+        $r = $this->getTemplateVariantLocator()->getRecord($path);
 
         return $r->exists();
     }
@@ -533,8 +534,8 @@ class AuthenticationType extends ConcreteObject
         }
 
         $atHandle = $this->getAuthenticationTypeHandle();
-        $path = implode('/', [DIRNAME_AUTHENTICATION, $atHandle, $handle]);
-        $r = $this->getLocator()->getRecord($path, true);
+        $path = implode('/', [DIRNAME_AUTHENTICATION, $atHandle, $handle . '.php']);
+        $r = $this->getTemplateVariantLocator()->getRecord($path);
         if (!$r->exists()) {
             return null;
         }
@@ -551,6 +552,11 @@ class AuthenticationType extends ConcreteObject
         }
 
         return $this->templateService->renderTemplate($r->getFile(), $data, $this);
+    }
+
+    protected function getTemplateVariantLocator(): TemplateVariantLocator
+    {
+        return new TemplateVariantLocator($this->getLocator());
     }
 
     protected function getLocator(): FileLocator

--- a/concrete/src/Block/View/BlockViewTemplate.php
+++ b/concrete/src/Block/View/BlockViewTemplate.php
@@ -9,6 +9,7 @@ use Concrete\Core\Package\PackageList;
 use Concrete\Core\Asset\JavascriptAsset;
 use Concrete\Core\Asset\CssAsset;
 use Concrete\Core\Filesystem\FileLocator;
+use Concrete\Core\Filesystem\TemplateVariantLocator;
 
 class BlockViewTemplate
 {
@@ -88,6 +89,7 @@ class BlockViewTemplate
             $locator->addLocation(new FileLocator\PackageLocation($obj->getPackageHandle(), true));
         }
         $locator->addLocation(new FileLocator\AllPackagesLocation($this->getPackageList()));
+        $templateLocator = new TemplateVariantLocator($locator);
 
         // if we've passed in "templates/" as the first part, we strip that off.
         if (strpos($bFilename, 'templates/') === 0) {
@@ -97,14 +99,12 @@ class BlockViewTemplate
         if ($bFilename) {
             // Use case a - bFilename that is a template file
             if (str_ends_with($bFilename, '.php') || str_ends_with($bFilename, '.html.twig')) {
-                $record = $locator->getRecord(
-                    DIRNAME_BLOCKS . '/' . $obj->getBlockTypeHandle() . '/' . DIRNAME_BLOCK_TEMPLATES . '/' . $bFilename,
-                    true,
+                $record = $templateLocator->getRecord(
+                    DIRNAME_BLOCKS . '/' . $obj->getBlockTypeHandle() . '/' . DIRNAME_BLOCK_TEMPLATES . '/' . $bFilename
                 );
                 $this->template = $record->getFile();
-                $record = $locator->getRecord(
-                    DIRNAME_BLOCKS . '/' . $obj->getBlockTypeHandle() . '/' . $this->render,
-                    true,
+                $record = $templateLocator->getRecord(
+                    DIRNAME_BLOCKS . '/' . $obj->getBlockTypeHandle() . '/' . $this->render
                 );
                 $this->baseURL = dirname($record->getUrl());
                 $this->basePath = dirname($record->getFile());
@@ -124,9 +124,8 @@ class BlockViewTemplate
         }
 
         // Use case c - no bFilename
-        $record = $locator->getRecord(
-            DIRNAME_BLOCKS . '/' . $obj->getBlockTypeHandle() . '/' . $this->render,
-            true,
+        $record = $templateLocator->getRecord(
+            DIRNAME_BLOCKS . '/' . $obj->getBlockTypeHandle() . '/' . $this->render
         );
         if ($record->exists()) {
             $this->baseURL = dirname($record->getUrl());

--- a/concrete/src/Board/Instance/Slot/Content/TemplateLocator.php
+++ b/concrete/src/Board/Instance/Slot/Content/TemplateLocator.php
@@ -4,6 +4,7 @@ namespace Concrete\Core\Board\Instance\Slot\Content;
 
 use Concrete\Core\Entity\Board\SlotTemplate;
 use Concrete\Core\Filesystem\FileLocator;
+use Concrete\Core\Filesystem\TemplateVariantLocator;
 use Concrete\Core\Page\Page;
 use Concrete\Core\Site\Service;
 
@@ -48,7 +49,7 @@ class TemplateLocator
                     $filename = DIRNAME_ELEMENTS . '/' . DIRNAME_BOARDS . '/' . DIRNAME_BOARD_SLOTS . '/' . $handle . '.php';
                     $this->themeLocation->setTheme($theme);
                     $this->fileLocator->addLocation($this->themeLocation);
-                    $record = $this->fileLocator->getRecord($filename, true);
+                    $record = (new TemplateVariantLocator($this->fileLocator))->getRecord($filename);
                     if ($record->exists()) {
                         return $record->getFile();
                     }

--- a/concrete/src/Board/Template/TemplateLocator.php
+++ b/concrete/src/Board/Template/TemplateLocator.php
@@ -4,6 +4,7 @@ namespace Concrete\Core\Board\Template;
 
 use Concrete\Core\Entity\Board\Template;
 use Concrete\Core\Filesystem\FileLocator;
+use Concrete\Core\Filesystem\TemplateVariantLocator;
 use Concrete\Core\Page\Theme\Theme;
 
 /**
@@ -40,7 +41,7 @@ class TemplateLocator
             $filename = DIRNAME_ELEMENTS . '/' . DIRNAME_BOARDS . '/' . $handle . '.php';
             $this->themeLocation->setTheme($theme);
             $this->fileLocator->addLocation($this->themeLocation);
-            $record = $this->fileLocator->getRecord($filename, true);
+            $record = (new TemplateVariantLocator($this->fileLocator))->getRecord($filename);
             if ($record->exists()) {
                 return $record->getFile();
             }

--- a/concrete/src/Controller/ElementController.php
+++ b/concrete/src/Controller/ElementController.php
@@ -3,6 +3,7 @@
 namespace Concrete\Core\Controller;
 
 use Concrete\Core\Filesystem\FileLocator;
+use Concrete\Core\Filesystem\TemplateVariantLocator;
 use Concrete\Core\Support\Facade\Facade;
 use Concrete\Core\View\BasicFileView;
 use Illuminate\Filesystem\Filesystem;
@@ -45,7 +46,7 @@ abstract class ElementController extends AbstractController
             if ($this->pkgHandle) {
                 $locator->addPackageLocation($this->pkgHandle);
             }
-            $r = $locator->getRecord(DIRNAME_ELEMENTS . '/' . $this->getElement(), true);
+            $r = (new TemplateVariantLocator($locator))->getRecord(DIRNAME_ELEMENTS . '/' . $this->getElement() . '.php');
             $this->view = new BasicFileView($r->getFile());
             $this->view->setController($this);
         }

--- a/concrete/src/Filesystem/Element.php
+++ b/concrete/src/Filesystem/Element.php
@@ -148,7 +148,7 @@ class Element implements LocatableFileInterface
      */
     public function getFileLocatorRecord()
     {
-        return $this->locator->getRecord($this->getElementPath(), true);
+        return (new TemplateVariantLocator($this->locator))->getRecord($this->getElementPath());
     }
 
     /**

--- a/concrete/src/Filesystem/FileLocator.php
+++ b/concrete/src/Filesystem/FileLocator.php
@@ -48,12 +48,6 @@ class FileLocator
         $this->filesystem = $filesystem;
     }
 
-    public function addDefaultLocations()
-    {
-        array_unshift($this->locations, new ApplicationLocation($this->filesystem));
-        $this->locations[] = new CoreLocation($this->filesystem);
-    }
-
     public function addLocation(LocationInterface $location)
     {
         $this->locations[] = $location;
@@ -66,9 +60,8 @@ class FileLocator
 
     public function getAllRecords($file)
     {
-        $this->addDefaultLocations();
         $records = [];
-        foreach ($this->locations as $location) {
+        foreach ($this->getSearchLocations() as $location) {
             $location->setFilesystem($this->filesystem);
             if ($record = $location->contains($file)) {
                 $records[] = $record;
@@ -80,51 +73,21 @@ class FileLocator
 
     /**
      * @param $file
-     * @param bool $template
-     *
      * @return Record|null
      */
-    public function getRecord($file, bool $template = false)
+    public function getRecord($file)
     {
-        $this->addDefaultLocations();
         $key = $this->getCacheKey($file);
         $item = $this->cache->getItem($key);
         $record = null;
 
         if ($item->isMiss()) {
             $item->lock();
-
-            $extensions = ['.php', '.html.twig'];
-            if ($template) {
-                foreach ($extensions as $extension) {
-                    $file = str_ends_with($file, $extension) ? substr($file, 0, -strlen($extension)) : $file;
-                }
-            }
-
-            foreach ($this->locations as $location) {
+            foreach ($this->getSearchLocations() as $location) {
                 $location->setFilesystem($this->filesystem);
-                if ($template) {
-                    $last = [];
-                    foreach ($extensions as $extension) {
-                        $fileWithExtension = $file . $extension;
-                        $found = $location->contains($fileWithExtension);
-                        if ($found) {
-                            $last[$extension] = $found;
-                            if ($found->exists()) {
-                                $record = $found;
-                                break 2;
-                            }
-                        }
-
-                    }
-                } elseif ($record = $location->contains($file)) {
+                if ($record = $location->contains($file)) {
                     break;
                 }
-            }
-
-            if ($template && !$record && isset($last)) {
-                // Use last non-existent .php file for backwards compatibility
-                $record = $last['.php'];
             }
 
             if (isset($record)) {
@@ -145,11 +108,28 @@ class FileLocator
         return $this->locations;
     }
 
+    /**
+     * Return the effective ordered list of locations used during file lookup.
+     *
+     * This includes the default application and core locations around any
+     * explicitly configured custom locations without mutating the locator state.
+     *
+     * @return LocationInterface[]
+     */
+    public function getSearchLocations()
+    {
+        return array_merge(
+            [new ApplicationLocation($this->filesystem)],
+            $this->locations,
+            [new CoreLocation($this->filesystem)]
+        );
+    }
+
     protected function getCacheKey($file)
     {
         $keys = [];
         $file = trim(str_replace('/', DIRECTORY_SEPARATOR, $file), DIRECTORY_SEPARATOR);
-        foreach ($this->locations as $location) {
+        foreach ($this->getSearchLocations() as $location) {
             $cacheKey = $location->getCacheKey();
             if (is_array($cacheKey)) {
                 $keys = array_merge($keys, $cacheKey);

--- a/concrete/src/Filesystem/TemplateVariantLocator.php
+++ b/concrete/src/Filesystem/TemplateVariantLocator.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Concrete\Core\Filesystem;
+
+use Concrete\Core\Filesystem\FileLocator\Record;
+
+/**
+ * Resolves the renderable template variant for an explicit template filename.
+ *
+ * This class differs from {@see FileLocator} in one important way: it is aware
+ * of PHP/Twig sibling templates and may return a different file extension than
+ * the one that was originally requested.
+ *
+ * This class also differs from {@see TemplateLocator}, which is an older,
+ * higher-level template selection helper unrelated to PHP/Twig sibling
+ * resolution.
+ *
+ * The expected contract is:
+ * - callers pass a full logical template path ending in `.php` or `.html.twig`
+ * - `.html.twig` requests only probe `.html.twig`
+ * - `.php` requests probe `.html.twig` first and then `.php`
+ * - location precedence is preserved from {@see FileLocator}; once a location
+ *   yields a candidate record, lower-priority locations are not considered
+ */
+class TemplateVariantLocator
+{
+    /**
+     * @var FileLocator
+     */
+    protected $fileLocator;
+
+    public function __construct(FileLocator $fileLocator)
+    {
+        $this->fileLocator = $fileLocator;
+    }
+
+    /**
+     * Resolve the best renderable template variant for a logical template path.
+     *
+     * The returned record may reference a different extension than the
+     * originally requested file. For example, asking for `view.php` may return
+     * a record for `view.html.twig` when that sibling template exists in a
+     * higher-priority location.
+     *
+     * @param string $file a logical file path ending in `.php` or `.html.twig`
+     *
+     * @return Record|null
+     */
+    public function getRecord(string $file)
+    {
+        $candidates = $this->getCandidateFiles($file);
+        $fallbackCandidates = $this->getFallbackCandidateFiles($file);
+        foreach ($this->fileLocator->getSearchLocations() as $location) {
+            $location->setFilesystem($this->fileLocator->getFilesystem());
+            $records = [];
+            foreach ($candidates as $candidate) {
+                $record = $location->contains($candidate);
+                if (!$record) {
+                    continue;
+                }
+                $records[$candidate] = $record;
+                if ($record->exists()) {
+                    return $record;
+                }
+            }
+            foreach ($fallbackCandidates as $candidate) {
+                if (isset($records[$candidate])) {
+                    return $records[$candidate];
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Build the ordered sibling-variant candidates for a template request.
+     *
+     * `.html.twig` requests are explicit and only probe Twig.
+     * `.php` requests first probe the Twig sibling and then the original PHP
+     * file to preserve transparent Twig support for legacy PHP callers.
+     *
+     * @param string $file
+     *
+     * @return string[]
+     */
+    protected function getCandidateFiles(string $file): array
+    {
+        if (str_ends_with($file, '.html.twig')) {
+            return [$file];
+        }
+        if (str_ends_with($file, '.php')) {
+            return [substr($file, 0, -4) . '.html.twig', $file];
+        }
+
+        throw new \InvalidArgumentException(t('TemplateVariantLocator requires an explicit .php or .html.twig filename.'));
+    }
+
+    /**
+     * Build the ordered fallback candidates for a template request.
+     *
+     * When no matching file exists within a winning location we prefer to fall
+     * back to the explicitly requested filename, which preserves legacy PHP
+     * behavior while still allowing Twig to transparently win when it exists.
+     *
+     * @param string $file
+     *
+     * @return string[]
+     */
+    protected function getFallbackCandidateFiles(string $file): array
+    {
+        if (str_ends_with($file, '.html.twig')) {
+            return [$file];
+        }
+        if (str_ends_with($file, '.php')) {
+            return [$file, substr($file, 0, -4) . '.html.twig'];
+        }
+
+        throw new \InvalidArgumentException(t('TemplateVariantLocator requires an explicit .php or .html.twig filename.'));
+    }
+}

--- a/concrete/src/Filesystem/TemplateVariantLocator.php
+++ b/concrete/src/Filesystem/TemplateVariantLocator.php
@@ -16,9 +16,10 @@ use Concrete\Core\Filesystem\FileLocator\Record;
  * resolution.
  *
  * The expected contract is:
- * - callers pass a full logical template path ending in `.php` or `.html.twig`
+ * - callers should pass a full logical template path ending in `.php` or `.html.twig`
  * - `.html.twig` requests only probe `.html.twig`
  * - `.php` requests probe `.html.twig` first and then `.php`
+ * - extensionless requests are treated as legacy `.php` requests for backwards compatibility
  * - location precedence is preserved from {@see FileLocator}; once a location
  *   yields a candidate record, lower-priority locations are not considered
  */
@@ -43,6 +44,8 @@ class TemplateVariantLocator
      * higher-priority location.
      *
      * @param string $file a logical file path ending in `.php` or `.html.twig`
+     *                     or a legacy extensionless path that should be treated
+     *                     like a `.php` request
      *
      * @return Record|null
      */
@@ -86,6 +89,7 @@ class TemplateVariantLocator
      */
     protected function getCandidateFiles(string $file): array
     {
+        $file = $this->normalizeLegacyPath($file);
         if (str_ends_with($file, '.html.twig')) {
             return [$file];
         }
@@ -93,7 +97,7 @@ class TemplateVariantLocator
             return [substr($file, 0, -4) . '.html.twig', $file];
         }
 
-        throw new \InvalidArgumentException(t('TemplateVariantLocator requires an explicit .php or .html.twig filename.'));
+        throw new \InvalidArgumentException(t('TemplateVariantLocator requires a .php or .html.twig filename.'));
     }
 
     /**
@@ -109,6 +113,7 @@ class TemplateVariantLocator
      */
     protected function getFallbackCandidateFiles(string $file): array
     {
+        $file = $this->normalizeLegacyPath($file);
         if (str_ends_with($file, '.html.twig')) {
             return [$file];
         }
@@ -116,6 +121,22 @@ class TemplateVariantLocator
             return [$file, substr($file, 0, -4) . '.html.twig'];
         }
 
-        throw new \InvalidArgumentException(t('TemplateVariantLocator requires an explicit .php or .html.twig filename.'));
+        throw new \InvalidArgumentException(t('TemplateVariantLocator requires a .php or .html.twig filename.'));
+    }
+
+    /**
+     * Normalize a legacy extensionless path into an equivalent `.php` request.
+     *
+     * This preserves backwards compatibility for older call sites that
+     * implicitly requested PHP templates, while still allowing Twig sibling
+     * templates to transparently win when they exist.
+     */
+    protected function normalizeLegacyPath(string $file): string
+    {
+        if (!str_ends_with($file, '.php') && !str_ends_with($file, '.html.twig')) {
+            return $file . '.php';
+        }
+
+        return $file;
     }
 }

--- a/concrete/src/Foundation/Environment.php
+++ b/concrete/src/Foundation/Environment.php
@@ -2,6 +2,7 @@
 namespace Concrete\Core\Foundation;
 
 use Concrete\Core\Filesystem\FileLocator;
+use Concrete\Core\Filesystem\TemplateVariantLocator;
 use Concrete\Core\Support\Facade\Facade;
 use Config;
 
@@ -49,7 +50,11 @@ class Environment
         if ($pkgHandle) {
             $locator->addLocation(new FileLocator\PackageLocation($pkgHandle));
         }
-        return $locator->getRecord($segment, $template);
+        if ($template) {
+            return (new TemplateVariantLocator($locator))->getRecord($segment);
+        }
+
+        return $locator->getRecord($segment);
     }
 
     public function getUncachedRecord($segment, $pkgHandle = false, bool $template = false)

--- a/concrete/src/Page/Container/TemplateLocator.php
+++ b/concrete/src/Page/Container/TemplateLocator.php
@@ -5,6 +5,7 @@ namespace Concrete\Core\Page\Container;
 use Concrete\Core\Entity\Page\Container;
 use Concrete\Core\Filesystem\FileLocator;
 use Concrete\Core\Filesystem\FileLocator\Record;
+use Concrete\Core\Filesystem\TemplateVariantLocator;
 use Concrete\Core\Page\Page;
 
 /**
@@ -44,7 +45,9 @@ class TemplateLocator
                 $this->themeLocation->setTheme($theme);
                 $this->fileLocator->addLocation($this->themeLocation);
 
-                $record = $this->fileLocator->getRecord($filename, $template);
+                $record = $template
+                    ? (new TemplateVariantLocator($this->fileLocator))->getRecord($filename)
+                    : $this->fileLocator->getRecord($filename);
                 if ($record->exists()) {
                     return $record->getFile();
                 }

--- a/concrete/src/Summary/Template/TemplateLocator.php
+++ b/concrete/src/Summary/Template/TemplateLocator.php
@@ -4,6 +4,7 @@ namespace Concrete\Core\Summary\Template;
 
 use Concrete\Core\Entity\Summary\Template;
 use Concrete\Core\Filesystem\FileLocator;
+use Concrete\Core\Filesystem\TemplateVariantLocator;
 use Concrete\Core\Page\Page;
 use Concrete\Core\Site\Service;
 
@@ -62,7 +63,7 @@ class TemplateLocator
                     if ($template->getPackageHandle()) {
                         $this->fileLocator->addPackageLocation($template->getPackageHandle());
                     }
-                    $record = $this->fileLocator->getRecord($filename, true);
+                    $record = (new TemplateVariantLocator($this->fileLocator))->getRecord($filename);
                     if ($record->exists()) {
                         return $record->getFile();
                     }

--- a/concrete/src/View/View.php
+++ b/concrete/src/View/View.php
@@ -6,6 +6,7 @@ use Concrete\Core\Asset\Output\StandardFormatter;
 use Concrete\Core\Feature\Traits\HandleRequiredFeaturesTrait;
 use Concrete\Core\Filesystem\FileLocator;
 use Concrete\Core\Filesystem\TemplateService;
+use Concrete\Core\Filesystem\TemplateVariantLocator;
 use Concrete\Core\Http\ResponseAssetGroup;
 use Concrete\Core\Page\Theme\ThemeRouteCollection;
 use Concrete\Core\Page\View\Preview\SkinCustomizerPreviewRequest;
@@ -522,7 +523,7 @@ class View extends AbstractView
             $_locator->addPackageLocation($_pkgHandle);
         }
 
-        $_record = $_locator->getRecord(DIRNAME_ELEMENTS . '/' . $_file, true);
+        $_record = (new TemplateVariantLocator($_locator))->getRecord(DIRNAME_ELEMENTS . '/' . $_file . '.php');
         $_file = $_record->getFile();
 
         $args['view'] = $view;

--- a/tests/tests/Authentication/AuthenticationTypeTest.php
+++ b/tests/tests/Authentication/AuthenticationTypeTest.php
@@ -5,8 +5,11 @@ namespace Concrete\Tests\Authentication;
 use Concrete\Core\Authentication\AuthenticationType;
 use Concrete\Core\Authentication\AuthenticationTypeController;
 use Concrete\Core\Filesystem\FileLocator;
+use Concrete\Core\Filesystem\FileLocator\LocationInterface;
 use Concrete\Core\Filesystem\TemplateService;
+use Concrete\Core\Filesystem\TemplateVariantLocator;
 use Concrete\Tests\TestCase;
+use Illuminate\Filesystem\Filesystem;
 use Mockery;
 
 final class AuthenticationTypeTest extends TestCase
@@ -19,6 +22,8 @@ final class AuthenticationTypeTest extends TestCase
     private $record;
     /** @var FileLocator&Mockery\MockInterface */
     private $fileLocator;
+    /** @var TemplateVariantLocator&Mockery\MockInterface */
+    private $templateVariantLocator;
     /** @var TemplateService&Mockery\MockInterface */
     private $templateService;
     /** @var AuthenticationType */
@@ -31,8 +36,8 @@ final class AuthenticationTypeTest extends TestCase
     {
         $this->setFullyDefinedController();
 
-        $this->fileLocator->expects('getRecord')
-            ->with('authentication/test_auth_type/' . $method, true)
+        $this->templateVariantLocator->expects('getRecord')
+            ->with('authentication/test_auth_type/' . $method . '.php')
             ->andReturn($this->record);
         $this->templateService->expects('renderTemplate')
             ->with($this->file, ['foo', $method], $this->authenticationType)
@@ -53,9 +58,9 @@ final class AuthenticationTypeTest extends TestCase
     {
         $this->setFullyDefinedController();
 
-        $this->fileLocator->expects('getRecord')
+        $this->templateVariantLocator->expects('getRecord')
             ->times(2)
-            ->with('authentication/test_auth_type/form', true)
+            ->with('authentication/test_auth_type/form.php')
             ->andReturn($this->record);
         $this->templateService->expects('renderTemplate')
             ->with($this->file, ['foo', 'form'], $this->authenticationType)
@@ -71,9 +76,9 @@ final class AuthenticationTypeTest extends TestCase
     {
         $this->setFullyDefinedController();
 
-        $this->fileLocator->expects('getRecord')
+        $this->templateVariantLocator->expects('getRecord')
             ->times(2)
-            ->with('authentication/test_auth_type/type_form', true)
+            ->with('authentication/test_auth_type/type_form.php')
             ->andReturn($this->record);
         $this->templateService->expects('renderTemplate')
             ->with($this->file, ['foo', 'edit', 'type_form'], $this->authenticationType)
@@ -89,9 +94,9 @@ final class AuthenticationTypeTest extends TestCase
     {
         $this->setEditController();
 
-        $this->fileLocator->expects('getRecord')
+        $this->templateVariantLocator->expects('getRecord')
             ->times(2)
-            ->with('authentication/test_auth_type/type_form', true)
+            ->with('authentication/test_auth_type/type_form.php')
             ->andReturn($this->record);
         $this->templateService->expects('renderTemplate')
             ->with($this->file, ['foo', 'edit'], $this->authenticationType)
@@ -107,9 +112,9 @@ final class AuthenticationTypeTest extends TestCase
     {
         $this->setViewController();
 
-        $this->fileLocator->expects('getRecord')
+        $this->templateVariantLocator->expects('getRecord')
             ->times(2)
-            ->with('authentication/test_auth_type/form', true)
+            ->with('authentication/test_auth_type/form.php')
             ->andReturn($this->record);
         $this->templateService->expects('renderTemplate')
             ->with($this->file, ['foo', 'view'], $this->authenticationType)
@@ -125,8 +130,25 @@ final class AuthenticationTypeTest extends TestCase
     {
         $this->setViewController();
         $this->authenticationType->pkgHandle = 'fake_package';
+        $this->authenticationType->templateVariantLocator = null;
 
-        $this->fileLocator->shouldReceive('getRecord')->andReturn($this->record);
+        $location = Mockery::mock(LocationInterface::class);
+        $location->shouldReceive('setFilesystem')->twice();
+        $location->shouldReceive('contains')
+            ->with('authentication/test_auth_type/form.html.twig')
+            ->twice()
+            ->andReturn(false);
+        $location->shouldReceive('contains')
+            ->with('authentication/test_auth_type/form.php')
+            ->twice()
+            ->andReturn($this->record);
+
+        $this->fileLocator->shouldReceive('getFilesystem')
+            ->twice()
+            ->andReturn(new Filesystem());
+        $this->fileLocator->shouldReceive('getSearchLocations')
+            ->twice()
+            ->andReturn([$location]);
         $this->templateService->shouldReceive('renderTemplate')->andReturn('foo');
 
         $this->fileLocator->expects('addPackageLocation')->with('fake_package');
@@ -149,18 +171,27 @@ final class AuthenticationTypeTest extends TestCase
             return $this->exists;
         });
         $this->fileLocator = Mockery::mock(FileLocator::class);
+        $this->templateVariantLocator = Mockery::mock(TemplateVariantLocator::class);
         $this->templateService = Mockery::mock(TemplateService::class);
 
         $this->authenticationType = new class($this->fileLocator, $this->templateService) extends AuthenticationType {
             protected $authTypeHandle = 'test_auth_type';
             /** @var string|false */
             public $pkgHandle = false;
+            /** @var TemplateVariantLocator|null */
+            public $templateVariantLocator;
             /** @return string|false */
             public function getPackageHandle()
             {
                 return $this->pkgHandle;
             }
+
+            protected function getTemplateVariantLocator(): TemplateVariantLocator
+            {
+                return $this->templateVariantLocator ?: parent::getTemplateVariantLocator();
+            }
         };
+        $this->authenticationType->templateVariantLocator = $this->templateVariantLocator;
     }
 
     protected function setFullyDefinedController(): void

--- a/tests/tests/Filesystem/FileLocatorTest.php
+++ b/tests/tests/Filesystem/FileLocatorTest.php
@@ -63,6 +63,27 @@ class FileLocatorTest extends TestCase
         $this->assertEquals('/path/to/server/packages/awesome/elements/awesome/thing.php', $record->getUrl());
     }
 
+    public function testGetLocationsReturnsOnlyExplicitLocations()
+    {
+        $this->locator->addPackageLocation('awesome');
+        $locations = $this->locator->getLocations();
+        $this->assertCount(1, $locations);
+        $this->assertInstanceOf(FileLocator\PackageLocation::class, $locations[0]);
+    }
+
+    public function testGetSearchLocationsIncludesDefaultsWithoutMutatingCustomLocations()
+    {
+        $this->locator->addPackageLocation('awesome');
+        $searchLocations = $this->locator->getSearchLocations();
+        $this->assertCount(3, $searchLocations);
+        $this->assertInstanceOf(FileLocator\ApplicationLocation::class, $searchLocations[0]);
+        $this->assertInstanceOf(FileLocator\PackageLocation::class, $searchLocations[1]);
+        $this->assertInstanceOf(FileLocator\CoreLocation::class, $searchLocations[2]);
+
+        $this->assertCount(1, $this->locator->getLocations());
+        $this->assertCount(3, $this->locator->getSearchLocations());
+    }
+
     public function testOverride()
     {
         $filesystem = $this->getMockBuilder(Filesystem::class)

--- a/tests/tests/Filesystem/TemplateVariantLocatorTest.php
+++ b/tests/tests/Filesystem/TemplateVariantLocatorTest.php
@@ -23,13 +23,24 @@ class TemplateVariantLocatorTest extends TestCase
         $this->app = Facade::getFacadeApplication();
     }
 
-    public function testRejectsPathsWithoutExtension()
+    public function testExtensionlessPathsAreTreatedAsLegacyPhpRequests()
     {
         $fileLocator = $this->createMock(FileLocator::class);
+        $fileLocator->expects($this->once())
+            ->method('getFilesystem')
+            ->willReturn(new Filesystem());
+        $location = new TemplateVariantTestLocation('custom', [
+            DIRNAME_ELEMENTS . '/foo.php' => true,
+        ]);
+        $fileLocator->expects($this->once())
+            ->method('getSearchLocations')
+            ->willReturn([$location]);
         $locator = new TemplateVariantLocator($fileLocator);
 
-        $this->expectException(\InvalidArgumentException::class);
-        $locator->getRecord(DIRNAME_ELEMENTS . '/foo');
+        $record = $locator->getRecord(DIRNAME_ELEMENTS . '/foo');
+
+        $this->assertEquals('/custom/' . DIRNAME_ELEMENTS . '/foo.php', $record->getFile());
+        $this->assertSame([DIRNAME_ELEMENTS . '/foo.html.twig', DIRNAME_ELEMENTS . '/foo.php'], $location->getLookups());
     }
 
     public function testExplicitTwigRequestOnlyChecksTwig()

--- a/tests/tests/Filesystem/TemplateVariantLocatorTest.php
+++ b/tests/tests/Filesystem/TemplateVariantLocatorTest.php
@@ -1,0 +1,286 @@
+<?php
+
+namespace Concrete\Tests\Filesystem;
+
+use Concrete\Core\Filesystem\FileLocator;
+use Concrete\Core\Filesystem\FileLocator\LocationInterface;
+use Concrete\Core\Filesystem\FileLocator\Record;
+use Concrete\Core\Filesystem\TemplateVariantLocator;
+use Concrete\Core\Page\Theme\Theme;
+use Concrete\Core\Support\Facade\Facade;
+use Illuminate\Filesystem\Filesystem;
+use Concrete\Tests\TestCase;
+
+class TemplateVariantLocatorTest extends TestCase
+{
+    /**
+     * @var \Concrete\Core\Application\Application
+     */
+    protected $app;
+
+    public function setUp(): void
+    {
+        $this->app = Facade::getFacadeApplication();
+    }
+
+    public function testRejectsPathsWithoutExtension()
+    {
+        $fileLocator = $this->createMock(FileLocator::class);
+        $locator = new TemplateVariantLocator($fileLocator);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $locator->getRecord(DIRNAME_ELEMENTS . '/foo');
+    }
+
+    public function testExplicitTwigRequestOnlyChecksTwig()
+    {
+        $fileLocator = $this->createMock(FileLocator::class);
+        $fileLocator->expects($this->once())
+            ->method('getFilesystem')
+            ->willReturn(new Filesystem());
+        $location = new TemplateVariantTestLocation('custom', [
+            DIRNAME_ELEMENTS . '/foo.html.twig' => true,
+            DIRNAME_ELEMENTS . '/foo.php' => true,
+        ]);
+        $fileLocator->expects($this->once())
+            ->method('getSearchLocations')
+            ->willReturn([$location]);
+
+        $locator = new TemplateVariantLocator($fileLocator);
+        $record = $locator->getRecord(DIRNAME_ELEMENTS . '/foo.html.twig');
+
+        $this->assertEquals('/custom/' . DIRNAME_ELEMENTS . '/foo.html.twig', $record->getFile());
+        $this->assertSame([DIRNAME_ELEMENTS . '/foo.html.twig'], $location->getLookups());
+    }
+
+    public function testPhpRequestPrefersExistingTwigVariantWithinSameLocation()
+    {
+        $fileLocator = $this->createMock(FileLocator::class);
+        $fileLocator->expects($this->once())
+            ->method('getFilesystem')
+            ->willReturn(new Filesystem());
+        $location = new TemplateVariantTestLocation('custom', [
+            DIRNAME_ELEMENTS . '/foo.html.twig' => true,
+            DIRNAME_ELEMENTS . '/foo.php' => true,
+        ]);
+        $fileLocator->expects($this->once())
+            ->method('getSearchLocations')
+            ->willReturn([$location]);
+
+        $locator = new TemplateVariantLocator($fileLocator);
+        $record = $locator->getRecord(DIRNAME_ELEMENTS . '/foo.php');
+
+        $this->assertEquals('/custom/' . DIRNAME_ELEMENTS . '/foo.html.twig', $record->getFile());
+        $this->assertSame([DIRNAME_ELEMENTS . '/foo.html.twig'], $location->getLookups());
+    }
+
+    public function testPhpRequestFallsBackToExistingPhpVariantWithinSameLocation()
+    {
+        $fileLocator = $this->createMock(FileLocator::class);
+        $fileLocator->expects($this->once())
+            ->method('getFilesystem')
+            ->willReturn(new Filesystem());
+        $location = new TemplateVariantTestLocation('custom', [
+            DIRNAME_ELEMENTS . '/foo.php' => true,
+        ]);
+        $fileLocator->expects($this->once())
+            ->method('getSearchLocations')
+            ->willReturn([$location]);
+
+        $locator = new TemplateVariantLocator($fileLocator);
+        $record = $locator->getRecord(DIRNAME_ELEMENTS . '/foo.php');
+
+        $this->assertEquals('/custom/' . DIRNAME_ELEMENTS . '/foo.php', $record->getFile());
+        $this->assertSame([DIRNAME_ELEMENTS . '/foo.html.twig', DIRNAME_ELEMENTS . '/foo.php'], $location->getLookups());
+    }
+
+    public function testPhpRequestFallsBackToRequestedPhpRecordWhenNothingExistsInWinningLocation()
+    {
+        $fileLocator = $this->createMock(FileLocator::class);
+        $fileLocator->expects($this->once())
+            ->method('getFilesystem')
+            ->willReturn(new Filesystem());
+        $location = new TemplateVariantTestLocation('package-like', [
+            DIRNAME_ELEMENTS . '/foo.html.twig' => false,
+            DIRNAME_ELEMENTS . '/foo.php' => false,
+        ]);
+        $fileLocator->expects($this->once())
+            ->method('getSearchLocations')
+            ->willReturn([$location]);
+
+        $locator = new TemplateVariantLocator($fileLocator);
+        $record = $locator->getRecord(DIRNAME_ELEMENTS . '/foo.php');
+
+        $this->assertEquals('/package-like/' . DIRNAME_ELEMENTS . '/foo.php', $record->getFile());
+        $this->assertSame([DIRNAME_ELEMENTS . '/foo.html.twig', DIRNAME_ELEMENTS . '/foo.php'], $location->getLookups());
+    }
+
+    public function testHigherPriorityFallbackBeatsLowerPriorityExistingLocation()
+    {
+        $fileLocator = $this->createMock(FileLocator::class);
+        $fileLocator->expects($this->once())
+            ->method('getFilesystem')
+            ->willReturn(new Filesystem());
+        $highPriority = new TemplateVariantTestLocation('package-like', [
+            DIRNAME_ELEMENTS . '/foo.php' => false,
+        ]);
+        $lowPriority = new TemplateVariantTestLocation('core-like', [
+            DIRNAME_ELEMENTS . '/foo.php' => true,
+        ]);
+        $fileLocator->expects($this->once())
+            ->method('getSearchLocations')
+            ->willReturn([$highPriority, $lowPriority]);
+
+        $locator = new TemplateVariantLocator($fileLocator);
+        $record = $locator->getRecord(DIRNAME_ELEMENTS . '/foo.php');
+
+        $this->assertEquals('/package-like/' . DIRNAME_ELEMENTS . '/foo.php', $record->getFile());
+        $this->assertSame([DIRNAME_ELEMENTS . '/foo.html.twig', DIRNAME_ELEMENTS . '/foo.php'], $highPriority->getLookups());
+        $this->assertSame([], $lowPriority->getLookups());
+    }
+
+    public function testApplicationExistingTemplateBeatsPackageFallback()
+    {
+        $filesystem = $this->getMockBuilder(Filesystem::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $filesystem->expects($this->once())
+            ->method('exists')
+            ->willReturnMap([
+                [DIR_APPLICATION . '/' . DIRNAME_ELEMENTS . '/foo.html.twig', true],
+            ]);
+
+        $fileLocator = $this->app->make(FileLocator::class);
+        $fileLocator->setFilesystem($filesystem);
+        $fileLocator->addPackageLocation('awesome');
+
+        $record = (new TemplateVariantLocator($fileLocator))->getRecord(DIRNAME_ELEMENTS . '/foo.php');
+
+        $this->assertEquals(DIR_APPLICATION . '/' . DIRNAME_ELEMENTS . '/foo.html.twig', $record->getFile());
+        $this->assertTrue($record->exists());
+    }
+
+    public function testThemeExistingTemplateBeatsPackageFallback()
+    {
+        $theme = $this->getMockBuilder(Theme::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $theme->expects($this->any())
+            ->method('getThemeHandle')
+            ->willReturn('brilliant');
+        $theme->expects($this->once())
+            ->method('getPackageHandle')
+            ->willReturn('brilliant_theme');
+
+        $filesystem = $this->getMockBuilder(Filesystem::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $filesystem->expects($this->exactly(3))
+            ->method('exists')
+            ->willReturnMap([
+                [DIR_APPLICATION . '/' . DIRNAME_ELEMENTS . '/foo.html.twig', false],
+                [DIR_APPLICATION . '/' . DIRNAME_ELEMENTS . '/foo.php', false],
+                [DIR_PACKAGES . '/brilliant_theme/themes/brilliant/' . DIRNAME_ELEMENTS . '/foo.html.twig', true],
+            ]);
+
+        $fileLocator = $this->app->make(FileLocator::class);
+        $fileLocator->setFilesystem($filesystem);
+        $fileLocator->addLocation(new FileLocator\ThemeElementLocation($theme));
+        $fileLocator->addPackageLocation('awesome');
+
+        $record = (new TemplateVariantLocator($fileLocator))->getRecord(DIRNAME_ELEMENTS . '/foo.php');
+
+        $this->assertEquals(DIR_PACKAGES . '/brilliant_theme/themes/brilliant/' . DIRNAME_ELEMENTS . '/foo.html.twig', $record->getFile());
+        $this->assertTrue($record->exists());
+    }
+
+    public function testPackageFallbackBeatsCoreCandidateForLegacyTraversalPath()
+    {
+        $request = DIRNAME_ELEMENTS . '/../blocks/html/templates/safe_2/view.php';
+        $filesystem = $this->getMockBuilder(Filesystem::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $filesystem->expects($this->exactly(4))
+            ->method('exists')
+            ->willReturnMap([
+                [DIR_APPLICATION . '/' . DIRNAME_ELEMENTS . '/../blocks/html/templates/safe_2/view.html.twig', false],
+                [DIR_APPLICATION . '/' . DIRNAME_ELEMENTS . '/../blocks/html/templates/safe_2/view.php', false],
+                [DIR_PACKAGES . '/awesome/' . DIRNAME_ELEMENTS . '/../blocks/html/templates/safe_2/view.html.twig', false],
+                [DIR_PACKAGES . '/awesome/' . DIRNAME_ELEMENTS . '/../blocks/html/templates/safe_2/view.php', false],
+            ]);
+
+        $fileLocator = $this->app->make(FileLocator::class);
+        $fileLocator->setFilesystem($filesystem);
+        $fileLocator->addPackageLocation('awesome');
+
+        $record = (new TemplateVariantLocator($fileLocator))->getRecord($request);
+
+        $this->assertEquals(DIR_PACKAGES . '/awesome/' . DIRNAME_ELEMENTS . '/../blocks/html/templates/safe_2/view.php', $record->getFile());
+        $this->assertFalse($record->exists());
+    }
+}
+
+final class TemplateVariantTestLocation implements LocationInterface
+{
+    /**
+     * @var string
+     */
+    private $name;
+
+    /**
+     * @var array<string, bool>
+     */
+    private $responses;
+
+    /**
+     * @var Filesystem|null
+     */
+    private $filesystem;
+
+    /**
+     * @var string[]
+     */
+    private $lookups = [];
+
+    /**
+     * @param array<string, bool> $responses
+     */
+    public function __construct(string $name, array $responses)
+    {
+        $this->name = $name;
+        $this->responses = $responses;
+    }
+
+    public function getCacheKey()
+    {
+        return $this->name;
+    }
+
+    public function setFilesystem(Filesystem $filesystem)
+    {
+        $this->filesystem = $filesystem;
+    }
+
+    public function contains($file)
+    {
+        $this->lookups[] = $file;
+        if (!array_key_exists($file, $this->responses)) {
+            return false;
+        }
+
+        $record = new Record($this->filesystem ?? new Filesystem());
+        $record->setFile('/' . $this->name . '/' . $file);
+        $record->setUrl('/' . $this->name . '/' . $file);
+        $record->setExists($this->responses[$file]);
+
+        return $record;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getLookups(): array
+    {
+        return $this->lookups;
+    }
+}


### PR DESCRIPTION
This pull request introduces a new `TemplateVariantLocator` class to centralize and standardize the logic for resolving PHP/Twig template variants, and refactors the codebase to use this new class in place of custom or ad-hoc template resolution logic. 

This change ensures that when a template is requested, the system will prefer Twig (`.html.twig`) templates over PHP (`.php`) templates where both exist, while preserving legacy compatibility. Additionally, the `FileLocator` class is refactored to separate location ordering logic and simplify its API.

The problem here is that our new Twig templating addition to FileLocator didn't preserve some of the more exotic qualities (that were intentional) of the existing FileLocator. Namely, PackageLocation should be preserved if present, even if the file in question doesn't appear to exist. Changing this behavior caused issues with more exotic uses of the library. These uses weren't necessarily intended as is, but the horse has left the barn there.

Should resolve #12887