### PR TITLE
Fix Date Added file search column callback

### DIFF
--- a/concrete/src/File/Search/ColumnSet/Column/FileVersionDateAddedColumn.php
+++ b/concrete/src/File/Search/ColumnSet/Column/FileVersionDateAddedColumn.php
@@ -23,6 +23,29 @@ class FileVersionDateAddedColumn extends Column implements PagerColumnInterface
 
     public function getColumnCallback()
     {
+        return [self::class, 'getDateAdded'];
+    }
+
+    public function getDateAdded($node)
+    {
+        $file = null;
+        if ($node instanceof \Concrete\Core\Entity\File\File) {
+            $file = $node;
+        } else if ($node->getTreeNodeTypeHandle() == 'file_folder') {
+            return '';
+        } else if ($node->getTreeNodeTypeHandle() == 'file') {
+            $file = $node->getTreeNodeFileObject();
+        }
+
+        if (is_object($file)) {
+            $version = $file->getVersion();
+            if (is_object($version)) {
+                $dateAdded = $version->getDateAdded();
+                if ($dateAdded instanceof \DateTimeInterface) {
+                    return app('date')->formatDateTime($dateAdded->getTimestamp());
+                }
+            }
+        }
     }
 
     public function filterListAtOffset(PagerProviderInterface $itemList, $mixed)

--- a/concrete/src/File/Search/ColumnSet/Column/FileVersionDateAddedColumn.php
+++ b/concrete/src/File/Search/ColumnSet/Column/FileVersionDateAddedColumn.php
@@ -26,7 +26,7 @@ class FileVersionDateAddedColumn extends Column implements PagerColumnInterface
         return [self::class, 'getDateAdded'];
     }
 
-    public function getDateAdded($node)
+    public function getDateAdded($node): string
     {
         $file = null;
         if ($node instanceof \Concrete\Core\Entity\File\File) {
@@ -46,6 +46,8 @@ class FileVersionDateAddedColumn extends Column implements PagerColumnInterface
                 }
             }
         }
+
+        return '';
     }
 
     public function filterListAtOffset(PagerProviderInterface $itemList, $mixed)


### PR DESCRIPTION
Fixes #12961

The FileVersionDateAddedColumn callback was defined but returned null, which made File Manager result rendering fail when the Date Added column was displayed. Return a callback that formats the approved file version date and handles both file tree nodes and direct file objects.
