### PR TITLE
Show clear marketplace package filesystem errors

### DIFF
--- a/concrete/controllers/single_page/dashboard/extend/install.php
+++ b/concrete/controllers/single_page/dashboard/extend/install.php
@@ -283,13 +283,22 @@ class Install extends DashboardPageController implements LoggerAwareInterface
                 'version' => $remotePackage->version
             ]);
             $repository->download($connection, $remotePackage, true);
-        } catch (PackageAlreadyExistsException|UnableToPlacePackageException $e) {
+        } catch (PackageAlreadyExistsException $e) {
             $this->getLogger()->error('Unable to move {handle}:{version} into package directory.', [
                 'name' => $remotePackage->name,
                 'handle' => $remotePackage->handle,
                 'version' => $remotePackage->version
             ]);
             $this->error->add(t('Unable to move package directory.'));
+            return;
+        } catch (UnableToPlacePackageException $e) {
+            $this->getLogger()->error('Unable to move {handle}:{version} into package directory. {message}', [
+                'name' => $remotePackage->name,
+                'handle' => $remotePackage->handle,
+                'version' => $remotePackage->version,
+                'message' => $e->getMessage(),
+            ]);
+            $this->error->add($e->getMessage());
             return;
         } catch (InvalidPackageException $e) {
             $this->getLogger()->error(

--- a/concrete/controllers/single_page/dashboard/extend/update.php
+++ b/concrete/controllers/single_page/dashboard/extend/update.php
@@ -6,6 +6,7 @@ use Concrete\Core\Config\Repository\Repository;
 use Concrete\Core\Error\UserMessageException;
 use Concrete\Core\Foundation\Composer;
 use Concrete\Core\Localization\Localization;
+use Concrete\Core\Marketplace\Exception\UnableToPlacePackageException;
 use Concrete\Core\Marketplace\PackageRepositoryInterface;
 use Concrete\Core\Package\PackageService;
 use Concrete\Core\Page\Controller\DashboardPageController;
@@ -123,6 +124,8 @@ class Update extends DashboardPageController
             $this->updatePackage($mri->handle);
         } catch (UserMessageException $x) {
             $this->error->add($x);
+        } catch (UnableToPlacePackageException $x) {
+            $this->error->add($x->getMessage());
         }
         $this->view();
     }

--- a/concrete/src/Marketplace/MarketplaceServiceProvider.php
+++ b/concrete/src/Marketplace/MarketplaceServiceProvider.php
@@ -9,6 +9,7 @@ use Concrete\Core\Http\Client\Client;
 use Concrete\Core\Logging\Channels;
 use Concrete\Core\Logging\LoggerFactory;
 use Concrete\Core\Site\Service;
+use Concrete\Core\System\SystemUser;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Serializer;
@@ -28,6 +29,7 @@ class MarketplaceServiceProvider extends Provider
                 $this->app->make('config/database'),
                 $this->app->make(Service::class),
                 $this->app->make(File::class),
+                $this->app->make(SystemUser::class),
                 $config->get('concrete.urls.package_repository'),
                 $config->get('concrete.urls.paths.package_repository')
             );

--- a/concrete/src/Marketplace/PackageRepository.php
+++ b/concrete/src/Marketplace/PackageRepository.php
@@ -20,6 +20,7 @@ use Concrete\Core\Marketplace\Model\RemotePackage;
 use Concrete\Core\Marketplace\Model\ValidateResult;
 use Concrete\Core\Marketplace\Update\UpdatedFieldInterface;
 use Concrete\Core\Site\Service;
+use Concrete\Core\System\SystemUser;
 use Concrete\Core\Url\Url;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\BadResponseException;
@@ -50,6 +51,8 @@ final class PackageRepository implements PackageRepositoryInterface
     private $paths;
     /** @var File */
     private $fileHelper;
+    /** @var SystemUser */
+    private $systemUser;
 
     public function __construct(
         Client $client,
@@ -58,6 +61,7 @@ final class PackageRepository implements PackageRepositoryInterface
         Repository $databaseConfig,
         Service $siteService,
         File $fileHelper,
+        SystemUser $systemUser,
         string $baseUri,
         array $paths
     ) {
@@ -67,6 +71,7 @@ final class PackageRepository implements PackageRepositoryInterface
         $this->databaseConfig = $databaseConfig;
         $this->siteService = $siteService;
         $this->fileHelper = $fileHelper;
+        $this->systemUser = $systemUser;
         $this->baseUri = $baseUri;
         $this->paths = $paths;
     }
@@ -130,6 +135,7 @@ final class PackageRepository implements PackageRepositoryInterface
         if (!$overwrite && file_exists(DIR_PACKAGES . '/' . $package->handle)) {
             throw new PackageAlreadyExistsException();
         }
