### PR TITLE
Fix Composer detection with composer v2

### DIFF
--- a/.github/workflows/composer-detection.yml
+++ b/.github/workflows/composer-detection.yml
@@ -21,6 +21,7 @@ jobs:
             -
               php-version: "8.3"
               composer-version: 2
+              disable-composer-audit: 1
     steps:
       -
         name: Install PHP ${{ matrix.php-version }}
@@ -87,6 +88,11 @@ jobs:
           repository: mlocati/concretecms-skeleton
           ref: main
           path: composer-repo
+      -
+        name: Disable composer audit
+        if: ${{ matrix.disable-composer-audit }}
+        working-directory: composer-repo
+        run: composer config --ansi --no-interaction audit.block-insecure false
       -
         name: Install dependencies
         working-directory: composer-repo


### PR DESCRIPTION
The Composer detection tests are currently failing when using composer v2 since some dependencies of the last published v9 are blocked by composer auditing.

Since the only thing we are testing is the composer detection in a temporary project, what about turning off composer auditing for that test?