### PR TITLE
Handle Marketplace package download timeouts

### DIFF
--- a/concrete/controllers/single_page/dashboard/extend/update.php
+++ b/concrete/controllers/single_page/dashboard/extend/update.php
@@ -6,6 +6,7 @@ use Concrete\Core\Config\Repository\Repository;
 use Concrete\Core\Error\UserMessageException;
 use Concrete\Core\Foundation\Composer;
 use Concrete\Core\Localization\Localization;
+use Concrete\Core\Marketplace\Exception\InvalidDownloadResponseException;
 use Concrete\Core\Marketplace\PackageRepositoryInterface;
 use Concrete\Core\Package\PackageService;
 use Concrete\Core\Page\Controller\DashboardPageController;
@@ -123,6 +124,8 @@ class Update extends DashboardPageController
             $this->updatePackage($mri->handle);
         } catch (UserMessageException $x) {
             $this->error->add($x);
+        } catch (InvalidDownloadResponseException $x) {
+            $this->error->add($x->getMessage());
         }
         $this->view();
     }

--- a/concrete/src/Marketplace/PackageRepository.php
+++ b/concrete/src/Marketplace/PackageRepository.php
@@ -23,8 +23,8 @@ use Concrete\Core\Site\Service;
 use Concrete\Core\Url\Url;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\BadResponseException;
-use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Uri;
 use GuzzleHttp\RequestOptions;
@@ -139,8 +139,8 @@ final class PackageRepository implements PackageRepositoryInterface
                 RequestOptions::ALLOW_REDIRECTS => true,
                 RequestOptions::SINK => $output,
             ]);
-        } catch (ClientException $e) {
-            throw new InvalidDownloadResponseException($e->getMessage());
+        } catch (GuzzleException $e) {
+            throw new InvalidDownloadResponseException(t('Unable to download the package from the marketplace.'), 0, $e);
         }
 
         // Unzip the archive

--- a/tests/tests/Marketplace/PackageRepositoryTest.php
+++ b/tests/tests/Marketplace/PackageRepositoryTest.php
@@ -8,6 +8,7 @@ use Concrete\Core\File\Service\File;
 use Concrete\Core\Marketplace\Connection;
 use Concrete\Core\Marketplace\ConnectionInterface;
 use Concrete\Core\Marketplace\Exception\InvalidConnectResponseException;
+use Concrete\Core\Marketplace\Exception\InvalidDownloadResponseException;
 use Concrete\Core\Marketplace\Exception\InvalidPackageException;
 use Concrete\Core\Marketplace\Exception\PackageAlreadyExistsException;
 use Concrete\Core\Marketplace\Exception\UnableToConnectException;
@@ -18,6 +19,7 @@ use Concrete\Tests\TestCase;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Uri;
@@ -395,6 +397,18 @@ class PackageRepositoryTest extends TestCase
 
         $this->assertTrue(file_exists(DIR_PACKAGES . '/foo/controller.php'));
         $this->assertEquals("worked\n", file_get_contents(DIR_PACKAGES . '/foo/controller.php'));
+    }
+
+    public function testDownloadConnectionError(): void
+    {
+        $connection = new Connection('pub', 'priv');
+        $this->client->expects('send')->andThrow(new ConnectException('Connection timed out', new Request('GET', 'http://download/path')));
+
+        $this->expectException(InvalidDownloadResponseException::class);
+        $this->expectExceptionMessage('Unable to download the package from the marketplace.');
+
+        $repository = $this->repository();
+        $repository->download($connection, $this->fakePackage);
     }
 
     /**


### PR DESCRIPTION
# Handle Marketplace package download timeouts

## Summary

- Catch Guzzle download failures while downloading Marketplace packages.
- Convert those failures to `InvalidDownloadResponseException` with a generic dashboard-safe message.
- Surface the error in the add-on update dashboard instead of allowing a crash.
- Add unit coverage for a `ConnectException` during package download.

## Details

Marketplace package downloads can fail before an HTTP response is available, for example with cURL timeout errors against short-lived signed S3 URLs. Previously, `PackageRepository::download()` only handled `ClientException`, so transport-level exceptions such as `ConnectException` could bubble out and crash the dashboard update flow.

This change catches `GuzzleException` in the download path and throws a generic `InvalidDownloadResponseException`. The dashboard update controller now catches that exception and adds its message to the dashboard error list.

The generic error also avoids exposing signed download URLs and temporary `X-Amz-*` query parameters in the UI.

## Testing

```text
php -l concrete/src/Marketplace/PackageRepository.php
php -l concrete/controllers/single_page/dashboard/extend/update.php
php -l tests/tests/Marketplace/PackageRepositoryTest.php
```

Container PHPUnit:

```text
./concrete/vendor/bin/phpunit --filter PackageRepositoryTest tests/tests/Marketplace/PackageRepositoryTest.php

OK (15 tests, 74 assertions)
```

Fixes #12976
