### PR TITLE
Apply 'quoted_printable_decode' function to mail details if content contains quoted-printable characters

### DIFF
--- a/concrete/src/Mail/Service.php
+++ b/concrete/src/Mail/Service.php
@@ -638,8 +638,11 @@ class Service implements LoggerAwareInterface
                     $email->html($this->email->getHtmlBody(), $this->email->getHtmlCharset());
                 }
 
-                // append the attached file names to the mail log
                 $mailDetails = $email->toString();
+                if (stripos($mailDetails, 'Content-Transfer-Encoding: quoted-printable') !== false) {
+                    $mailDetails = quoted_printable_decode($mailDetails);
+                }
+                // append the attached file names to the mail log
                 foreach ($this->email->getAttachments() as $attachedFile) {
                     $mailDetails .= "\n" . t("[Attached File: %s]", $attachedFile->asDebugString());
                 }


### PR DESCRIPTION
Apply quoted_printable_decode in instances where the mail body contained quoted-printable encoded characters. Moved comment concerning the attached file names to above the loop that relates to the comment.

Fixes: #12924 