### PR TITLE
Update symfony/yaml version to ^5

### DIFF
--- a/concrete/composer.json
+++ b/concrete/composer.json
@@ -57,7 +57,7 @@
     "symfony/messenger": "^5.2",
     "symfony/serializer": "^5.2",
     "symfony/service-contracts": "^2.5",
-    "symfony/yaml":"^4",
+    "symfony/yaml":"^5",
     "scssphp/scssphp": "^1.4",
     "doctrine/annotations": "^1.13.2",
     "doctrine/dbal": "^2.13.2",


### PR DESCRIPTION
Updated symfony/yaml dependency version from ^4 to ^5.
The latest release supports PHP 7.2+ and the changelogs don't specify anything too radical: 
- https://github.com/symfony/yaml/blob/v5.4.52/composer.json#L19
- https://github.com/symfony/yaml/blob/v5.4.52/CHANGELOG.md