### PR TITLE
Let theme area classes use a `*` wildcard and inherit through nested sub-areas

### DIFF
--- a/concrete/src/Area/Area.php
+++ b/concrete/src/Area/Area.php
@@ -301,6 +301,18 @@ class Area extends ConcreteObject implements \Concrete\Core\Permission\ObjectInt
     }
 
     /**
+     * Returns the handle of the top-level area this area belongs to. A
+     * top-level or global area is its own root; sub-areas resolve to the
+     * page-template area they ultimately descend from.
+     *
+     * @return string
+     */
+    public function getTopLevelAreaHandle()
+    {
+        return $this->getAreaHandle();
+    }
+
+    /**
      * Returns the total number of blocks in an area.
      *
      * @param Page $c must be passed if the display() method has not been run on the area object yet.

--- a/concrete/src/Area/SubArea.php
+++ b/concrete/src/Area/SubArea.php
@@ -95,6 +95,30 @@ class SubArea extends Area
         return $this->arParentID;
     }
 
+    /**
+     * Walk up the parent chain so the top-level (page-template) area handle
+     * is returned, not the dynamic composite handle of an intermediate
+     * sub-area. A broken parent chain falls back to the last handle reached.
+     *
+     * @return string
+     */
+    public function getTopLevelAreaHandle()
+    {
+        $db = Loader::db();
+        $arHandle = $this->getAreaHandle();
+        $arParentID = $this->arParentID;
+        while ($arParentID > 0) {
+            $row = $db->GetRow('select arHandle, arParentID from Areas where arID = ?', array($arParentID));
+            if (!$row) {
+                break;
+            }
+            $arHandle = $row['arHandle'];
+            $arParentID = $row['arParentID'];
+        }
+
+        return $arHandle;
+    }
+
     public function getAreaCustomTemplates($include_parent_templates = true)
     {
         $these_templates = parent::getAreaCustomTemplates();

--- a/concrete/views/dialogs/area/design.php
+++ b/concrete/views/dialogs/area/design.php
@@ -5,18 +5,11 @@ defined('C5_EXECUTE') or die("Access Denied.");
 $pt = $c->getCollectionThemeObject();
 
 $areaClasses = $pt->getThemeAreaClasses();
-$customClasses = array();
+$areaHandle = $a->getTopLevelAreaHandle();
+$customClasses = $areaClasses[$areaHandle] ?? [];
 
-// Use the area handle as the key to map against area classes
-$areaHandle = $a->getAreaHandle();
-
-// If its a SubArea, find the parent handle and use that
-if ($a instanceof \Concrete\Core\Area\SubArea) {
-    $areaHandle = \Concrete\Core\Area\Area::getAreaHandleFromID($a->getAreaParentID());
-}
-
-if (isset($areaClasses[$areaHandle])) {
-    $customClasses = $areaClasses[$areaHandle];
+if (isset($areaClasses['*'])) {
+    $customClasses = array_unique(array_merge($customClasses, $areaClasses['*']));
 }
 
 $gf = $pt->getThemeGridFrameworkObject();


### PR DESCRIPTION
Fixes #12912

`getThemeBlockClasses()` lets a theme apply classes to every block with a `*` key, and the block design dialog merges that on top of the block-type list. The area side had neither half: `getThemeAreaClasses()` only ever matched an exact area handle, and for sub-areas it looked at the immediate parent only — so a `*` wasn't possible and a container-in-a-container's design dialog came up empty because the immediate parent is a composite handle like `Main : 5 : Body`, never a theme key.

This adds `Area::getTopLevelAreaHandle()` — a top-level or global area returns its own handle; `SubArea` overrides it to walk `arParentID` up to the root, the same way `getSubAreaParentPermissionsObject()` already walks for permission inheritance. The area design dialog calls that and then merges a `*` key, so it now lines up with the block dialog. The old `instanceof SubArea` branch goes away.

Net effect: a `*` in `getThemeAreaClasses()` reaches every area, and a named top-level area's classes reach its sub-areas at any nesting depth. Behavior for top-level areas and first-level sub-areas is unchanged. The methods only populate the design-palette dropdown, so this is a discoverability fix — manually-set classes were never affected.

Tested on Atomik with a `*` key plus a named top-level area: top-level areas, first-level sub-areas, and nested container-in-container sub-areas all resolve the inherited and wildcard classes (checked against both `Main` and `Page Header`).
