### PR TITLE
Fix dashboard navigation cache isolation

### DIFF
--- a/concrete/src/Application/UserInterface/Dashboard/Navigation/AbstractNavigationCache.php
+++ b/concrete/src/Application/UserInterface/Dashboard/Navigation/AbstractNavigationCache.php
@@ -52,6 +52,8 @@ abstract class AbstractNavigationCache
 
     protected function getSessionIdentifier(): string
     {
-        return $this->getIdentifier() . '@' . $this->localization->getLocale();
+        $userID = (int) $this->session->get('uID');
+
+        return $this->getIdentifier() . '@' . $this->localization->getLocale() . '@' . $userID;
     }
 }

--- a/tests/tests/Navigation/DashboardNavigationCacheTest.php
+++ b/tests/tests/Navigation/DashboardNavigationCacheTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Concrete\Tests\Navigation;
+
+use Concrete\Core\Application\UserInterface\Dashboard\Navigation\AbstractNavigationCache;
+use Concrete\Core\Application\UserInterface\Dashboard\Navigation\Navigation;
+use Concrete\Core\Localization\Localization;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Session\Session;
+use Symfony\Component\HttpFoundation\Session\Storage\MockArraySessionStorage;
+
+class DashboardNavigationCacheTest extends TestCase
+{
+    public function testNavigationCacheIsSeparatedByUser(): void
+    {
+        $session = new Session(new MockArraySessionStorage());
+        $cache = $this->createCache($session);
+
+        $session->set('uID', 1);
+        $cache->set(new Navigation());
+
+        $session->set('uID', 2);
+        $this->assertFalse($cache->has());
+
+        $cache->set(new Navigation());
+
+        $this->assertTrue($session->has('dashboard_favorites_menu@en_US@1'));
+        $this->assertTrue($session->has('dashboard_favorites_menu@en_US@2'));
+    }
+
+    public function testClearRemovesNavigationCacheForEveryUser(): void
+    {
+        $session = new Session(new MockArraySessionStorage());
+        $cache = $this->createCache($session);
+
+        $session->set('uID', 1);
+        $cache->set(new Navigation());
+
+        $session->set('uID', 2);
+        $cache->set(new Navigation());
+
+        $cache->clear();
+
+        $this->assertFalse($session->has('dashboard_favorites_menu@en_US@1'));
+        $this->assertFalse($session->has('dashboard_favorites_menu@en_US@2'));
+    }
+
+    private function createCache(Session $session): AbstractNavigationCache
+    {
+        $localization = $this->createMock(Localization::class);
+        $localization->method('getLocale')->willReturn(Localization::BASE_LOCALE);
+
+        return new class ($session, $localization) extends AbstractNavigationCache {
+            public function getIdentifier(): string
+            {
+                return 'dashboard_favorites_menu';
+            }
+        };
+    }
+}


### PR DESCRIPTION
Fixes #12963

This fixes dashboard navigation cache isolation when the active user changes within the same session.

Previously, dashboard navigation cache entries were keyed by navigation identifier and locale only. This meant that cached navigation generated for one user could be reused after the session switched to another user.

The cache key now includes the active user ID, so dashboard navigation cache entries are separated per user.

A unit test covers:

- cache entries are separated when the same session changes from `uID = 1` to `uID = 2`
- clearing the cache still removes all user-specific entries for the navigation cache

Tested with PHPUnit 9.6.34.

Before the fix:

```text
FAILURES!
Tests: 2, Assertions: 3, Failures: 1.
```

After the fix:

```text
OK (2 tests, 5 assertions)
```
