### PR TITLE
Prevent duplicate composer controls from causing a publish hang

### DIFF
--- a/concrete/src/Page/Type/Composer/Control/Control.php
+++ b/concrete/src/Page/Type/Composer/Control/Control.php
@@ -2,6 +2,7 @@
 
 namespace Concrete\Core\Page\Type\Composer\Control;
 
+use Concrete\Core\Error\UserMessageException;
 use Concrete\Core\Page\Type\Type;
 use Loader;
 use Concrete\Core\Foundation\ConcreteObject;
@@ -198,6 +199,19 @@ abstract class Control extends ConcreteObject
      */
     public function addToPageTypeComposerFormLayoutSet(PageTypeComposerFormLayoutSet $set)
     {
+        $pageType = $set->getPageTypeObject();
+        if ($pageType !== null) {
+            foreach (static::getList($pageType) as $existing) {
+                if ($existing->getPageTypeComposerControlTypeHandle() === $this->getPageTypeComposerControlTypeHandle()
+                    && (string) $existing->getPageTypeComposerControlIdentifier() === (string) $this->getPageTypeComposerControlIdentifier()
+                ) {
+                    throw new UserMessageException(
+                        t('This control has already been added to this page type.')
+                    );
+                }
+            }
+        }
+
         $db = Loader::db();
         $displayOrder = $db->GetOne('select count(ptComposerFormLayoutSetControlID) from PageTypeComposerFormLayoutSetControls where ptComposerFormLayoutSetID = ?', array($set->getPageTypeComposerFormLayoutSetID()));
         if (!$displayOrder) {
@@ -231,10 +245,16 @@ abstract class Control extends ConcreteObject
     {
         $sets = PageTypeComposerFormLayoutSet::getList($pagetype);
         $controls = array();
+        $seen = array();
         foreach ($sets as $s) {
             $setControls = PageTypeComposerFormLayoutSetControl::getList($s);
             foreach ($setControls as $sc) {
                 $cnt = $sc->getPageTypeComposerControlObject();
+                $key = $cnt->getPageTypeComposerControlTypeHandle() . ':' . $cnt->getPageTypeComposerControlIdentifier();
+                if (isset($seen[$key])) {
+                    continue;
+                }
+                $seen[$key] = true;
                 $cnt->setPageTypeComposerFormLayoutSetControlObject($sc);
                 $cnt->setPageTypeComposerFormControlRequired($sc->isPageTypeComposerFormLayoutSetControlRequired());
                 $controls[] = $cnt;


### PR DESCRIPTION
## Problem

Adding the same attribute (or block/core page property) twice to a page type's composer form causes a hang on publish, resulting in a 504 Gateway Timeout.

When a duplicate control exists, `saveForm()` iterates the result of `Control::getList()` and calls `publishToPage()` for each. This triggers `setAttribute()` twice for the same `(cID, cvID, akID)` combination on the same database connection, causing a MySQL deadlock / indefinite wait.

While collection attributes are the most dangerous case, the bug is not specific to any single attribute type. It can be triggered by any control type added more than once across any sets of the same page type.

## Fix

- **Prevention:** `addToPageTypeComposerFormLayoutSet()` now checks whether a control with the same type handle and identifier already exists in any set for the page type before inserting. If a duplicate is found, it throws a `UserMessageException`, preventing new duplicates from being created via the UI.
- **Mitigation:** `getList()` now deduplicates results by a `typeHandle:identifier` key. This ensures that sites with pre-existing duplicate rows in `PageTypeComposerFormLayoutSetControls` are immediately protected from the hang without requiring a database migration.

## How to Reproduce

1. Go to **Dashboard** -> **Pages & Themes** -> **Page Types** -> **[Any Type]** -> **Form**.
2. Add the same attribute twice (e.g., add "Navbar Style" to two different sets).
3. Create a new page of that type via the composer and publish it.
4. Observe that the request hangs indefinitely (504).

*Note: Removing one of the duplicate controls resolves the hang immediately.*