### PR TITLE
Add package upgrade/uninstall event hooks

### DIFF
--- a/concrete/src/Package/Event/PackageEvent.php
+++ b/concrete/src/Package/Event/PackageEvent.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\Core\Package\Event;
+
+use Concrete\Core\Package\Package;
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+/**
+ * Informational event fired before (on_package_uninstall) and after (on_package_uninstalled) a package is uninstalled.
+ * When on_package_uninstall fires, the package entity is still intact.
+ * When on_package_uninstalled fires, the package row has been deleted — getPackage()->getPackageEntity() returns a detached entity.
+ * To prevent uninstall with an error message, use UninstallEvent with on_package_test_for_uninstall instead.
+ */
+class PackageEvent
+{
+    /**
+     * @var Package
+     */
+    protected $package;
+
+    public function __construct(Package $package)
+    {
+        $this->package = $package;
+    }
+
+    public function getPackage(): Package
+    {
+        return $this->package;
+    }
+}

--- a/concrete/src/Package/Event/PackageEvent.php
+++ b/concrete/src/Package/Event/PackageEvent.php
@@ -9,9 +9,9 @@ use Concrete\Core\Package\Package;
 defined('C5_EXECUTE') or die('Access Denied.');
 
 /**
- * Informational event fired before (on_package_uninstall) and after (on_package_uninstalled) a package is uninstalled.
- * When on_package_uninstall fires, the package entity is still intact.
- * When on_package_uninstalled fires, the package row has been deleted — getPackage()->getPackageEntity() returns a detached entity.
+ * Informational event fired before (on_before_package_uninstall) and after (on_after_package_uninstall) a package is uninstalled.
+ * When on_before_package_uninstall fires, the package entity is still intact.
+ * When on_after_package_uninstall fires, the package row has been deleted — getPackage()->getPackageEntity() returns a detached entity.
  * To prevent uninstall with an error message, use UninstallEvent with on_package_test_for_uninstall instead.
  */
 class PackageEvent

--- a/concrete/src/Package/Event/UninstallEvent.php
+++ b/concrete/src/Package/Event/UninstallEvent.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\Core\Package\Event;
+
+use Concrete\Core\Error\ErrorList\ErrorList;
+use Concrete\Core\Package\Package;
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+/**
+ * Event fired by testForUninstall() as on_package_test_for_uninstall.
+ * Listeners add errors to getError() to block the uninstall with a user-visible message.
+ */
+class UninstallEvent extends PackageEvent
+{
+    /**
+     * @var ErrorList
+     */
+    protected $error;
+
+    public function __construct(Package $package, ErrorList $error)
+    {
+        parent::__construct($package);
+        $this->error = $error;
+    }
+
+    /**
+     * Add errors to this list to prevent the package from being uninstalled.
+     */
+    public function getError(): ErrorList
+    {
+        return $this->error;
+    }
+}

--- a/concrete/src/Package/Event/UpgradeEvent.php
+++ b/concrete/src/Package/Event/UpgradeEvent.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\Core\Package\Event;
+
+use Concrete\Core\Error\ErrorList\ErrorList;
+use Concrete\Core\Package\Package;
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+/**
+ * Event fired by testForUpgrade() as on_package_test_for_upgrade.
+ * Listeners add errors to getError() to block the upgrade with a user-visible message.
+ *
+ * Note: there is an optional bootstrap auto-upgrade path in Application::setupPackages().
+ * It is disabled by default and has no dashboard UI; it can only be enabled by setting
+ * concrete.updates.enable_auto_update_packages in application/config/concrete.php.
+ * When active, it calls upgrade() directly and bypasses testForUpgrade(), so this event
+ * is never dispatched on that path.
+ *
+ * If your package requires a hard precondition on all upgrade paths, consider overriding
+ * upgrade() in your Package subclass to call testForUpgrade() first, or hooking into
+ * on_before_package_upgrade to perform a final check before the schema migration runs.
+ */
+class UpgradeEvent extends PackageEvent
+{
+    /**
+     * @var ErrorList
+     */
+    protected $error;
+
+    public function __construct(Package $package, ErrorList $error)
+    {
+        parent::__construct($package);
+        $this->error = $error;
+    }
+
+    /**
+     * Add errors to this list to prevent the package from being upgraded.
+     */
+    public function getError(): ErrorList
+    {
+        return $this->error;
+    }
+}

--- a/concrete/src/Package/Package.php
+++ b/concrete/src/Package/Package.php
@@ -19,6 +19,7 @@ use Concrete\Core\Events\EventDispatcher;
 use Concrete\Core\Package\Dependency\DependencyChecker;
 use Concrete\Core\Package\Event\PackageEvent;
 use Concrete\Core\Package\Event\UninstallEvent;
+use Concrete\Core\Package\Event\UpgradeEvent;
 use Concrete\Core\Package\ItemCategory\Manager;
 use Concrete\Core\Page\Theme\Theme;
 use Doctrine\Common\Proxy\ProxyGenerator;