+        $this->assertPackageDirectoryWritable();
 
         // Try to start the download
         try {
@@ -161,7 +167,15 @@ final class PackageRepository implements PackageRepositoryInterface
         $packageDir = DIR_PACKAGES . '/' . $package->handle;
         if ($overwrite && file_exists($packageDir)) {
             if (!$this->rename($packageDir, $packageDir . '.old')) {
-                throw new UnableToPlacePackageException();
+                throw $this->createUnableToPlacePackageException(
+                    t(
+                        'Unable to back up the existing package directory from "%1$s" to "%2$s".',
+                        $packageDir,
+                        $packageDir . '.old'
+                    ),
+                    $packageDir,
+                    $packageDir . '.old'
+                );
             }
         }
 
@@ -169,7 +183,15 @@ final class PackageRepository implements PackageRepositoryInterface
             if ($overwrite) {
                 $this->rename($packageDir . '.old', $packageDir);
             }
-            throw new UnableToPlacePackageException();
+            throw $this->createUnableToPlacePackageException(
+                t(
+                    'Unable to move the downloaded package directory from "%1$s" to "%2$s".',
+                    $unzipPath . '/' . $package->handle,
+                    $packageDir
+                ),
+                $unzipPath . '/' . $package->handle,
+                $packageDir
+            );
         }
 
         $this->rimraf($package->handle . '.old');
@@ -193,6 +215,45 @@ final class PackageRepository implements PackageRepositoryInterface
         // Remove the old directory
         $this->fileHelper->removeAll($old, true);
         return true;
+    }
+
+    private function assertPackageDirectoryWritable(): void
+    {
+        if (!is_dir(DIR_PACKAGES)) {
+            throw $this->createUnableToPlacePackageException(
+                t('The package directory "%s" does not exist.', DIR_PACKAGES),
+                DIR_PACKAGES
+            );
+        }
+        if (!is_writable(DIR_PACKAGES)) {
+            throw $this->createUnableToPlacePackageException(
+                t('Unable to write to the package directory "%s".', DIR_PACKAGES),
+                DIR_PACKAGES
+            );
+        }
+    }
+
+    private function createUnableToPlacePackageException(
+        string $message,
+        string $sourcePath,
+        ?string $destinationPath = null
+    ): UnableToPlacePackageException {
+        $paths = $destinationPath === null
+            ? t('Path: %s', $sourcePath)
+            : t('Source: %1$s Destination: %2$s', $sourcePath, $destinationPath);
+
+        $username = $this->systemUser->getCurrentUserName();
+        if ($username === '') {
+            $username = t('unknown');
+        }
+
+        return new UnableToPlacePackageException(t(
+            '%1$s %2$s Current PHP process user: %3$s. ' .
+            'Update filesystem permissions from your shell or hosting control panel, then try again.',
+            $message,
+            $paths,
+            $username
+        ));
     }
 
     protected function rimraf(string $handle)

--- a/tests/tests/Marketplace/PackageRepositoryTest.php
+++ b/tests/tests/Marketplace/PackageRepositoryTest.php
@@ -11,9 +11,11 @@ use Concrete\Core\Marketplace\Exception\InvalidConnectResponseException;
 use Concrete\Core\Marketplace\Exception\InvalidPackageException;
 use Concrete\Core\Marketplace\Exception\PackageAlreadyExistsException;
 use Concrete\Core\Marketplace\Exception\UnableToConnectException;
+use Concrete\Core\Marketplace\Exception\UnableToPlacePackageException;
 use Concrete\Core\Marketplace\Model\RemotePackage;
 use Concrete\Core\Marketplace\PackageRepository;
 use Concrete\Core\Site\Service;
+use Concrete\Core\System\SystemUser;
 use Concrete\Tests\TestCase;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\BadResponseException;
@@ -54,6 +56,9 @@ class PackageRepositoryTest extends TestCase
     /** @var File&MockInterface */
     private $fileService;
 
+    /** @var SystemUser&MockInterface */
+    private $systemUser;
+
     /** @var Site&MockInterface */
     private $fakeSite;
 
@@ -67,9 +72,11 @@ class PackageRepositoryTest extends TestCase
         $this->config = \Mockery::spy(Repository::class);
         $this->siteService = \Mockery::spy(Service::class);
         $this->fileService = \Mockery::mock(File::class);
+        $this->systemUser = \Mockery::mock(SystemUser::class);
         $this->fakeSite = Mockery::spy(Site::class);
         $this->siteService->shouldReceive('getDefault')->andReturn($this->fakeSite);
         $this->fileService->shouldReceive('getTemporaryDirectory')->andReturn('/tmp');
