### PR TITLE
Check for PHP syntax errors everywhere

### DIFF
--- a/.github/workflows/check-syntax.yml
+++ b/.github/workflows/check-syntax.yml
@@ -10,10 +10,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version:
+        include:
           # This list should include at least the value of Concrete\Core\Install\Preconditions\PhpVersion::MINIMUM_PHP_VERSION
-          - "7.3"
-          - "8.5"
+          -
+            php-version: "7.3"
+            exclude: |
+              tests/assets/Foundation/jobs/index_search.php
+          -
+            php-version: "8.5"
+            exclude: |
+              tests/assets/Foundation/jobs/index_search.php
     steps:
       -
         name: Checkout
@@ -30,6 +36,7 @@ jobs:
         name: Check syntax
         uses: mlocati/check-php-syntax@v1
         with:
+          exclude: ${{ matrix.exclude }}
           include: |
             concrete/bin/concrete
             concrete/bin/concrete5

--- a/.github/workflows/check-syntax.yml
+++ b/.github/workflows/check-syntax.yml
@@ -30,8 +30,7 @@ jobs:
         name: Check syntax
         uses: mlocati/check-php-syntax@v1
         with:
-          directory: concrete
           include: |
-            bin/concrete
-            bin/concrete5
+            concrete/bin/concrete
+            concrete/bin/concrete5
           fail-on-warnings: true

--- a/.github/workflows/check-syntax.yml
+++ b/.github/workflows/check-syntax.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       -
         name: Install PHP
         uses: shivammathur/setup-php@v2

--- a/tests/tests/Localization/Adapter/Laminas/Translation/Loader/Gettext/PackagesTranslationLoaderTest.php
+++ b/tests/tests/Localization/Adapter/Laminas/Translation/Loader/Gettext/PackagesTranslationLoaderTest.php
@@ -52,7 +52,7 @@ class PackagesTranslationLoaderTest extends ConcreteDatabaseTestCase
         // First make sure that none of the packages already exist
         foreach ($packages as $pkg => $dir) {
             if ($filesystem->exists(DIR_PACKAGES . '/' . $pkg)) {
-                throw new Exception("A package directory for a package named ${pkg} already exists. It cannot exist prior to running these tests.");
+                throw new Exception("A package directory for a package named {$pkg} already exists. It cannot exist prior to running these tests.");
             }
         }
         // Then, move the package folders to the package folder

--- a/tests/tests/Marketplace/PackageRepositoryTest.php
+++ b/tests/tests/Marketplace/PackageRepositoryTest.php
@@ -328,7 +328,7 @@ class PackageRepositoryTest extends TestCase
         $this->connectRequestReturns('/get/packages', true, [new Response(200, [], '{"id":1}')]);
         $this->assertEmpty($repository->getPackages($connection));
 
-        $package = function(string $handle, string $id, string $version, array $compat = null) {
+        $package = function(string $handle, string $id, string $version, ?array $compat = null) {
             $compat = $compat ?? [1, 2, 3, 4, 5];
             return [
                 'handle' => $handle,


### PR DESCRIPTION
We currently check for PHP 7.3/8.5 syntax errors only in the `concrete` directory.

What about checking everything?