@@ -849,12 +850,28 @@ abstract class Package implements LocalizablePackageInterface
 
     /**
      * Perform tests before this package is upgraded.
+     * Fires the on_package_test_for_upgrade event; listeners may add errors to the event's ErrorList to veto the upgrade.
      *
-     * @return \Concrete\Core\Error\ErrorList\ErrorList|true return null if the package can be upgraded, an ErrorList instance otherwise
+     * Note: there is an optional bootstrap auto-upgrade path in Application::setupPackages().
+     * It is disabled by default and has no dashboard UI; it can only be enabled by setting
+     * concrete.updates.enable_auto_update_packages in application/config/concrete.php.
+     * When active, it calls upgrade() directly and bypasses this method, so
+     * on_package_test_for_upgrade is never dispatched on that path.
+     *
+     * @return \Concrete\Core\Error\ErrorList\ErrorList|true return true if the package can be upgraded, an ErrorList instance otherwise
      */
     public function testForUpgrade()
     {
-        return $this->testForInstall(false);
+        $errors = $this->app->make('error');
+
+        $result = $this->testForInstall(false);
+        if ($result !== true) {
+            $errors->add($result);
+        }
+
+        $this->getEventDispatcher()->dispatch('on_package_test_for_upgrade', new UpgradeEvent($this, $errors));
+
+        return $errors->has() ? $errors : true;
     }
 
     /**
@@ -1070,10 +1087,17 @@ abstract class Package implements LocalizablePackageInterface
     }
 
     /**
-     * Upgrades a package's database and refreshes all blocks.
+     * Upgrades a package's database and refreshes all blocks:
+     * - fires the on_before_package_upgrade event (informational; the schema has not yet been migrated at this point)
+     * - runs schema migration and refreshes block types
+     * - fires the on_after_package_upgrade event (informational; schema migration and block-type refresh are complete)
+     * Neither informational event prevents the upgrade. To veto with an error message, use on_package_test_for_upgrade instead.
      */
     public function upgrade()
     {
+        $dispatcher = $this->getEventDispatcher();
+        $dispatcher->dispatch('on_before_package_upgrade', new PackageEvent($this));
+
         $this->upgradeDatabase();
 
         // now we refresh all blocks
@@ -1092,6 +1116,8 @@ abstract class Package implements LocalizablePackageInterface
 
         $navigationCache = $this->app->make(FavoritesNavigationCache::class);
         $navigationCache->clear();
+
+        $dispatcher->dispatch('on_after_package_upgrade', new PackageEvent($this));
     }
 
     /**

--- a/concrete/src/Package/Package.php
+++ b/concrete/src/Package/Package.php
@@ -999,12 +999,12 @@ abstract class Package implements LocalizablePackageInterface
     /**
      * Installs a package database from an XML file.
      *
+     * If set to ContentImporter::IMPORT_MODE_UPGRADE, the schema will be checked against the current schema, supporting upgrades at a
+     * performance penalty. If set to ContentImporter::IMPORT_MODE_INSTALL the schema will be compared against an empty schema, which is
+     * a much faster operation and should be used when you know the installation is taking place against an empty database.
+     * ContentImporter::IMPORT_MODE_UPGRADE preserves backward compatibility as this was the way things always used to be handled.
+     *
      * @param string $xmlFile Path to the database XML file
-     * @param string $importMode - If set to ContentImporter::IMPORT_MODE_UPGRADE, the schema will be checked against
-     *                           the current schema, supporting upgrades at a performance penalty. If set to ContentImporter::IMPORT_MODE_INSTALL
-     *                           the schema will be compared against an empty schema, which is a much faster operation and should be used when
-     *                           you know the installation is taking place against an empty database. ContentImporter::IMPORT_MODE_UPGRADE
-     *                           preserves backward compatibility as this was the way things always used to be handled.
      * @throws \Doctrine\DBAL\ConnectionException
      * @return bool|\stdClass Returns false if the XML file could not be found
      */

--- a/concrete/src/Package/Package.php
+++ b/concrete/src/Package/Package.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Concrete\Core\Package;
 
 use Concrete\Core\Application\Application;
@@ -12,18 +15,21 @@ use Concrete\Core\Database\EntityManager\Driver\CoreDriver;
 use Concrete\Core\Database\EntityManager\Provider\PackageProviderFactory;
 use Concrete\Core\Database\Schema\Schema;
 use Concrete\Core\Entity\Package as PackageEntity;
+use Concrete\Core\Events\EventDispatcher;
 use Concrete\Core\Package\Dependency\DependencyChecker;
+use Concrete\Core\Package\Event\PackageEvent;
+use Concrete\Core\Package\Event\UninstallEvent;
 use Concrete\Core\Package\ItemCategory\Manager;
 use Concrete\Core\Page\Theme\Theme;
-use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Doctrine\Common\Proxy\ProxyGenerator;
 use Doctrine\DBAL\Schema\Comparator as SchemaComparator;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Tools\Setup;
+use Doctrine\Persistence\Mapping\Driver\MappingDriverChain;
 use Gettext\Translations;
