### PR TITLE
Ensure 'Incorrect DATETIME' SQL error does not occur if no end date o…

### DIFF
--- a/concrete/blocks/page_list/controller.php
+++ b/concrete/blocks/page_list/controller.php
@@ -403,8 +403,12 @@ class Controller extends BlockController implements UsesFeatureInterface
                 break;
 
             case 'between':
-                $start = "{$this->filterDateStart} 00:00:00";
-                $end = "{$this->filterDateEnd} 23:59:59";
+                if (!empty($this->filterDateStart)) {
+                    $start = "{$this->filterDateStart} 00:00:00";
+                }
+                if (!empty($this->filterDateEnd)) {
+                    $end = "{$this->filterDateEnd} 23:59:59";
+                }
                 break;
 
             case 'all':


### PR DESCRIPTION
…r start date is set in a page list with a between filter

If no between values are set in the page list block's filter by public date, prevents 'Incorrect DATETIME' SQL errors.

This table describes the behaviour based on which filters are set.
Start | End | Result
-- | -- | --
set | set | both filters applied
set | empty | only >= start
empty | set | only <= end
empty | empty | no public-date filter (same as “all”)

Fixes: #12816 
