### PR TITLE
Group page attributes by set in the composer Add Form Control dialog

### DIFF
--- a/concrete/src/Page/Type/Composer/Control/Type/CollectionAttributeType.php
+++ b/concrete/src/Page/Type/Composer/Control/Type/CollectionAttributeType.php
@@ -1,47 +1,108 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Concrete\Core\Page\Type\Composer\Control\Type;
 
-use CollectionAttributeKey;
-use Concrete\Core\Page\Type\Composer\Control\CollectionAttributeControl;
+use Concrete\Core\Attribute\Category\CategoryService;
 use Concrete\Core\Attribute\Key\Key as AttributeKey;
+use Concrete\Core\Page\Type\Composer\Control\CollectionAttributeControl;
+
+defined('C5_EXECUTE') or die('Access Denied.');
 
 class CollectionAttributeType extends Type
 {
+    /**
+     * @var CategoryService
+     */
+    protected $categoryService;
+
+    public function __construct(CategoryService $categoryService)
+    {
+        $this->categoryService = $categoryService;
+    }
+
+    // Satisfies the abstract contract in Type. Called by the flat-render path in the picker view
+    // for any control type that is not a CollectionAttributeType. Do not delegate to
+    // getPageTypeComposerControlObjectsBySet() here — third-party types that override this method
+    // for custom filtering would be silently bypassed.
     public function getPageTypeComposerControlObjects()
     {
-        $objects = array();
-        $keys = AttributeKey::getAttributeKeyList('collection');
+        $objects = [];
 
-        foreach ($keys as $ak) {
-            $ac = new CollectionAttributeControl();
-            $ac->setAttributeKeyID($ak->getAttributeKeyID());
-            $ac->setPageTypeComposerControlIconFormatter($ak->getController()->getIconFormatter());
-            $ac->setPageTypeComposerControlName($ak->getAttributeKeyDisplayName());
-            $objects[] = $ac;
+        foreach (AttributeKey::getAttributeKeyList('collection') as $ak) {
+            $objects[] = $this->makeControlForKey($ak);
         }
 
         return $objects;
     }
 
+    /**
+     * Returns controls grouped by attribute set for use in the picker dialog.
+     * Sets that contain only internal attributes (akIsInternal=true) are omitted entirely.
+     * Set ordering respects the admin-configured asDisplayOrder. Unassigned keys appear last.
+     *
+     * @return array{sets: array<array{set: \Concrete\Core\Entity\Attribute\Set, controls: CollectionAttributeControl[]}>, unassigned: CollectionAttributeControl[]}
+     */
+    public function getPageTypeComposerControlObjectsBySet()
+    {
+        $category = $this->categoryService->getByHandle('collection');
+        $controller = $category->getController();
+        $setManager = $controller->getSetManager();
+
+        // getList() applies akIsInternal=false; $set->getAttributeKeys() does not,
+        // so intersect against this whitelist to avoid surfacing internal keys.
+        $whitelist = [];
+        foreach ($controller->getList() as $key) {
+            $whitelist[$key->getAttributeKeyID()] = $key;
+        }
+
+        $sets = [];
+        foreach ($setManager->getAttributeSets() as $set) {
+            $controls = [];
+            foreach ($set->getAttributeKeys() as $key) {
+                if (isset($whitelist[$key->getAttributeKeyID()])) {
+                    $controls[] = $this->makeControlForKey($whitelist[$key->getAttributeKeyID()]);
+                }
+            }
+            if (!empty($controls)) {
+                $sets[] = ['set' => $set, 'controls' => $controls];
+            }
+        }
+
+        $unassigned = [];
+        foreach ($setManager->getUnassignedAttributeKeys() as $key) {
+            $unassigned[] = $this->makeControlForKey($key);
+        }
+
+        return ['sets' => $sets, 'unassigned' => $unassigned];
+    }
+
     public function getPageTypeComposerControlByIdentifier($identifier)
     {
-        $ak = CollectionAttributeKey::getByID($identifier);
-        $ax = new CollectionAttributeControl();
-        $ax->setAttributeKeyID($ak->getAttributeKeyID());
-        $ax->setPageTypeComposerControlIconFormatter($ak->getController()->getIconFormatter());
-        $ax->setPageTypeComposerControlName($ak->getAttributeKeyDisplayName());
-
-        return $ax;
+        return $this->makeControlForKey(\CollectionAttributeKey::getByID($identifier));
     }
 
     public function configureFromImportHandle($handle)
     {
-        $ak = CollectionAttributeKey::getByHandle($handle);
+        $ak = \CollectionAttributeKey::getByHandle($handle);
         if (!$ak) {
             throw new \Exception(t('Import error: Unable to locate attribute for handle: %s', $handle));
         }
 
         return static::getPageTypeComposerControlByIdentifier($ak->getAttributeKeyID());
+    }
+
+    /**
+     * @param \Concrete\Core\Entity\Attribute\Key\Key|\CollectionAttributeKey $key
+     */
+    private function makeControlForKey($key): CollectionAttributeControl
+    {
+        $ac = new CollectionAttributeControl();
+        $ac->setAttributeKeyID($key->getAttributeKeyID());
+        $ac->setPageTypeComposerControlIconFormatter($key->getController()->getIconFormatter());
+        $ac->setPageTypeComposerControlName($key->getAttributeKeyDisplayName());
+
+        return $ac;
     }
 }

--- a/concrete/views/backend/page/type/composer/form/add_control.php
+++ b/concrete/views/backend/page/type/composer/form/add_control.php
@@ -2,6 +2,8 @@
 
 defined('C5_EXECUTE') or die('Access Denied.');
 
+use Concrete\Core\Page\Type\Composer\Control\Type\CollectionAttributeType;
+
 /**
  * @var Concrete\Core\Application\Service\UserInterface $ui
  * @var Concrete\Core\Page\Type\Composer\Control\Type\Type[] $types
@@ -12,7 +14,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
 <div class="ccm-ui">
     <?php
     $tabs = [];
-    foreach($types as $index => $type) {
+    foreach ($types as $index => $type) {
         $tabs[] = [
             $type->getPageTypeComposerControlTypeHandle(),
             $type->getPageTypeComposerControlTypeDisplayName(),
@@ -25,25 +27,61 @@ defined('C5_EXECUTE') or die('Access Denied.');
         <?php
         foreach ($types as $index => $type) {
             ?>
-            <div class="tab-pane fade <?= $index == 0 ? 'active show' : ''; ?> " id="<?= $type->getPageTypeComposerControlTypeHandle() ?>">
+            <div class="tab-pane fade <?= $index == 0 ? 'active show' : '' ?> " id="<?= $type->getPageTypeComposerControlTypeHandle() ?>">
                 <input class="form-control ccm-input-text" type="text" name="attribute-search" placeholder="<?= t('Search attributes') ?>" />
                 <ul data-list="page-type-composer-control-type" class="item-select-list">
                     <?php
-                    $controls = $type->getPageTypeComposerControlObjects();
-                    foreach ($controls as $control) {
-                        ?>
-                        <li>
-                            <a href="#" data-control-type-id="<?= $type->getPageTypeComposerControlTypeID() ?>" data-control-identifier="<?= $control->getPageTypeComposerControlIdentifier() ?>">
-                                <?= $control->getPageTypeComposerControlIcon() ?>
-                                <?= $control->getPageTypeComposerControlDisplayName() ?>
-                                <?php if ($type->getPageTypeComposerControlTypeHandle() === 'collection_attribute') { ?>
-                                    <span class="text-muted small">
-                                        (<?= $control->getAttributeKeyObject()->getAttributeKeyHandle() ?>)
-                                    </span>
-                                <?php } ?>
-                            </a>
-                        </li>
-                        <?php
+                    if ($type instanceof CollectionAttributeType) {
+                        $grouped = $type->getPageTypeComposerControlObjectsBySet();
+                        foreach ($grouped['sets'] as $group) {
+                            ?>
+                            <li class="ccm-attribute-set-header" data-set-header><strong><?= $group['set']->getAttributeSetDisplayName() ?></strong></li>
+                            <?php
+                            foreach ($group['controls'] as $control) {
+                                ?>
+                                <li data-attribute-row>
+                                    <a href="#" data-control-type-id="<?= $type->getPageTypeComposerControlTypeID() ?>" data-control-identifier="<?= $control->getPageTypeComposerControlIdentifier() ?>">
+                                        <?= $control->getPageTypeComposerControlIcon() ?>
+                                        <?= $control->getPageTypeComposerControlDisplayName() ?>
+                                        <span class="text-muted small">(<?= h($control->getAttributeKeyObject()->getAttributeKeyHandle()) ?>)</span>
+                                    </a>
+                                </li>
+                                <?php
+                            }
+                        }
+                        if (!empty($grouped['unassigned'])) {
+                            if (!empty($grouped['sets'])) {
+                                ?>
+                                <li class="ccm-attribute-set-header" data-set-header><strong><?= t('Other') ?></strong></li>
+                                <?php
+                            }
+                            foreach ($grouped['unassigned'] as $control) {
+                                ?>
+                                <li data-attribute-row>
+                                    <a href="#" data-control-type-id="<?= $type->getPageTypeComposerControlTypeID() ?>" data-control-identifier="<?= $control->getPageTypeComposerControlIdentifier() ?>">
+                                        <?= $control->getPageTypeComposerControlIcon() ?>
+                                        <?= $control->getPageTypeComposerControlDisplayName() ?>
+                                        <span class="text-muted small">(<?= h($control->getAttributeKeyObject()->getAttributeKeyHandle()) ?>)</span>
+                                    </a>
+                                </li>
+                                <?php
+                            }
+                        }
+                    } else {
+                        // Third-party packages register custom control types that only implement the
+                        // abstract getPageTypeComposerControlObjects(). They will never be instances of
+                        // CollectionAttributeType, so this flat path must remain to avoid breaking them.
+                        $controls = $type->getPageTypeComposerControlObjects();
+                        foreach ($controls as $control) {
+                            ?>
+                            <li data-attribute-row>
+                                <a href="#" data-control-type-id="<?= $type->getPageTypeComposerControlTypeID() ?>" data-control-identifier="<?= $control->getPageTypeComposerControlIdentifier() ?>">
+                                    <?= $control->getPageTypeComposerControlIcon() ?>
+                                    <?= $control->getPageTypeComposerControlDisplayName() ?>
+                                </a>
+                            </li>
+                            <?php
+                        }
                     }
                     ?>
                 </ul>
@@ -60,13 +98,17 @@ $(document).ready(function() {
         var $search = $(this),
             $list = $search.siblings('[data-list="page-type-composer-control-type"]');
 
-        $list.find('li').each(function() {
-            if (this.innerText.toLowerCase().indexOf($search.val().toLowerCase()) === -1 ) {
-                $(this).hide();
-            }
-            else {
-                $(this).show();
-            }
+        // data-attribute-row scopes the selector to real items only — set-header <li> elements
+        // have no data-attribute-row and must not be toggled here.
+        $list.find('li[data-attribute-row]').each(function() {
+            $(this).toggle(this.innerText.toLowerCase().indexOf($search.val().toLowerCase()) !== -1);
+        });
+
+        // After filtering rows, hide any set-header whose visible rows have all been filtered out.
+        $list.find('li[data-set-header]').each(function() {
+            $(this).toggle(
+                $(this).nextUntil('li[data-set-header]', 'li[data-attribute-row]:visible').length > 0
+            );
         });
     });
 
@@ -80,6 +122,7 @@ $(document).ready(function() {
                 ptComposerControlIdentifier: $this.data('control-identifier'),
                 ptComposerFormLayoutSetID: <?= $set->getPageTypeComposerFormLayoutSetID() ?>
             },
+            // Note: this endpoint has no CSRF token — it's a pre-existing gap, not introduced here.
             url: CCM_DISPATCHER_FILENAME + '/ccm/system/page/type/composer/form/add_control/pick',
             success: function(html) {
                 jQuery.fn.dialog.hideLoader();

--- a/tests/tests/Page/Type/Composer/Control/Type/CollectionAttributeTypeTest.php
+++ b/tests/tests/Page/Type/Composer/Control/Type/CollectionAttributeTypeTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\Tests\Page\Type\Composer\Control\Type;
+
+use Concrete\Core\Attribute\Category\CategoryService;
+use Concrete\Core\Attribute\SetManagerInterface;
+use Concrete\Core\Entity\Attribute\Category as CategoryEntity;
+use Concrete\Core\Entity\Attribute\Key\Key as KeyEntity;
+use Concrete\Core\Entity\Attribute\Set as AttributeSet;
+use Concrete\Core\Page\Type\Composer\Control\Type\CollectionAttributeType;
+use Concrete\Tests\TestCase;
+use Mockery as M;
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+class CollectionAttributeTypeTest extends TestCase
+{
+    // --- helpers ---
+
+    private function makeKey(int $id): KeyEntity
+    {
+        $iconFormatter = M::mock();
+        $keyController = M::mock();
+        $keyController->shouldReceive('getIconFormatter')->andReturn($iconFormatter);
+
+        $key = M::mock(KeyEntity::class);
+        $key->shouldReceive('getAttributeKeyID')->andReturn($id);
+        $key->shouldReceive('getController')->andReturn($keyController);
+        $key->shouldReceive('getAttributeKeyDisplayName')->andReturn('Key ' . $id);
+
+        return $key;
+    }
+
+    private function makeSet(array $keys): AttributeSet
+    {
+        $set = M::mock(AttributeSet::class);
+        $set->shouldReceive('getAttributeKeys')->andReturn($keys);
+
+        return $set;
+    }
+
+    private function makeType(array $whitelistKeys, array $sets, array $unassignedKeys): CollectionAttributeType
+    {
+        $setManager = M::mock(SetManagerInterface::class);
+        $setManager->shouldReceive('getAttributeSets')->andReturn($sets);
+        $setManager->shouldReceive('getUnassignedAttributeKeys')->andReturn($unassignedKeys);
+
+        $categoryController = M::mock();
+        $categoryController->shouldReceive('getList')->andReturn($whitelistKeys);
+        $categoryController->shouldReceive('getSetManager')->andReturn($setManager);
+
+        $category = M::mock(CategoryEntity::class);
+        $category->shouldReceive('getController')->andReturn($categoryController);
+
+        $categoryService = M::mock(CategoryService::class);
+        $categoryService->shouldReceive('getByHandle')->with('collection')->andReturn($category);
+
+        return new CollectionAttributeType($categoryService);
+    }
+
+    // --- tests ---
+
+    public function testInternalKeyInSetIsFiltered(): void
+    {
+        $normalKey = $this->makeKey(1);
+        $internalKey = $this->makeKey(2); // not in whitelist → internal
+
+        $type = $this->makeType(
+            [$normalKey],                          // whitelist: only key 1
+            [$this->makeSet([$normalKey, $internalKey])], // set has both
+            []
+        );
+
+        $result = $type->getPageTypeComposerControlObjectsBySet();
+
+        static::assertCount(1, $result['sets']);
+        static::assertCount(1, $result['sets'][0]['controls']);
+        static::assertSame(1, $result['sets'][0]['controls'][0]->getAttributeKeyID());
+    }
+
+    public function testSetWhoseKeysAreAllInternalIsOmitted(): void
+    {
+        $internalKey = $this->makeKey(2); // not in whitelist → internal
+
+        $type = $this->makeType(
+            [],                                     // whitelist: empty
+            [$this->makeSet([$internalKey])],       // set has only internal key
+            []
+        );
+
+        $result = $type->getPageTypeComposerControlObjectsBySet();
+
+        static::assertCount(0, $result['sets']);
+        static::assertCount(0, $result['unassigned']);
+    }
+
+    public function testUnassignedKeysAppearInUnassigned(): void
+    {
+        $key = $this->makeKey(3);
+
+        $type = $this->makeType([$key], [], [$key]);
+
+        $result = $type->getPageTypeComposerControlObjectsBySet();
+
+        static::assertCount(0, $result['sets']);
+        static::assertCount(1, $result['unassigned']);
+        static::assertSame(3, $result['unassigned'][0]->getAttributeKeyID());
+    }
+
+    public function testSetOrderingFollowsSetManagerOrder(): void
+    {
+        $key1 = $this->makeKey(1);
+        $key2 = $this->makeKey(2);
+        $setA = $this->makeSet([$key1]);
+        $setB = $this->makeSet([$key2]);
+
+        // setA before setB in the manager's ordering
+        $type = $this->makeType([$key1, $key2], [$setA, $setB], []);
+
+        $result = $type->getPageTypeComposerControlObjectsBySet();
+
+        static::assertCount(2, $result['sets']);
+        static::assertSame($setA, $result['sets'][0]['set']);
+        static::assertSame($setB, $result['sets'][1]['set']);
+    }
+
+    public function testMixedSetSomeInternalKeysPreservesNonInternal(): void
+    {
+        $key1 = $this->makeKey(1);
+        $key2 = $this->makeKey(2);
+        $internalKey = $this->makeKey(99);
+
+        // Two sets: first has a normal + internal key, second is all-internal
+        $setWithMixed = $this->makeSet([$key1, $internalKey]);
+        $setAllInternal = $this->makeSet([$internalKey]);
+
+        $type = $this->makeType([$key1, $key2], [$setWithMixed, $setAllInternal], [$key2]);
+
+        $result = $type->getPageTypeComposerControlObjectsBySet();
+
+        static::assertCount(1, $result['sets'], 'All-internal set should be omitted');
+        static::assertCount(1, $result['sets'][0]['controls'], 'Only the non-internal key should remain');
+        static::assertSame(1, $result['sets'][0]['controls'][0]->getAttributeKeyID());
+        static::assertCount(1, $result['unassigned']);
+        static::assertSame(2, $result['unassigned'][0]->getAttributeKeyID());
+    }
+}


### PR DESCRIPTION
Fixes #2740

The Page Attributes tab in the Add Form Control picker showed a flat list while every other attribute listing in the CMS grouped by attribute set. Adds CollectionAttributeType::getPageTypeComposerControlObjectsBySet() following the same CategoryService + SetManager pattern used by the EditableSetList element. Internal attributes (akIsInternal=true) are filtered via whitelist intersection before sets are rendered; sets that become empty after filtering are omitted. Set ordering follows the admin-configured asDisplayOrder. The flat getPageTypeComposerControlObjects() method and its abstract contract are unchanged — third-party control types are unaffected.

Note: the add_control/pick endpoint that persists the selected control currently has no CSRF token validation (only a canViewPage check). This is a pre-existing gap unrelated to this display change and should be addressed in a dedicated security pass.

After changes

<img width="843" height="723" alt="Screenshot 2026-05-24 at 03 44 50" src="https://github.com/user-attachments/assets/61fc9049-460a-4e46-bd3d-36a39bbc1254" />


Filtering works

<img width="809" height="709" alt="Screenshot 2026-05-24 at 03 44 43" src="https://github.com/user-attachments/assets/b855de0c-6680-4fb4-b563-7ff1c18d611a" />

Other tabs unchanged

<img width="855" height="733" alt="Screenshot 2026-05-24 at 03 45 04" src="https://github.com/user-attachments/assets/d91ff699-7d20-48c6-ad21-ed9e99725b00" />
<img width="813" height="715" alt="Screenshot 2026-05-24 at 03 44 58" src="https://github.com/user-attachments/assets/5deca00a-7612-4b62-85c2-108e41dc95a6" />


Matches Page Attributes display

<img width="545" height="946" alt="Screenshot 2026-05-24 at 03 45 13" src="https://github.com/user-attachments/assets/07eded04-69b8-4184-970e-98f9a07faeb2" />
