### PR TITLE
Fix stale package controller use after Marketplace add-on download

### DIFF
--- a/concrete/controllers/single_page/dashboard/extend/update.php
+++ b/concrete/controllers/single_page/dashboard/extend/update.php
@@ -24,6 +24,17 @@ class Update extends DashboardPageController
             return;
         }
         $previousVersion = $packageController->getPackageEntity()->getPackageVersion();
+        $newVersion = $packageController->getPackageVersion();
+        if (version_compare($newVersion, $previousVersion, '<=')) {
+            $this->error->add(t(
+                'Package "%1$s" was not updated because the loaded package controller still reports version %2$s. Clear the PHP opcode cache and try again.',
+                t($packageController->getPackageName()) ?: $packageController->getPackageHandle(),
+                $newVersion
+            ));
+
+            return;
+        }
+
         Localization::getInstance()->withContext(Localization::CONTEXT_SYSTEM, static function () use ($packageController) {
             $packageController->upgradeCoreData();
             $packageController->upgrade();
@@ -32,7 +43,7 @@ class Update extends DashboardPageController
             t('Package "%1$s" has been updated successfully from version %2$s to version %3$s.',
                 t($packageController->getPackageName()) ?: $packageController->getPackageHandle(),
                 $previousVersion,
-                $packageController->getPackageVersion()
+                $newVersion
             )
         );
     }
@@ -55,10 +66,21 @@ class Update extends DashboardPageController
         }
 
         $connection = $packageRepository->getConnection();
+        $localUpdates = $packageService->getLocalUpgradeablePackages();
+        $localUpdateHandles = array_map(static function ($package) {
+            return $package->getPackageHandle();
+        }, $localUpdates);
+        $remoteUpdates = array_values(array_filter(
+            $packageService->getRemotelyUpgradeablePackages(),
+            static function ($package) use ($localUpdateHandles) {
+                return !in_array($package->getPackageHandle(), $localUpdateHandles, true);
+            }
+        ));
+
         $this->set('connection', $connection);
         $this->set('remotePackages', $connection ? $packageRepository->getPackages($connection, true) : []);
-        $this->set('localUpdates', $packageService->getLocalUpgradeablePackages());
-        $this->set('remoteUpdates', $packageService->getRemotelyUpgradeablePackages());
+        $this->set('localUpdates', $localUpdates);
+        $this->set('remoteUpdates', $remoteUpdates);
     }
 
     public function do_update($pkgHandle = false)
@@ -120,7 +142,9 @@ class Update extends DashboardPageController
             }
 
             $packageRepository->download($connection, $mri, true);
-            $this->updatePackage($mri->handle);
+            $this->set('autoUpgradePackageHandle', $mri->handle);
+            $this->set('autoUpgradePackageName', t($local->getPackageName()) ?: $local->getPackageHandle());
+            $this->set('autoUpgradePackageVersion', $mri->version);
         } catch (UserMessageException $x) {
             $this->error->add($x);
         }

--- a/concrete/single_pages/dashboard/extend/update.php
+++ b/concrete/single_pages/dashboard/extend/update.php
@@ -9,6 +9,12 @@ $localUpdates = $localUpdates ?? [];
 $remoteUpdates = $remoteUpdates ?? [];
 /** @var \Concrete\Core\Marketplace\Model\RemotePackage[] $remotePackages */
 $remotePackages = $remotePackages ?? [];
+/** @var string|null $autoUpgradePackageHandle */
+$autoUpgradePackageHandle = $autoUpgradePackageHandle ?? null;
+/** @var string|null $autoUpgradePackageName */
+$autoUpgradePackageName = $autoUpgradePackageName ?? null;
+/** @var string|null $autoUpgradePackageVersion */
+$autoUpgradePackageVersion = $autoUpgradePackageVersion ?? null;
 
 defined('C5_EXECUTE') or die('Access Denied.');
 $valt = Loader::helper('validation/token');
@@ -28,7 +34,22 @@ if (!$tp->canInstallPackages()) {
     </p>
     <?php
 } else {
-    if (count($localUpdates) == 0 && count($remoteUpdates) == 0) {
+    if ($autoUpgradePackageHandle !== null) {
+        ?>
+        <div class="alert alert-info">
+            <?= h(t('Completing update for package "%1$s" to version %2$s. Please wait...', $autoUpgradePackageName, $autoUpgradePackageVersion)) ?>
+        </div>
+        <form method="post" action="<?= View::url('/dashboard/extend/update', 'do_update', $autoUpgradePackageHandle) ?>" id="ccm-update-addons-auto-upgrade">
+            <?= $valt->output('update_addon') ?>
+            <noscript>
+                <button type="submit" class="btn btn-primary"><?= t('Complete Update') ?></button>
+            </noscript>
+        </form>
+        <script>
+        document.getElementById('ccm-update-addons-auto-upgrade').submit();
+        </script>
+        <?php
+    } elseif (count($localUpdates) == 0 && count($remoteUpdates) == 0) {
         ?>
 			<p><?=t('No updates for your add-ons are available.')?></p>
         <?php


### PR DESCRIPTION
Fixes #12974

## Summary

- Separate remote Marketplace package downloads from package upgrade execution with an automatic second POST request.
- Avoid showing duplicate remote update actions when the downloaded package is already available as a local upgrade.
- Prevent false success messages when the loaded package controller version is not greater than the installed version.

## Testing

- `php -l concrete/controllers/single_page/dashboard/extend/update.php`
- `php -l concrete/single_pages/dashboard/extend/update.php`