### PR TITLE
Fix Stack List dashboard redirect

### DIFF
--- a/concrete/controllers/single_page/dashboard/blocks/stacks.php
+++ b/concrete/controllers/single_page/dashboard/blocks/stacks.php
@@ -13,7 +13,6 @@ use Concrete\Core\Page\Page;
 use Concrete\Core\Page\Stack\Stack;
 use Concrete\Core\Page\Stack\StackList;
 use Concrete\Core\Permission\Checker;
-use Concrete\Core\Routing\Redirect;
 use Concrete\Core\Support\Facade\StackFolder;
 use Concrete\Core\User\User;
 use Concrete\Core\Workflow\Request\ApprovePageRequest;
@@ -617,7 +616,7 @@ class Stacks extends DashboardPageController
 
     public function list_page()
     {
-        return Redirect::to('/dashboard/blocks/stacks');
+        return $this->buildRedirect('/dashboard/blocks/stacks');
     }
 
     public function delete_stackfolder()

--- a/concrete/controllers/single_page/dashboard/blocks/stacks.php
+++ b/concrete/controllers/single_page/dashboard/blocks/stacks.php
@@ -13,6 +13,7 @@ use Concrete\Core\Page\Page;
 use Concrete\Core\Page\Stack\Stack;
 use Concrete\Core\Page\Stack\StackList;
 use Concrete\Core\Permission\Checker;
+use Concrete\Core\Routing\Redirect;
 use Concrete\Core\Support\Facade\StackFolder;
 use Concrete\Core\User\User;
 use Concrete\Core\Workflow\Request\ApprovePageRequest;
@@ -616,7 +617,7 @@ class Stacks extends DashboardPageController
 
     public function list_page()
     {
-        return Redirect::to('/');
+        return Redirect::to('/dashboard/blocks/stacks');
     }
 
     public function delete_stackfolder()


### PR DESCRIPTION
Fixes #12968

This fixes the legacy dashboard Stack List route:

```text
/dashboard/blocks/stacks/list
```

Previously, the route called `Stacks::list_page()`, which returned:

```php
Redirect::to('/');
```

That sent users to the site homepage instead of the dashboard stacks page.

The method now uses the controller redirect helper and redirects to:

```text
/dashboard/blocks/stacks
```

Tested with:

```text
php -l concrete/controllers/single_page/dashboard/blocks/stacks.php
```
