### PR TITLE
Don't show a token error when the login form is submitted after login already succeeded

### DIFF
--- a/concrete/controllers/single_page/login.php
+++ b/concrete/controllers/single_page/login.php
@@ -120,6 +120,14 @@ class Login extends PageController implements LoggerAwareInterface
     {
         $valt = $this->app->make('token');
         if (!$valt->validate('login_' . $type)) {
+            // The token is bound to the user id, so a duplicate submission of the login
+            // form fails validation once the first submission has logged the user in. They
+            // are already authenticated at this point, so send them to their post-login
+            // destination instead of showing a token error.
+            $u = $this->app->make(User::class);
+            if ($u->isRegistered()) {
+                return $this->app->make(PostLoginLocation::class)->getPostLoginRedirectResponse(true);
+            }
             $this->error->add($valt->getErrorMessage());
         } else {
             try {


### PR DESCRIPTION
Fixes #12959

The CSRF token embeds the user id, and `Token::validate()` recomputes the hash against the current request's user. The login form is rendered while logged out, so its token carries `uID = 0`. That validates fine as long as you're still logged out when it's checked. But once the session is authenticated, the same token fails — and there are several ways it gets submitted after that point: a double-click or a password manager auto-submitting alongside your click, a second tab still showing the old form after you logged in elsewhere, a back-button/bfcache return to the form, or a "remember me" cookie authenticating the session between render and submit. In each case `authenticate()` adds "Invalid form token" and falls through to render the login page, which shows "You are already logged in" because you are. Both land on the same page and it looks like the login broke, even though it didn't.

This checks for that case: if the token fails but the user is already registered, the login already happened, so redirect to the post-login location instead of showing the error. It reuses the same `getPostLoginRedirectResponse()` the normal flow uses, so the submission ends up where a normal login would have.

Keying on the end-state rather than any one trigger means it covers all of these paths at once, not just one. The security path is untouched — the short-circuit only fires when `isRegistered()` is already true, so it authenticates no one new, and a logged-out user posting a bad token is rejected exactly as before. It does mean a token that fails for some other reason gets smoothed over on the login path for an already-authenticated user, but login shrugging off a stale token is the right behavior regardless.

Verified against a scripted double-POST (same token, same session): before, the second POST returned 200 with both messages; after, it 302s to the post-login destination. A logged-out request with a bad token still errors, and a normal single login is unchanged.
