### PR TITLE
Load version comment by the workflow version instead of most recent version

### DIFF
--- a/concrete/src/Workflow/Request/ApprovePageRequest.php
+++ b/concrete/src/Workflow/Request/ApprovePageRequest.php
@@ -54,11 +54,11 @@ class ApprovePageRequest extends PageRequest
     public function getWorkflowRequestDescriptionObject()
     {
         $d = new WorkflowDescription();
-        $c = Page::getByID($this->cID, 'RECENT');
+        $c = Page::getByID($this->cID, $this->cvID);
         $link = Loader::helper('navigation')->getLinkToCollection($c, true);
         $v = $c->getVersionObject();
         if (is_object($v)) {
-            $comments = $c->getVersionObject()->getVersionComments();
+            $comments = $v->getVersionComments();
 
             if (!$this->isNewPageRequest()) {
                 // new version of existing page


### PR DESCRIPTION
When requesting the workflow comment use the workflow version instead of the most recent version comment. Removed repeated 'getVersionObject' call as the value was already being cached in $v.

Fixes: #12755 