-use Localization;
-use stdClass;
+
+defined('C5_EXECUTE') or die('Access Denied.');
 
 abstract class Package implements LocalizablePackageInterface
 {
@@ -32,77 +38,77 @@ abstract class Package implements LocalizablePackageInterface
      *
      * @var int
      */
-    const E_PACKAGE_NOT_FOUND = 1;
+    public const E_PACKAGE_NOT_FOUND = 1;
 
     /**
      * Error code: You've already installed that package.
      *
      * @var int
      */
-    const E_PACKAGE_INSTALLED = 2;
+    public const E_PACKAGE_INSTALLED = 2;
 
     /**
      * Error code: This package requires Concrete version %s or greater.
      *
      * @var int
      */
-    const E_PACKAGE_VERSION = 3;
+    public const E_PACKAGE_VERSION = 3;
 
     /**
      * Error code: An error occurred while downloading the package.
      *
      * @var int
      */
-    const E_PACKAGE_DOWNLOAD = 4;
+    public const E_PACKAGE_DOWNLOAD = 4;
 
     /**
      * Error code: Concrete was not able to save the package after download.
      *
      * @var int
      */
-    const E_PACKAGE_SAVE = 5;
+    public const E_PACKAGE_SAVE = 5;
 
     /**
      * Error code: An error occurred while trying to unzip the package.
      *
      * @var int
      */
-    const E_PACKAGE_UNZIP = 6;
+    public const E_PACKAGE_UNZIP = 6;
 
     /**
      * Error code: An error occurred while trying to install the package.
      *
      * @var int
      */
-    const E_PACKAGE_INSTALL = 7;
+    public const E_PACKAGE_INSTALL = 7;
 
     /**
      * Error code: Unable to backup old package directory to %s.
      *
      * @var int
      */
-    const E_PACKAGE_MIGRATE_BACKUP = 8;
+    public const E_PACKAGE_MIGRATE_BACKUP = 8;
 
     /**
      * Error code: This package isn't currently available for this version of Concrete.
      *
      * @var int
      */
-    const E_PACKAGE_INVALID_APP_VERSION = 20;
+    public const E_PACKAGE_INVALID_APP_VERSION = 20;
 
     /**
      * Error code: This package contains the active site theme, please change the theme before uninstalling.
      *
      * @var int
      */
-    const E_PACKAGE_THEME_ACTIVE = 21;
+    public const E_PACKAGE_THEME_ACTIVE = 21;
 
     /**
      * Error code: This package requires PHP version %1$s or greater (the current PHP version is %2$s).
      *
      * @var int
      */
-    const E_PACKAGE_PHP_VERSION = 22;
+    public const E_PACKAGE_PHP_VERSION = 22;
 
     /**
      * Absolute path to the /concrete/packages directory.
@@ -212,7 +218,7 @@ abstract class Package implements LocalizablePackageInterface
      * @var array
      */
     protected $pkgContentSwapFiles = [
-        "content.xml" => "Default"
+        'content.xml' => 'Default',
     ];
 
     /**
@@ -286,9 +292,6 @@ abstract class Package implements LocalizablePackageInterface
         $this->entity = $entity;
     }
 
-    /**
-     * @return array
-     */
     public function getContentSwapFiles(): array
     {
         return $this->pkgContentSwapFiles;
@@ -297,9 +300,10 @@ abstract class Package implements LocalizablePackageInterface
     /**
      * @return $this
      */
-    public function setContentSwapFiles(array $pkgContentSwapFiles): Package
+    public function setContentSwapFiles(array $pkgContentSwapFiles): self
     {
         $this->pkgContentSwapFiles = $pkgContentSwapFiles;
+
         return $this;
     }
 
@@ -431,7 +435,7 @@ abstract class Package implements LocalizablePackageInterface
      */
     public function getPackageHandle()
     {
-        return isset($this->pkgHandle) ? $this->pkgHandle : '';
+        return $this->pkgHandle ?? '';
     }
 
     /**
@@ -461,7 +465,7 @@ abstract class Package implements LocalizablePackageInterface
      */
     public function getPackageVersion()
     {
-        return isset($this->pkgVersion) ? $this->pkgVersion : '';
+        return $this->pkgVersion ?? '';
     }
 
     /**
@@ -476,8 +480,6 @@ abstract class Package implements LocalizablePackageInterface
 
     /**
      * Get the minimum PHP version compatible with the package.
-     *
-     * @return string
      *
      * @example '' if the package is compatible with any PHP version that's already compatible with the core
      * @example '8' if the package requires PHP 8.0.0 and later
@@ -608,14 +610,9 @@ abstract class Package implements LocalizablePackageInterface
      * Install the package info row and the database (doctrine entities and db.xml).
      * Packages installing additional content should override this method, call the parent method (`parent::install()`).
      *
-     * @param array $data The data received from:
-     * - the dashboard/install element of the package when installing via web
-     * - the options passed to the CLI command when installing via CLI
-     * - <option name="..." value="..." /> elements defined under the <package> element when installing via CIF
-     *
      * @return \Concrete\Core\Entity\Package
      */
-    public function install(/** array $data */)
+    public function install(/* array $data */)
     {
         PackageList::refreshCache();
         $em = $this->app->make(EntityManagerInterface::class);
@@ -631,7 +628,7 @@ abstract class Package implements LocalizablePackageInterface
 
         $this->installDatabase();
 
-        Localization::clearCache();
+        \Localization::clearCache();
 
         $navigationCache = $this->app->make(NavigationCache::class);
         $navigationCache->clear();
@@ -641,12 +638,18 @@ abstract class Package implements LocalizablePackageInterface
 
     /**
      * Uninstall the package:
+     * - fires the on_package_uninstall event (informational; at this point the package entity is still intact)
      * - delete the installed items associated to the package
      * - destroy the package proxy classes of entities
-     * - remove the package info row.
+     * - remove the package info row from the database
+     * - fires the on_package_uninstalled event (informational; the package entity has been removed — getPackageEntity() returns a detached entity).
+     * Neither lifecycle event prevents uninstall. To prevent uninstall with an error message, use on_package_test_for_uninstall instead.
      */
     public function uninstall()
     {
+        $dispatcher = $this->getEventDispatcher();
+        $dispatcher->dispatch('on_package_uninstall', new PackageEvent($this));
+
         /** @var Manager $manager */
         $manager = $this->app->make(Manager::class, ['application' => $this->app]);
         $categories = $manager->getPackageItemCategories();
@@ -671,7 +674,7 @@ abstract class Package implements LocalizablePackageInterface
         $em->remove($package);
         $em->flush();
 
-        Localization::clearCache();
+        \Localization::clearCache();
 
         if ($dbm) {
             $dbm->generateProxyClasses();
@@ -680,6 +683,7 @@ abstract class Package implements LocalizablePackageInterface
         $navigationCache = $this->app->make(NavigationCache::class);
         $navigationCache->clear();
 
+        $dispatcher->dispatch('on_package_uninstalled', new PackageEvent($this));
     }
 
     /**
@@ -694,6 +698,7 @@ abstract class Package implements LocalizablePackageInterface
             $file = $prefix . $name;
             if (is_file($file)) {
                 $contents = $this->app->make('helper/file')->getContents($file);
+
                 return nl2br(h($contents));
             }
         }
@@ -849,13 +854,12 @@ abstract class Package implements LocalizablePackageInterface
      */
     public function testForUpgrade()
     {
-        $result = $this->testForInstall(false);
-
-        return $result;
+        return $this->testForInstall(false);
     }
 
     /**
      * Perform tests before this package is uninstalled.
+     * Fires the on_package_test_for_uninstall event; listeners may add errors to the event's ErrorList to veto the uninstall.
      *
      * @return \Concrete\Core\Error\ErrorList\ErrorList|true return true if the package can be uninstalled, an ErrorList instance otherwise
      */
@@ -881,6 +885,9 @@ abstract class Package implements LocalizablePackageInterface
         // Step 2, check for package dependencies
         $dependencyChecker = $this->app->build(DependencyChecker::class);
         $errors->add($dependencyChecker->testForUninstall($this));
+
+        // Step 3, allow event listeners to veto the uninstall with error messages
+        $this->getEventDispatcher()->dispatch('on_package_test_for_uninstall', new UninstallEvent($this, $errors));
 
         return $errors->has() ? $errors : true;
     }
@@ -958,6 +965,7 @@ abstract class Package implements LocalizablePackageInterface
         if (method_exists($this, 'getPackageEntityPath')) {
             return [$this->getPackageEntityPath()];
         }
+
         // If we're using a legacy package, we scan the entire src directory
         return [$this->getPackagePath() . '/' . DIRNAME_CLASSES];
     }
@@ -993,13 +1001,12 @@ abstract class Package implements LocalizablePackageInterface
      *
      * @param string $xmlFile Path to the database XML file
      * @param string $importMode - If set to ContentImporter::IMPORT_MODE_UPGRADE, the schema will be checked against
-     * the current schema, supporting upgrades at a performance penalty. If set to ContentImporter::IMPORT_MODE_INSTALL
-     * the schema will be compared against an empty schema, which is a much faster operation and should be used when
-     * you know the installation is taking place against an empty database. ContentImporter::IMPORT_MODE_UPGRADE
-     * preserves backward compatibility as this was the way things always used to be handled.
+     *                           the current schema, supporting upgrades at a performance penalty. If set to ContentImporter::IMPORT_MODE_INSTALL
+     *                           the schema will be compared against an empty schema, which is a much faster operation and should be used when
+     *                           you know the installation is taking place against an empty database. ContentImporter::IMPORT_MODE_UPGRADE
+     *                           preserves backward compatibility as this was the way things always used to be handled.
+     * @throws \Doctrine\DBAL\ConnectionException
      * @return bool|\stdClass Returns false if the XML file could not be found
-     *@throws \Doctrine\DBAL\ConnectionException
-     *
      */
     public static function installDB($xmlFile, string $importMode = ContentImporter::IMPORT_MODE_UPGRADE)
     {
@@ -1040,7 +1047,7 @@ abstract class Package implements LocalizablePackageInterface
             }
         }
 
-        $result = new stdClass();
+        $result = new \stdClass();
         $result->result = false;
 
         return $result;
@@ -1078,7 +1085,7 @@ abstract class Package implements LocalizablePackageInterface
             $item->refresh();
         }
 
