### PR TITLE
security: add allowed_classes to unserialize() in Workflow, Form blocks, and File/Set

### DIFF
--- a/concrete/blocks/form/controller.php
+++ b/concrete/blocks/form/controller.php
@@ -539,7 +539,7 @@ class Controller extends BlockController
                     $answerLong = '';
                     $answer = $txt->sanitize($_POST['Question' . $row['msqID']] ?? '');
                     if (!empty($row['options'])) {
-                        $settings = unserialize($row['options']);
+                        $settings = unserialize($row['options'], ['allowed_classes' => false]);
                         if (is_array($settings) && array_key_exists('send_notification_from', $settings) && $settings['send_notification_from'] == 1) {
                             $email = $txt->email($answer);
                             if (!empty($email)) {

--- a/concrete/blocks/form/mini_survey.php
+++ b/concrete/blocks/form/mini_survey.php
@@ -146,7 +146,7 @@ class MiniSurvey
             if ($key == 'options') {
                 $key = 'optionVals';
                 if ($questionRow['inputType'] == 'email') {
-                    $options = unserialize($val);
+                    $options = unserialize($val, ['allowed_classes' => false]);
                     if (is_array($options)) {
                         foreach ($options as $o_key => $o_val) {
                             $val = $o_key . '::' . $o_val . ';';

--- a/concrete/src/File/Set/Set.php
+++ b/concrete/src/File/Set/Set.php
@@ -209,8 +209,8 @@ class Set
                 $row2 = $db->GetRow(
                     'SELECT fsSearchRequest, fsResultColumns FROM FileSetSavedSearches WHERE fsID = ?',
                     array($fsID));
-                $fs->fsSearchRequest = @unserialize($row2['fsSearchRequest']);
-                $fs->fsResultColumns = @unserialize($row2['fsResultColumns']);
+                $fs->fsSearchRequest = @unserialize($row2['fsSearchRequest'], ['allowed_classes' => false]);
+                $fs->fsResultColumns = @unserialize($row2['fsResultColumns'], ['allowed_classes' => false]);
             }
 
             return $fs;

--- a/concrete/src/Workflow/Progress/Progress.php
+++ b/concrete/src/Workflow/Progress/Progress.php
@@ -301,7 +301,7 @@ abstract class Progress extends ConcreteObject implements SubjectInterface
         if (is_array($row) && ($row['wphID'])) {
             $obj = new $class();
             $obj->setPropertiesFromArray($row);
-            $obj->object = @unserialize($row['object']);
+            $obj->object = @unserialize($row['object'], ['allowed_classes' => [\Concrete\Core\Workflow\Progress\Response::class]]);
 
             return $obj;
         }

--- a/concrete/src/Workflow/Request/Request.php
+++ b/concrete/src/Workflow/Request/Request.php
@@ -74,7 +74,7 @@ abstract class Request extends ConcreteObject
         $db = Database::connection();
         $wrObject = $db->getOne('select wrObject from WorkflowRequestObjects where wrID = ?', array($wrID));
         if ($wrObject) {
-            $wr = unserialize($wrObject);
+            $wr = unserialize($wrObject, ['allowed_classes' => [\Concrete\Core\Workflow\Request\Request::class]]);
 
             return $wr;
         }


### PR DESCRIPTION
## Summary

Follow-up to #12935 — adds `allowed_classes` to additional `unserialize()` call sites in Workflow, Form blocks, and File/Set.

## Changes

| File | Column / data | Fix |
|------|---------------|-----|
| `src/Workflow/Request/Request.php` | `WorkflowRequestObjects.wrObject` — serialized `Request` object | `allowed_classes => [Request::class]` |
| `src/Workflow/Progress/Progress.php` | `WorkflowProgressHistory.object` — serialized `Response` object | `allowed_classes => [Response::class]` |
| `blocks/form/mini_survey.php` | Form option values — array of scalars | `allowed_classes => false` |
| `blocks/form/controller.php` | Form field configuration — array of scalars | `allowed_classes => false` |
| `src/File/Set/Set.php` | `fsSearchRequest`, `fsResultColumns` — search param arrays | `allowed_classes => false` |

## Security impact

Without this fix, an attacker with database write access can store crafted PHP serialized payloads containing gadget chains in these columns, achieving Remote Code Execution via PHP Object Injection when the data is deserialized.

Adding `allowed_classes` restricts which PHP classes can be instantiated during deserialization, preventing gadget chain exploitation even if an attacker can write to the database.