### PR TITLE
Add version-author filter to page changes report and page search (#3283)

### DIFF
--- a/concrete/controllers/single_page/dashboard/reports/page_changes.php
+++ b/concrete/controllers/single_page/dashboard/reports/page_changes.php
@@ -1,23 +1,33 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Concrete\Controller\SinglePage\Dashboard\Reports;
 
 use Concrete\Core\Csv\Export\PageActivityExporter;
 use Concrete\Core\Csv\WriterFactory;
-use Concrete\Core\Page\Controller\DashboardPageController;
+use Concrete\Core\Form\Service\Widget\UserSelector;
 use Concrete\Core\Page\Collection\Version\GlobalVersionList;
+use Concrete\Core\Page\Controller\DashboardPageController;
 use Symfony\Component\HttpFoundation\StreamedResponse;
+
+defined('C5_EXECUTE') or die('Access Denied.');
 
 class PageChanges extends DashboardPageController
 {
     public function view()
     {
         $this->set('dt', $this->app->make('helper/form/date_time'));
+        $this->set('userSelector', $this->app->make(UserSelector::class));
     }
 
     public function csv_export()
     {
         if (!$this->token->validate('export_page_changes')) {
             $this->error->add($this->token->getErrorMessage());
+            $this->view();
+
+            return;
         }
 
         if ($this->error->has()) {
@@ -47,7 +57,8 @@ class PageChanges extends DashboardPageController
     private function getWriter()
     {
         return $this->app->make(
-            PageActivityExporter::class, [
+            PageActivityExporter::class,
+            [
                 'writer' => $this->app->make(WriterFactory::class)
                     ->createFromPath('php://output', 'w'),
             ]
@@ -61,7 +72,7 @@ class PageChanges extends DashboardPageController
      */
     private function getVersionList()
     {
-        /* @var \Concrete\Core\Form\Service\Widget\DateTime $dt */
+        /** @var \Concrete\Core\Form\Service\Widget\DateTime $dt */
         $dt = $this->app->make('helper/form/date_time');
 
         $startDate = $dt->translate('startDate', null, true);
@@ -76,6 +87,11 @@ class PageChanges extends DashboardPageController
 
         if ($endDate !== null) {
             $versionList->filterByApprovedBefore($endDate);
+        }
+
+        $versionAuthorID = (int) $this->request->request->get('versionAuthorID', 0);
+        if ($versionAuthorID > 0) {
+            $versionList->filterByVersionAuthorUserID($versionAuthorID);
         }
 
         return $versionList;

--- a/concrete/single_pages/dashboard/reports/page_changes.php
+++ b/concrete/single_pages/dashboard/reports/page_changes.php
@@ -1,11 +1,12 @@
 <?php
 defined('C5_EXECUTE') or die('Access Denied.');
 
-/* @var \Concrete\Core\Form\Service\Widget\DateTime $dt */
-/* @var \Concrete\Core\Validation\CSRF\Token $token */
+// @var \Concrete\Core\Form\Service\Widget\DateTime $dt
+// @var \Concrete\Core\Validation\CSRF\Token $token
+// @var \Concrete\Core\Form\Service\Widget\UserSelector $userSelector
 ?>
 
-<form role="form" method="post" action="<?php echo $controller->action('csv_export'); ?>">
+<form role="form" method="post" action="<?= $controller->action('csv_export') ?>">
     <?php
     $token->output('export_page_changes');
     ?>
@@ -14,11 +15,10 @@ defined('C5_EXECUTE') or die('Access Denied.');
         <div class="col-sm-12 col-md-6">
             <div class="form-group">
                 <label for="startDate" class="control-label form-label">
-                    <?php echo tc('Start date', 'From'); ?>
+                    <?= tc('Start date', 'From') ?>
                 </label>
                 <div>
-                    <?php
-                    echo $dt->datetime('startDate', null, true);
+                    <?= $dt->datetime('startDate', null, true);
                     ?>
                 </div>
             </div>
@@ -26,12 +26,24 @@ defined('C5_EXECUTE') or die('Access Denied.');
         <div class="col-sm-12 col-md-6">
             <div class="form-group">
                 <label for="endDate" class="control-label form-label">
-                    <?php echo tc('End date', 'To'); ?>
+                    <?= tc('End date', 'To') ?>
                 </label>
                 <div>
-                    <?php
-                    echo $dt->datetime('endDate', null, true);
+                    <?= $dt->datetime('endDate', null, true);
                     ?>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-sm-12 col-md-6">
+            <div class="form-group">
+                <label class="control-label form-label">
+                    <?= t('Author') ?>
+                </label>
+                <div>
+                    <?= $userSelector->selectUser('versionAuthorID') ?>
                 </div>
             </div>
         </div>
@@ -39,7 +51,7 @@ defined('C5_EXECUTE') or die('Access Denied.');
 
     <div class="ccm-search-fields-submit clearfix">
         <button type="submit" class="btn btn-primary float-end">
-            <?php echo t('Export to CSV'); ?>
+            <?= t('Export to CSV') ?>
         </button>
     </div>
 </form>

--- a/concrete/src/Page/Collection/Version/GlobalVersionList.php
+++ b/concrete/src/Page/Collection/Version/GlobalVersionList.php
@@ -1,8 +1,13 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Concrete\Core\Page\Collection\Version;
 
 use Concrete\Core\Search\ItemList\Database\ItemList as DatabaseItemList;
 use Concrete\Core\Search\StickyRequest;
+
+defined('C5_EXECUTE') or die('Access Denied.');
 
 /**
  * An object that holds a list of collection versions.
@@ -12,9 +17,6 @@ use Concrete\Core\Search\StickyRequest;
  */
 class GlobalVersionList extends DatabaseItemList
 {
-    /**
-     * @param \Concrete\Core\Search\StickyRequest|null $req
-     */
     public function __construct(?StickyRequest $req = null)
     {
         parent::__construct($req);
@@ -36,7 +38,8 @@ class GlobalVersionList extends DatabaseItemList
     public function createQuery()
     {
         $this->query->select('cv.*')
-            ->from('CollectionVersions', 'cv');
+            ->from('CollectionVersions', 'cv')
+        ;
     }
 
     /**
@@ -51,31 +54,37 @@ class GlobalVersionList extends DatabaseItemList
             ->select('count(1)')
             ->setMaxResults(1)
             ->execute()
-            ->fetchColumn();
+            ->fetchColumn()
+        ;
     }
 
     /**
      * Filter versions that are approved after a certain date.
-     *
-     * @param \DateTime $date
      */
     public function filterByApprovedAfter(\DateTime $date)
     {
         $this->query->andWhere(
-             'cv.cvDateApproved >= ' . $this->query->createNamedParameter($date->format('Y-m-d H:i-s'))
+            'cv.cvDateApproved >= ' . $this->query->createNamedParameter($date->format('Y-m-d H:i-s'))
         );
     }
 
     /**
      * Filter versions that are approved before a certain date.
-     *
-     * @param \DateTime $date
      */
     public function filterByApprovedBefore(\DateTime $date)
     {
         $this->query->andWhere(
-             'cv.cvDateApproved <= ' . $this->query->createNamedParameter($date->format('Y-m-d H:i-s'))
+            'cv.cvDateApproved <= ' . $this->query->createNamedParameter($date->format('Y-m-d H:i-s'))
         );
+    }
+
+    /**
+     * Filter versions by the user who authored them.
+     */
+    public function filterByVersionAuthorUserID(int $uID)
+    {
+        $this->query->andWhere('cv.cvAuthorUID = :cvAuthorUID');
+        $this->query->setParameter('cvAuthorUID', $uID);
     }
 
     /**

--- a/concrete/src/Page/PageList.php
+++ b/concrete/src/Page/PageList.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Concrete\Core\Page;
 
 use Concrete\Core\Entity\Block\BlockType\BlockType;
@@ -19,23 +21,33 @@ use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\User\User;
 use Pagerfanta\Adapter\DoctrineDbalAdapter;
 
+defined('C5_EXECUTE') or die('Access Denied.');
+
 /**
  * An object that allows a filtered list of pages to be returned.
  */
 class PageList extends DatabaseItemList implements PagerProviderInterface, PaginationProviderInterface
 {
-    const PAGE_VERSION_ACTIVE = 1;
-    const PAGE_VERSION_RECENT = 2;
-    const PAGE_VERSION_RECENT_UNAPPROVED = 3;
-    const PAGE_VERSION_SCHEDULED = 4;
+    public const PAGE_VERSION_ACTIVE = 1;
 
-    const SITE_TREE_CURRENT = -1;
-    const SITE_TREE_ALL = 0;
+    public const PAGE_VERSION_RECENT = 2;
 
-    /** @var \Closure | integer | null */
+    public const PAGE_VERSION_RECENT_UNAPPROVED = 3;
+
+    public const PAGE_VERSION_SCHEDULED = 4;
+
+    public const SITE_TREE_CURRENT = -1;
+
+    public const SITE_TREE_ALL = 0;
+
+    /**
+     * @var \Closure|int|null
+     */
     protected $permissionsChecker;
 
-    /** @var Tree */
+    /**
+     * @var Tree
+     */
     protected $siteTree = self::SITE_TREE_CURRENT;
 
     /**
@@ -130,9 +142,6 @@ class PageList extends DatabaseItemList implements PagerProviderInterface, Pagin
         $this->siteTree = self::SITE_TREE_CURRENT;
     }
 
-    /**
-     * @param bool $includeSystemPages
-     */
     public function includeSystemPages()
     {
         $this->includeSystemPages = true;
@@ -197,7 +206,8 @@ class PageList extends DatabaseItemList implements PagerProviderInterface, Pagin
                 ->leftJoin('p', 'CollectionSearchIndexAttributes', 'csi', 'csi.cID = if(pa.cID is null, p.cID, pa.cID)')
                 ->innerJoin('p', 'CollectionVersions', 'cv', 'cv.cID = if(pa.cID is null, p.cID, pa.cID)')
                 ->innerJoin('p', 'Collections', 'c', 'p.cID = c.cID')
-                ->andWhere('p.cIsTemplate = 0 or pa.cIsTemplate = 0');
+                ->andWhere('p.cIsTemplate = 0 or pa.cIsTemplate = 0')
+            ;
         } else {
             $query->from('Pages', 'p')
                 ->leftJoin('p', 'PageSearchIndex', 'psi', 'p.cID = psi.cID')
@@ -206,7 +216,8 @@ class PageList extends DatabaseItemList implements PagerProviderInterface, Pagin
                 ->innerJoin('p', 'Collections', 'c', 'p.cID = c.cID')
                 ->innerJoin('p', 'CollectionVersions', 'cv', 'p.cID = cv.cID')
                 ->andWhere('p.cPointerID < 1')
-                ->andWhere('p.cIsTemplate = 0');
+                ->andWhere('p.cIsTemplate = 0')
+            ;
         }
 
         switch ($this->pageVersionToRetrieve) {
@@ -216,7 +227,8 @@ class PageList extends DatabaseItemList implements PagerProviderInterface, Pagin
             case self::PAGE_VERSION_RECENT_UNAPPROVED:
                 $query
                     ->andWhere('cv.cvID = (select max(cvID) from CollectionVersions where cID = cv.cID)')
-                    ->andWhere('cvIsApproved = 0');
+                    ->andWhere('cvIsApproved = 0')
+                ;
                 break;
             case self::PAGE_VERSION_SCHEDULED:
                 $now = new \DateTime();
@@ -302,6 +314,7 @@ class PageList extends DatabaseItemList implements PagerProviderInterface, Pagin
     {
         if (isset($this->permissionsChecker) && $this->permissionsChecker === -1) {
             $query = $this->deliverQueryObject();
+
             // We need to reset the potential custom order by here because otherwise, if we've added
             // items to the select parts, and we're ordering by them, we get a SQL error
             // when we get total results, because we're resetting the select
@@ -313,19 +326,15 @@ class PageList extends DatabaseItemList implements PagerProviderInterface, Pagin
 
     public function getPaginationAdapter()
     {
-        $adapter = new DoctrineDbalAdapter($this->deliverQueryObject(), function ($query) {
+        return new DoctrineDbalAdapter($this->deliverQueryObject(), static function ($query) {
             // We need to reset the potential custom order by here because otherwise, if we've added
             // items to the select parts, and we're ordering by them, we get a SQL error
             // when we get total results, because we're resetting the select
             $query->resetQueryParts(['groupBy', 'orderBy'])->select('count(distinct p.cID)')->setMaxResults(1);
         });
-
-        return $adapter;
     }
 
     /**
-     * @param $queryRow
-     *
      * @return \Concrete\Core\Page\Page
      */
     public function getResult($queryRow)
@@ -380,8 +389,6 @@ class PageList extends DatabaseItemList implements PagerProviderInterface, Pagin
 
     /**
      * Filters by type of collection (using the handle field).
-     *
-     * @param mixed $ptHandle
      */
     public function filterByPageTypeHandle($ptHandle)
     {
@@ -398,9 +405,6 @@ class PageList extends DatabaseItemList implements PagerProviderInterface, Pagin
 
     /**
      * Filters by page template.
-     *
-     * @param mixed $ptHandle
-     * @param TemplateEntity $template
      */
     public function filterByPageTemplate(TemplateEntity $template)
     {
@@ -412,7 +416,6 @@ class PageList extends DatabaseItemList implements PagerProviderInterface, Pagin
      * Filters by date added.
      *
      * @param string $date
-     * @param mixed $comparison
      */
     public function filterByDateAdded($date, $comparison = '=')
     {
@@ -422,7 +425,6 @@ class PageList extends DatabaseItemList implements PagerProviderInterface, Pagin
     /**
      * Filter by number of children.
      *
-     * @param $number
      * @param string $comparison
      */
     public function filterByNumberOfChildren($number, $comparison = '>')
@@ -444,7 +446,6 @@ class PageList extends DatabaseItemList implements PagerProviderInterface, Pagin
     /**
      * Filter by last modified date.
      *
-     * @param $date
      * @param string $comparison
      */
     public function filterByDateLastModified($date, $comparison = '=')
@@ -456,7 +457,6 @@ class PageList extends DatabaseItemList implements PagerProviderInterface, Pagin
      * Filters by public date.
      *
      * @param string $date
-     * @param mixed $comparison
      */
     public function filterByPublicDate($date, $comparison = '=')
     {
@@ -465,8 +465,6 @@ class PageList extends DatabaseItemList implements PagerProviderInterface, Pagin
 
     /**
      * Filters by package.
-     *
-     * @param Package $package
      */
     public function filterByPackage(Package $package)
     {
@@ -493,8 +491,6 @@ class PageList extends DatabaseItemList implements PagerProviderInterface, Pagin
 
     /**
      * Filters by user ID).
-     *
-     * @param mixed $uID
      */
     public function filterByUserID($uID)
     {
@@ -503,9 +499,22 @@ class PageList extends DatabaseItemList implements PagerProviderInterface, Pagin
     }
 
     /**
+     * Filters pages by the author of the version selected by the current page version mode.
+     * By default (PAGE_VERSION_ACTIVE) this matches pages whose live approved version was authored by the given user.
+     * Note: this only checks the single version fetched per page (determined by setPageVersionToRetrieve()).
+     * It does not match pages where the user edited any historical version. A subquery across all versions
+     * would be required for that behaviour.
+     */
+    public function filterByVersionAuthorUserID(int $uID)
+    {
+        $this->query->andWhere('cv.cvAuthorUID = :cvAuthorUID');
+        $this->query->setParameter('cvAuthorUID', $uID);
+    }
+
+    /**
      * Filters by page type ID.
      *
-     * @param array | integer $ptID
+     * @param array|int $ptID
      */
     public function filterByPageTypeID($ptID)
     {
@@ -523,7 +532,7 @@ class PageList extends DatabaseItemList implements PagerProviderInterface, Pagin
     /**
      * Filters by parent ID.
      *
-     * @param array | integer $cParentID
+     * @param array|int $cParentID
      */
     public function filterByParentID($cParentID)
     {
@@ -541,7 +550,6 @@ class PageList extends DatabaseItemList implements PagerProviderInterface, Pagin
     /**
      * Filters a list by page name.
      *
-     * @param $name
      * @param bool $exact
      */
     public function filterByName($name, $exact = false)
@@ -560,7 +568,6 @@ class PageList extends DatabaseItemList implements PagerProviderInterface, Pagin
     /**
      * Filter a list by page path.
      *
-     * @param $path
      * @param bool $includeAllChildren
      */
     public function filterByPath($path, $includeAllChildren = true)
@@ -587,8 +594,6 @@ class PageList extends DatabaseItemList implements PagerProviderInterface, Pagin
 
     /**
      * Filters keyword fields by keywords (including name, description, content, and attributes.
-     *
-     * @param $keywords
      */
     public function filterByKeywords($keywords)
     {
@@ -620,8 +625,6 @@ class PageList extends DatabaseItemList implements PagerProviderInterface, Pagin
 
     /**
      * Filters by topic. Doesn't look at specific attributes –instead, actually joins to the topics table.
-     *
-     * @param mixed $topic
      */
     public function filterByTopic($topic)
     {
@@ -648,8 +651,6 @@ class PageList extends DatabaseItemList implements PagerProviderInterface, Pagin
 
     /**
      * Filters a page list by a particular block type occurring in the version of a page.
-     *
-     * @param BlockType $bt
      */
     public function filterByBlockType(BlockType $bt)
     {
@@ -666,7 +667,8 @@ class PageList extends DatabaseItemList implements PagerProviderInterface, Pagin
                 'cv2.cID = cvb2.cID and cv2.cvID = cvb2.cvID'
             )
             ->innerJoin('cvb2', 'Blocks', 'b', 'cvb2.bID = b.bID')
-            ->andWhere('b.btID = :btID');
+            ->andWhere('b.btID = :btID')
+        ;
 
         $this->query->andWhere(
             $this->query->expr()->in('p.cID', $query->getSQL())
@@ -675,9 +677,7 @@ class PageList extends DatabaseItemList implements PagerProviderInterface, Pagin
     }
 
     /**
-     * Filters a page list by a particular container occurring in a page
-     *
-     * @param Container $container
+     * Filters a page list by a particular container occurring in a page.
      */
     public function filterByContainer(Container $container)
     {
@@ -695,7 +695,8 @@ class PageList extends DatabaseItemList implements PagerProviderInterface, Pagin
             )
             ->innerJoin('cvb2', 'btCoreContainer', 'bcc', 'cvb2.bID = bcc.bID')
             ->innerJoin('bcc', 'PageContainerInstances', 'pci', 'bcc.containerInstanceID = pci.containerInstanceID')
-            ->andWhere('pci.containerID = :containerID');
+            ->andWhere('pci.containerID = :containerID')
+        ;
 
         $this->query->andWhere(
             $this->query->expr()->in('p.cID', $query->getSQL())
@@ -708,7 +709,6 @@ class PageList extends DatabaseItemList implements PagerProviderInterface, Pagin
         $this->query->andWhere('p.cCacheFullPageContent = :cacheSettings');
         $this->query->setParameter('cacheSettings', $value);
     }
-
 
     /**
      * Sorts this list by display order.
@@ -794,8 +794,6 @@ class PageList extends DatabaseItemList implements PagerProviderInterface, Pagin
 
     /**
      * @deprecated
-     *
-     * @param mixed $ctHandle
      */
     public function filterByCollectionTypeHandle($ctHandle)
     {
@@ -804,8 +802,6 @@ class PageList extends DatabaseItemList implements PagerProviderInterface, Pagin
 
     /**
      * @deprecated
-     *
-     * @param mixed $ctID
      */
     public function filterByCollectionTypeID($ctID)
     {
@@ -871,6 +867,7 @@ class PageList extends DatabaseItemList implements PagerProviderInterface, Pagin
                 }
             }
         }
+
         return false;
     }
 }

--- a/concrete/src/Page/Search/ColumnSet/Available.php
+++ b/concrete/src/Page/Search/ColumnSet/Available.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Concrete\Core\Page\Search\ColumnSet;
 
 use Concrete\Core\Page\Search\ColumnSet\Column\PageIDColumn;
@@ -8,9 +11,25 @@ use Concrete\Core\Page\Search\ColumnSet\Column\UrlPathColumn;
 use Concrete\Core\Search\Column\Column;
 use Concrete\Core\Support\Facade\Application;
 
+defined('C5_EXECUTE') or die('Access Denied.');
+
 class Available extends DefaultSet
 {
     protected $attributeClass = 'CollectionAttributeKey';
+
+    /**
+     * @param \Concrete\Core\Page\Page $c
+     *
+     * @return string|null
+     */
+    public static function getVersionAuthorName($c)
+    {
+        $vObj = $c->getVersionObject();
+        if ($vObj) {
+            // h() is required: the search results template renders column values unescaped via JS.
+            return h($vObj->getVersionAuthorUserName());
+        }
+    }
 
     /**
      * @see \Concrete\Core\Page\Collection\Version\Version::get()
@@ -47,5 +66,8 @@ class Available extends DefaultSet
         $this->addColumn(new UrlPathColumn());
         parent::__construct();
         $this->addColumn(new Column('cvStatus', t('Version Status'), ['\Concrete\Core\Page\Search\ColumnSet\Available', 'getCollectionVersionStatus'], false));
+        // Note: DefaultSet::getCollectionAuthor() shows the page owner (p.uID), not the version author.
+        // "Last Edited By" is intentionally a separate column showing who authored the approved version (cvAuthorUID).
+        $this->addColumn(new Column('cvAuthorUID', t('Last Edited By'), ['\Concrete\Core\Page\Search\ColumnSet\Available', 'getVersionAuthorName'], false));
     }
 }

--- a/concrete/src/Page/Search/Field/Field/VersionAuthorField.php
+++ b/concrete/src/Page/Search/Field/Field/VersionAuthorField.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\Core\Page\Search\Field\Field;
+
+use Concrete\Core\Form\Service\Widget\UserSelector;
+use Concrete\Core\Search\Field\AbstractField;
+use Concrete\Core\Search\ItemList\ItemList;
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+class VersionAuthorField extends AbstractField
+{
+    protected $requestVariables = [
+        'version_author',
+    ];
+
+    public function getKey()
+    {
+        return 'version_author';
+    }
+
+    public function getDisplayName()
+    {
+        return t('Approved Version Author');
+    }
+
+    public function filterList(ItemList $list)
+    {
+        $uID = (int) $this->getData('version_author');
+        if ($uID > 0) {
+            $list->filterByVersionAuthorUserID($uID);
+        }
+    }
+
+    public function renderSearchField()
+    {
+        $userSelector = \Core::make(UserSelector::class);
+
+        // selectUser() expects false (not null or 0) to mean "no current selection".
+        return $userSelector->selectUser('version_author', $this->getData('version_author') ?: false);
+    }
+}

--- a/concrete/src/Page/Search/Field/Manager.php
+++ b/concrete/src/Page/Search/Field/Manager.php
@@ -1,4 +1,7 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Concrete\Core\Page\Search\Field;
 
 use Concrete\Core\Attribute\Category\PageCategory;
@@ -11,6 +14,7 @@ use Concrete\Core\Page\Search\Field\Field\DatePublicField;
 use Concrete\Core\Page\Search\Field\Field\IncludePageAliasesField;
 use Concrete\Core\Page\Search\Field\Field\IncludeSystemPagesField;
 use Concrete\Core\Page\Search\Field\Field\NumberOfChildrenField;
+use Concrete\Core\Page\Search\Field\Field\PageOwnerField;
 use Concrete\Core\Page\Search\Field\Field\PageTemplateField;
 use Concrete\Core\Page\Search\Field\Field\PageTypeField;
 use Concrete\Core\Page\Search\Field\Field\ParentPageField;
@@ -18,18 +22,18 @@ use Concrete\Core\Page\Search\Field\Field\PermissionsInheritanceField;
 use Concrete\Core\Page\Search\Field\Field\SiteField;
 use Concrete\Core\Page\Search\Field\Field\SiteLocaleField;
 use Concrete\Core\Page\Search\Field\Field\ThemeField;
+use Concrete\Core\Page\Search\Field\Field\VersionAuthorField;
 use Concrete\Core\Page\Search\Field\Field\VersionStatusField;
 use Concrete\Core\Search\Field\AttributeKeyField;
 use Concrete\Core\Search\Field\Field\KeywordsField;
-use Concrete\Core\Page\Search\Field\Field\PageOwnerField;
 use Concrete\Core\Search\Field\Manager as FieldManager;
 use Concrete\Core\Site\InstallationService;
 use Concrete\Core\Support\Facade\Facade;
-use Doctrine\ORM\EntityManager;
+
+defined('C5_EXECUTE') or die('Access Denied.');
 
 class Manager extends FieldManager
 {
-
     protected $fileCategory;
 
     public function __construct(PageCategory $fileCategory)
@@ -47,6 +51,7 @@ class Manager extends FieldManager
             new IncludePageAliasesField(),
             new IncludeSystemPagesField(),
             new VersionStatusField(),
+            new VersionAuthorField(),
             new PermissionsInheritanceField(),
             new DateLastModifiedField(),
             new DatePublicField(),
@@ -66,13 +71,10 @@ class Manager extends FieldManager
         }
         $this->addGroup(t('Core Properties'), $properties);
         $attributes = [];
-        foreach($fileCategory->getSearchableList() as $key) {
+        foreach ($fileCategory->getSearchableList() as $key) {
             $field = new AttributeKeyField($key);
             $attributes[] = $field;
         }
         $this->addGroup(t('Custom Attributes'), $attributes);
-
     }
-
-
 }

--- a/tests/tests/Page/GlobalVersionListTest.php
+++ b/tests/tests/Page/GlobalVersionListTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\Tests\Page;
+
+use Concrete\Core\Page\Collection\Version\GlobalVersionList;
+use Concrete\TestHelpers\Page\PageTestCase;
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+class GlobalVersionListTest extends PageTestCase
+{
+    protected $pageData = [
+        ['Version List Page 1', false],
+        ['Version List Page 2', false],
+        ['Version List Page 3', false],
+    ];
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        $self = new static('');
+        foreach ($self->pageData as $data) {
+            call_user_func_array([$self, 'createPage'], $data);
+        }
+    }
+
+    public function testFilterByVersionAuthorUserIDNoMatch()
+    {
+        $list = new GlobalVersionList();
+        $list->filterByVersionAuthorUserID(99999);
+        static::assertEquals(0, $list->getTotalResults());
+    }
+
+    public function testFilterByVersionAuthorUserIDMatch()
+    {
+        // Pages are created in tests with no logged-in user, so cvAuthorUID defaults to 0.
+        // We created 3 pages above; assert at least those 3 are returned.
+        $filtered = new GlobalVersionList();
+        $filtered->filterByVersionAuthorUserID(0);
+        static::assertGreaterThanOrEqual(3, $filtered->getTotalResults());
+    }
+}

--- a/tests/tests/Page/PageListTest.php
+++ b/tests/tests/Page/PageListTest.php
@@ -1,18 +1,20 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Concrete\Tests\Page;
 
 use Concrete\Core\Entity\Site\SkeletonTree;
 use Concrete\Core\Page\PageList;
 use Concrete\TestHelpers\Page\PageTestCase;
-use Config;
-use Page;
-use PageTemplate;
-use PageType;
+
+defined('C5_EXECUTE') or die('Access Denied.');
 
 class PageListTest extends PageTestCase
 {
-    /** @var \Concrete\Core\Page\PageList */
+    /**
+     * @var \Concrete\Core\Page\PageList
+     */
     protected $list;
 
     protected $pageData = [
@@ -89,7 +91,7 @@ class PageListTest extends PageTestCase
         ]);
     }
 
-    public static function setUpBeforeClass():void
+    public static function setUpBeforeClass(): void
     {
         parent::setUpBeforeClass();
 
@@ -97,13 +99,13 @@ class PageListTest extends PageTestCase
         \Concrete\Core\Permission\Access\Entity\Type::add('page_owner', 'Page Owner');
         \Concrete\Core\Permission\Category::add('page');
         \Concrete\Core\Permission\Key\Key::add('page', 'view_page', 'View Page', '', 0, 0);
-        PageTemplate::add('left_sidebar', 'Left Sidebar');
-        PageTemplate::add('right_sidebar', 'Right Sidebar');
-        PageType::add([
+        \PageTemplate::add('left_sidebar', 'Left Sidebar');
+        \PageTemplate::add('right_sidebar', 'Right Sidebar');
+        \PageType::add([
             'handle' => 'alternate',
             'name' => 'Alternate',
         ]);
-        PageType::add([
+        \PageType::add([
             'handle' => 'another',
             'name' => 'Another',
         ]);
@@ -124,31 +126,31 @@ class PageListTest extends PageTestCase
 
     public function testGetUnfilteredTotal()
     {
-        $this->assertEquals(15, $this->list->getTotalResults());
+        static::assertEquals(15, $this->list->getTotalResults());
     }
 
     public function testFilterByTypeNone()
     {
         $this->list->filterByPageTypeHandle('fuzzy');
-        $this->assertEquals(0, $this->list->getTotalResults());
+        static::assertEquals(0, $this->list->getTotalResults());
     }
 
     public function testFilterByTypeValid1()
     {
         $this->list->filterByPageTypeHandle('basic');
-        $this->assertEquals(9, $this->list->getTotalResults());
+        static::assertEquals(9, $this->list->getTotalResults());
 
         $pagination = $this->list->getPagination();
-        $this->assertEquals(9, $pagination->getTotalResults());
+        static::assertEquals(9, $pagination->getTotalResults());
         $results = $pagination->getCurrentPageResults();
-        $this->assertCount(9, $results);
-        $this->assertInstanceOf('\Concrete\Core\Page\Page', $results[0]);
+        static::assertCount(9, $results);
+        static::assertInstanceOf('\Concrete\Core\Page\Page', $results[0]);
     }
 
     public function testFilterByTypeValid2()
     {
         $this->list->filterByPageTypeHandle(['alternate', 'another']);
-        $this->assertEquals(5, $this->list->getTotalResults());
+        static::assertEquals(5, $this->list->getTotalResults());
     }
 
     public function testSortByIDAscending()
@@ -156,9 +158,9 @@ class PageListTest extends PageTestCase
         $this->list->sortByCollectionIDAscending();
         $pagination = $this->list->getPagination();
         $results = $pagination->getCurrentPageResults();
-        $this->assertEquals(1, $results[0]->getCollectionID());
-        $this->assertEquals(2, $results[1]->getCollectionID());
-        $this->assertEquals(3, $results[2]->getCollectionID());
+        static::assertEquals(1, $results[0]->getCollectionID());
+        static::assertEquals(2, $results[1]->getCollectionID());
+        static::assertEquals(3, $results[2]->getCollectionID());
     }
 
     public function testSortByNameAscending()
@@ -166,17 +168,17 @@ class PageListTest extends PageTestCase
         $this->list->sortByName();
         $pagination = $this->list->getPagination();
         $results = $pagination->getCurrentPageResults();
-        $this->assertEquals('Abracadabra', $results[0]->getCollectionName());
-        $this->assertEquals('Another Fun Page', $results[1]->getCollectionName());
-        $this->assertEquals('Another Page', $results[2]->getCollectionName());
-        $this->assertEquals('Brace Yourself', $results[3]->getCollectionName());
+        static::assertEquals('Abracadabra', $results[0]->getCollectionName());
+        static::assertEquals('Another Fun Page', $results[1]->getCollectionName());
+        static::assertEquals('Another Page', $results[2]->getCollectionName());
+        static::assertEquals('Brace Yourself', $results[3]->getCollectionName());
     }
 
     public function testFilterByKeywords()
     {
         $this->list->filterByKeywords('brac', true);
         $total = $this->list->getTotalResults();
-        $this->assertEquals(2, $total);
+        static::assertEquals(2, $total);
     }
 
     public function testItemsPerPage()
@@ -184,7 +186,7 @@ class PageListTest extends PageTestCase
         $pagination = $this->list->getPagination();
         $pagination->setMaxPerPage(2);
         $pages = $pagination->getCurrentPageResults();
-        $this->assertEquals(2, count($pages));
+        static::assertEquals(2, count($pages));
     }
 
     public function testPaginationObject()
@@ -192,38 +194,38 @@ class PageListTest extends PageTestCase
         $this->list->sortByCollectionIDAscending();
         $pagination = $this->list->getPagination();
         $pagination->setMaxPerPage(2);
-        $this->assertInstanceOf('\Concrete\Core\Search\Pagination\Pagination', $pagination);
-        $this->assertEquals(2, $pagination->getMaxPerPage());
-        $this->assertEquals(15, $pagination->getTotalResults());
-        $this->assertEquals(1, $pagination->getCurrentPage());
-        $this->assertEquals(false, $pagination->hasPreviousPage());
-        $this->assertEquals(true, $pagination->hasNextPage());
-        $this->assertEquals(true, $pagination->haveToPaginate());
+        static::assertInstanceOf('\Concrete\Core\Search\Pagination\Pagination', $pagination);
+        static::assertEquals(2, $pagination->getMaxPerPage());
+        static::assertEquals(15, $pagination->getTotalResults());
+        static::assertEquals(1, $pagination->getCurrentPage());
+        static::assertFalse($pagination->hasPreviousPage());
+        static::assertTrue($pagination->hasNextPage());
+        static::assertTrue($pagination->haveToPaginate());
     }
 
     public function testExcludingAliasesAndBasicGet()
     {
-        $subject = Page::getByPath('/test-page-2');
-        $parent = Page::getByPath('/another-fun-page');
+        $subject = \Page::getByPath('/test-page-2');
+        $parent = \Page::getByPath('/another-fun-page');
         $subject->addCollectionAlias($parent);
         $this->list->sortBy('cID', 'desc');
 
         $results = $this->list->getResults();
-        $this->assertEquals(15, count($results));
-        $this->assertEquals('Foobler', $results[0]->getCollectionName());
+        static::assertEquals(15, count($results));
+        static::assertEquals('Foobler', $results[0]->getCollectionName());
     }
 
     public function testFilterByParentID()
     {
-        $subject = Page::getByPath('/test-page-2');
-        $parent = Page::getByPath('/another-fun-page');
+        $subject = \Page::getByPath('/test-page-2');
+        $parent = \Page::getByPath('/another-fun-page');
         $subject->addCollectionAlias($parent);
-        $parent = Page::getByPath('/another-fun-page');
+        $parent = \Page::getByPath('/another-fun-page');
         $this->list->filterByParentID($parent->getCollectionID());
         $pagination = $this->list->getPagination();
         $results = $pagination->getCurrentPageResults();
-        $this->assertEquals(1, count($results));
-        $this->assertEquals(1, $pagination->getTotalResults());
+        static::assertEquals(1, count($results));
+        static::assertEquals(1, $pagination->getTotalResults());
     }
 
     public function testFilterByPageTypeID()
@@ -232,30 +234,30 @@ class PageListTest extends PageTestCase
         $this->list->filterByPageTypeID($type->getPageTypeID());
         $pagination = $this->list->getPagination();
         $results = $pagination->getCurrentPageResults();
-        $this->assertEquals(4, count($results));
+        static::assertEquals(4, count($results));
     }
 
     public function testFilterByNumChildren()
     {
         $this->list->filterByNumberOfChildren(2, '>=');
         $results = $this->list->getResults();
-        $ids = array_map(function ($result) {
+        $ids = array_map(static function ($result) {
             return $result->getCollectionID();
         }, $results);
 
         // A function to reduce a list of pages into the minimum child count
-        $minimumChild = function ($carry, $value) {
+        $minimumChild = static function ($carry, $value) {
             $childCount = $value->getNumChildren();
 
             return ($carry === null || $childCount < $carry) ? $childCount : $carry;
         };
 
         // Make sure there are no results with less than 2 children
-        $this->assertGreaterThanOrEqual(2, array_reduce($results, $minimumChild));
-        $this->assertContains(1, $ids);
+        static::assertGreaterThanOrEqual(2, array_reduce($results, $minimumChild));
+        static::assertContains(1, $ids);
 
-        $subject = Page::getByPath('/test-page-2');
-        $parent = Page::getByPath('/holy-mackerel');
+        $subject = \Page::getByPath('/test-page-2');
+        $parent = \Page::getByPath('/holy-mackerel');
         $subject->addCollectionAlias($parent);
 
         $nl = new \Concrete\Core\Page\PageList();
@@ -264,44 +266,44 @@ class PageListTest extends PageTestCase
         $nl->filterByNumberOfChildren(1, '>=');
 
         // Make sure there are no results with less than 1 child
-        $this->assertGreaterThanOrEqual(1, array_reduce($nl->getResults(), $minimumChild));
+        static::assertGreaterThanOrEqual(1, array_reduce($nl->getResults(), $minimumChild));
     }
 
     public function testFilterByActiveAndSystem()
     {
-        \SinglePage::addGlobal(Config::get('concrete.paths.trash'));
+        \SinglePage::addGlobal(\Config::get('concrete.paths.trash'));
 
-        $c = Page::getByPath('/test-trash');
+        $c = \Page::getByPath('/test-trash');
         $c->moveToTrash();
 
         $results = $this->list->getResults();
-        $this->assertCount(13, $results);
+        static::assertCount(13, $results);
 
         $this->list->includeSystemPages(); // This includes the items inside trash because we're stupid.
         $totalResults = $this->list->getTotalResults();
-        $this->assertEquals(14, $totalResults);
+        static::assertEquals(14, $totalResults);
 
         $pagination = $this->list->getPagination();
-        $this->assertEquals(14, $pagination->getTotalResults());
+        static::assertEquals(14, $pagination->getTotalResults());
         $results = $this->list->getResults();
-        $this->assertCount(14, $results);
+        static::assertCount(14, $results);
 
         $this->list->includeInactivePages();
         $totalResults = $this->list->getTotalResults();
-        $this->assertEquals(16, $totalResults);
+        static::assertEquals(16, $totalResults);
         $pagination = $this->list->getPagination();
-        $this->assertEquals(16, $pagination->getTotalResults());
+        static::assertEquals(16, $pagination->getTotalResults());
         $results = $this->list->getResults();
-        $this->assertCount(16, $results);
+        static::assertCount(16, $results);
     }
 
     public function testAliases()
     {
-        $parent = Page::getByPath('/test-page-2/foo-bar');
-        $subject = Page::getByPath('/another-fun-page');
+        $parent = \Page::getByPath('/test-page-2/foo-bar');
+        $subject = \Page::getByPath('/another-fun-page');
         $subject->addCollectionAlias($parent);
 
-        $pc = Page::getByPath('/brace-yourself');
+        $pc = \Page::getByPath('/brace-yourself');
         $pc->move($parent);
 
         $page = $this->createPage('Page 2', $parent);
@@ -310,11 +312,11 @@ class PageListTest extends PageTestCase
         $this->list->filterByParentID($parent->getCollectionID());
         $this->list->includeAliases();
         $totalResults = $this->list->getTotalResults();
-        $this->assertEquals(3, $totalResults);
+        static::assertEquals(3, $totalResults);
 
         $this->list->filterByKeywords('Page');
         $totalResults = $this->list->getTotalResults(); // should get two.
-        $this->assertEquals(2, $totalResults);
+        static::assertEquals(2, $totalResults);
 
         $nl = new \Concrete\Core\Page\PageList();
         $nl->includeAliases();
@@ -323,44 +325,44 @@ class PageListTest extends PageTestCase
         $nl->getQueryObject()->addOrderBy('p.cID', 'asc');
         $total = $nl->getPagination()->getTotalResults();
         $results = $nl->getPagination()->setMaxPerPage(10)->getCurrentPageResults();
-        $this->assertEquals(18, $total);
-        $this->assertCount(10, $results);
-        $this->assertTrue($results[2]->isAlias());
-        $this->assertEquals('Another Fun Page', $results[2]->getCollectionName());
-        $this->assertEquals($results[2]->getCollectionID(), $subject->getCollectionID());
-        $this->assertEquals(20, $results[2]->getCollectionPointerOriginalID());
-        $this->assertEquals(8, $results[2]->getCollectionID());
+        static::assertEquals(18, $total);
+        static::assertCount(10, $results);
+        static::assertTrue($results[2]->isAlias());
+        static::assertEquals('Another Fun Page', $results[2]->getCollectionName());
+        static::assertEquals($results[2]->getCollectionID(), $subject->getCollectionID());
+        static::assertEquals(20, $results[2]->getCollectionPointerOriginalID());
+        static::assertEquals(8, $results[2]->getCollectionID());
     }
 
     public function testIndexedSearch()
     {
-        $c = Page::getByPath('/another-fun-page');
+        $c = \Page::getByPath('/another-fun-page');
         $c->update(['cDescription' => 'A page of all pages.']);
         $c->reindex();
 
         $this->list->filterByFulltextKeywords('Page');
         $this->list->sortByRelevance();
         $results = $this->list->getResults();
-        $this->assertCount(6, $results);
+        static::assertCount(6, $results);
 
-        $ids = array_map(function ($c) { return $c->getCollectionID(); }, $results);
-        $this->assertContains($c->getCollectionID(), $ids);
+        $ids = array_map(static function ($c) { return $c->getCollectionID(); }, $results);
+        static::assertContains($c->getCollectionID(), $ids);
 
-        //$this->assertEquals(8, $results[0]->getCollectionID());
-        $this->assertGreaterThan(0, $results[0]->getPageIndexScore());
-        $this->assertGreaterThan(0, $results[1]->getPageIndexScore());
-        $this->assertEquals($results[1]->getPageIndexScore(), $results[2]->getPageIndexScore());
+        // $this->assertEquals(8, $results[0]->getCollectionID());
+        static::assertGreaterThan(0, $results[0]->getPageIndexScore());
+        static::assertGreaterThan(0, $results[1]->getPageIndexScore());
+        static::assertEquals($results[1]->getPageIndexScore(), $results[2]->getPageIndexScore());
     }
 
     public function testFilterByName()
     {
         $this->list->filterByName('Brace Yourself', true);
-        $this->assertEquals(1, $this->list->getTotalResults());
+        static::assertEquals(1, $this->list->getTotalResults());
 
         $nl = new \Concrete\Core\Page\PageList();
         $nl->ignorePermissions();
         $nl->filterByName('Foo', false);
-        $this->assertEquals(3, $nl->getTotalResults());
+        static::assertEquals(3, $nl->getTotalResults());
     }
 
     public function testFilterByPath()
@@ -369,12 +371,12 @@ class PageListTest extends PageTestCase
 
         $this->list->filterByPath('/test-page-1');
         $totalResults = $this->list->getTotalResults();
-        $this->assertEquals(2, $totalResults);
+        static::assertEquals(2, $totalResults);
         $nl = new \Concrete\Core\Page\PageList();
         $nl->ignorePermissions();
         $nl->filterByPath('/test-page-1', false);
         $pagination = $nl->getPagination();
-        $this->assertEquals(1, $pagination->getNBResults());
+        static::assertEquals(1, $pagination->getNBResults());
     }
 
     public function testFilterByMultiplePaths()
@@ -385,7 +387,7 @@ class PageListTest extends PageTestCase
         $this->list->filterByPath('/test-page-1');
         $this->list->filterByPath('/test-page-2');
         $totalResults = $this->list->getTotalResults();
-        $this->assertEquals(4, $totalResults);
+        static::assertEquals(4, $totalResults);
     }
 
     public function testFilterByPathWithArray()
@@ -394,7 +396,7 @@ class PageListTest extends PageTestCase
 
         $this->list->filterByPath(['/test-page-1']);
         $totalResults = $this->list->getTotalResults();
-        $this->assertEquals(18, $totalResults);
+        static::assertEquals(18, $totalResults);
     }
 
     public function testFilterByPagesWithCustomStyles()
@@ -402,7 +404,20 @@ class PageListTest extends PageTestCase
         $this->list->filterByPagesWithCustomStyles();
         $this->list->filterByPagesWithCustomStyles();
         $totalResults = $this->list->getTotalResults();
-        $this->assertEquals(0, $totalResults);
+        static::assertEquals(0, $totalResults);
+    }
+
+    public function testFilterByVersionAuthorUserIDNoMatch()
+    {
+        $this->list->filterByVersionAuthorUserID(99999);
+        static::assertEquals(0, $this->list->getTotalResults());
+    }
+
+    public function testFilterByVersionAuthorUserIDMatch()
+    {
+        // Pages are created in tests with no logged-in user, so cvAuthorUID defaults to 0.
+        $this->list->filterByVersionAuthorUserID(0);
+        static::assertGreaterThan(0, $this->list->getTotalResults());
     }
 
     public function testBasicFeedSave()
@@ -417,15 +432,15 @@ class PageListTest extends PageTestCase
         $pf->setDescription('My Description');
         $pf->save();
 
-        $this->assertEquals('blog', $pf->getHandle());
-        $this->assertEquals(1, $pf->getID());
+        static::assertEquals('blog', $pf->getHandle());
+        static::assertEquals(1, $pf->getID());
 
         $pf->ignorePermissions();
         $pl = $pf->getPageListObject();
-        $this->assertInstanceOf(PageList::class, $pl);
-        $this->assertEquals(1, $pl->getTotalResults());
+        static::assertInstanceOf(PageList::class, $pl);
+        static::assertEquals(1, $pl->getTotalResults());
 
         $results = $pl->getResults();
-        $this->assertEquals('Foobler', $results[0]->getCollectionName());
+        static::assertEquals('Foobler', $results[0]->getCollectionName());
     }
 }

--- a/tests/tests/Page/Search/Field/Field/VersionAuthorFieldTest.php
+++ b/tests/tests/Page/Search/Field/Field/VersionAuthorFieldTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\Tests\Page\Search\Field\Field;
+
+use Concrete\Core\Page\PageList;
+use Concrete\Core\Page\Search\Field\Field\VersionAuthorField;
+use Concrete\Tests\TestCase;
+use Mockery as M;
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+class VersionAuthorFieldTest extends TestCase
+{
+    /**
+     * @var VersionAuthorField
+     */
+    private $field;
+
+    /**
+     * @before
+     */
+    public function prepare(): void
+    {
+        $this->field = new VersionAuthorField();
+    }
+
+    /**
+     * @after
+     */
+    public function destroy(): void
+    {
+        $this->field = null;
+    }
+
+    public function testGetKey(): void
+    {
+        static::assertSame('version_author', $this->field->getKey());
+    }
+
+    public function testGetDisplayName(): void
+    {
+        static::assertNotEmpty($this->field->getDisplayName());
+    }
+
+    public function testFilterListDoesNothingWhenNoData(): void
+    {
+        $list = M::mock(PageList::class);
+        $list->shouldNotReceive('filterByVersionAuthorUserID');
+
+        $this->field->filterList($list);
+    }
+
+    public function testFilterListDoesNothingWhenZeroUID(): void
+    {
+        $this->field->loadDataFromRequest(['version_author' => '0']);
+
+        $list = M::mock(PageList::class);
+        $list->shouldNotReceive('filterByVersionAuthorUserID');
+
+        $this->field->filterList($list);
+    }
+
+    public function testFilterListWithValidUID(): void
+    {
+        $this->field->loadDataFromRequest(['version_author' => '42']);
+
+        $list = M::mock(PageList::class);
+        $list->shouldReceive('filterByVersionAuthorUserID')->with(42)->once();
+
+        $this->field->filterList($list);
+    }
+}


### PR DESCRIPTION
- Page Changes report: new UserSelector "Author" field filters the CSV export by cvAuthorUID (the user who authored the approved version)
- Page Search: new VersionAuthorField ("Approved Version Author") and "Last Edited By" available column, both wired into the existing field manager and column set
- PageList::filterByVersionAuthorUserID() filters by the author of the version selected by the current page version mode (default: approved)
- GlobalVersionList::filterByVersionAuthorUserID() filters across all historical versions, used by the CSV export
- Unit tests for VersionAuthorField, PageList, and GlobalVersionList
- CSRF check in csv_export() now short-circuits immediately on failure

Closes #3283 