-        Localization::clearCache();
+        \Localization::clearCache();
 
         $navigationCache = $this->app->make(NavigationCache::class);
         $navigationCache->clear();
@@ -1128,7 +1135,7 @@ abstract class Package implements LocalizablePackageInterface
         $provider = $providerFactory->getEntityManagerProvider();
         $drivers = $provider->getDrivers();
         if (empty($drivers)) {
-            return null;
+            return;
         }
         $config = Setup::createConfiguration(true, $this->app->make('config')->get('database.proxy_classes'));
         $driverImpl = new MappingDriverChain();
@@ -1136,12 +1143,12 @@ abstract class Package implements LocalizablePackageInterface
 
         // Add all the installed packages so that the new package could potentially extend packages that are already / installed
         $packages = $this->app->make(PackageService::class)->getInstalledList();
-        foreach($packages as $package) {
+        foreach ($packages as $package) {
             $existingProviderFactory = new PackageProviderFactory($this->app, $package->getController());
             $existingProvider = $existingProviderFactory->getEntityManagerProvider();
             $existingDrivers = $existingProvider->getDrivers();
             if (!empty($existingDrivers)) {
-                foreach($existingDrivers as $existingDriver) {
+                foreach ($existingDrivers as $existingDriver) {
                     $driverImpl->addDriver($existingDriver->getDriver(), $existingDriver->getNamespace());
                 }
             }
@@ -1186,8 +1193,6 @@ abstract class Package implements LocalizablePackageInterface
     /**
      * Override this method in your package controller to add strings to the translator, so that you can translate dynamically generated strings.
      *
-     * @param Translations $translations
-     *
      * @example
      * If you add to this method these two strings:
      *
@@ -1217,6 +1222,11 @@ abstract class Package implements LocalizablePackageInterface
     public function getPackageDependencies()
     {
         return $this->packageDependencies;
+    }
+
+    protected function getEventDispatcher(): EventDispatcher
+    {
+        return $this->app->make(EventDispatcher::class);
     }
 
     /**
@@ -1268,7 +1278,7 @@ abstract class Package implements LocalizablePackageInterface
         foreach ($classes as $class) {
             // We have to do this check because we include core entities in this list because without it packages that extend
             // the core will complain.
-            if (strpos($class->getName(), 'Concrete\Core\Entity') === 0) {
+            if (str_starts_with($class->getName(), 'Concrete\Core\Entity')) {
                 continue;
             }
             $proxyFileName = $proxyGenerator->getProxyFileName($class->getName(), $config->getProxyDir());
@@ -1280,8 +1290,6 @@ abstract class Package implements LocalizablePackageInterface
 
     /**
      * Get the minimum PHP version compatible with the package.
-     *
-     * @return int|null
      *
      * @example null if the package is compatible with any PHP version that's already compatible with the core
      * @example 80000 if the package requires PHP 8.0.0 and later

--- a/concrete/src/Package/Package.php
+++ b/concrete/src/Package/Package.php
@@ -638,17 +638,17 @@ abstract class Package implements LocalizablePackageInterface
 
     /**
      * Uninstall the package:
-     * - fires the on_package_uninstall event (informational; at this point the package entity is still intact)
+     * - fires the on_before_package_uninstall event (informational; at this point the package entity is still intact)
      * - delete the installed items associated to the package
      * - destroy the package proxy classes of entities
      * - remove the package info row from the database
-     * - fires the on_package_uninstalled event (informational; the package entity has been removed — getPackageEntity() returns a detached entity).
+     * - fires the on_after_package_uninstall event (informational; the package entity has been removed — getPackageEntity() returns a detached entity).
      * Neither lifecycle event prevents uninstall. To prevent uninstall with an error message, use on_package_test_for_uninstall instead.
      */
     public function uninstall()
     {
         $dispatcher = $this->getEventDispatcher();
-        $dispatcher->dispatch('on_package_uninstall', new PackageEvent($this));
+        $dispatcher->dispatch('on_before_package_uninstall', new PackageEvent($this));
 
         /** @var Manager $manager */
         $manager = $this->app->make(Manager::class, ['application' => $this->app]);
@@ -683,7 +683,7 @@ abstract class Package implements LocalizablePackageInterface
         $navigationCache = $this->app->make(NavigationCache::class);
         $navigationCache->clear();
 
-        $dispatcher->dispatch('on_package_uninstalled', new PackageEvent($this));
+        $dispatcher->dispatch('on_after_package_uninstall', new PackageEvent($this));
     }
 
     /**

--- a/tests/helpers/Package/PackageForTestingEvents.php
+++ b/tests/helpers/Package/PackageForTestingEvents.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\TestHelpers\Package;
+
+use Concrete\Core\Package\Package;
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+class PackageForTestingEvents extends Package
+{
+    public function getPackagePath(): string
+    {
+        return __DIR__;
+    }
+
+    public function getPackageHandle(): string
+    {
+        return 'test_package';
+    }
+
+    // Return null so uninstall() skips proxy-class generation, which requires a live entity manager.
+    public function getPackageEntityManager(): ?\Doctrine\ORM\EntityManager
+    {
+        return null;
+    }
+}

--- a/tests/tests/Package/PackageEventTest.php
+++ b/tests/tests/Package/PackageEventTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\Tests\Package;
+
+use Concrete\Core\Package\Event\PackageEvent;
+use Concrete\Core\Package\Package;
+use Concrete\Tests\TestCase;
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+class PackageEventTest extends TestCase
+{
+    public function testGetPackage(): void
+    {
+        $package = \Mockery::mock(Package::class);
+        $event = new PackageEvent($package);
+
+        static::assertSame($package, $event->getPackage());
+    }
+}

--- a/tests/tests/Package/PackageUpgradeEventDispatchTest.php
+++ b/tests/tests/Package/PackageUpgradeEventDispatchTest.php
@@ -1,0 +1,297 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\Tests\Package;
+
+use Concrete\Core\Application\Application;
+use Concrete\Core\Application\UserInterface\Dashboard\Navigation\FavoritesNavigationCache;
+use Concrete\Core\Application\UserInterface\Dashboard\Navigation\NavigationCache;
+use Concrete\Core\Entity\Package as PackageEntity;
+use Concrete\Core\Error\ErrorList\ErrorList;
+use Concrete\Core\Events\EventDispatcher;
+use Concrete\Core\Package\Dependency\DependencyChecker;
+use Concrete\Core\Package\Event\PackageEvent;
+use Concrete\Core\Package\Event\UpgradeEvent;
+use Concrete\Core\Package\ItemCategory\Manager;
+use Concrete\TestHelpers\Package\PackageForTestingEvents;
+use Concrete\Tests\TestCase;
+use Mockery as M;
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+/**
+ * Tests that Package::upgrade() dispatches on_before_package_upgrade and on_after_package_upgrade,
+ * and that Package::testForUpgrade() dispatches on_package_test_for_upgrade.
+ *
+ * Unlike testForUninstall(), testForUpgrade() does not call Theme::getSiteTheme(), so the
+ * veto event dispatch and error-propagation paths can be fully unit-tested here.
+ */
+class PackageUpgradeEventDispatchTest extends TestCase
+{
+    private function createMockApp(EventDispatcher $dispatcher): Application
+    {
+        $blockTypeDriver = M::mock();
+        $blockTypeDriver->shouldReceive('getItems')->andReturn([]);
+
+        $manager = M::mock(Manager::class);
+        $manager->shouldReceive('driver')->with('block_type')->andReturn($blockTypeDriver);
+
+        $dependencyChecker = M::mock(DependencyChecker::class);
+        $dependencyChecker->shouldReceive('testForInstall')->andReturn(new ErrorList());
+
+        $navCache = M::mock(NavigationCache::class);
+        $navCache->shouldReceive('clear');
+
+        $favNavCache = M::mock(FavoritesNavigationCache::class);
+        $favNavCache->shouldReceive('clear');
+
+        $app = M::mock(Application::class);
+        $app->shouldReceive('make')->with(EventDispatcher::class)->andReturn($dispatcher);
+        $app->shouldReceive('make')->with(Manager::class, M::type('array'))->andReturn($manager);
+        $app->shouldReceive('make')->with('error')->andReturnUsing(static function (): ErrorList {
+            return new ErrorList();
+        });
+        $app->shouldReceive('build')->with(DependencyChecker::class)->andReturn($dependencyChecker);
+        $app->shouldReceive('make')->with(NavigationCache::class)->andReturn($navCache);
+        $app->shouldReceive('make')->with(FavoritesNavigationCache::class)->andReturn($favNavCache);
+
+        return $app;
+    }
+
+    private function createPackage(Application $app): PackageForTestingEvents
+    {
+        $package = new class ($app) extends PackageForTestingEvents {
+            // Stub out the DB schema import so upgrade() can run without a live database.
+            public function upgradeDatabase(): void
+            {
+            }
+        };
+        $package->setPackageEntity(M::mock(PackageEntity::class));
+
+        return $package;
+    }
+
+    public function testGetEventDispatcherReturnsInstanceFromContainer(): void
+    {
+        $dispatcher = M::mock(EventDispatcher::class);
+
+        $app = M::mock(Application::class);
+        $app->shouldReceive('make')->with(EventDispatcher::class)->once()->andReturn($dispatcher);
+
+        $result = (new \ReflectionMethod(PackageForTestingEvents::class, 'getEventDispatcher'))
+            ->invoke(new PackageForTestingEvents($app))
+        ;
+
+        static::assertSame($dispatcher, $result);
+    }
+
+    public function testUpgradeDispatchesBeforeAndAfterInOrder(): void
+    {
+        $callLog = [];
+
+        $dispatcher = M::mock(EventDispatcher::class);
+        $dispatcher->shouldReceive('dispatch')
+            ->twice()
+            ->andReturnUsing(static function (string $name) use (&$callLog): void {
+                $callLog[] = $name;
+            })
+        ;
+
+        $this->createPackage($this->createMockApp($dispatcher))->upgrade();
+
+        static::assertSame(['on_before_package_upgrade', 'on_after_package_upgrade'], $callLog);
+    }
+
+    public function testUpgradeEventsExposeThePackageInstance(): void
+    {
+        $captured = [];
+
+        $dispatcher = M::mock(EventDispatcher::class);
+        $dispatcher->shouldReceive('dispatch')
+            ->twice()
+            ->andReturnUsing(static function (string $name, PackageEvent $event) use (&$captured): void {
+                $captured[$name] = $event->getPackage();
+            })
+        ;
+
+        $app = $this->createMockApp($dispatcher);
+        $package = $this->createPackage($app);
+        $package->upgrade();
+
+        static::assertSame($package, $captured['on_before_package_upgrade']);
+        static::assertSame($package, $captured['on_after_package_upgrade']);
+    }
+
+    public function testTestForUpgradeDispatchesVetoEvent(): void
+    {
+        $dispatched = [];
+
+        $dispatcher = M::mock(EventDispatcher::class);
+        $dispatcher->shouldReceive('dispatch')
+            ->once()
+            ->andReturnUsing(static function (string $name) use (&$dispatched): void {
+                $dispatched[] = $name;
+            })
+        ;
+
+        $app = $this->createMockApp($dispatcher);
+
+        // Override testForInstall() so it passes without needing APP_VERSION or a live DependencyChecker
+        $package = new class ($app) extends PackageForTestingEvents {
+            public function testForInstall($testForAlreadyInstalled = true)
+            {
+                return true;
+            }
+        };
+        $package->setPackageEntity(M::mock(PackageEntity::class));
+
+        $package->testForUpgrade();
+
+        static::assertSame(['on_package_test_for_upgrade'], $dispatched);
+    }
+
+    public function testListenerVetoBlocksUpgrade(): void
+    {
+        $dispatcher = M::mock(EventDispatcher::class);
+        $dispatcher->shouldReceive('dispatch')
+            ->once()
+            ->andReturnUsing(static function (string $name, UpgradeEvent $event): void {
+                $event->getError()->add('Package B requires Package A >= 2.0');
+            })
+        ;
+
+        $app = $this->createMockApp($dispatcher);
+
+        $package = new class ($app) extends PackageForTestingEvents {
+            public function testForInstall($testForAlreadyInstalled = true)
+            {
+                return true;
+            }
+        };
+        $package->setPackageEntity(M::mock(PackageEntity::class));
+
+        $result = $package->testForUpgrade();
+
+        static::assertInstanceOf(ErrorList::class, $result);
+        static::assertTrue($result->has());
+    }
+
+    public function testTestForInstallFailurePropagatesIntoVetoEvent(): void
+    {
+        $capturedEvent = null;
+
+        $dispatcher = M::mock(EventDispatcher::class);
+        $dispatcher->shouldReceive('dispatch')
+            ->once()
+            ->andReturnUsing(static function (string $name, UpgradeEvent $event) use (&$capturedEvent): void {
+                $capturedEvent = $event;
+            })
+        ;
+
+        $app = $this->createMockApp($dispatcher);
+
+        $installErrors = new ErrorList();
+        $installErrors->add('Requires ConcreteCMS >= 99.0');
+
+        $package = new class ($app, $installErrors) extends PackageForTestingEvents {
+            /**
+             * @var ErrorList
+             */
+            private $installErrors;
+
+            public function __construct(Application $app, ErrorList $installErrors)
+            {
+                parent::__construct($app);
+                $this->installErrors = $installErrors;
+            }
+
+            public function testForInstall($testForAlreadyInstalled = true)
+            {
+                return $this->installErrors;
+            }
+        };
+        $package->setPackageEntity(M::mock(PackageEntity::class));
+
+        $result = $package->testForUpgrade();
+
+        static::assertInstanceOf(ErrorList::class, $result);
+        static::assertInstanceOf(UpgradeEvent::class, $capturedEvent);
+        static::assertTrue($capturedEvent->getError()->has());
+    }
+
+    public function testErrorListIsFreshOnEachCall(): void
+    {
+        $callCount = 0;
+        $dispatcher = M::mock(EventDispatcher::class);
+        $dispatcher->shouldReceive('dispatch')
+            ->twice()
+            ->andReturnUsing(static function (string $name, UpgradeEvent $event) use (&$callCount): void {
+                $callCount++;
+                if ($callCount === 1) {
+                    $event->getError()->add('blocking error');
+                }
+                // Second call: no errors added — result must be true.
+            })
+        ;
+
+        $app = $this->createMockApp($dispatcher);
+
+        $package = new class ($app) extends PackageForTestingEvents {
+            public function testForInstall($testForAlreadyInstalled = true)
+            {
+                return true;
+            }
+        };
+        $package->setPackageEntity(M::mock(PackageEntity::class));
+
+        $first = $package->testForUpgrade();
+        static::assertInstanceOf(ErrorList::class, $first);
+
+        // Second call must not carry over errors from the first — each call gets a fresh ErrorList.
+        $second = $package->testForUpgrade();
+        static::assertTrue($second);
+    }
+
+    public function testInstallErrorsAndListenerErrorsAreFlattenedInResult(): void
+    {
+        $dispatcher = M::mock(EventDispatcher::class);
+        $dispatcher->shouldReceive('dispatch')
+            ->once()
+            ->andReturnUsing(static function (string $name, UpgradeEvent $event): void {
+                $event->getError()->add('listener error');
+            })
+        ;
+
+        $app = $this->createMockApp($dispatcher);
+
+        $installErrors = new ErrorList();
+        $installErrors->add('install error 1');
+        $installErrors->add('install error 2');
+
+        $package = new class ($app, $installErrors) extends PackageForTestingEvents {
+            /**
+             * @var ErrorList
+             */
+            private $installErrors;
+
+            public function __construct(Application $app, ErrorList $installErrors)
+            {
+                parent::__construct($app);
+                $this->installErrors = $installErrors;
+            }
+
+            public function testForInstall($testForAlreadyInstalled = true)
+            {
+                return $this->installErrors;
+            }
+        };
+        $package->setPackageEntity(M::mock(PackageEntity::class));
+
+        $result = $package->testForUpgrade();
+
+        static::assertInstanceOf(ErrorList::class, $result);
+        // 2 from testForInstall() + 1 from the listener — must be flat, not nested.
+        static::assertCount(3, $result->getList());
+    }
+}

--- a/tests/tests/Package/UninstallEventTest.php
+++ b/tests/tests/Package/UninstallEventTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\Tests\Package;
+
+use Concrete\Core\Error\ErrorList\ErrorList;
+use Concrete\Core\Package\Event\UninstallEvent;
+use Concrete\Core\Package\Package;
+use Concrete\Tests\TestCase;
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+/**
+ * Tests the UninstallEvent class in isolation.
+ *
+ * Integration coverage note: the dispatch of on_package_test_for_uninstall from
+ * Package::testForUninstall() is not covered here because that method calls
+ * Theme::getSiteTheme() unconditionally, which requires a live database. A future
+ * refactor guarding that call behind a non-empty themes check would make it testable,
+ * but that change is out of scope here. Verify end-to-end behavior manually via the
+ * dashboard or the c5:package:uninstall CLI command.
+ */
+class UninstallEventTest extends TestCase
+{
+    public function testGetPackage(): void
+    {
+        $package = \Mockery::mock(Package::class);
+        $error = new ErrorList();
+
+        $event = new UninstallEvent($package, $error);
+
+        static::assertSame($package, $event->getPackage());
+    }
+
+    public function testGetErrorReturnsSameInstance(): void
+    {
+        $package = \Mockery::mock(Package::class);
+        $error = new ErrorList();
+
+        $event = new UninstallEvent($package, $error);
+
+        static::assertSame($error, $event->getError());
+    }
+
+    public function testErrorsAddedByListenerAreReflectedInOriginalList(): void
+    {
+        $package = \Mockery::mock(Package::class);
+        $error = new ErrorList();
+
+        $event = new UninstallEvent($package, $error);
+
+        // Simulate what a listener would do to veto the uninstall
+        $event->getError()->add('Package B is required by Package A');
+
+        static::assertTrue($error->has());
+        static::assertCount(1, $error->getList());
+    }
+}

--- a/tests/tests/Package/UpgradeEventTest.php
+++ b/tests/tests/Package/UpgradeEventTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\Tests\Package;
+
+use Concrete\Core\Error\ErrorList\ErrorList;
+use Concrete\Core\Package\Event\UpgradeEvent;
+use Concrete\Core\Package\Package;
+use Concrete\Tests\TestCase;
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+/**
+ * Tests the UpgradeEvent class in isolation.
+ *
+ * Integration coverage: the dispatch of on_package_test_for_upgrade from Package::testForUpgrade()
+ * is covered in PackageUpgradeEventDispatchTest, which also tests the veto and error-propagation
+ * paths. Unlike the uninstall equivalent, testForUpgrade() has no live-database dependency, so
+ * full unit isolation is achievable.
+ */
+class UpgradeEventTest extends TestCase
+{
+    public function testGetPackage(): void
+    {
+        $package = \Mockery::mock(Package::class);
+        $error = new ErrorList();
+
+        $event = new UpgradeEvent($package, $error);
+
+        static::assertSame($package, $event->getPackage());
+    }
+
+    public function testGetErrorReturnsSameInstance(): void
+    {
+        $package = \Mockery::mock(Package::class);
+        $error = new ErrorList();
+
+        $event = new UpgradeEvent($package, $error);
+
+        static::assertSame($error, $event->getError());
+    }
+
+    public function testErrorsAddedByListenerAreReflectedInOriginalList(): void
+    {
+        $package = \Mockery::mock(Package::class);
+        $error = new ErrorList();
+
+        $event = new UpgradeEvent($package, $error);
+
+        // Simulate what a listener would do to veto the upgrade
+        $event->getError()->add('Package B requires Package A >= 2.0; upgrading would break it');
+
+        static::assertTrue($error->has());
+        static::assertCount(1, $error->getList());
+    }
+}


### PR DESCRIPTION
Listeners can react to and veto package removal

Fires `on_package_test_for_uninstall` (UninstallEvent; listeners add errors to veto), `on_before package_uninstall` (informational; entity intact), and `on_after_package_uninstal` (informational; entity detached). Adds PackageEvent and UninstallEvent classes plus unit tests for both.

Likewise, `on_package_test_for_upgrade`, `on_before_package_upgrade`, and `on_after_package_upgrade`.

Closes #3002