### PR TITLE
Fix advanced board templates

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -36,7 +36,7 @@ jobs:
           - "composer:v2"
 
         include:
-          - php-version: 8.0
+          - php-version: 8.1
             operating-system: "ubuntu-latest"
             dependencies: "highest"
           - php-version: 7.3

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -86,6 +86,8 @@ jobs:
       - name: "Install highest dependencies"
         if: ${{ matrix.dependencies == 'highest' }}
         run: |
+          echo "CCM_TEST_SKIP_CHECKCOMPOSERPLATFORM=1" >>"$GITHUB_ENV"
+          composer config --unset platform.php
           composer update --no-interaction --no-progress
 
       - name: "Install locked dependencies"

--- a/concrete/src/Block/View/BlockViewTemplate.php
+++ b/concrete/src/Block/View/BlockViewTemplate.php
@@ -102,13 +102,18 @@ class BlockViewTemplate
                 $record = $templateLocator->getRecord(
                     DIRNAME_BLOCKS . '/' . $obj->getBlockTypeHandle() . '/' . DIRNAME_BLOCK_TEMPLATES . '/' . $bFilename
                 );
-                $this->template = $record->getFile();
-                $record = $templateLocator->getRecord(
-                    DIRNAME_BLOCKS . '/' . $obj->getBlockTypeHandle() . '/' . $this->render
-                );
-                $this->baseURL = dirname($record->getUrl());
-                $this->basePath = dirname($record->getFile());
-                return;
+                if ($record && $record->exists()) {
+                    $this->template = $record->getFile();
+                    $record = $templateLocator->getRecord(
+                        DIRNAME_BLOCKS . '/' . $obj->getBlockTypeHandle() . '/' . $this->render
+                    );
+                    if ($record) {
+                        $this->baseURL = dirname($record->getUrl());
+                        $this->basePath = dirname($record->getFile());
+                    }
+
+                    return;
+                }
             }
 
             // Use case b - bFilename that is a directory

--- a/concrete/src/Summary/SummaryObjectExtractor.php
+++ b/concrete/src/Summary/SummaryObjectExtractor.php
@@ -57,7 +57,6 @@ class SummaryObjectExtractor
                 }
             }
         }
-        $resolvedFields['summaryObject'] = $summaryObject;
         return $resolvedFields;
     }
 

--- a/concrete/src/Summary/SummaryObjectExtractor.php
+++ b/concrete/src/Summary/SummaryObjectExtractor.php
@@ -57,6 +57,7 @@ class SummaryObjectExtractor
                 }
             }
         }
+        $resolvedFields['summaryObject'] = $summaryObject;
         return $resolvedFields;
     }
 

--- a/concrete/src/Summary/Template/Renderer.php
+++ b/concrete/src/Summary/Template/Renderer.php
@@ -125,7 +125,7 @@ class Renderer implements LoggerAwareInterface
             if ($this->summaryObjectSupportsTemplate($summaryObjectFields, $template)) {
                 // note: we used to include <span class="ccm-summary-template-header"></span> around this, but it's
                 // too prescriptive and annoying, it causes problems with more advanced flexbox styling.
-
+                $summaryObjectFields['summaryObject'] = $summaryObject;
                 echo $this->templateService->renderTemplate($file, $summaryObjectFields);
             }
         } else {

--- a/concrete/src/Summary/Template/Renderer.php
+++ b/concrete/src/Summary/Template/Renderer.php
@@ -120,11 +120,11 @@ class Renderer implements LoggerAwareInterface
         $template = $summaryObject->getTemplate();
         $file = $this->templateLocator->getFileToRender($template);
         if ($file) {
-            $summaryObjectInspector = $this->summaryObjectInspector; // This is included here for use in the template.
             $summaryObjectFields = $this->summaryObjectExtractor->getData($summaryObject);
             if ($this->summaryObjectSupportsTemplate($summaryObjectFields, $template)) {
                 // note: we used to include <span class="ccm-summary-template-header"></span> around this, but it's
                 // too prescriptive and annoying, it causes problems with more advanced flexbox styling.
+                $summaryObjectFields['summaryObjectInspector'] = $this->summaryObjectInspector;
                 $summaryObjectFields['summaryObject'] = $summaryObject;
                 echo $this->templateService->renderTemplate($file, $summaryObjectFields);
             }

--- a/tests/tests/Block/BlockViewTemplateTest.php
+++ b/tests/tests/Block/BlockViewTemplateTest.php
@@ -38,6 +38,17 @@ class BlockViewTemplateTest extends TestCase
         $this->assertEquals(DIR_BASE_CORE . '/blocks/autonav', $bv->getBasePath());
         $this->assertEquals(DIR_BASE_CORE . '/blocks/autonav/templates/breadcrumb.php', $bv->getTemplate());
     }
+
+    public function testCoreBlockWithMissingCustomTemplateFallsBackToDefaultView()
+    {
+        $block = $this->getMockBlock('autonav', 'missing_template.php');
+        $packageList = $this->getMockPackageList();
+        $bv = new BlockViewTemplate($block, $packageList);
+
+        $this->assertEquals('/path/to/server/concrete/blocks/autonav', $bv->getBaseURL());
+        $this->assertEquals(DIR_BASE_CORE . '/blocks/autonav', $bv->getBasePath());
+        $this->assertEquals(DIR_BASE_CORE . '/blocks/autonav/view.php', $bv->getTemplate());
+    }
     
     public function testApplicationBlockView()
     {


### PR DESCRIPTION
Advanced board templates relied on a `$summaryObject` corresponding to the original summary object being available in the template. This used to work automatically when we just used include but now that we have a special template class we need to explicitly bring it through. 