### PR TITLE
Fix deleting all keys in Cache/Driver/RedisStashDriver

### DIFF
--- a/concrete/src/Cache/Driver/RedisStashDriver.php
+++ b/concrete/src/Cache/Driver/RedisStashDriver.php
@@ -283,6 +283,7 @@ class RedisStashDriver extends AbstractDriver
                     } else {
                         $keys = $this->redis->keys('*');
                     }
+                    $keys = array_values(array_filter($keys, 'is_string'));
 
                     // Predis doesnt give us an easy way to remove the prefix as keys returns all keys with prefixes
                     foreach ($keys as $key) {
@@ -294,6 +295,7 @@ class RedisStashDriver extends AbstractDriver
 
                 } else {
                     $keys = $this->redis->keys('*');
+                    $keys = array_values(array_filter($keys, 'is_string'));
                     // Remove the prefix
                     $this->redis->setOption(\Redis::OPT_PREFIX, null);
                     // Delete all keys


### PR DESCRIPTION
I have a strange behaviour...

Sometimes

```php
$this->redis->keys('*');
```

returns a list of strings (as expected).

But sometimes (maybe when there isn't any key?) that function returns something like this (in JSON format):

```json
{
	"127.0.0.1:6379": []
}
```

that is, an array with one key, `"127.0.0.1:6379"`, whose value is an array.

This causes this `FatalError`:

```
Error: RedisArray::del(): DEL: all keys must be string.
```


Let's fix this.