+        $this->systemUser->shouldReceive('getCurrentUserName')->andReturn('www-data');
         $this->fakePackage = new RemotePackage(
             'foo',
             '',
@@ -93,6 +100,7 @@ class PackageRepositoryTest extends TestCase
             $this->config,
             $this->siteService,
             $this->fileService,
+            $this->systemUser,
             $baseUri,
             $paths
         );
@@ -395,6 +403,42 @@ class PackageRepositoryTest extends TestCase
 
         $this->assertTrue(file_exists(DIR_PACKAGES . '/foo/controller.php'));
         $this->assertEquals("worked\n", file_get_contents(DIR_PACKAGES . '/foo/controller.php'));
+    }
+
+    public function testDownloadPackageDirectoryNotWritable(): void
+    {
+        if (DIRECTORY_SEPARATOR === '\\') {
+            $this->markTestSkipped('Changing directory writability is not reliable on Windows.');
+        }
+
+        $originalPermissions = fileperms(DIR_PACKAGES) & 0777;
+        if (!@chmod(DIR_PACKAGES, 0555)) {
+            $this->markTestSkipped('Unable to change package directory permissions.');
+        }
+
+        clearstatcache(true, DIR_PACKAGES);
+        if (is_writable(DIR_PACKAGES)) {
+            @chmod(DIR_PACKAGES, $originalPermissions);
+            $this->markTestSkipped('The current process can still write to the package directory.');
+        }
+
+        $connection = new Connection('pub', 'priv');
+        $repository = $this->repository();
+        $e = null;
+
+        try {
+            $repository->download($connection, $this->fakePackage);
+        } catch (\Throwable $e) {
+        } finally {
+            @chmod(DIR_PACKAGES, $originalPermissions);
+        }
+
+        $this->assertInstanceOf(UnableToPlacePackageException::class, $e);
+        $this->assertStringContainsString('Unable to write to the package directory', $e->getMessage());
+        $this->assertStringContainsString(DIR_PACKAGES, $e->getMessage());
+        $this->assertStringContainsString('Current PHP process user:', $e->getMessage());
+        $this->assertStringContainsString('www-data', $e->getMessage());
+        $this->assertStringContainsString('shell or hosting control panel', $e->getMessage());
     }
 
     /**


### PR DESCRIPTION
## Problem

When a marketplace package is downloaded or updated from the dashboard, Concrete has to place the package files under the site's `packages/` directory.

If that directory is not writable by the PHP/web-server user, the operation fails before the package can be installed or upgraded. Until now, the dashboard collapsed that failure into a generic message:

> Unable to move package directory.

That message confirms that the operation failed, but it does not tell the site owner what directory is involved, which system user needs permission, or what kind of hosting/server action is needed to fix it.

## What Changed

This patch makes marketplace package placement failures more actionable.

At the repository layer, `PackageRepository::download()` now checks whether `DIR_PACKAGES` exists and is writable before attempting the download/placement workflow. When Concrete cannot write there, or when an existing package directory cannot be backed up/moved during overwrite, the repository throws `UnableToPlacePackageException` with a detailed message.

The detailed message includes:

- the package directory or source/destination paths involved;
- the current PHP process user, resolved through the existing `Concrete\Core\System\SystemUser` helper;
- a short instruction to update filesystem permissions from the shell or hosting control panel.

The dashboard install and update controllers now preserve that detailed `UnableToPlacePackageException` message instead of replacing it with the old generic move error.

## Before / After

Before this patch, the dashboard only showed:

> Unable to move package directory.

After this patch, the same permissions problem produces an actionable message. In the manual dashboard check, `/app/packages` was made non-writable for `www-data`, and the dashboard showed:

> Unable to write to the package directory "/app/packages". Path: /app/packages Current PHP process user: www-data. Update filesystem permissions from your shell or hosting control panel, then try again.

## Scope

This is intentionally limited to marketplace package download/update placement failures. It does not introduce a new generic filesystem abstraction, and it does not change unrelated package install/uninstall behavior.

The patch reuses the existing `SystemUser` service where possible so the message reports the same kind of PHP/web-server user information Concrete already exposes elsewhere.

## Testing

- Ran `git diff --check`.
- Ran `php -l` on all changed PHP files.
- Ran the marketplace repository test suite inside the container as `www-data`:

```bash
./concrete/vendor/bin/phpunit --filter PackageRepositoryTest tests/tests/Marketplace/PackageRepositoryTest.php
```

Result:

```txt
OK (15 tests, 77 assertions)
```

- Manually verified the dashboard behavior by making `/app/packages` non-writable and confirming that the new detailed error appeared in the UI.

Fixes #12978