### PR TITLE
Fix TypeError in EditPagePropertiesPageKey causing Sitemap "Internal …

### DIFF
--- a/concrete/src/Permission/Key/EditPagePropertiesPageKey.php
+++ b/concrete/src/Permission/Key/EditPagePropertiesPageKey.php
@@ -142,7 +142,7 @@ class EditPagePropertiesPageKey extends PageKey
             $asl->allowEditDateTime() ||
             $asl->allowEditUserID() ||
             $asl->allowEditPaths() ||
-            ($asl->getAttributesAllowedPermission() == 'A' || ($asl->getAttributesAllowedPermission() == 'C' && count($asl->getAttributesAllowedArray() > 0)))
+            ($asl->getAttributesAllowedPermission() == 'A' || ($asl->getAttributesAllowedPermission() == 'C' && count($asl->getAttributesAllowedArray()) > 0))
         ) {
             return true;
         } else {


### PR DESCRIPTION
…Server Error"

**Describing the bug:**
When a non-superuser with restricted/advanced permissions attempts to expand a page node in the Full Sitemap, it triggers an AJAX `Load error! (Internal Server Error)`. 

**Root cause:**
This occurs due to a misplaced parenthesis inside `concrete/src/Permission/Key/EditPagePropertiesPageKey.php` (around line 145) when validating attributes. The operator is placed inside the `count()` function, causing it to evaluate a boolean instead of an array. 

In PHP 8+, this strictness throws a Fatal Error (`TypeError: count(): Argument #1 ($value) must be of type Countable|array, bool given`), crashing the backend request and breaking the sitemap UI for those users.

**Original buggy code:**
`count($asl->getAttributesAllowedArray() > 0)`

**Correct fix (moved parenthesis):**
`count($asl->getAttributesAllowedArray()) > 0`

**Environment:**
* Concrete CMS Version: 9.5.x (Bug present since 8.5.x)
* PHP Version: 8.1 / 8.2+

*Check these before submitting new pull requests*

- [x] I read the __guidelines for contributing__ linked above. My pull request conforms to the coding style guidelines described within.

If this condition is met, feel free to delete this whole message and to submit your pull request.

Thank you, your help is really appreciated!
