### PR TITLE
Fix minor migration issues

### DIFF
--- a/concrete/src/Updater/Migrations/Migrations/Version20150616000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20150616000000.php
@@ -19,7 +19,7 @@ class Version20150616000000 extends AbstractMigration implements RepeatableMigra
             'Stacks',
         ]);
 
-        if (\Core::make('multilingual/detector')->isEnabled()) {
+        if (\Core::make('multilingual/detector')->isEnabled() && method_exists(StackList::class, 'rescanMultilingualStacks')) {
             StackList::rescanMultilingualStacks();
         }
     }

--- a/concrete/src/Updater/Migrations/Migrations/Version20150619000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20150619000000.php
@@ -14,7 +14,9 @@ class Version20150619000000 extends AbstractMigration implements RepeatableMigra
      */
     public function upgradeDatabase()
     {
-        $this->deleteInvalidForeignKey('AreaLayoutsUsingPresets', 'arLayoutID', 'AreaLayouts', 'arLayoutID');
+        if ($this->connection->getSchemaManager()->tablesExist(['AreaLayoutsUsingPresets'])) {
+            $this->deleteInvalidForeignKey('AreaLayoutsUsingPresets', 'arLayoutID', 'AreaLayouts', 'arLayoutID');
+        }
         $this->refreshDatabaseTables([
             'AreaLayouts',
             'AreaLayoutsUsingPresets',

--- a/concrete/src/Updater/Migrations/Migrations/Version20160725000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20160725000000.php
@@ -1160,7 +1160,9 @@ class Version20160725000000 extends AbstractMigration implements LongRunningMigr
         // Delete members page if profiles not enabled
         if (!\Config::get('concrete.user.profiles_enabled')) {
             $c = \Page::getByPath('/members');
-            $c->moveToTrash();
+            if ($c && !$c->isError()) {
+                $c->moveToTrash();
+            }
         }
     }
 

--- a/concrete/src/Updater/Migrations/Migrations/Version20210729191135.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20210729191135.php
@@ -19,6 +19,7 @@ final class Version20210729191135 extends AbstractMigration implements Repeatabl
         $marketplaceExists = $db->fetchOne("select count(*) from PermissionKeyCategories where pkCategoryHandle = 'marketplace'");
         $marketplaceNewsflowExists = $db->fetchOne("select count(*) from PermissionKeyCategories where pkCategoryHandle = 'marketplace_newsflow'");
         if ($marketplaceExists && $marketplaceNewsflowExists) {
+            $db->executeStatement("update PermissionKeys set pkCategoryID = (select pkCategoryID from PermissionKeyCategories where pkCategoryHandle = 'marketplace') where pkCategoryID = (select pkCategoryID from PermissionKeyCategories where pkCategoryHandle = 'marketplace_newsflow')");
             $db->executeStatement("delete from PermissionKeyCategories where pkCategoryHandle = 'marketplace_newsflow'");
         } elseif ($marketplaceNewsflowExists) {
             $db->executeStatement("update PermissionKeyCategories set pkCategoryHandle = 'marketplace' where pkCategoryHandle = 'marketplace_newsflow'");

--- a/concrete/src/Updater/Migrations/Migrations/Version20210729191135.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20210729191135.php
@@ -14,9 +14,15 @@ final class Version20210729191135 extends AbstractMigration implements Repeatabl
         $db = $this->connection;
         $db->executeStatement('update BlockTypes set btHandle = "desktop_concrete_latest", btName = "Desktop Concrete Latest" where btHandle = "desktop_newsflow_latest"');
         if ($db->tableExists('btDesktopNewsflowLatest') && !$db->tableExists('btDesktopConcreteLatest')) {
-            $this->connection->execute(sprintf('alter table %s rename %s', 'btDesktopNewsflowLatest', 'btDesktopConcreteLatest'));
+            $this->connection->executeStatement(sprintf('alter table %s rename %s', 'btDesktopNewsflowLatest', 'btDesktopConcreteLatest'));
         }
-        $this->connection->executeStatement("update PermissionKeyCategories set pkCategoryHandle = 'marketplace' where pkCategoryHandle = 'marketplace_newsflow'");
+        $marketplaceExists = $db->fetchOne("select count(*) from PermissionKeyCategories where pkCategoryHandle = 'marketplace'");
+        $marketplaceNewsflowExists = $db->fetchOne("select count(*) from PermissionKeyCategories where pkCategoryHandle = 'marketplace_newsflow'");
+        if ($marketplaceExists && $marketplaceNewsflowExists) {
+            $db->executeStatement("delete from PermissionKeyCategories where pkCategoryHandle = 'marketplace_newsflow'");
+        } elseif ($marketplaceNewsflowExists) {
+            $db->executeStatement("update PermissionKeyCategories set pkCategoryHandle = 'marketplace' where pkCategoryHandle = 'marketplace_newsflow'");
+        }
         $db->executeStatement('update AuthenticationTypes set authTypeHandle = "external_concrete", authTypeName = "External Concrete" where authTypeHandle = "external_concrete5"');
         $db->executeStatement('update OauthUserMap set namespace = "external_concrete" where namespace="external_concrete5"');
     }


### PR DESCRIPTION
I'm currently trying to upgrade a 5.7 website to 9.4.8.
I've fixed some minor migration issues:

- Can't move /member page when it does not exist
- Do not run `StackList::rescanMultilingualStacks()` when it already removed. See b4c2f728612918356544ec7cd254f8ff4301b34a
- Do not check an invalid foreign key when the table does not exist
- Fix "Duplicate entry 'marketplace' for key 'PermissionKeyCategories.pkCategoryHandle'" error

I encountered one more issue during the upgrade, but it hasn't been fixed yet because I thought we needed to discuss it. See #12914