### PR TITLE
Remove unnecessary closing anchor tag

### DIFF
--- a/concrete/blocks/calendar/controller.php
+++ b/concrete/blocks/calendar/controller.php
@@ -363,7 +363,7 @@ class Controller extends BlockController implements UsesFeatureInterface
 
                     $string = $formatter->getOccurrenceDateString($occurrence);
 
-                    return sprintf('<div class="ccm-block-calendar-dialog-event-time">%s</a></div>', $string);
+                    return sprintf('<div class="ccm-block-calendar-dialog-event-time">%s</div>', $string);
                 case 'linkToPage':
                     $formatter = $this->app->make(CalendarServiceProvider::class)->getLinkFormatter();
                     $url = $formatter->getEventOccurrenceFrontendViewLink($occurrence);


### PR DESCRIPTION
In the date output of a calendar event there was a closing anchor tag which appears to be out of place. This PR removes it.