### PR TITLE
Read / write replica support

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -6,6 +6,53 @@
 	4.	Visit your Concrete website in your web browser. You should see an installation screen where you can step through the process of entering your database details, your administrative username details and more. 
 	5.	Upon completing this process, Concrete should be installed.
 	
+## Primary/Replica Database Configuration
+
+The database connection in `application/config/database.php` can use one or more
+read replicas. Existing top-level settings remain the primary connection and the
+defaults inherited by each replica:
+
+```php
+'connections' => [
+    'concrete' => [
+        'driver' => 'concrete_pdo_mysql',
+        'server' => 'writer.example',
+        'database' => 'app',
+        'username' => 'app',
+        'password' => 'secret',
+        'character_set' => 'utf8mb4',
+        'collation' => 'utf8mb4_unicode_ci',
+
+        // Optional overrides for the primary connection.
+        'primary' => [
+            'server' => 'writer.example',
+        ],
+
+        // Replica settings inherit the finalized primary settings.
+        'replica' => [
+            ['server' => 'reader-a.example'],
+            ['server' => 'reader-b.example'],
+        ],
+
+        // Preserve the replica connection for an explicit switch back.
+        'keepReplica' => true,
+    ],
+],
+```
+
+DBAL read methods such as `executeQuery()` and the fetch helpers use a replica
+until the primary is selected. Write methods such as `executeStatement()`,
+transactions, prepared statements, and the deprecated `query()` and
+`Execute()` APIs always select the primary. Routing is based on the DBAL method,
+not SQL inspection: write SQL passed to `executeQuery()` will be sent to a
+replica.
+
+After the primary is selected, reads stay on it to provide read-your-writes
+consistency. With `keepReplica` enabled, application code may explicitly call
+`ensureConnectedToReplica()`; doing so can return stale data when replication
+is delayed.
+
+
 ## Simpler Installation
 
 concretecms.com offers hosting and will pre-install Concrete for you:

--- a/concrete/attributes/select/controller.php
+++ b/concrete/attributes/select/controller.php
@@ -646,7 +646,7 @@ EOT
             $q .= 'and cParentID = ?';
         }
         $q .= ' group by avSelectOptionID order by total desc limit ' . $limit;
-        $r = $db->Execute($q, $v);
+        $r = $db->executeQuery($q, $v);
         $options = new ArrayCollection();
         while ($row = $r->fetch()) {
             $opt = new SelectValueUsedOption();

--- a/concrete/blocks/core_conversation/controller.php
+++ b/concrete/blocks/core_conversation/controller.php
@@ -212,7 +212,7 @@ class Controller extends BlockController implements UsesFeatureInterface
         $conv = Conversation::add();
         $conv->setConversationPageObject($newPage);
         $this->conversation = $conv;
-        $db->executeQuery('update btCoreConversation set cnvID = ? where bID = ?', [$conv->getConversationID(), $newBID]);
+        $db->executeStatement('update btCoreConversation set cnvID = ? where bID = ?', [$conv->getConversationID(), $newBID]);
     }
 
     /**

--- a/concrete/blocks/faq/controller.php
+++ b/concrete/blocks/faq/controller.php
@@ -107,14 +107,14 @@ class Controller extends BlockController implements FileTrackableInterface, Uses
     public function delete()
     {
         $db = $this->app->make('database')->connection();
-        $db->executeQuery('DELETE FROM btFaqEntries WHERE bID = ?', [$this->bID]);
+        $db->executeStatement('DELETE FROM btFaqEntries WHERE bID = ?', [$this->bID]);
         parent::delete();
     }
 
     public function save($args)
     {
         $db = $this->app->make('database')->connection();
-        $db->executeQuery('DELETE FROM btFaqEntries WHERE bID = ?', [$this->bID]);
+        $db->executeStatement('DELETE FROM btFaqEntries WHERE bID = ?', [$this->bID]);
         parent::save($args);
         $count = isset($args['sortOrder']) ? count($args['sortOrder']) : 0;
 
@@ -124,7 +124,7 @@ class Controller extends BlockController implements FileTrackableInterface, Uses
                 $args['description'][$i] = LinkAbstractor::translateTo($args['description'][$i]);
             }
 
-            $db->executeQuery(
+            $db->executeStatement(
                 'INSERT INTO btFaqEntries (bID, title, linkTitle, description, sortOrder) VALUES(?,?,?,?,?)',
                 [
                     $this->bID,

--- a/concrete/blocks/form/controller.php
+++ b/concrete/blocks/form/controller.php
@@ -719,7 +719,7 @@ class Controller extends BlockController
 
         //delete the form block
         $q = "delete from {$this->btTable} where bID = '{$this->bID}'";
-        $r = $db->executeStatement($q);
+        $db->executeStatement($q);
 
         parent::delete();
 

--- a/concrete/blocks/form/controller.php
+++ b/concrete/blocks/form/controller.php
@@ -266,7 +266,7 @@ class Controller extends BlockController
             $q = "update {$this->btTable} set questionSetId = ?, surveyName=?, submitText=?, notifyMeOnSubmission=?, recipientEmail=?, thankyouMsg=?, displayCaptcha=?, redirectCID=?, addFilesToSet=? where bID = ? AND questionSetId= ?";
         }
 
-        $rs = $db->query($q, $v);
+        $rs = $db->executeStatement($q, $v);
 
         //Add Questions (for programmatically creating forms, such as during the site install)
         if (count($data['questions']) > 0) {
@@ -294,7 +294,7 @@ class Controller extends BlockController
         $db = $this->app->make('database/connection');
         $v = [$this->bID];
         $q = "select * from {$this->btTable} where bID = ? LIMIT 1";
-        $r = $db->query($q, $v);
+        $r = $db->executeQuery($q, $v);
         $row = $r->fetch();
 
         //if the same block exists in multiple collections with the same questionSetID
@@ -319,13 +319,13 @@ class Controller extends BlockController
             //with a new Block ID and a new Question
             $v = [$newQuestionSetId, $row['surveyName'], $row['submitText'], $newBID, $row['thankyouMsg'], (int) ($row['notifyMeOnSubmission']), $row['recipientEmail'], $row['displayCaptcha'], $row['addFilesToSet']];
             $q = "insert into {$this->btTable} ( questionSetId, surveyName, submitText, bID,thankyouMsg,notifyMeOnSubmission,recipientEmail,displayCaptcha,addFilesToSet) values (?, ?, ?, ?, ?, ?, ?, ?,?)";
-            $result = $db->executeQuery($q, $v);
+            $result = $db->executeStatement($q, $v);
 
-            $rs = $db->query("SELECT * FROM {$this->btQuestionsTablename} WHERE questionSetId={$oldQuestionSetId} AND bID=" . (int) ($this->bID));
+            $rs = $db->executeQuery("SELECT * FROM {$this->btQuestionsTablename} WHERE questionSetId={$oldQuestionSetId} AND bID=" . (int) ($this->bID));
             while ($row = $rs->fetch()) {
                 $v = [$newQuestionSetId, (int) ($row['msqID']), (int) $newBID, $row['question'], $row['inputType'], $row['options'], $row['position'], $row['width'], $row['height'], $row['required'], $row['defaultDate']];
                 $sql = "INSERT INTO {$this->btQuestionsTablename} (questionSetId,msqID,bID,question,inputType,options,position,width,height,required,defaultDate) VALUES (?,?,?,?,?,?,?,?,?,?,?)";
-                $db->executeQuery($sql, $v);
+                $db->executeStatement($sql, $v);
             }
 
             return $newQuestionSetId;
@@ -486,7 +486,7 @@ class Controller extends BlockController
                 $uID = $u->getUserID();
             }
             $q = "insert into {$this->btAnswerSetTablename} (questionSetId, uID) values (?,?)";
-            $db->query($q, [$qsID, $uID]);
+            $db->executeStatement($q, [$qsID, $uID]);
             $answerSetID = $db->lastInsertId();
             $this->lastAnswerSetId = $answerSetID;
 
@@ -565,7 +565,7 @@ class Controller extends BlockController
 
                 $v = [$row['msqID'], $answerSetID, $answer, $answerLong];
                 $q = "insert into {$this->btAnswersTablename} (msqID,asID,answer,answerLong) values (?,?,?,?)";
-                $db->query($q, $v);
+                $db->executeStatement($q, $v);
             }
             $foundSpam = false;
 
@@ -579,8 +579,8 @@ class Controller extends BlockController
                 $foundSpam = true;
                 $q = "delete from {$this->btAnswerSetTablename} where asID = ?";
                 $v = [$this->lastAnswerSetId];
-                $db->executeQuery($q, $v);
-                $db->executeQuery("delete from {$this->btAnswersTablename} where asID = ?", [$this->lastAnswerSetId]);
+                $db->executeStatement($q, $v);
+                $db->executeStatement("delete from {$this->btAnswersTablename} where asID = ?", [$this->lastAnswerSetId]);
             }
 
             if ((int) ($this->notifyMeOnSubmission) > 0 && !$foundSpam) {
@@ -697,29 +697,29 @@ class Controller extends BlockController
 
         //get all answer sets
         $q = "SELECT asID FROM {$this->btAnswerSetTablename} WHERE questionSetId = " . (int) ($info['questionSetId'] ?? 0);
-        $answerSetsRS = $db->query($q);
+        $answerSetsRS = $db->executeQuery($q);
 
         //delete the questions
         $deleteData['questionsIDs'] = $db->fetchAll("SELECT qID FROM {$this->btQuestionsTablename} WHERE questionSetId = " . (int) ($info['questionSetId'] ?? 0) . ' AND bID=' . (int) ($this->bID));
         foreach ($deleteData['questionsIDs'] as $questionData) {
-            $db->query("DELETE FROM {$this->btQuestionsTablename} WHERE qID=" . (int) ($questionData['qID']));
+            $db->executeStatement("DELETE FROM {$this->btQuestionsTablename} WHERE qID=" . (int) ($questionData['qID']));
         }
 
         //delete left over answers
         $strandedAnswerIDs = $db->fetchAll('SELECT fa.aID FROM `btFormAnswers` AS fa LEFT JOIN btFormQuestions as fq ON fq.msqID=fa.msqID WHERE fq.msqID IS NULL');
         foreach ($strandedAnswerIDs as $strandedAnswer) {
-            $db->query('DELETE FROM `btFormAnswers` WHERE aID=' . (int) ($strandedAnswer['aID']));
+            $db->executeStatement('DELETE FROM `btFormAnswers` WHERE aID=' . (int) ($strandedAnswer['aID']));
         }
 
         //delete the left over answer sets
         $deleteData['strandedAnswerSetIDs'] = $db->fetchAll('SELECT aset.asID FROM btFormAnswerSet AS aset LEFT JOIN btFormAnswers AS fa ON aset.asID=fa.asID WHERE fa.asID IS NULL');
         foreach ($deleteData['strandedAnswerSetIDs'] as $strandedAnswerSetIDs) {
-            $db->query('DELETE FROM btFormAnswerSet WHERE asID=' . (int) ($strandedAnswerSetIDs['asID']));
+            $db->executeStatement('DELETE FROM btFormAnswerSet WHERE asID=' . (int) ($strandedAnswerSetIDs['asID']));
         }
 
         //delete the form block
         $q = "delete from {$this->btTable} where bID = '{$this->bID}'";
-        $r = $db->query($q);
+        $r = $db->executeStatement($q);
 
         parent::delete();
 
@@ -773,13 +773,13 @@ class Controller extends BlockController
         $pendingQuestions = $db->fetchAll('SELECT msqID FROM btFormQuestions WHERE bID=0 && questionSetId=?', $vals);
         foreach ($pendingQuestions as $pendingQuestion) {
             $vals = [(int) ($this->bID), (int) ($pendingQuestion['msqID'])];
-            $db->query('DELETE FROM btFormQuestions WHERE bID=? AND msqID=?', $vals);
+            $db->executeStatement('DELETE FROM btFormQuestions WHERE bID=? AND msqID=?', $vals);
         }
         //}
 
         //assign any new questions the new block id
         $vals = [(int) ($data['bID']), (int) ($data['qsID']), (int) ($data['oldQsID'])];
-        $rs = $db->query('UPDATE btFormQuestions SET bID=?, questionSetId=? WHERE bID=0 && questionSetId=?', $vals);
+        $rs = $db->executeStatement('UPDATE btFormQuestions SET bID=?, questionSetId=? WHERE bID=0 && questionSetId=?', $vals);
 
         //These are deleted or edited questions.  (edited questions have already been created with the new bID).
         $ignoreQuestionIDsDirty = explode(',', $data['ignoreQuestionIDs']);
@@ -797,7 +797,7 @@ class Controller extends BlockController
         }
         $vals = [$this->bID, (int) ($data['qsID'])];
         $pendingDeleteQIDs = implode(',', $pendingDeleteQIDs);
-        $unchangedQuestions = $db->query('DELETE FROM btFormQuestions WHERE bID=? AND questionSetId=? AND msqID IN (' . $pendingDeleteQIDs . ')', $vals);
+        $unchangedQuestions = $db->executeStatement('DELETE FROM btFormQuestions WHERE bID=? AND questionSetId=? AND msqID IN (' . $pendingDeleteQIDs . ')', $vals);
     }
 
     /**

--- a/concrete/blocks/form/mini_survey.php
+++ b/concrete/blocks/form/mini_survey.php
@@ -118,7 +118,7 @@ class MiniSurvey
                 ];
                 $sql = 'INSERT INTO btFormQuestions (msqID,questionSetId,question,inputType,options,position,width,height,required,defaultDate) VALUES (?,?,?,?,?,?,?,?,?,?)';
             }
-            $result = $this->db->executeQuery($sql, $dataValues);
+            $result = $this->db->executeStatement($sql, $dataValues);
             $this->lastSavedMsqID = (int) ($values['msqID']);
             $this->lastSavedqID = (int) ($this->db->fetchColumn('SELECT MAX(qID) FROM btFormQuestions WHERE bID=0 AND msqID=?', [$values['msqID']]));
             $jsonVals['qID'] = $this->lastSavedqID;
@@ -163,7 +163,7 @@ class MiniSurvey
     public function deleteQuestion($qsID, $msqID)
     {
         $sql = 'DELETE FROM btFormQuestions WHERE questionSetId=' . (int) $qsID . ' AND msqID=' . (int) $msqID . ' AND bID=0';
-        $this->db->executeQuery($sql);
+        $this->db->executeStatement($sql);
     }
 
     public static function loadQuestions($qsID, $bID = 0, $showPending = 0)
@@ -394,7 +394,7 @@ class MiniSurvey
         foreach ($qIDs as $qID) {
             $vals = [$positionNum, (int) $qID, (int) $qsID];
             $sql = 'UPDATE btFormQuestions SET position=? WHERE msqID=? AND questionSetId=?';
-            $rs = $this->db->executeQuery($sql, $vals);
+            $rs = $this->db->executeStatement($sql, $vals);
             $positionNum++;
         }
     }
@@ -418,13 +418,13 @@ class MiniSurvey
         //form block was just upgraded, so set the bID column
         if (!$questionsWithBIDs) {
             $vals = [(int) $bID, (int) $qsID];
-            $rs = $db->executeQuery('UPDATE btFormQuestions SET bID=? WHERE bID=0 AND questionSetId=?', $vals);
+            $rs = $db->executeStatement('UPDATE btFormQuestions SET bID=? WHERE bID=0 AND questionSetId=?', $vals);
 
             return;
         }
 
         //Then remove all temp/placeholder questions for this questionSetId that haven't been assigned to a block
         $vals = [(int) $qsID];
-        $rs = $db->executeQuery('DELETE FROM btFormQuestions WHERE bID=0 AND questionSetId=?', $vals);
+        $rs = $db->executeStatement('DELETE FROM btFormQuestions WHERE bID=0 AND questionSetId=?', $vals);
     }
 }

--- a/concrete/blocks/form/statistics.php
+++ b/concrete/blocks/form/statistics.php
@@ -73,7 +73,7 @@ class Statistics
         $dh = $app->make('date');
         $now = $dh->getOverridableNow();
 
-        return $db->query('SELECT s.* FROM ' . $MiniSurvey->btTable . ' AS s, Blocks AS b, BlockTypes AS bt
+        return $db->executeQuery('SELECT s.* FROM ' . $MiniSurvey->btTable . ' AS s, Blocks AS b, BlockTypes AS bt
             WHERE s.bID=b.bID AND b.btID=bt.btID AND bt.btHandle="form" AND EXISTS (
             SELECT 1 FROM CollectionVersionBlocks cvb
             INNER JOIN CollectionVersions cv ON cvb.cID=cv.cID AND cvb.cvID=cv.cvID AND 1=cv.cvIsApproved AND (cv.cvPublishDate IS NULL OR cv.cvPublishDate <= ?) AND (cv.cvPublishEndDate IS NULL OR cv.cvPublishEndDate >= ?)
@@ -99,7 +99,7 @@ class Statistics
         //get answers sets
         $sql = 'SELECT * FROM btFormAnswerSet AS aSet ' .
             'WHERE aSet.questionSetId=' . $questionSet . ' ORDER BY ' . $orderBySQL . ' ' . $limit;
-        $answerSetsRS = $db->query($sql);
+        $answerSetsRS = $db->executeQuery($sql);
         //load answers into a nicer multi-dimensional array
         $answerSets = [];
         $answerSetIds = [0];
@@ -111,7 +111,7 @@ class Statistics
 
         //get answers
         $sql = 'SELECT * FROM btFormAnswers AS a WHERE a.asID IN (' . implode(',', $answerSetIds) . ')';
-        $answersRS = $db->query($sql);
+        $answersRS = $db->executeQuery($sql);
 
         //load answers into a nicer multi-dimensional array
         while ($answer = $answersRS->fetch()) {

--- a/concrete/blocks/image/controller.php
+++ b/concrete/blocks/image/controller.php
@@ -594,7 +594,7 @@ class Controller extends BlockController implements FileTrackableInterface, Uses
                 /** @noinspection PhpUnhandledExceptionInspection */
                 /** @noinspection SqlDialectInspection */
                 /** @noinspection SqlNoDataSourceInspection */
-                $db->executeQuery('INSERT INTO btContentImageBreakpoints (bID, breakpointHandle, ftTypeID) values(?, ?, ?)',
+                $db->executeStatement('INSERT INTO btContentImageBreakpoints (bID, breakpointHandle, ftTypeID) values(?, ?, ?)',
                     [
                         $this->bID,
                         $breakpointHandle,

--- a/concrete/blocks/image_slider/controller.php
+++ b/concrete/blocks/image_slider/controller.php
@@ -211,7 +211,7 @@ class Controller extends BlockController implements FileTrackableInterface, Uses
         $args['maxWidth'] = isset($args['maxWidth']) ? (int) $args['maxWidth'] : 0;
 
         $db = Database::get();
-        $db->execute('DELETE from btImageSliderEntries WHERE bID = ?', [$this->bID]);
+        $db->executeStatement('DELETE from btImageSliderEntries WHERE bID = ?', [$this->bID]);
         parent::save($args);
         if (isset($args['sortOrder'])) {
             $count = count($args['sortOrder']);
@@ -237,7 +237,7 @@ class Controller extends BlockController implements FileTrackableInterface, Uses
                     $args['description'][$i] = LinkAbstractor::translateTo($args['description'][$i]);
                 }
 
-                $db->execute('INSERT INTO btImageSliderEntries (bID, fID, title, description, sortOrder, linkURL, internalLinkCID) values(?, ?, ?, ?,?,?,?)',
+                $db->executeStatement('INSERT INTO btImageSliderEntries (bID, fID, title, description, sortOrder, linkURL, internalLinkCID) values(?, ?, ?, ?,?,?,?)',
                     [
                         $this->bID,
                         (int) $args['fID'][$i],

--- a/concrete/blocks/survey/controller.php
+++ b/concrete/blocks/survey/controller.php
@@ -91,7 +91,7 @@ class Controller extends BlockController implements UsesFeatureInterface
             $db = Database::connection();
             $v = [$this->bID];
             $q = 'SELECT optionID, optionName, displayOrder FROM btSurveyOptions WHERE bID = ? ORDER BY displayOrder ASC';
-            $r = $db->query($q, $v);
+            $r = $db->executeQuery($q, $v);
             $this->options = [];
             if ($r) {
                 while ($row = $r->fetch()) {
@@ -122,10 +122,10 @@ class Controller extends BlockController implements UsesFeatureInterface
         $v = [$this->bID];
 
         $q = 'DELETE FROM btSurveyOptions WHERE bID = ?';
-        $db->query($q, $v);
+        $db->executeStatement($q, $v);
 
         $q = 'DELETE FROM btSurveyResults WHERE bID = ?';
-        $db->query($q, $v);
+        $db->executeStatement($q, $v);
 
         parent::delete();
     }
@@ -182,7 +182,7 @@ class Controller extends BlockController implements UsesFeatureInterface
                     $this->cID,
                 ];
                 $q = 'INSERT INTO btSurveyResults (optionID, bID, uID, ipAddress, cID) VALUES (?, ?, ?, ?, ?)';
-                $db->query($q, $v);
+                $db->executeStatement($q, $v);
                 $cookieJar = $this->app->make(ResponseCookieJar::class);
                 $cookieKey = 'ccmPoll' . $this->bID . '-' . $this->cID;
                 $config = $this->app->make('config');

--- a/concrete/controllers/backend/attributes.php
+++ b/concrete/controllers/backend/attributes.php
@@ -40,7 +40,7 @@ class Attributes extends Controller
             $db = \Loader::db();
             for ($i = 0; $i < count($uats); $i++) {
                 $v = array($i, $as->getAttributeSetID(), $uats[$i]);
-                $db->query("update AttributeSetKeys set asDisplayOrder = ? where asID = ? and akID = ?", $v);
+                $db->executeStatement("update AttributeSetKeys set asDisplayOrder = ? where asID = ? and akID = ?", $v);
             }
         }
     }

--- a/concrete/controllers/dialog/logs/bulk/delete.php
+++ b/concrete/controllers/dialog/logs/bulk/delete.php
@@ -46,7 +46,7 @@ class Delete extends BackendInterfaceController
                 /** @noinspection PhpUnhandledExceptionInspection */
                 /** @noinspection SqlDialectInspection */
                 /** @noinspection SqlNoDataSourceInspection */
-                $db->executeQuery("DELETE FROM Logs WHERE logID = ?", [$logItem]);
+                $db->executeStatement("DELETE FROM Logs WHERE logID = ?", [$logItem]);
             }
 
             $this->flash('success', t('Log entries successfully deleted.')); // It will be displayed on page reload

--- a/concrete/controllers/dialog/logs/delete.php
+++ b/concrete/controllers/dialog/logs/delete.php
@@ -53,7 +53,7 @@ class Delete extends BackendInterfaceController
         /** @noinspection PhpUnhandledExceptionInspection */
         /** @noinspection SqlDialectInspection */
         /** @noinspection SqlNoDataSourceInspection */
-        $db->executeQuery("DELETE FROM Logs WHERE logID = ?", [$logItem]);
+        $db->executeStatement("DELETE FROM Logs WHERE logID = ?", [$logItem]);
 
         $this->flash('success', t('Log entry successfully deleted.')); // It will be displayed on page reload
 

--- a/concrete/controllers/dialog/logs/delete_all.php
+++ b/concrete/controllers/dialog/logs/delete_all.php
@@ -38,7 +38,7 @@ class DeleteAll extends BackendInterfaceController
             /** @noinspection PhpUnhandledExceptionInspection */
             /** @noinspection SqlDialectInspection */
             /** @noinspection SqlNoDataSourceInspection */
-            $db->executeQuery("TRUNCATE TABLE Logs");
+            $db->executeStatement("TRUNCATE TABLE Logs");
 
             $this->flash('success', t('Log cleared successfully.'));
             $editResponse->setRedirectURL((string) $this->app->make(ResolverManagerInterface::class)->resolve(['/dashboard/reports/logs']));

--- a/concrete/controllers/single_page/dashboard/pages/themes.php
+++ b/concrete/controllers/single_page/dashboard/pages/themes.php
@@ -288,7 +288,7 @@ class Themes extends DashboardSitePageController
 
             // clean up a page types that are pointing to this deleted theme as the default
             $db = $this->app->make('database')->connection();
-            $db->query('update PageTypes set ptDefaultThemeID = null where ptDefaultThemeID = ?', [$pThemeID]);
+            $db->executeStatement('update PageTypes set ptDefaultThemeID = null where ptDefaultThemeID = ?', [$pThemeID]);
 
             $this->set('message', t('Theme uninstalled.'));
         } catch (Exception $e) {

--- a/concrete/controllers/single_page/dashboard/reports/forms/legacy.php
+++ b/concrete/controllers/single_page/dashboard/reports/forms/legacy.php
@@ -226,10 +226,10 @@ class Legacy extends DashboardPageController
         $db = Loader::db();
         $v = [intval($asID)];
         $q = 'DELETE FROM btFormAnswers WHERE asID = ?';
-        $r = $db->query($q, $v);
+        $r = $db->executeQuery($q, $v);
 
         $q = 'DELETE FROM btFormAnswerSet WHERE asID = ?';
-        $r = $db->query($q, $v);
+        $r = $db->executeQuery($q, $v);
     }
 
     //DELETE A FORM ANSWERS
@@ -239,7 +239,7 @@ class Legacy extends DashboardPageController
         $v = [intval($qsID)];
         $q = 'SELECT asID FROM btFormAnswerSet WHERE questionSetId = ?';
 
-        $r = $db->query($q, $v);
+        $r = $db->executeQuery($q, $v);
         while ($row = $r->fetch()) {
             $asID = $row['asID'];
             $this->deleteAnswers($asID);
@@ -254,12 +254,12 @@ class Legacy extends DashboardPageController
 
         $v = [intval($bID)];
         $q = 'DELETE FROM btFormQuestions WHERE bID = ?';
-        $r = $db->query($q, $v);
+        $r = $db->executeQuery($q, $v);
 
         $q = 'DELETE FROM btForm WHERE bID = ?';
-        $r = $db->query($q, $v);
+        $r = $db->executeQuery($q, $v);
 
         $q = 'DELETE FROM Blocks WHERE bID = ?';
-        $r = $db->query($q, $v);
+        $r = $db->executeQuery($q, $v);
     }
 }

--- a/concrete/controllers/single_page/dashboard/reports/forms/legacy.php
+++ b/concrete/controllers/single_page/dashboard/reports/forms/legacy.php
@@ -226,10 +226,10 @@ class Legacy extends DashboardPageController
         $db = Loader::db();
         $v = [intval($asID)];
         $q = 'DELETE FROM btFormAnswers WHERE asID = ?';
-        $r = $db->executeQuery($q, $v);
+        $db->executeStatement($q, $v);
 
         $q = 'DELETE FROM btFormAnswerSet WHERE asID = ?';
-        $r = $db->executeQuery($q, $v);
+        $db->executeStatement($q, $v);
     }
 
     //DELETE A FORM ANSWERS
@@ -254,12 +254,12 @@ class Legacy extends DashboardPageController
 
         $v = [intval($bID)];
         $q = 'DELETE FROM btFormQuestions WHERE bID = ?';
-        $r = $db->executeQuery($q, $v);
+        $db->executeStatement($q, $v);
 
         $q = 'DELETE FROM btForm WHERE bID = ?';
-        $r = $db->executeQuery($q, $v);
+        $db->executeStatement($q, $v);
 
         $q = 'DELETE FROM Blocks WHERE bID = ?';
-        $r = $db->executeQuery($q, $v);
+        $db->executeStatement($q, $v);
     }
 }

--- a/concrete/controllers/single_page/dashboard/reports/surveys.php
+++ b/concrete/controllers/single_page/dashboard/reports/surveys.php
@@ -58,7 +58,7 @@ class Surveys extends DashboardPageController
                   LEFT JOIN Users ON Users.uID = btSurveyResults.uID
 			 WHERE
 				btSurveyResults.bID = ? AND btSurveyResults.cId = ?';
-        $r = $db->query($q, $v);
+        $r = $db->executeQuery($q, $v);
 
         // Set default information in case query returns nothing
         $current_survey = 'Unknown Survey';
@@ -79,7 +79,7 @@ class Surveys extends DashboardPageController
             // If there is no user-submitted information pertaining to this survey, just get the name
             $q = 'SELECT question FROM btSurvey WHERE bID = ?';
             $v = [$bID];
-            $r = $db->query($q, $v);
+            $r = $db->executeQuery($q, $v);
             if ($row = $r->fetch()) {
                 $current_survey = $row['question'];
             }

--- a/concrete/controllers/single_page/dashboard/system/basics/reset_edit_mode.php
+++ b/concrete/controllers/single_page/dashboard/system/basics/reset_edit_mode.php
@@ -20,8 +20,8 @@ class ResetEditMode extends DashboardSitePageController
 
                 /** @var Connection $db */
                 $db = $this->app->make(Connection::class);
-                $db->executeQuery("TRUNCATE Piles");
-                $db->executeQuery("TRUNCATE PileContents");
+                $db->executeStatement("TRUNCATE Piles");
+                $db->executeStatement("TRUNCATE PileContents");
 
             } catch (DBALException $exception) {
                 $this->error->add(t("Error while clearing the clipboard."));

--- a/concrete/controllers/single_page/dashboard/system/calendar/import.php
+++ b/concrete/controllers/single_page/dashboard/system/calendar/import.php
@@ -16,9 +16,9 @@ class Import extends DashboardPageController
              * @var $db Connection
              */
             $db = $this->app->make(Connection::class);
-            $db->executeQuery('set foreign_key_checks = 0');
+            $db->executeStatement('set foreign_key_checks = 0');
             if ($db->tableExists('_CalendarEventOccurrences')) {
-                $db->executeQuery('delete o from _CalendarEventOccurrences o left join _CalendarEvents e on o.eventID = e.eventID where e.eventID is null');
+                $db->executeStatement('delete o from _CalendarEventOccurrences o left join _CalendarEvents e on o.eventID = e.eventID where e.eventID is null');
             }
 
             $r1 = $db->executeQuery('select * from _Calendars order by caID asc');
@@ -82,21 +82,21 @@ class Import extends DashboardPageController
                         ]);
                     }
                 }
-                $db->executeQuery('insert into Calendars (caID, caName, siteID) values (?, ?, ?)', [
+                $db->executeStatement('insert into Calendars (caID, caName, siteID) values (?, ?, ?)', [
                     $row1['caID'],
                     $row1['caName'],
                     $site->getSiteID()
                 ]);
             }
 
-            $db->executeQuery("update CalendarEventRepetitions set repetitionObject = replace(repetitionObject, 'O:43:\"PortlandLabs\\\Calendar\\\Event\\\EventRepetition', 'O:44:\"Concrete\\\Core\\\Calendar\\\Event\\\EventRepetition')");
+            $db->executeStatement("update CalendarEventRepetitions set repetitionObject = replace(repetitionObject, 'O:43:\"PortlandLabs\\\Calendar\\\Event\\\EventRepetition', 'O:44:\"Concrete\\\Core\\\Calendar\\\Event\\\EventRepetition')");
 
-            $db->executeQuery('drop table if exists _CalendarEventAttributeValues');
-            $db->executeQuery('drop table if exists _CalendarEventOccurrences');
-            $db->executeQuery('drop table if exists _CalendarEventRepetitions');
-            $db->executeQuery('drop table if exists _CalendarEventSearchIndexAttributes');
-            $db->executeQuery('drop table if exists _CalendarEvents');
-            $db->executeQuery('drop table if exists _Calendars');
+            $db->executeStatement('drop table if exists _CalendarEventAttributeValues');
+            $db->executeStatement('drop table if exists _CalendarEventOccurrences');
+            $db->executeStatement('drop table if exists _CalendarEventRepetitions');
+            $db->executeStatement('drop table if exists _CalendarEventSearchIndexAttributes');
+            $db->executeStatement('drop table if exists _CalendarEvents');
+            $db->executeStatement('drop table if exists _Calendars');
 
             $this->flash('success', t('Data imported successfully.'));
             return $this->redirect('/dashboard/system/calendar/import', 'view');

--- a/concrete/controllers/single_page/dashboard/system/conversations/editor.php
+++ b/concrete/controllers/single_page/dashboard/system/conversations/editor.php
@@ -50,8 +50,8 @@ class Editor extends DashboardPageController
 
             return;
         }
-        $db->executeQuery('UPDATE ConversationEditors SET cnvEditorIsActive=0');
-        $db->executeQuery('UPDATE ConversationEditors SET cnvEditorIsActive=1 WHERE cnvEditorHandle=?', array($active));
+        $db->executeStatement('UPDATE ConversationEditors SET cnvEditorIsActive=0');
+        $db->executeStatement('UPDATE ConversationEditors SET cnvEditorIsActive=1 WHERE cnvEditorHandle=?', array($active));
         $this->redirect('/dashboard/system/conversations/editor', 'success');
     }
 }

--- a/concrete/controllers/single_page/dashboard/system/conversations/points.php
+++ b/concrete/controllers/single_page/dashboard/system/conversations/points.php
@@ -27,7 +27,7 @@ class Points extends DashboardPageController
                 $rtID = $crt->getConversationRatingTypeID();
                 $rtPoints = $this->post('rtPoints_' . $rtID);
                 if (is_string($rtPoints) && is_numeric($rtPoints)) {
-                    $db->Execute('UPDATE ConversationRatingTypes SET cnvRatingTypeCommunityPoints = ? WHERE cnvRatingTypeID = ? LIMIT 1',
+                    $db->executeStatement('UPDATE ConversationRatingTypes SET cnvRatingTypeCommunityPoints = ? WHERE cnvRatingTypeID = ? LIMIT 1',
                         array($rtPoints, $rtID));
                 }
             }

--- a/concrete/controllers/single_page/dashboard/system/conversations/settings.php
+++ b/concrete/controllers/single_page/dashboard/system/conversations/settings.php
@@ -66,8 +66,8 @@ class Settings extends DashboardPageController
 
             return;
         }
-        $db->executeQuery('UPDATE ConversationEditors SET cnvEditorIsActive=0');
-        $db->executeQuery('UPDATE ConversationEditors SET cnvEditorIsActive=1 WHERE cnvEditorHandle=?', array($active));
+        $db->executeStatement('UPDATE ConversationEditors SET cnvEditorIsActive=0');
+        $db->executeStatement('UPDATE ConversationEditors SET cnvEditorIsActive=1 WHERE cnvEditorHandle=?', array($active));
     }
 
     public function success()

--- a/concrete/src/Antispam/Library.php
+++ b/concrete/src/Antispam/Library.php
@@ -118,7 +118,7 @@ class Library extends ConcreteObject
             $pkgID = $pkg->getPackageID();
         }
         $db = Loader::db();
-        $db->Execute('insert into SystemAntispamLibraries (saslHandle, saslName, pkgID) values (?, ?, ?)', array($saslHandle, $saslName, $pkgID));
+        $db->executeStatement('insert into SystemAntispamLibraries (saslHandle, saslName, pkgID) values (?, ?, ?)', array($saslHandle, $saslName, $pkgID));
 
         return static::getByHandle($saslHandle);
     }
@@ -129,7 +129,7 @@ class Library extends ConcreteObject
     public function delete()
     {
         $db = Loader::db();
-        $db->Execute('delete from SystemAntispamLibraries where saslHandle = ?', array($this->saslHandle));
+        $db->executeStatement('delete from SystemAntispamLibraries where saslHandle = ?', array($this->saslHandle));
     }
 
     /**
@@ -139,7 +139,7 @@ class Library extends ConcreteObject
     {
         $db = Loader::db();
         self::deactivateAll();
-        $db->Execute('update SystemAntispamLibraries set saslIsActive = 1 where saslHandle = ?', array($this->saslHandle));
+        $db->executeStatement('update SystemAntispamLibraries set saslIsActive = 1 where saslHandle = ?', array($this->saslHandle));
     }
 
     /**
@@ -148,7 +148,7 @@ class Library extends ConcreteObject
     public static function deactivateAll()
     {
         $db = Loader::db();
-        $db->Execute('update SystemAntispamLibraries set saslIsActive = 0');
+        $db->executeStatement('update SystemAntispamLibraries set saslIsActive = 0');
     }
 
     /**

--- a/concrete/src/Area/Area.php
+++ b/concrete/src/Area/Area.php
@@ -587,8 +587,8 @@ class Area extends ConcreteObject implements \Concrete\Core\Permission\ObjectInt
 
         $db = Database::connection();
         $v = array($this->getAreaHandle(), $this->getCollectionID());
-        $db->executeQuery('delete from AreaPermissionAssignments where arHandle = ? and cID = ?', $v);
-        $db->executeQuery('update Areas set arOverrideCollectionPermissions = 0 where arID = ?', array($this->getAreaID()));
+        $db->executeStatement('delete from AreaPermissionAssignments where arHandle = ? and cID = ?', $v);
+        $db->executeStatement('update Areas set arOverrideCollectionPermissions = 0 where arID = ?', array($this->getAreaID()));
 
         // now we set rescan this area to determine where it -should- be inheriting from
         $this->arOverrideCollectionPermissions = false;
@@ -633,7 +633,7 @@ class Area extends ConcreteObject implements \Concrete\Core\Permission\ObjectInt
                     array($cIDToCheck, $this->getAreaHandle())
                 );
                 if ($arInheritPermissionsFromAreaOnCID > 0) {
-                    $db->executeQuery(
+                    $db->executeStatement(
                         'update Areas set arInheritPermissionsFromAreaOnCID = ? where arID = ?',
                         array($arInheritPermissionsFromAreaOnCID, $this->getAreaID())
                     );
@@ -653,7 +653,7 @@ class Area extends ConcreteObject implements \Concrete\Core\Permission\ObjectInt
                         if ($row['cID'] > 0) {
                             // then that means we have successfully found a parent area record that we can inherit from. So we set
                             // out current area to inherit from that COLLECTION ID (not area ID - from the collection ID)
-                            $db->executeQuery(
+                            $db->executeStatement(
                                 'update Areas set arInheritPermissionsFromAreaOnCID = ? where arID = ?',
                                 array($row['cID'], $this->getAreaID())
                             );
@@ -671,7 +671,7 @@ class Area extends ConcreteObject implements \Concrete\Core\Permission\ObjectInt
                         array($areac->getPermissionsCollectionID(), $this->getAreaHandle())
                     );
                     if ($doOverride && $areac->getPermissionsCollectionID() > 0) {
-                        $db->executeQuery(
+                        $db->executeStatement(
                             'update Areas set arInheritPermissionsFromAreaOnCID = ? where arID = ?',
                             array($areac->getPermissionsCollectionID(), $this->getAreaID())
                         );
@@ -707,7 +707,7 @@ class Area extends ConcreteObject implements \Concrete\Core\Permission\ObjectInt
         while ($row = $r->fetch()) {
             // these are all the areas we need to update.
             if ($this->getAreaCollectionInheritID() > 0) {
-                $db->executeQuery(
+                $db->executeStatement(
                     'update Areas set arInheritPermissionsFromAreaOnCID = ? where arID = ?',
                     array($this->getAreaCollectionInheritID(), $row['arID'])
                 );
@@ -738,7 +738,7 @@ class Area extends ConcreteObject implements \Concrete\Core\Permission\ObjectInt
 
         $db = Database::connection();
         $v = array($this->getAreaHandle(), 'TEMPLATE', $masterCollection->getCollectionID());
-        $db->executeQuery(
+        $db->executeStatement(
             'update Areas, Pages set Areas.arInheritPermissionsFromAreaOnCID = '.$toSetCID.' where Areas.cID = Pages.cID and Areas.arHandle = ? and cInheritPermissionsFrom = ? and arOverrideCollectionPermissions = 0 and cInheritPermissionsFromCID = ?',
             $v
         );
@@ -924,7 +924,7 @@ class Area extends ConcreteObject implements \Concrete\Core\Permission\ObjectInt
         $cID = $this->getCollectionID();
         $v = array($cID, $this->getAreaHandle());
         // update the Area record itself. Hopefully it's been created.
-        $db->executeQuery(
+        $db->executeStatement(
             'update Areas set arOverrideCollectionPermissions = 1, arInheritPermissionsFromAreaOnCID = 0 where arID = ?',
             array($this->getAreaID())
         );

--- a/concrete/src/Area/GlobalArea.php
+++ b/concrete/src/Area/GlobalArea.php
@@ -137,8 +137,8 @@ class GlobalArea extends Area
     public static function deleteByName($arHandle)
     {
         $db = Loader::db();
-        $db->Execute('select cID from Areas where arHandle = ? and arIsGlobal = 1', [$arHandle]);
-        $db->Execute('delete from Areas where arHandle = ? and arIsGlobal = 1', [$arHandle]);
+        $db->executeQuery('select cID from Areas where arHandle = ? and arIsGlobal = 1', [$arHandle]);
+        $db->executeStatement('delete from Areas where arHandle = ? and arIsGlobal = 1', [$arHandle]);
     }
 
     /**

--- a/concrete/src/Area/Layout/Column.php
+++ b/concrete/src/Area/Layout/Column.php
@@ -122,7 +122,7 @@ abstract class Column extends ConcreteObject implements ColumnInterface
     {
         $db = Database::connection();
         $v = array($newAreaLayout->getAreaLayoutID(), $this->arLayoutColumnIndex, $this->arLayoutColumnDisplayID);
-        $db->executeQuery('insert into AreaLayoutColumns (arLayoutID, arLayoutColumnIndex, arLayoutColumnDisplayID) values (?, ?, ?)', $v);
+        $db->executeStatement('insert into AreaLayoutColumns (arLayoutID, arLayoutColumnIndex, arLayoutColumnDisplayID) values (?, ?, ?)', $v);
         $newAreaLayoutColumnID = $db->Insert_ID();
 
         return $newAreaLayoutColumnID;
@@ -220,13 +220,13 @@ abstract class Column extends ConcreteObject implements ColumnInterface
     {
         $db = Database::connection();
         $this->arID = $arID;
-        $db->executeQuery('update AreaLayoutColumns set arID = ? where arLayoutColumnID = ?', array($arID, $this->arLayoutColumnID));
+        $db->executeStatement('update AreaLayoutColumns set arID = ? where arLayoutColumnID = ?', array($arID, $this->arLayoutColumnID));
     }
 
     public function delete()
     {
         $db = Database::connection();
-        $db->executeQuery("delete from AreaLayoutColumns where arLayoutColumnID = ?", array($this->arLayoutColumnID));
+        $db->executeStatement("delete from AreaLayoutColumns where arLayoutColumnID = ?", array($this->arLayoutColumnID));
 
         // now we check to see if this area id is in use anywhere else. If it isn't we delete the sub area.
         $r = $db->fetchColumn('select count(arLayoutColumnID) from AreaLayoutColumns where arID = ?', array($this->arID));

--- a/concrete/src/Area/Layout/CustomColumn.php
+++ b/concrete/src/Area/Layout/CustomColumn.php
@@ -58,7 +58,7 @@ class CustomColumn extends Column
         $areaLayoutColumnID = parent::duplicate($newAreaLayout);
         $db = Loader::db();
         $v = array($areaLayoutColumnID, $this->arLayoutColumnWidth);
-        $db->Execute('insert into AreaLayoutCustomColumns (arLayoutColumnID, arLayoutColumnWidth) values (?, ?)', $v);
+        $db->executeStatement('insert into AreaLayoutCustomColumns (arLayoutColumnID, arLayoutColumnWidth) values (?, ?)', $v);
         $newAreaLayoutColumn = self::getByID($areaLayoutColumnID);
 
         return $newAreaLayoutColumn;
@@ -118,13 +118,13 @@ class CustomColumn extends Column
     {
         $this->arLayoutColumnWidth = $width;
         $db = Loader::db();
-        $db->Execute('update AreaLayoutCustomColumns set arLayoutColumnWidth = ? where arLayoutColumnID = ?', array($width, $this->arLayoutColumnID));
+        $db->executeStatement('update AreaLayoutCustomColumns set arLayoutColumnWidth = ? where arLayoutColumnID = ?', array($width, $this->arLayoutColumnID));
     }
 
     public function delete()
     {
         $db = Loader::db();
-        $db->Execute("delete from AreaLayoutCustomColumns where arLayoutColumnID = ?", array($this->arLayoutColumnID));
+        $db->executeStatement("delete from AreaLayoutCustomColumns where arLayoutColumnID = ?", array($this->arLayoutColumnID));
         parent::delete();
     }
 }

--- a/concrete/src/Area/Layout/CustomLayout.php
+++ b/concrete/src/Area/Layout/CustomLayout.php
@@ -70,7 +70,7 @@ class CustomLayout extends Layout
     {
         $db = Loader::db();
         $v = array($this->arLayoutSpacing, $this->arLayoutIsCustom);
-        $db->Execute('insert into AreaLayouts (arLayoutSpacing, arLayoutIsCustom) values (?, ?)', $v);
+        $db->executeStatement('insert into AreaLayouts (arLayoutSpacing, arLayoutIsCustom) values (?, ?)', $v);
         $newAreaLayoutID = $db->Insert_ID();
         if ($newAreaLayoutID) {
             $newAreaLayout = Layout::getByID($newAreaLayoutID);
@@ -92,7 +92,7 @@ class CustomLayout extends Layout
             $spacing = 0;
         }
         $db = Loader::db();
-        $db->Execute('update AreaLayouts set arLayoutSpacing = ? where arLayoutID = ?', array($spacing, $this->arLayoutID));
+        $db->executeStatement('update AreaLayouts set arLayoutSpacing = ? where arLayoutID = ?', array($spacing, $this->arLayoutID));
         $this->arLayoutSpacing = $spacing;
     }
 
@@ -102,7 +102,7 @@ class CustomLayout extends Layout
     public function enableAreaLayoutCustomColumnWidths()
     {
         $db = Loader::db();
-        $db->Execute('update AreaLayouts set arLayoutIsCustom = ? where arLayoutID = ?', array(1, $this->arLayoutID));
+        $db->executeStatement('update AreaLayouts set arLayoutIsCustom = ? where arLayoutID = ?', array(1, $this->arLayoutID));
         $this->arLayoutIsCustom = true;
     }
 
@@ -112,7 +112,7 @@ class CustomLayout extends Layout
     public function disableAreaLayoutCustomColumnWidths()
     {
         $db = Loader::db();
-        $db->Execute('update AreaLayouts set arLayoutIsCustom = ? where arLayoutID = ?', array(0, $this->arLayoutID));
+        $db->executeStatement('update AreaLayouts set arLayoutIsCustom = ? where arLayoutID = ?', array(0, $this->arLayoutID));
         $this->arLayoutIsCustom = false;
     }
 
@@ -134,7 +134,7 @@ class CustomLayout extends Layout
         }
 
         $db = Loader::db();
-        $db->Execute('insert into AreaLayouts (arLayoutSpacing, arLayoutIsCustom, arLayoutUsesThemeGridFramework) values (?, ?, ?)', array($spacing, $iscustom, 0));
+        $db->executeStatement('insert into AreaLayouts (arLayoutSpacing, arLayoutIsCustom, arLayoutUsesThemeGridFramework) values (?, ?, ?)', array($spacing, $iscustom, 0));
         $arLayoutID = $db->Insert_ID();
         if ($arLayoutID) {
             $ar = static::getByID($arLayoutID);
@@ -150,7 +150,7 @@ class CustomLayout extends Layout
     {
         $columnID = parent::addLayoutColumn();
         $db = Loader::db();
-        $db->Execute('insert into AreaLayoutCustomColumns (arLayoutColumnID, arLayoutColumnWidth) values (?, 0)', array($columnID));
+        $db->executeStatement('insert into AreaLayoutCustomColumns (arLayoutColumnID, arLayoutColumnWidth) values (?, 0)', array($columnID));
 
         return CustomColumn::getByID($columnID);
     }

--- a/concrete/src/Area/Layout/Layout.php
+++ b/concrete/src/Area/Layout/Layout.php
@@ -141,7 +141,7 @@ abstract class Layout extends ConcreteObject
     public function getAreaLayoutColumns()
     {
         $db = Database::connection();
-        $r = $db->Execute('select arLayoutColumnID from AreaLayoutColumns where arLayoutID = ? order by arLayoutColumnIndex asc', [$this->arLayoutID]);
+        $r = $db->executeQuery('select arLayoutColumnID from AreaLayoutColumns where arLayoutID = ? order by arLayoutColumnIndex asc', [$this->arLayoutID]);
         $columns = [];
         $class = '\\Concrete\\Core\\Area\\Layout\\' . Core::make('helper/text')->camelcase($this->arLayoutType) . 'Column';
         while ($row = $r->fetch()) {
@@ -168,7 +168,7 @@ abstract class Layout extends ConcreteObject
             $arLayoutColumnDisplayID = 1;
         }
         $index = $db->GetOne('select count(arLayoutColumnID) from AreaLayoutColumns where arLayoutID = ?', [$this->arLayoutID]);
-        $db->Execute('insert into AreaLayoutColumns (arLayoutID, arLayoutColumnIndex, arLayoutColumnDisplayID) values (?, ?, ?)', [$this->arLayoutID, $index, $arLayoutColumnDisplayID]);
+        $db->executeStatement('insert into AreaLayoutColumns (arLayoutID, arLayoutColumnIndex, arLayoutColumnDisplayID) values (?, ?, ?)', [$this->arLayoutID, $index, $arLayoutColumnDisplayID]);
 
         return $db->Insert_ID();
     }
@@ -199,8 +199,8 @@ abstract class Layout extends ConcreteObject
             $col->delete();
         }
         $db = Database::connection();
-        $db->Execute('delete from AreaLayouts where arLayoutID = ?', [$this->arLayoutID]);
-        $db->Execute('delete from AreaLayoutPresets where arLayoutID = ?', [$this->arLayoutID]);
+        $db->executeStatement('delete from AreaLayouts where arLayoutID = ?', [$this->arLayoutID]);
+        $db->executeStatement('delete from AreaLayoutPresets where arLayoutID = ?', [$this->arLayoutID]);
     }
 
     /**

--- a/concrete/src/Area/Layout/Preset/UserPreset.php
+++ b/concrete/src/Area/Layout/Preset/UserPreset.php
@@ -32,7 +32,7 @@ class UserPreset extends ConcreteObject
     public static function add(Layout $arLayout, $name)
     {
         $db = Loader::db();
-        $db->Execute(
+        $db->executeStatement(
             'insert into AreaLayoutPresets (arLayoutID, arLayoutPresetName) values (?, ?)',
             array(
                 $arLayout->getAreaLayoutID(),
@@ -49,7 +49,7 @@ class UserPreset extends ConcreteObject
     public static function getList()
     {
         $db = Loader::db();
-        $r = $db->Execute('select arLayoutPresetID from AreaLayoutPresets order by arLayoutPresetName asc');
+        $r = $db->executeQuery('select arLayoutPresetID from AreaLayoutPresets order by arLayoutPresetName asc');
         $presets = array();
         while ($row = $r->fetch()) {
             $preset = static::getByID($row['arLayoutPresetID']);
@@ -86,7 +86,7 @@ class UserPreset extends ConcreteObject
     public function delete()
     {
         $db = Loader::db();
-        $db->Execute(
+        $db->executeStatement(
             'delete from AreaLayoutPresets where arLayoutPresetID = ?',
             array(
                 $this->arLayoutPresetID,
@@ -132,7 +132,7 @@ class UserPreset extends ConcreteObject
     public function updateAreaLayoutObject(Layout $arLayout)
     {
         $db = Loader::db();
-        $db->Execute(
+        $db->executeStatement(
             'update AreaLayoutPresets set arLayoutID = ? where arLayoutPresetID = ?',
             array(
                 $arLayout->getAreaLayoutID(),
@@ -148,7 +148,7 @@ class UserPreset extends ConcreteObject
     public function updateName($arLayoutPresetName)
     {
         $db = Loader::db();
-        $db->Execute(
+        $db->executeStatement(
             'update AreaLayoutPresets set arLayoutPresetName = ? where arLayoutPresetID = ?',
             array(
                 $arLayoutPresetName,

--- a/concrete/src/Area/Layout/PresetLayout.php
+++ b/concrete/src/Area/Layout/PresetLayout.php
@@ -89,11 +89,11 @@ class PresetLayout extends Layout
     {
         $db = Loader::db();
         $v = array($this->arLayoutIsPreset);
-        $db->Execute('insert into AreaLayouts (arLayoutIsPreset) values (?)', $v);
+        $db->executeStatement('insert into AreaLayouts (arLayoutIsPreset) values (?)', $v);
         $newAreaLayoutID = $db->Insert_ID();
         if ($newAreaLayoutID) {
             $v = array($newAreaLayoutID, $this->getAreaLayoutPresetHandle());
-            $db->Execute('insert into AreaLayoutsUsingPresets (arLayoutID, preset) values (?, ?)', $v);
+            $db->executeStatement('insert into AreaLayoutsUsingPresets (arLayoutID, preset) values (?, ?)', $v);
             $newAreaLayout = Layout::getByID($newAreaLayoutID);
 
             $columns = $this->getAreaLayoutColumns();
@@ -113,10 +113,10 @@ class PresetLayout extends Layout
     public static function add(PresetInterface $preset)
     {
         $db = Loader::db();
-        $db->Execute('insert into AreaLayouts (arLayoutIsPreset) values (?)', array(1));
+        $db->executeStatement('insert into AreaLayouts (arLayoutIsPreset) values (?)', array(1));
         $arLayoutID = $db->Insert_ID();
         if ($arLayoutID) {
-            $db->Execute('insert into AreaLayoutsUsingPresets (arLayoutID, preset) values (?, ?)', array($arLayoutID, $preset->getIdentifier()));
+            $db->executeStatement('insert into AreaLayoutsUsingPresets (arLayoutID, preset) values (?, ?)', array($arLayoutID, $preset->getIdentifier()));
             $ar = static::getByID($arLayoutID);
 
             return $ar;

--- a/concrete/src/Area/Layout/ThemeGridColumn.php
+++ b/concrete/src/Area/Layout/ThemeGridColumn.php
@@ -64,7 +64,7 @@ class ThemeGridColumn extends Column
         $areaLayoutColumnID = parent::duplicate($newAreaLayout);
         $db = Loader::db();
         $v = array($areaLayoutColumnID, $this->arLayoutColumnSpan, $this->arLayoutColumnOffset);
-        $db->Execute('insert into AreaLayoutThemeGridColumns (arLayoutColumnID, arLayoutColumnSpan, arLayoutColumnOffset) values (?, ?, ?)', $v);
+        $db->executeStatement('insert into AreaLayoutThemeGridColumns (arLayoutColumnID, arLayoutColumnSpan, arLayoutColumnOffset) values (?, ?, ?)', $v);
         $newAreaLayoutColumn = self::getByID($areaLayoutColumnID);
 
         return $newAreaLayoutColumn;
@@ -210,7 +210,7 @@ class ThemeGridColumn extends Column
     public function delete()
     {
         $db = Loader::db();
-        $db->Execute("delete from AreaLayoutThemeGridColumns where arLayoutColumnID = ?", array($this->arLayoutColumnID));
+        $db->executeStatement("delete from AreaLayoutThemeGridColumns where arLayoutColumnID = ?", array($this->arLayoutColumnID));
         parent::delete();
     }
 
@@ -223,7 +223,7 @@ class ThemeGridColumn extends Column
             $span = 0;
         }
         $db = Loader::db();
-        $db->Execute('update AreaLayoutThemeGridColumns set arLayoutColumnSpan = ? where arLayoutColumnID = ?', array($span, $this->arLayoutColumnID));
+        $db->executeStatement('update AreaLayoutThemeGridColumns set arLayoutColumnSpan = ? where arLayoutColumnID = ?', array($span, $this->arLayoutColumnID));
         $this->arLayoutColumnSpan = $span;
     }
 
@@ -236,7 +236,7 @@ class ThemeGridColumn extends Column
             $offset = 0;
         }
         $db = Loader::db();
-        $db->Execute(
+        $db->executeStatement(
             'update AreaLayoutThemeGridColumns set arLayoutColumnOffset = ? where arLayoutColumnID = ?',
             array($offset, $this->arLayoutColumnID)
         );

--- a/concrete/src/Area/Layout/ThemeGridLayout.php
+++ b/concrete/src/Area/Layout/ThemeGridLayout.php
@@ -113,7 +113,7 @@ class ThemeGridLayout extends Layout
     {
         $db = Loader::db();
         $v = array($this->arLayoutMaxColumns, 1);
-        $db->Execute('insert into AreaLayouts (arLayoutMaxColumns, arLayoutUsesThemeGridFramework) values (?, ?)', $v);
+        $db->executeStatement('insert into AreaLayouts (arLayoutMaxColumns, arLayoutUsesThemeGridFramework) values (?, ?)', $v);
         $newAreaLayoutID = $db->Insert_ID();
         if ($newAreaLayoutID) {
             $newAreaLayout = Layout::getByID($newAreaLayoutID);
@@ -135,7 +135,7 @@ class ThemeGridLayout extends Layout
             $max = 0;
         }
         $db = Loader::db();
-        $db->Execute('update AreaLayouts set arLayoutMaxColumns = ? where arLayoutID = ?', array($max, $this->arLayoutID));
+        $db->executeStatement('update AreaLayouts set arLayoutMaxColumns = ? where arLayoutID = ?', array($max, $this->arLayoutID));
         $this->arLayoutMaxColumns = $max;
     }
 
@@ -154,7 +154,7 @@ class ThemeGridLayout extends Layout
     {
         $columnID = parent::addLayoutColumn();
         $db = Loader::db();
-        $db->Execute('insert into AreaLayoutThemeGridColumns (arLayoutColumnID) values (?)', array($columnID));
+        $db->executeStatement('insert into AreaLayoutThemeGridColumns (arLayoutColumnID) values (?)', array($columnID));
 
         return ThemeGridColumn::getByID($columnID);
     }
@@ -165,7 +165,7 @@ class ThemeGridLayout extends Layout
     public static function add()
     {
         $db = Loader::db();
-        $db->Execute('insert into AreaLayouts (arLayoutSpacing, arLayoutIsCustom, arLayoutUsesThemeGridFramework) values (?, ?, ?)', array(0, 0, 1));
+        $db->executeStatement('insert into AreaLayouts (arLayoutSpacing, arLayoutIsCustom, arLayoutUsesThemeGridFramework) values (?, ?, ?)', array(0, 0, 1));
         $arLayoutID = $db->Insert_ID();
         if ($arLayoutID) {
             $ar = static::getByID($arLayoutID);

--- a/concrete/src/Area/SubArea.php
+++ b/concrete/src/Area/SubArea.php
@@ -139,6 +139,6 @@ class SubArea extends Area
                 $b->deleteBlock();
             }
         }
-        $db->Execute('delete from Areas where arID = ?', array($this->arID));
+        $db->executeStatement('delete from Areas where arID = ?', array($this->arID));
     }
 }

--- a/concrete/src/Attribute/Category/SearchIndexer/StandardSearchIndexer.php
+++ b/concrete/src/Attribute/Category/SearchIndexer/StandardSearchIndexer.php
@@ -90,7 +90,7 @@ class StandardSearchIndexer implements SearchIndexerInterface
 
                 $queries = $schema->toSql($this->connection->getDatabasePlatform());
                 foreach ($queries as $query) {
-                    $this->connection->query($query);
+                    $this->connection->executeStatement($query);
                 }
             }
         }

--- a/concrete/src/Attribute/Key/SearchIndexer/StandardSearchIndexer.php
+++ b/concrete/src/Attribute/Key/SearchIndexer/StandardSearchIndexer.php
@@ -173,7 +173,7 @@ class StandardSearchIndexer implements SearchIndexerInterface
         $primaryValue = $category->getIndexedSearchPrimaryKeyValue($subject);
         $columnValues = [];
 
-        $exists = $this->connection->query(
+        $exists = $this->connection->executeQuery(
             "select count({$primary}) from {$category->getIndexedSearchTable()} where {$primary} = {$primaryValue}"
         )->fetchColumn();
 

--- a/concrete/src/Attribute/StandardSetManager.php
+++ b/concrete/src/Attribute/StandardSetManager.php
@@ -107,7 +107,7 @@ class StandardSetManager implements SetManagerInterface
     {
         $db = \Database::connection();
         for ($i = 0; $i < count($asIDs); ++$i) {
-            $db->executeQuery(
+            $db->executeStatement(
                 "UPDATE AttributeSets SET asDisplayOrder = {$i} WHERE akCategoryID = ? AND asID = ?",
                 array($this->categoryEntity->getAttributeKeyCategoryID(), $asIDs[$i])
             );

--- a/concrete/src/Attribute/Value/Value.php
+++ b/concrete/src/Attribute/Value/Value.php
@@ -108,7 +108,7 @@ class Value extends ConcreteObject implements AttributeValueInterface
     {
         $this->getController()->deleteValue();
         $db = Loader::db();
-        $db->executeStatement('delete from AttributeValues where avID = ?', $this->getAttributeValueID());
+        $db->executeStatement('delete from AttributeValues where avID = ?', [$this->getAttributeValueID()]);
     }
 
     public function getAttributeKey()

--- a/concrete/src/Attribute/Value/Value.php
+++ b/concrete/src/Attribute/Value/Value.php
@@ -108,7 +108,7 @@ class Value extends ConcreteObject implements AttributeValueInterface
     {
         $this->getController()->deleteValue();
         $db = Loader::db();
-        $db->Execute('delete from AttributeValues where avID = ?', $this->getAttributeValueID());
+        $db->executeStatement('delete from AttributeValues where avID = ?', $this->getAttributeValueID());
     }
 
     public function getAttributeKey()

--- a/concrete/src/Authentication/AuthenticationType.php
+++ b/concrete/src/Authentication/AuthenticationType.php
@@ -58,7 +58,7 @@ class AuthenticationType extends ConcreteObject
     {
         $list = [];
         $db = Loader::db();
-        $q = $db->query('SELECT * FROM AuthenticationTypes'
+        $q = $db->executeQuery('SELECT * FROM AuthenticationTypes'
             . ($activeOnly ? ' WHERE authTypeIsEnabled=1 ' : '')
             . ' ORDER BY ' . ($sorted ? 'authTypeDisplayOrder' : 'authTypeID'));
         while ($row = $q->fetch()) {
@@ -141,7 +141,7 @@ class AuthenticationType extends ConcreteObject
         $db = Loader::db();
         $list = [];
 
-        $q = $db->query('SELECT * FROM AuthenticationTypes WHERE pkgID=?', [$pkg->getPackageID()]);
+        $q = $db->executeQuery('SELECT * FROM AuthenticationTypes WHERE pkgID=?', [$pkg->getPackageID()]);
         while ($row = $q->fetch()) {
             $list[] = self::load($row);
         }
@@ -176,7 +176,7 @@ class AuthenticationType extends ConcreteObject
             $pkgID = $pkg->getPackageID();
         }
         $db = Loader::db();
-        $db->Execute(
+        $db->executeStatement(
             'INSERT INTO AuthenticationTypes (authTypeHandle, authTypeName, authTypeIsEnabled, authTypeDisplayOrder, pkgID) values (?, ?, ?, ?, ?)',
             [$atHandle, $atName, 1, intval($order), $pkgID]);
         $est = self::getByHandle($atHandle);
@@ -283,7 +283,7 @@ class AuthenticationType extends ConcreteObject
     public function setAuthenticationTypeName($authTypeName)
     {
         $db = Loader::db();
-        $db->Execute(
+        $db->executeStatement(
             'UPDATE AuthenticationTypes SET authTypeName=? WHERE authTypeID=?',
             [$authTypeName, $this->getAuthenticationTypeID()]);
     }
@@ -297,7 +297,7 @@ class AuthenticationType extends ConcreteObject
     public function setAuthenticationTypeDisplayOrder($order)
     {
         $db = Loader::db();
-        $db->Execute(
+        $db->executeStatement(
             'UPDATE AuthenticationTypes SET authTypeDisplayOrder=? WHERE authTypeID=?',
             [$order, $this->getAuthenticationTypeID()]);
     }
@@ -336,7 +336,7 @@ class AuthenticationType extends ConcreteObject
             throw new Exception(t('The core authentication cannot be disabled.'));
         }
         $db = Loader::db();
-        $db->Execute(
+        $db->executeStatement(
             'UPDATE AuthenticationTypes SET authTypeIsEnabled=0 WHERE AuthTypeID=?',
             [$this->getAuthenticationTypeID()]);
     }
@@ -348,7 +348,7 @@ class AuthenticationType extends ConcreteObject
     public function enable()
     {
         $db = Loader::db();
-        $db->Execute(
+        $db->executeStatement(
             'UPDATE AuthenticationTypes SET authTypeIsEnabled=1 WHERE AuthTypeID=?',
             [$this->getAuthenticationTypeID()]);
     }
@@ -364,7 +364,7 @@ class AuthenticationType extends ConcreteObject
             $this->controller->deleteType();
         }
 
-        $db->Execute('DELETE FROM AuthenticationTypes WHERE authTypeID=?', [$this->authTypeID]);
+        $db->executeStatement('DELETE FROM AuthenticationTypes WHERE authTypeID=?', [$this->authTypeID]);
     }
 
     /**

--- a/concrete/src/Block/Block.php
+++ b/concrete/src/Block/Block.php
@@ -678,7 +678,7 @@ EOT
             );
             $q = 'update CollectionVersionBlocks set cbDisplayOrder = cbDisplayOrder + 1 where cID = ? and (cvID = ? or cbIncludeAll=1) and arHandle = ? and cbDisplayOrder > ?';
             $v = [$c->getCollectionID(), $c->getVersionID(), $this->getAreaHandle(), $block->getBlockDisplayOrder()];
-            $db->Execute($q, $v);
+            $db->executeStatement($q, $v);
 
             // now we set this block's display order to 1 + the current block
             $q = 'update CollectionVersionBlocks set cbDisplayOrder = ? where bID = ? and cID = ? and (cvID = ? or cbIncludeAll=1) and arHandle = ?';
@@ -689,15 +689,15 @@ EOT
                 $c->getVersionID(),
                 $this->getAreaHandle(),
             ];
-            $db->Execute($q, $v);
+            $db->executeStatement($q, $v);
         } else {
             $q = 'update CollectionVersionBlocks set cbDisplayOrder = cbDisplayOrder + 1 where cID = ? and (cvID = ? or cbIncludeAll=1) and arHandle = ?';
             $v = [$c->getCollectionID(), $c->getVersionID(), $this->getAreaHandle()];
-            $db->Execute($q, $v);
+            $db->executeStatement($q, $v);
 
             $q = 'update CollectionVersionBlocks set cbDisplayOrder = ? where bID = ? and cID = ? and (cvID = ? or cbIncludeAll=1) and arHandle = ?';
             $v = [0, $this->getBlockID(), $c->getCollectionID(), $c->getVersionID(), $this->getAreaHandle()];
-            $db->Execute($q, $v);
+            $db->executeStatement($q, $v);
         }
     }
 

--- a/concrete/src/Block/BlockController.php
+++ b/concrete/src/Block/BlockController.php
@@ -308,7 +308,7 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
             if ($this->cacheBlockRecord() && Config::get('concrete.cache.blocks')) {
                 $record = base64_encode(serialize($this->record));
                 $db = Database::connection();
-                $db->Execute('update Blocks set btCachedBlockRecord = ? where bID = ?', [$record, $this->bID]);
+                $db->executeStatement('update Blocks set btCachedBlockRecord = ? where bID = ?', [$record, $this->bID]);
             }
         }
 
@@ -441,7 +441,7 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
                     // this is the first time we're loading
                     $record = base64_encode(serialize($this->record));
                     $db = Database::connection();
-                    $db->Execute('update Blocks set btCachedBlockRecord = ? where bID = ?', [$record, $this->bID]);
+                    $db->executeStatement('update Blocks set btCachedBlockRecord = ? where bID = ?', [$record, $this->bID]);
                 }
             }
         }

--- a/concrete/src/Block/BlockType/BlockType.php
+++ b/concrete/src/Block/BlockType/BlockType.php
@@ -171,7 +171,7 @@ class BlockType
             $platform = $db->getDatabasePlatform();
             foreach ($sm->listTableColumns('Blocks') as $tableColumn) {
                 if (strcasecmp($tableColumn->getName(), 'btCachedBlockRecord') === 0) {
-                    $db->query('update Blocks set btCachedBlockRecord = null');
+                    $db->executeStatement('update Blocks set btCachedBlockRecord = null');
                     break;
                 }
             }

--- a/concrete/src/Captcha/Library.php
+++ b/concrete/src/Captcha/Library.php
@@ -155,7 +155,7 @@ class Library extends ConcreteObject
         }
         $app = Facade::getFacadeApplication();
         $db = $app->make('database')->connection();
-        $db->executeQuery('insert into SystemCaptchaLibraries (sclHandle, sclName, pkgID) values (?, ?, ?)', [$sclHandle, $sclName, $pkgID]);
+        $db->executeStatement('insert into SystemCaptchaLibraries (sclHandle, sclName, pkgID) values (?, ?, ?)', [$sclHandle, $sclName, $pkgID]);
 
         return static::getByHandle($sclHandle);
     }
@@ -173,7 +173,7 @@ class Library extends ConcreteObject
         }
         $app = Facade::getFacadeApplication();
         $db = $app->make('database')->connection();
-        $db->executeQuery('delete from SystemCaptchaLibraries where sclHandle = ?', [$this->sclHandle]);
+        $db->executeStatement('delete from SystemCaptchaLibraries where sclHandle = ?', [$this->sclHandle]);
     }
 
     /**
@@ -183,8 +183,8 @@ class Library extends ConcreteObject
     {
         $app = Facade::getFacadeApplication();
         $db = $app->make('database')->connection();
-        $db->executeQuery('update SystemCaptchaLibraries set sclIsActive = 0');
-        $db->executeQuery('update SystemCaptchaLibraries set sclIsActive = 1 where sclHandle = ?', [$this->sclHandle]);
+        $db->executeStatement('update SystemCaptchaLibraries set sclIsActive = 0');
+        $db->executeStatement('update SystemCaptchaLibraries set sclIsActive = 1 where sclHandle = ?', [$this->sclHandle]);
         $this->sclIsActive = 1;
     }
 

--- a/concrete/src/Config/ConfigStore.php
+++ b/concrete/src/Config/ConfigStore.php
@@ -27,7 +27,7 @@ class ConfigStore
         if (!$this->db) {
             return;
         }
-        $r = $this->db->Execute('select * from ConfigStore where uID = 0 order by cfKey asc');
+        $r = $this->db->executeQuery('select * from ConfigStore where uID = 0 order by cfKey asc');
         while ($row = $r->fetch()) {
             if (!$row['pkgID']) {
                 $row['pkgID'] = 0;
@@ -90,7 +90,7 @@ class ConfigStore
             return;
         }
 
-        $db->query(
+        $db->executeStatement(
             "replace into ConfigStore (cfKey, timestamp, cfValue, pkgID) values (?, ?, ?, ?)",
             array($cfKey, $timestamp, $cfValue, $pkgID)
         );
@@ -101,7 +101,7 @@ class ConfigStore
         $db = Loader::db();
         if ($pkgID > 0) {
             unset($this->rows["{$cfKey}.{$pkgID}"]);
-            $db->query(
+            $db->executeStatement(
                 "delete from ConfigStore where cfKey = ? and pkgID = ?",
                 array($cfKey, $pkgID)
             );
@@ -111,7 +111,7 @@ class ConfigStore
                     unset($this->rows[$key]);
                 }
             }
-            $db->query(
+            $db->executeStatement(
                 "delete from ConfigStore where cfKey = ?",
                 array($cfKey)
             );

--- a/concrete/src/Console/Command/InstallCommand.php
+++ b/concrete/src/Console/Command/InstallCommand.php
@@ -153,12 +153,12 @@ EOT
             $attach_mode = $options['force_attach'];
             if (!$attach_mode && $options['auto_attach']) {
                 $db = $app->make('database')->connection();
-                if ($db->query('show tables')->rowCount()) {
+                if ($db->executeQuery('show tables')->rowCount()) {
                     $attach_mode = true;
                 }
             }
             $db = app('database');
-            $db->executeQuery('set foreign_key_checks = 0');
+            $db->executeStatement('set foreign_key_checks = 0');
 
             $routines = $spl->getInstallRoutines();
             foreach ($routines as $r) {

--- a/concrete/src/Console/Command/ResetCommand.php
+++ b/concrete/src/Console/Command/ResetCommand.php
@@ -49,7 +49,7 @@ EOT
             }
         }
         $cn = Database::get();
-        $cn->executeQuery('set foreign_key_checks = 0');
+        $cn->executeStatement('set foreign_key_checks = 0');
         if (Database::getDefaultConnection()) {
             $output->write("Listing tables... ");
             /* @var $cn \Concrete\Core\Database\Connection\Connection */

--- a/concrete/src/Conversation/Conversation.php
+++ b/concrete/src/Conversation/Conversation.php
@@ -162,7 +162,7 @@ class Conversation extends ConcreteObject implements \Concrete\Core\Permission\O
     public function setConversationPageObject($c)
     {
         $db = Loader::db();
-        $db->Execute('update Conversations set cID = ? where cnvID = ?',
+        $db->executeStatement('update Conversations set cID = ? where cnvID = ?',
             array($c->getCollectionID(), $this->getConversationID()));
         $this->cID = $c->getCollectionID();
     }
@@ -180,7 +180,7 @@ class Conversation extends ConcreteObject implements \Concrete\Core\Permission\O
 
         $total = $db->GetOne('select count(cnvMessageID) from ConversationMessages where cnvID = ? and cnvIsMessageDeleted = 0 and cnvIsMessageApproved = 1',
             array($this->cnvID));
-        $db->Execute('update Conversations set cnvDateLastMessage = ?, cnvMessagesTotal = ? where cnvID = ?', array(
+        $db->executeStatement('update Conversations set cnvDateLastMessage = ?, cnvMessagesTotal = ? where cnvID = ?', array(
             $date,
             $total,
             $this->getConversationID(),
@@ -208,7 +208,7 @@ class Conversation extends ConcreteObject implements \Concrete\Core\Permission\O
     public function setConversationParentMessageID($cnvParentMessageID)
     {
         $db = Loader::db();
-        $db->Execute('update Conversations set cnvParentMessageID = ? where cnvID = ?',
+        $db->executeStatement('update Conversations set cnvParentMessageID = ? where cnvID = ?',
             array($cnvParentMessageID, $this->getConversationID()));
         $this->cnvMessageParentID = $cnvParentMessageID;
     }
@@ -217,7 +217,7 @@ class Conversation extends ConcreteObject implements \Concrete\Core\Permission\O
     {
         $db = Loader::db();
         $date = Loader::helper('date')->getOverridableNow();
-        $r = $db->Execute('insert into Conversations (cnvDateCreated, cnvDateLastMessage) values (?, ?)',
+        $r = $db->executeStatement('insert into Conversations (cnvDateCreated, cnvDateLastMessage) values (?, ?)',
             array($date, $date));
 
         return static::getByID($db->Insert_ID());
@@ -226,56 +226,56 @@ class Conversation extends ConcreteObject implements \Concrete\Core\Permission\O
     public function setConversationAttachmentOverridesEnabled($cnvAttachmentOverridesEnabled)
     {
         $db = Loader::db();
-        $db->Execute('update Conversations set cnvAttachmentOverridesEnabled = ? where cnvID = ?',
+        $db->executeStatement('update Conversations set cnvAttachmentOverridesEnabled = ? where cnvID = ?',
             array(intval($cnvAttachmentOverridesEnabled), $this->getConversationID()));
     }
 
     public function setConversationNotificationOverridesEnabled($cnvNotificationOverridesEnabled)
     {
         $db = Loader::db();
-        $db->Execute('update Conversations set cnvNotificationOverridesEnabled = ? where cnvID = ?',
+        $db->executeStatement('update Conversations set cnvNotificationOverridesEnabled = ? where cnvID = ?',
             array(intval($cnvNotificationOverridesEnabled), $this->getConversationID()));
     }
 
     public function setConversationAttachmentsEnabled($cnvAttachmentsEnabled)
     {
         $db = Loader::db();
-        $db->Execute('update Conversations set cnvAttachmentsEnabled = ? where cnvID = ?',
+        $db->executeStatement('update Conversations set cnvAttachmentsEnabled = ? where cnvID = ?',
             array(intval($cnvAttachmentsEnabled), $this->getConversationID()));
     }
 
     public function setConversationMaxFileSizeGuest($cnvMaxFileSizeGuest)
     {
         $db = Loader::db();
-        $db->Execute('update Conversations set cnvMaxFileSizeGuest = ? where cnvID = ?',
+        $db->executeStatement('update Conversations set cnvMaxFileSizeGuest = ? where cnvID = ?',
             array(intval($cnvMaxFileSizeGuest), $this->getConversationID()));
     }
 
     public function setConversationMaxFileSizeRegistered($cnvMaxFileSizeRegistered)
     {
         $db = Loader::db();
-        $db->Execute('update Conversations set cnvMaxFileSizeRegistered = ? where cnvID = ?',
+        $db->executeStatement('update Conversations set cnvMaxFileSizeRegistered = ? where cnvID = ?',
             array(intval($cnvMaxFileSizeRegistered), $this->getConversationID()));
     }
 
     public function setConversationMaxFilesGuest($cnvMaxFilesGuest)
     {
         $db = Loader::db();
-        $db->Execute('update Conversations set cnvMaxFilesGuest = ? where cnvID = ?',
+        $db->executeStatement('update Conversations set cnvMaxFilesGuest = ? where cnvID = ?',
             array(intval($cnvMaxFilesGuest), $this->getConversationID()));
     }
 
     public function setConversationMaxFilesRegistered($cnvMaxFilesRegistered)
     {
         $db = Loader::db();
-        $db->Execute('update Conversations set cnvMaxFilesRegistered = ? where cnvID = ?',
+        $db->executeStatement('update Conversations set cnvMaxFilesRegistered = ? where cnvID = ?',
             array(intval($cnvMaxFilesRegistered), $this->getConversationID()));
     }
 
     public function setConversationFileExtensions($cnvFileExtensions)
     {
         $db = Loader::db();
-        $db->Execute('update Conversations set cnvFileExtensions = ? where cnvID = ?',
+        $db->executeStatement('update Conversations set cnvFileExtensions = ? where cnvID = ?',
             array($cnvFileExtensions, $this->getConversationID()));
     }
 
@@ -291,7 +291,7 @@ class Conversation extends ConcreteObject implements \Concrete\Core\Permission\O
     public function setConversationSubscriptionEnabled($cnvEnableSubscription)
     {
         $db = Loader::db();
-        $db->Execute('update Conversations set cnvEnableSubscription = ? where cnvID = ?',
+        $db->executeStatement('update Conversations set cnvEnableSubscription = ? where cnvID = ?',
             array(intval($cnvEnableSubscription), $this->getConversationID()));
     }
 
@@ -308,7 +308,7 @@ class Conversation extends ConcreteObject implements \Concrete\Core\Permission\O
             $ids = $db->GetCol('select uID from ConversationSubscriptions where cnvID = 0');
         }
 
-        $r = $db->Execute('select uID, type from ConversationSubscriptions where cnvID = ?',
+        $r = $db->executeQuery('select uID, type from ConversationSubscriptions where cnvID = ?',
             array($this->getConversationID()));
         while ($row = $r->fetch()) {
             if ($row['type'] == 'U' && in_array($row['uID'], $ids)) {

--- a/concrete/src/Conversation/Conversation.php
+++ b/concrete/src/Conversation/Conversation.php
@@ -217,7 +217,7 @@ class Conversation extends ConcreteObject implements \Concrete\Core\Permission\O
     {
         $db = Loader::db();
         $date = Loader::helper('date')->getOverridableNow();
-        $r = $db->executeStatement('insert into Conversations (cnvDateCreated, cnvDateLastMessage) values (?, ?)',
+        $db->executeStatement('insert into Conversations (cnvDateCreated, cnvDateLastMessage) values (?, ?)',
             array($date, $date));
 
         return static::getByID($db->Insert_ID());

--- a/concrete/src/Conversation/FlagType/FlagType.php
+++ b/concrete/src/Conversation/FlagType/FlagType.php
@@ -35,7 +35,7 @@ class FlagType extends ConcreteObject
     public function delete()
     {
         $db = Loader::db();
-        $db->Execute('DELETE FROM ConversationFlaggedMessageTypes WHERE cnvMessageFlagTypeID=?', array($this->id));
+        $db->executeStatement('DELETE FROM ConversationFlaggedMessageTypes WHERE cnvMessageFlagTypeID=?', array($this->id));
     }
 
     public static function getByID($id)
@@ -73,7 +73,7 @@ class FlagType extends ConcreteObject
         if ($ft = static::getByHandle($handle)) {
             return $ft;
         }
-        $db->execute('INSERT INTO ConversationFlaggedMessageTypes (cnvMessageFlagTypeHandle) VALUES (?)', array($handle));
+        $db->executeStatement('INSERT INTO ConversationFlaggedMessageTypes (cnvMessageFlagTypeHandle) VALUES (?)', array($handle));
         $id = $db->Insert_ID();
 
         return new static($id, $handle);

--- a/concrete/src/Conversation/Message/Message.php
+++ b/concrete/src/Conversation/Message/Message.php
@@ -183,7 +183,7 @@ class Message extends ConcreteObject implements ObjectInterface, SubjectInterfac
 
         $this->cnvMessageReview = $review;
         $db = Loader::db();
-        $db->Execute('update ConversationMessages set cnvMessageReview = ? where cnvMessageID = ?', array(
+        $db->executeStatement('update ConversationMessages set cnvMessageReview = ? where cnvMessageID = ?', array(
             $review,
             $this->getConversationMessageID()
         ));
@@ -193,7 +193,7 @@ class Message extends ConcreteObject implements ObjectInterface, SubjectInterfac
     {
         $this->cnvMessageDateCreated = $cnvMessageDateCreated;
         $db = Loader::db();
-        $db->Execute('update ConversationMessages set cnvMessageDateCreated = ? where cnvMessageID = ?', array(
+        $db->executeStatement('update ConversationMessages set cnvMessageDateCreated = ? where cnvMessageID = ?', array(
             $cnvMessageDateCreated,
             $this->getConversationMessageID()
         ));
@@ -203,7 +203,7 @@ class Message extends ConcreteObject implements ObjectInterface, SubjectInterfac
     {
         $this->cnvMessageBody = $cnvMessageBody;
         $db = Loader::db();
-        $db->Execute('update ConversationMessages set cnvMessageBody = ? where cnvMessageID = ?', array(
+        $db->executeStatement('update ConversationMessages set cnvMessageBody = ? where cnvMessageID = ?', array(
             $cnvMessageBody,
             $this->getConversationMessageID(),
         ));
@@ -221,7 +221,7 @@ class Message extends ConcreteObject implements ObjectInterface, SubjectInterfac
     public function approve()
     {
         $db = Loader::db();
-        $db->execute('UPDATE ConversationMessages SET cnvIsMessageApproved=1 WHERE cnvMessageID=?',
+        $db->executeStatement('UPDATE ConversationMessages SET cnvIsMessageApproved=1 WHERE cnvMessageID=?',
             array($this->cnvMessageID));
         $this->cnvIsMessageApproved = true;
 
@@ -236,7 +236,7 @@ class Message extends ConcreteObject implements ObjectInterface, SubjectInterfac
     public function unapprove()
     {
         $db = Loader::db();
-        $db->execute('UPDATE ConversationMessages SET cnvIsMessageApproved=0 WHERE cnvMessageID=?',
+        $db->executeStatement('UPDATE ConversationMessages SET cnvIsMessageApproved=0 WHERE cnvMessageID=?',
             array($this->cnvMessageID));
         $this->cnvIsMessageApproved = false;
 
@@ -381,7 +381,7 @@ class Message extends ConcreteObject implements ObjectInterface, SubjectInterfac
         if (!$this->hasRatedMessage($ratingType, $commentRatingUserID)) {
             $cnvRatingTypeID = $db->GetOne('SELECT * FROM ConversationRatingTypes WHERE cnvRatingTypeHandle = ?',
                 array($ratingType->cnvRatingTypeHandle));
-            $db->Execute('INSERT INTO ConversationMessageRatings (cnvMessageID, cnvRatingTypeID, cnvMessageRatingIP, timestamp, uID) VALUES (?, ?, ?, ?, ?)',
+            $db->executeStatement('INSERT INTO ConversationMessageRatings (cnvMessageID, cnvRatingTypeID, cnvMessageRatingIP, timestamp, uID) VALUES (?, ?, ?, ?, ?)',
                 array(
                     $this->getConversationMessageID(),
                     $cnvRatingTypeID,
@@ -430,7 +430,7 @@ class Message extends ConcreteObject implements ObjectInterface, SubjectInterfac
                     return;
                 }
             }
-            $db->execute('INSERT INTO ConversationFlaggedMessages (cnvMessageFlagTypeID, cnvMessageID) VALUES (?,?)',
+            $db->executeStatement('INSERT INTO ConversationFlaggedMessages (cnvMessageFlagTypeID, cnvMessageID) VALUES (?,?)',
                 array($flagtype->getConversationFlagTypeID(), $this->getConversationMessageID()));
             $this->cnvMessageFlagTypes[] = $flagtype;
             $this->unapprove();
@@ -444,7 +444,7 @@ class Message extends ConcreteObject implements ObjectInterface, SubjectInterfac
     {
         if ($flagtype instanceof FlagType) {
             $db = Loader::db();
-            $db->execute('DELETE FROM ConversationFlaggedMessages WHERE cnvMessageFlagTypeID = ? AND cnvMessageID = ?',
+            $db->executeStatement('DELETE FROM ConversationFlaggedMessages WHERE cnvMessageFlagTypeID = ? AND cnvMessageID = ?',
                 array($flagtype->getConversationFlagTypeID(), $this->getConversationMessageID()));
             $this->cnvMessageFlagTypes[] = $flagtype;
 
@@ -483,7 +483,7 @@ class Message extends ConcreteObject implements ObjectInterface, SubjectInterfac
         if (!is_object($f)) {
             return false;
         } else {
-            $db->Execute('INSERT INTO ConversationMessageAttachments (cnvMessageID, fID) VALUES (?, ?)', array(
+            $db->executeStatement('INSERT INTO ConversationMessageAttachments (cnvMessageID, fID) VALUES (?, ?)', array(
                 $this->getConversationMessageID(),
                 $f->getFileID(),
             ));
@@ -500,7 +500,7 @@ class Message extends ConcreteObject implements ObjectInterface, SubjectInterfac
     public function removeFile($cnvMessageAttachmentID)
     {
         $db = Loader::db();
-        $db->Execute('DELETE FROM ConversationMessageAttachments WHERE cnvMessageAttachmentID = ?', array(
+        $db->executeStatement('DELETE FROM ConversationMessageAttachments WHERE cnvMessageAttachmentID = ?', array(
             $cnvMessageAttachmentID,
         ));
         // remove from file manager.
@@ -569,7 +569,7 @@ class Message extends ConcreteObject implements ObjectInterface, SubjectInterfac
         /** @var \Concrete\Core\Permission\IPService $iph */
         $iph = Core::make('helper/validation/ip');
         $ip = $iph->getRequestIP();
-        $r = $db->Execute('insert into ConversationMessages (cnvMessageSubject, cnvMessageBody, cnvMessageDateCreated, cnvMessageParentID, cnvEditorID, cnvMessageLevel, cnvID, uID, cnvMessageAuthorName, cnvMessageAuthorEmail, cnvMessageAuthorWebsite, cnvMessageSubmitIP, cnvMessageSubmitUserAgent) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+        $r = $db->executeStatement('insert into ConversationMessages (cnvMessageSubject, cnvMessageBody, cnvMessageDateCreated, cnvMessageParentID, cnvEditorID, cnvMessageLevel, cnvID, uID, cnvMessageAuthorName, cnvMessageAuthorEmail, cnvMessageAuthorWebsite, cnvMessageSubmitIP, cnvMessageSubmitUserAgent) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
             array(
                 $cnvMessageSubject,
                 $cnvMessageBody,
@@ -599,7 +599,7 @@ class Message extends ConcreteObject implements ObjectInterface, SubjectInterfac
     public function delete()
     {
         $db = Loader::db();
-        $db->Execute('update ConversationMessages set cnvIsMessageDeleted = 1, cnvIsMessageApproved = 0 where cnvMessageID = ?',
+        $db->executeStatement('update ConversationMessages set cnvIsMessageDeleted = 1, cnvIsMessageApproved = 0 where cnvMessageID = ?',
             array(
                 $this->cnvMessageID,
             ));
@@ -615,7 +615,7 @@ class Message extends ConcreteObject implements ObjectInterface, SubjectInterfac
     public function restore()
     {
         $db = Loader::db();
-        $db->Execute('update ConversationMessages set cnvIsMessageDeleted = 0 where cnvMessageID = ?', array(
+        $db->executeStatement('update ConversationMessages set cnvIsMessageDeleted = 0 where cnvMessageID = ?', array(
             $this->cnvMessageID,
         ));
 

--- a/concrete/src/Conversation/Message/Message.php
+++ b/concrete/src/Conversation/Message/Message.php
@@ -569,7 +569,7 @@ class Message extends ConcreteObject implements ObjectInterface, SubjectInterfac
         /** @var \Concrete\Core\Permission\IPService $iph */
         $iph = Core::make('helper/validation/ip');
         $ip = $iph->getRequestIP();
-        $r = $db->executeStatement('insert into ConversationMessages (cnvMessageSubject, cnvMessageBody, cnvMessageDateCreated, cnvMessageParentID, cnvEditorID, cnvMessageLevel, cnvID, uID, cnvMessageAuthorName, cnvMessageAuthorEmail, cnvMessageAuthorWebsite, cnvMessageSubmitIP, cnvMessageSubmitUserAgent) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+        $db->executeStatement('insert into ConversationMessages (cnvMessageSubject, cnvMessageBody, cnvMessageDateCreated, cnvMessageParentID, cnvEditorID, cnvMessageLevel, cnvID, uID, cnvMessageAuthorName, cnvMessageAuthorEmail, cnvMessageAuthorWebsite, cnvMessageSubmitIP, cnvMessageSubmitUserAgent) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
             array(
                 $cnvMessageSubject,
                 $cnvMessageBody,

--- a/concrete/src/Conversation/Message/ThreadedList.php
+++ b/concrete/src/Conversation/Message/ThreadedList.php
@@ -77,7 +77,7 @@ class ThreadedList extends ItemList
     {
         $db = Loader::db();
         $v = array($this->cnvID, $cnvMessageParentID);
-        $r = $db->Execute('select cnvMessageID from ConversationMessages where cnvID = ? and cnvMessageParentID = ?', $v);
+        $r = $db->executeQuery('select cnvMessageID from ConversationMessages where cnvID = ? and cnvMessageParentID = ?', $v);
         $messages = array();
         while ($row = $r->fetch()) {
             $msg = ConversationMessage::getByID($row['cnvMessageID']);

--- a/concrete/src/Conversation/Rating/DownVoteType.php
+++ b/concrete/src/Conversation/Rating/DownVoteType.php
@@ -18,7 +18,7 @@ class DownVoteType extends Type
     public function adjustConversationMessageRatingTotalScore(Message $message)
     {
         $db = Loader::db();
-        $db->Execute('update ConversationMessages set cnvMessageTotalRatingScore = cnvMessageTotalRatingScore - 1 where cnvMessageID = ?', array(
+        $db->executeStatement('update ConversationMessages set cnvMessageTotalRatingScore = cnvMessageTotalRatingScore - 1 where cnvMessageID = ?', array(
             $message->getConversationMessageID(),
         ));
     }

--- a/concrete/src/Conversation/Rating/Type.php
+++ b/concrete/src/Conversation/Rating/Type.php
@@ -47,7 +47,7 @@ abstract class Type extends ConcreteObject
             $pkgID = $pkg ?: 0;
         }
         $db = Database::connection();
-        $db->Execute('insert into ConversationRatingTypes (cnvRatingTypeHandle, cnvRatingTypeName, cnvRatingTypeCommunityPoints, pkgID) values (?, ?, ?, ?)', array($cnvRatingTypeHandle, $cnvRatingTypeName, $cnvRatingTypeCommunityPoints, $pkgID));
+        $db->executeStatement('insert into ConversationRatingTypes (cnvRatingTypeHandle, cnvRatingTypeName, cnvRatingTypeCommunityPoints, pkgID) values (?, ?, ?, ?)', array($cnvRatingTypeHandle, $cnvRatingTypeName, $cnvRatingTypeCommunityPoints, $pkgID));
 
         return static::getByHandle($cnvRatingTypeHandle);
     }
@@ -116,7 +116,7 @@ abstract class Type extends ConcreteObject
     public function delete()
     {
         $db = Database::connection();
-        $db->Execute('delete from ConversationRatingTypes where cnvRatingTypeHandle = ?', array($this->cnvRatingTypeHandle));
+        $db->executeStatement('delete from ConversationRatingTypes where cnvRatingTypeHandle = ?', array($this->cnvRatingTypeHandle));
     }
 
     public function getConversationRatingTypeHandle()

--- a/concrete/src/Conversation/Rating/UpVoteType.php
+++ b/concrete/src/Conversation/Rating/UpVoteType.php
@@ -18,7 +18,7 @@ class UpVoteType extends Type
     public function adjustConversationMessageRatingTotalScore(Message $message)
     {
         $db = Loader::db();
-        $db->Execute('update ConversationMessages set cnvMessageTotalRatingScore = cnvMessageTotalRatingScore + 1 where cnvMessageID = ?', array(
+        $db->executeStatement('update ConversationMessages set cnvMessageTotalRatingScore = cnvMessageTotalRatingScore + 1 where cnvMessageID = ?', array(
             $message->getConversationMessageID(),
         ));
     }

--- a/concrete/src/Database/CharacterSetCollation/Manager.php
+++ b/concrete/src/Database/CharacterSetCollation/Manager.php
@@ -114,7 +114,7 @@ class Manager
     {
         $schemaManager = $connection->getSchemaManager();
         $tableNames = $schemaManager->listTableNames();
-        $connection->executeQuery('SET foreign_key_checks = 0');
+        $connection->executeStatement('SET foreign_key_checks = 0');
         try {
             foreach ($tableNames as $tableName) {
                 $updated = false;
@@ -138,7 +138,7 @@ class Manager
                 }
             }
         } finally {
-            $connection->executeQuery('SET foreign_key_checks = 1');
+            $connection->executeStatement('SET foreign_key_checks = 1');
         }
     }
 
@@ -163,7 +163,7 @@ class Manager
         if (strcasecmp($collation, $row['Collation']) === 0) {
             return false;
         }
-        $connection->executeQuery('ALTER TABLE ' . $connection->quoteIdentifier($tableName) . ' CONVERT TO CHARACTER SET ' . $characterSet . ' COLLATE ' . $collation);
+        $connection->executeStatement('ALTER TABLE ' . $connection->quoteIdentifier($tableName) . ' CONVERT TO CHARACTER SET ' . $characterSet . ' COLLATE ' . $collation);
 
         return true;
     }

--- a/concrete/src/Database/Connection/Connection.php
+++ b/concrete/src/Database/Connection/Connection.php
@@ -2,6 +2,7 @@
 
 namespace Concrete\Core\Database\Connection;
 
+use Doctrine\DBAL\Connections\PrimaryReadReplicaConnection;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\DBAL\Schema\Column as DbalColumn;
 use Doctrine\DBAL\Schema\Table as DbalTable;
@@ -12,7 +13,7 @@ use ORM;
 use PDO;
 use Throwable;
 
-class Connection extends \Doctrine\DBAL\Connection
+class Connection extends PrimaryReadReplicaConnection
 {
     /** @var EntityManager */
     protected $entityManager;
@@ -37,6 +38,25 @@ class Connection extends \Doctrine\DBAL\Connection
      * @var array
      */
     private $overriddenParams = [];
+
+    /**
+     * Avoid opening two physical connections when no replica is configured.
+     *
+     * @param string|null $connectionName
+     *
+     * @return bool
+     */
+    protected function performConnect(?string $connectionName = null): bool
+    {
+        if (($connectionName ?? 'replica') === 'replica'
+            && count($this->getParams()['replica']) === 1
+            && $this->getParams()['primary'] === $this->getParams()['replica'][0]
+        ) {
+            return parent::performConnect('primary');
+        }
+
+        return parent::performConnect($connectionName);
+    }
 
     /**
      * @deprecated Please use the ORM facade instead of this method:
@@ -87,6 +107,7 @@ class Connection extends \Doctrine\DBAL\Connection
      */
     public function Execute($q, $arguments = [])
     {
+        $this->ensureConnectedToPrimary();
         if ($q instanceof \Doctrine\DBAL\Statement) {
             return $q->execute($arguments);
         } else {
@@ -100,6 +121,7 @@ class Connection extends \Doctrine\DBAL\Connection
 
     public function query()
     {
+        $this->ensureConnectedToPrimary();
         $args = func_get_args();
         if (isset($args) && isset($args[1]) && (is_string($args[1]) || is_array($args[1]))) {
             return $this->executeQuery($args[0], $args[1]);
@@ -143,7 +165,7 @@ class Connection extends \Doctrine\DBAL\Connection
                     }
                     if (!empty($chunks)) {
                         $sql = 'ALTER TABLE ' . $this->quoteIdentifier($tableName) . ' ADD INDEX ' . implode(', ADD INDEX ', $chunks);
-                        $this->executeQuery($sql);
+                        $this->executeStatement($sql);
                     }
                 }
             }
@@ -550,7 +572,7 @@ class Connection extends \Doctrine\DBAL\Connection
      */
     public function refreshCharactersetCollation($characterSet, $collation)
     {
-        $this->executeQuery('SET NAMES ' . $this->quote($characterSet) . ' COLLATE ' . $this->quote($collation));
+        $this->executeStatement('SET NAMES ' . $this->quote($characterSet) . ' COLLATE ' . $this->quote($collation));
         $this->overriddenParams['character_set'] = $characterSet;
         $this->overriddenParams['collation'] = $collation;
     }

--- a/concrete/src/Database/Connection/ConnectionFactory.php
+++ b/concrete/src/Database/Connection/ConnectionFactory.php
@@ -32,9 +32,7 @@ class ConnectionFactory
             $driver = $this->driver_manager->driver();
         }
 
-        $params = $config;
-        $params['host'] = array_get($params, 'host', array_get($config, 'server'));
-        $params['user'] = array_get($params, 'user', array_get($config, 'username'));
+        $params = $this->normalizeConnectionParams($config);
         if (!isset($params['driverOptions'])) {
             $params['driverOptions'] = [];
         }
@@ -56,6 +54,85 @@ class ConnectionFactory
         $connection =  new $wrapperClass($params, $driver);
         $connection->getDatabasePlatform()->registerDoctrineTypeMapping('json', 'json_array');
         return $connection;
+    }
+
+    /**
+     * Normalize both the legacy Concrete configuration keys and Doctrine's
+     * primary/replica configuration structure.
+     *
+     * The top-level connection settings are the defaults for the primary. An
+     * explicit primary configuration overrides those defaults, and every
+     * replica inherits the resulting primary configuration.
+     *
+     * @param \ArrayAccess|array $config
+     *
+     * @return array
+     */
+    private function normalizeConnectionParams($config)
+    {
+        $params = is_array($config) ? $config : iterator_to_array($config);
+        $primaryOverrides = array_get($params, 'primary', []);
+        $replicaOverrides = array_get($params, 'replica', []);
+
+        unset($params['primary'], $params['replica']);
+        $params = $this->normalizeEndpointParams($params);
+
+        $endpointDefaults = $params;
+        unset($endpointDefaults['wrapperClass'], $endpointDefaults['keepReplica']);
+
+        $primary = array_replace(
+            $endpointDefaults,
+            $this->normalizeEndpointParams(is_array($primaryOverrides) ? $primaryOverrides : [])
+        );
+
+        $replicas = [];
+        if (is_array($replicaOverrides)) {
+            foreach ($replicaOverrides as $replica) {
+                if (is_array($replica)) {
+                    $replicas[] = array_replace($primary, $this->normalizeEndpointParams($replica));
+                }
+            }
+        }
+        if ($replicas === []) {
+            $replicas[] = $primary;
+        }
+
+        // Keep the finalized primary values at the top level for compatibility
+        // with DBAL and Concrete code that reads Connection::getParams().
+        $params = array_replace($params, $primary);
+        $params['primary'] = $primary;
+        $params['replica'] = $replicas;
+
+        return $params;
+    }
+
+    /**
+     * @param array $params
+     *
+     * @return array
+     */
+    private function normalizeEndpointParams(array $params)
+    {
+        if (!isset($params['host']) && isset($params['server'])) {
+            $params['host'] = $params['server'];
+        }
+        if (!isset($params['server']) && isset($params['host'])) {
+            $params['server'] = $params['host'];
+        }
+        if (!isset($params['user']) && isset($params['username'])) {
+            $params['user'] = $params['username'];
+        }
+        if (!isset($params['username']) && isset($params['user'])) {
+            $params['username'] = $params['user'];
+        }
+        if (!isset($params['database']) && isset($params['dbname'])) {
+            $params['database'] = $params['dbname'];
+        }
+        if (!isset($params['dbname']) && isset($params['database'])) {
+            $params['dbname'] = $params['database'];
+        }
+
+        return $params;
     }
 
     /**

--- a/concrete/src/Database/Connection/ConnectionFactory.php
+++ b/concrete/src/Database/Connection/ConnectionFactory.php
@@ -70,7 +70,14 @@ class ConnectionFactory
      */
     private function normalizeConnectionParams($config)
     {
-        $params = is_array($config) ? $config : iterator_to_array($config);
+        if ($config instanceof \Traversable) {
+            $params = iterator_to_array($config);
+        } elseif (is_object($config) && method_exists($config, 'all')) {
+            $params = $config->all();
+        } else {
+            $params = (array) $config;
+        }
+
         $primaryOverrides = array_get($params, 'primary', []);
         $replicaOverrides = array_get($params, 'replica', []);
 
@@ -107,12 +114,14 @@ class ConnectionFactory
     }
 
     /**
-     * @param array $params
+     * @param array|\ArrayAccess $params
      *
      * @return array
      */
     private function normalizeEndpointParams(array $params)
     {
+        $result['host'] = $params['host'] ?? $params['server'] ?? null;
+
         if (!isset($params['host']) && isset($params['server'])) {
             $params['host'] = $params['server'];
         }

--- a/concrete/src/Database/DatabaseStructureManager.php
+++ b/concrete/src/Database/DatabaseStructureManager.php
@@ -229,7 +229,7 @@ class DatabaseStructureManager
                 $migrateSql = $schemaDiff->toSql($platform);
                 foreach ($migrateSql as $sql) {
                     if ($queryFilter === null || $queryFilter($sql) !== false) {
-                        $conn->executeQuery($sql);
+                        $conn->executeStatement($sql);
                     }
                 }
 
@@ -289,7 +289,7 @@ class DatabaseStructureManager
 
             if (count($sqls) > 0) {
                 foreach ($sqls as $sql) {
-                    $conn->executeQuery($sql);
+                    $conn->executeStatement($sql);
                 }
 
                 return true;
@@ -335,7 +335,7 @@ class DatabaseStructureManager
         }
         $sqls = $fromSchema->getMigrateToSql($toSchema, $conn->getDatabasePlatform());
         foreach ($sqls as $sql) {
-            $conn->executeQuery($sql);
+            $conn->executeStatement($sql);
         }
     }
 

--- a/concrete/src/Database/Schema/Schema.php
+++ b/concrete/src/Database/Schema/Schema.php
@@ -73,7 +73,7 @@ class Schema
         $schemaDiff = $comparator->compare($fromSchema, $toSchema);
         $saveQueries = $schemaDiff->toSaveSql($db->getDatabasePlatform());
         foreach ($saveQueries as $query) {
-            $db->query($query);
+            $db->executeStatement($query);
         }
 
     }

--- a/concrete/src/Editor/Snippet.php
+++ b/concrete/src/Editor/Snippet.php
@@ -76,7 +76,7 @@ abstract class Snippet extends ConcreteObject
             $pkgID = $pkg->getPackageID();
         }
         $db = Loader::db();
-        $db->Execute('insert into SystemContentEditorSnippets (scsHandle, scsName, pkgID) values (?, ?, ?)', array($scsHandle, $scsName, $pkgID));
+        $db->executeStatement('insert into SystemContentEditorSnippets (scsHandle, scsName, pkgID) values (?, ?, ?)', array($scsHandle, $scsName, $pkgID));
 
         return static::getByHandle($scsHandle);
     }
@@ -84,19 +84,19 @@ abstract class Snippet extends ConcreteObject
     public function delete()
     {
         $db = Loader::db();
-        $db->Execute('delete from SystemContentEditorSnippets where scsHandle = ?', array($this->scsHandle));
+        $db->executeStatement('delete from SystemContentEditorSnippets where scsHandle = ?', array($this->scsHandle));
     }
 
     public function activate()
     {
         $db = Loader::db();
-        $db->Execute('update SystemContentEditorSnippets set scsIsActive = 1 where scsHandle = ?', array($this->scsHandle));
+        $db->executeStatement('update SystemContentEditorSnippets set scsIsActive = 1 where scsHandle = ?', array($this->scsHandle));
     }
 
     public function deactivate()
     {
         $db = Loader::db();
-        $db->Execute('update SystemContentEditorSnippets set scsIsActive = 0 where scsHandle = ?', array($this->scsHandle));
+        $db->executeStatement('update SystemContentEditorSnippets set scsIsActive = 0 where scsHandle = ?', array($this->scsHandle));
     }
 
     public static function getList()

--- a/concrete/src/Entity/Block/BlockType/BlockType.php
+++ b/concrete/src/Entity/Block/BlockType/BlockType.php
@@ -339,7 +339,7 @@ class BlockType
     {
         $db = Loader::db();
         $list = array();
-        $r = $db->Execute(
+        $r = $db->executeQuery(
                 'select btsID from BlockTypeSetBlockTypes where btID = ? order by displayOrder asc',
                 array($this->getBlockTypeID()));
         while ($row = $r->fetch()) {
@@ -507,15 +507,15 @@ EOT
 
         $sql = "UPDATE BlockTypes SET btDisplayOrder = btDisplayOrder - 1 WHERE btDisplayOrder > ?";
         $vals = array($this->btDisplayOrder);
-        $db->Execute($sql, $vals);
+        $db->executeStatement($sql, $vals);
 
         $sql = "UPDATE BlockTypes SET btDisplayOrder = btDisplayOrder + 1 WHERE btDisplayOrder >= ?";
         $vals = array($displayOrder);
-        $db->Execute($sql, $vals);
+        $db->executeStatement($sql, $vals);
 
         $sql = "UPDATE BlockTypes SET btDisplayOrder = ? WHERE btID = ?";
         $vals = array($displayOrder, $this->btID);
-        $db->Execute($sql, $vals);
+        $db->executeStatement($sql, $vals);
 
         // now we remove the block type from cache
         /** @var \Concrete\Core\Cache\Cache $cache */
@@ -568,7 +568,7 @@ EOT
             $schemaDiff = $comparator->compare($fromSchema, $toSchema);
             $saveQueries = $schemaDiff->toSaveSql($db->getDatabasePlatform());
             foreach ($saveQueries as $query) {
-                $db->query($query);
+                $db->executeStatement($query);
             }
         }
     }
@@ -593,7 +593,7 @@ EOT
     public function delete()
     {
         $db = Loader::db();
-        $r = $db->Execute(
+        $r = $db->executeQuery(
                 'select cID, cvID, b.bID, arHandle
                 from CollectionVersionBlocks cvb
                     inner join Blocks b on b.bID  = cvb.bID
@@ -658,7 +658,7 @@ EOT
         $v = array($bName, $bDate, $bDate, $bIsActive, $btID, $uID);
         $q = "insert into Blocks (bName, bDateAdded, bDateModified, bIsActive, btID, uID) values (?, ?, ?, ?, ?, ?)";
 
-        $res = $db->executeQuery($q, $v);
+        $res = $db->executeStatement($q, $v);
 
         // we get the block object for the block we just added
         if ($res) {

--- a/concrete/src/Entity/File/File.php
+++ b/concrete/src/Entity/File/File.php
@@ -302,7 +302,7 @@ class File implements \Concrete\Core\Permission\ObjectInterface, AttributeObject
     public function resetPermissions($fOverrideSetPermissions = 0)
     {
         $db = Loader::db();
-        $db->Execute('delete from FilePermissionAssignments where fID = ?', [$this->fID]);
+        $db->executeStatement('delete from FilePermissionAssignments where fID = ?', [$this->fID]);
         if ($fOverrideSetPermissions) {
             $permissions = PermissionKey::getList('file');
             foreach ($permissions as $pk) {
@@ -656,11 +656,11 @@ class File implements \Concrete\Core\Permission\ObjectInterface, AttributeObject
 
         $v = [$this->fID];
         $q = 'select fID, paID, pkID from FilePermissionAssignments where fID = ?';
-        $r = $db->query($q, $v);
+        $r = $db->executeQuery($q, $v);
         while ($row = $r->fetch()) {
             $v = [$nf->getFileID(), $row['paID'], $row['pkID']];
             $q = 'insert into FilePermissionAssignments (fID, paID, pkID) values (?, ?, ?)';
-            $db->query($q, $v);
+            $db->executeStatement($q, $v);
         }
 
         $fe = new \Concrete\Core\File\Event\DuplicateFile($this);
@@ -775,11 +775,11 @@ class File implements \Concrete\Core\Permission\ObjectInterface, AttributeObject
             }
             $em->flush();
 
-            $db->executeQuery('DELETE FROM FileSetFiles WHERE fID = ?', [$this->fID]);
-            $db->executeQuery('DELETE FROM FileSearchIndexAttributes WHERE fID = ?', [$this->fID]);
-            $db->executeQuery('DELETE FROM FilePermissionAssignments WHERE fID = ?', [$this->fID]);
-            $db->executeQuery('DELETE FROM FileImageThumbnailPaths WHERE fileID = ?', [$this->fID]);
-            $db->executeQuery('DELETE FROM Files WHERE fID = ?', [$this->fID]);
+            $db->executeStatement('DELETE FROM FileSetFiles WHERE fID = ?', [$this->fID]);
+            $db->executeStatement('DELETE FROM FileSearchIndexAttributes WHERE fID = ?', [$this->fID]);
+            $db->executeStatement('DELETE FROM FilePermissionAssignments WHERE fID = ?', [$this->fID]);
+            $db->executeStatement('DELETE FROM FileImageThumbnailPaths WHERE fileID = ?', [$this->fID]);
+            $db->executeStatement('DELETE FROM Files WHERE fID = ?', [$this->fID]);
 
             $em->commit();
 

--- a/concrete/src/Entity/File/Version.php
+++ b/concrete/src/Entity/File/Version.php
@@ -878,7 +878,7 @@ class Version implements ObjectInterface
     {
         $app = Application::getFacadeApplication();
         $db = $app->make(Connection::class);
-        $db->executeQuery(
+        $db->executeStatement(
             'INSERT INTO FileVersionLog (fID, fvID, fvUpdateTypeID, fvUpdateTypeAttributeID) VALUES (?, ?, ?, ?)',
             [
                 $this->getFileID(),
@@ -1247,7 +1247,7 @@ class Version implements ObjectInterface
         }
 
         /** @noinspection PhpUnhandledExceptionInspection */
-        $db->executeQuery('DELETE FROM FileVersionLog WHERE fID = ? AND fvID = ?', [$this->getFileID(), $this->fvID]);
+        $db->executeStatement('DELETE FROM FileVersionLog WHERE fID = ? AND fvID = ?', [$this->getFileID(), $this->fvID]);
 
         if ($deleteFilesAndThumbnails) {
             if ($this->getTypeObject()->getGenericType() === FileType::T_IMAGE) {

--- a/concrete/src/Express/Entity/Listener.php
+++ b/concrete/src/Express/Entity/Listener.php
@@ -29,9 +29,9 @@ class Listener
         $em = $event->getEntityManager();
         $db = $em->getConnection();
 
-        $db->Execute('delete from atExpressSettings where exEntityID = ?', array($entity->getID()));
+        $db->executeStatement('delete from atExpressSettings where exEntityID = ?', array($entity->getID()));
         $table = $entity->getAttributeKeyCategory()->getIndexedSearchTable();
-        $db->Execute('DROP TABLE IF EXISTS ' . $table);
+        $db->executeStatement('DROP TABLE IF EXISTS ' . $table);
 
         $entity->setDefaultEditForm(null);
         $entity->setDefaultViewForm(null);

--- a/concrete/src/Express/Entry/Listener.php
+++ b/concrete/src/Express/Entry/Listener.php
@@ -41,10 +41,10 @@ class Listener
         $db = $event->getEntityManager()->getConnection();
 
         // Delete any express entry attributes that have this selected.
-        $db->Execute('delete from atExpressSelectedEntries where exEntryID = ?', array($entry->getID()));
+        $db->executeStatement('delete from atExpressSelectedEntries where exEntryID = ?', array($entry->getID()));
 
         // Delete this from any associations that reference it
-        $db->Execute('delete from ExpressEntityAssociationEntries where exEntryID = ?', array($entry->getID()));
+        $db->executeStatement('delete from ExpressEntityAssociationEntries where exEntryID = ?', array($entry->getID()));
 
         $category = \Core::make('Concrete\Core\Attribute\Category\ExpressCategory');
 

--- a/concrete/src/Express/Search/Index/EntityIndex.php
+++ b/concrete/src/Express/Search/Index/EntityIndex.php
@@ -72,7 +72,7 @@ class EntityIndex extends AbstractIndex implements ApplicationAwareInterface
 
         // Truncate the existing search index
         if ($table) {
-            $this->connection->Execute(sprintf('truncate table %s', $table));
+            $this->connection->executeStatement(sprintf('truncate table %s', $table));
         }
     }
 

--- a/concrete/src/File/Set/File.php
+++ b/concrete/src/File/Set/File.php
@@ -35,7 +35,7 @@ class File
     public static function getFileSetFiles(Set $fs)
     {
         $db = Loader::db();
-        $r = $db->query('SELECT fsfID FROM FileSetFiles WHERE fsID = ? ORDER BY fsDisplayOrder ASC', array($fs->getFileSetID()));
+        $r = $db->executeQuery('SELECT fsfID FROM FileSetFiles WHERE fsID = ? ORDER BY fsDisplayOrder ASC', array($fs->getFileSetID()));
         $files = array();
         while ($row = $r->fetch()) {
             $fsf = static::getByID($row['fsfID']);

--- a/concrete/src/File/Set/Set.php
+++ b/concrete/src/File/Set/Set.php
@@ -405,11 +405,11 @@ class Set
     public function updateFileSetDisplayOrder($files)
     {
         $db = Database::connection();
-        $db->executeQuery('UPDATE FileSetFiles SET fsDisplayOrder = 0 WHERE fsID = ?', array($this->getFileSetID()));
+        $db->executeStatement('UPDATE FileSetFiles SET fsDisplayOrder = 0 WHERE fsID = ?', array($this->getFileSetID()));
         $i = 0;
         if (is_array($files)) {
             foreach ($files as $fID) {
-                $db->executeQuery(
+                $db->executeStatement(
                     'UPDATE FileSetFiles SET fsDisplayOrder = ? WHERE fsID = ? AND fID = ?',
                     array($i, $this->getFileSetID(), $fID)
                 );
@@ -551,7 +551,7 @@ class Set
         } else {
             $file_set_file = File::createAndGetFile($f_id, $this->fsID);
             $db = $app->make(Connection::class);
-            $db->executeQuery(
+            $db->executeStatement(
                 'DELETE FROM FileSetFiles WHERE fID = ? AND fsID = ?',
                 [$f_id, $this->getFileSetID()]
             );
@@ -586,9 +586,9 @@ class Set
 
         $db = Database::connection();
         $db->delete('FileSets', array('fsID' => $this->fsID));
-        $db->executeQuery('DELETE FROM FileSetSavedSearches WHERE fsID = ?', array($this->fsID));
-        $db->executeQuery('DELETE FROM FileSetFiles WHERE fsID = ?', array($this->fsID));
-        $db->executeQuery('DELETE FROM FileImageThumbnailTypeFileSets WHERE ftfsFileSetID = ?', [$this->fsID]);
+        $db->executeStatement('DELETE FROM FileSetSavedSearches WHERE fsID = ?', array($this->fsID));
+        $db->executeStatement('DELETE FROM FileSetFiles WHERE fsID = ?', array($this->fsID));
+        $db->executeStatement('DELETE FROM FileImageThumbnailTypeFileSets WHERE ftfsFileSetID = ?', [$this->fsID]);
     }
 
     /*
@@ -599,18 +599,18 @@ class Set
         $db = Database::connection();
 
         $q = "SELECT fsID, paID, pkID FROM FileSetPermissionAssignments WHERE fsID = 0";
-        $r = $db->query($q);
+        $r = $db->executeQuery($q);
         while ($row = $r->fetch()) {
             $v = array($this->fsID, $row['paID'], $row['pkID']);
             $q = "INSERT INTO FileSetPermissionAssignments (fsID, paID, pkID) VALUES (?, ?, ?)";
-            $db->executeQuery($q, $v);
+            $db->executeStatement($q, $v);
         }
     }
 
     public function resetPermissions()
     {
         $db = Database::connection();
-        $db->executeQuery('DELETE FROM FileSetPermissionAssignments WHERE fsID = ?', array($this->fsID));
+        $db->executeStatement('DELETE FROM FileSetPermissionAssignments WHERE fsID = ?', array($this->fsID));
     }
 
     public function assignPermissions(
@@ -620,7 +620,7 @@ class Set
     ) {
         $db = Database::connection();
         if ($this->fsID > 0) {
-            $db->executeQuery("UPDATE FileSets SET fsOverrideGlobalPermissions = 1 WHERE fsID = ?", array($this->fsID));
+            $db->executeStatement("UPDATE FileSets SET fsOverrideGlobalPermissions = 1 WHERE fsID = ?", array($this->fsID));
             $this->fsOverrideGlobalPermissions = true;
         }
 

--- a/concrete/src/File/Type/Type.php
+++ b/concrete/src/File/Type/Type.php
@@ -363,7 +363,7 @@ class Type
     {
         $app = Application::getFacadeApplication();
         $db = $app->make('database')->connection();
-        $stm = $db->query('select distinct fvType from FileVersions where fvIsApproved = 1 and fvType is not null and fvType <> 0');
+        $stm = $db->executeQuery('select distinct fvType from FileVersions where fvIsApproved = 1 and fvType is not null and fvType <> 0');
         $types = [];
         while ($row = $stm->fetch()) {
             $types[] = (int) $row['fvType'];

--- a/concrete/src/Foundation/Runtime/Boot/DefaultBooter.php
+++ b/concrete/src/Foundation/Runtime/Boot/DefaultBooter.php
@@ -298,12 +298,18 @@ class DefaultBooter implements BootInterface, ApplicationAwareInterface
 
         // Make sure we have all the stuff we expect
         $connection = array_get($db_config, "connections.{$defaultConnection}");
+        if (is_array($connection)) {
+            $primary = array_get($connection, 'primary', []);
+            if (is_array($primary)) {
+                $connection = array_replace($connection, $primary);
+            }
+        }
 
         // Make sure we have all the keys we are expecting
         return $defaultConnection && $connection &&
-            array_get($connection, 'database') &&
-            array_get($connection, 'username') &&
-            array_get($connection, 'server');
+            (array_get($connection, 'database') || array_get($connection, 'dbname')) &&
+            (array_get($connection, 'username') || array_get($connection, 'user')) &&
+            (array_get($connection, 'server') || array_get($connection, 'host'));
     }
 
     private function initializeClassAliases(Repository $config): void

--- a/concrete/src/Html/Service/Navigation.php
+++ b/concrete/src/Html/Service/Navigation.php
@@ -40,7 +40,7 @@ class Navigation
         if ($currentcParentID > 0) {
             while (is_numeric($currentcParentID) && $currentcParentID > 0 && $currentcParentID) {
                 $q = "select cID, cParentID from Pages where cID = '{$currentcParentID}'";
-                $r = $db->query($q);
+                $r = $db->executeQuery($q);
                 $row = $r->fetch();
                 if ($row['cID']) {
                     $cArray[] = Page::getByID($row['cID'], 'ACTIVE');

--- a/concrete/src/Job/Job.php
+++ b/concrete/src/Job/Job.php
@@ -143,7 +143,7 @@ abstract class Job extends ConcreteObject
         } else {
             $q = "SELECT jID FROM Jobs ORDER BY jDateLastRun, jID";
         }
-        $r = $db->Execute($q);
+        $r = $db->executeQuery($q);
         $jobs = array();
         while ($row = $r->fetch()) {
             $j = static::getByID($row['jID']);
@@ -158,7 +158,7 @@ abstract class Job extends ConcreteObject
     public function reset()
     {
         $db = Loader::db();
-        $db->Execute('update Jobs set jLastStatusCode = 0, jStatus = \'ENABLED\' where jID = ?', array($this->jID));
+        $db->executeStatement('update Jobs set jLastStatusCode = 0, jStatus = \'ENABLED\' where jID = ?', array($this->jID));
     }
 
     public function markStarted()
@@ -170,7 +170,7 @@ abstract class Job extends ConcreteObject
         $timestampH = date('Y-m-d g:i:s A');
         $timestamp = date('Y-m-d H:i:s');
         $this->jDateLastRun = $timestampH;
-        $rs = $db->query("UPDATE Jobs SET jStatus='RUNNING', jDateLastRun=? WHERE jHandle=?", array($timestamp, $this->jHandle));
+        $rs = $db->executeStatement("UPDATE Jobs SET jStatus='RUNNING', jDateLastRun=? WHERE jHandle=?", array($timestamp, $this->jHandle));
     }
 
     public function markCompleted($resultCode = 0, $resultMsg = false)
@@ -187,8 +187,8 @@ abstract class Job extends ConcreteObject
             $jStatus = 'ERROR';
         }
         $timestamp = date('Y-m-d H:i:s');
-        $rs = $db->query("UPDATE Jobs SET jStatus=?, jLastStatusCode = ?, jLastStatusText=? WHERE jHandle=?", array($jStatus, $resultCode, $resultMsg, $this->jHandle));
-        $rs = $db->query("INSERT INTO JobsLog (jID, jlMessage, jlTimestamp, jlError) VALUES(?,?,?,?)", array($this->jID, $resultMsg, $timestamp, $resultCode));
+        $rs = $db->executeStatement("UPDATE Jobs SET jStatus=?, jLastStatusCode = ?, jLastStatusText=? WHERE jHandle=?", array($jStatus, $resultCode, $resultMsg, $this->jHandle));
+        $rs = $db->executeStatement("INSERT INTO JobsLog (jID, jlMessage, jlTimestamp, jlError) VALUES(?,?,?,?)", array($this->jID, $resultMsg, $timestamp, $resultCode));
 
         $je = new Event($this);
         Events::dispatch('on_job_execute', $je);
@@ -361,7 +361,7 @@ abstract class Job extends ConcreteObject
         if (!in_array($jStatus, $this->availableJStatus)) {
             $jStatus = 'ENABLED';
         }
-        $rs = $db->query("UPDATE Jobs SET jStatus=? WHERE jHandle=?", array($jStatus, $this->jHandle));
+        $rs = $db->executeStatement("UPDATE Jobs SET jStatus=? WHERE jHandle=?", array($jStatus, $this->jHandle));
     }
 
     public static function installByHandle($jHandle = '')
@@ -379,7 +379,7 @@ abstract class Job extends ConcreteObject
     {
         $db = Loader::db();
         $list = array();
-        $r = $db->Execute('select jHandle from Jobs where pkgID = ? order by jHandle asc', array($pkg->getPackageID()));
+        $r = $db->executeQuery('select jHandle from Jobs where pkgID = ? order by jHandle asc', array($pkg->getPackageID()));
         while ($row = $r->fetch()) {
             $list[] = static::getJobObjByHandle($row['jHandle']);
         }
@@ -394,7 +394,7 @@ abstract class Job extends ConcreteObject
         if (class_exists($className)) {
             $j = Core::make($className);
             $db = Loader::db();
-            $db->Execute('insert into Jobs (jName, jDescription, jDateInstalled, jNotUninstallable, jHandle, pkgID) values (?, ?, ?, ?, ?, ?)',
+            $db->executeStatement('insert into Jobs (jName, jDescription, jDateInstalled, jNotUninstallable, jHandle, pkgID) values (?, ?, ?, ?, ?, ?)',
                 array($j->getJobName(), $j->getJobDescription(), Loader::helper('date')->getOverridableNow(), 0, $jHandle, $pkg->getPackageID()));
 
             $je = new Event($j);
@@ -411,9 +411,9 @@ abstract class Job extends ConcreteObject
         $jobExists = $db->getOne('SELECT count(*) FROM Jobs WHERE jHandle=?', array($this->jHandle));
         $vals = array($this->getJobName(), $this->getJobDescription(),  date('Y-m-d H:i:s'), $this->jNotUninstallable, $this->jHandle);
         if ($jobExists) {
-            $db->query('UPDATE Jobs SET jName=?, jDescription=?, jDateInstalled=?, jNotUninstallable=? WHERE jHandle=?', $vals);
+            $db->executeStatement('UPDATE Jobs SET jName=?, jDescription=?, jDateInstalled=?, jNotUninstallable=? WHERE jHandle=?', $vals);
         } else {
-            $db->query('INSERT INTO Jobs (jName, jDescription, jDateInstalled, jNotUninstallable, jHandle) VALUES(?,?,?,?,?)', $vals);
+            $db->executeStatement('INSERT INTO Jobs (jName, jDescription, jDateInstalled, jNotUninstallable, jHandle) VALUES(?,?,?,?,?)', $vals);
         }
 
         $je = new Event($this);
@@ -429,7 +429,7 @@ abstract class Job extends ConcreteObject
         }
 
         $db = Loader::db();
-        $db->query('DELETE FROM Jobs WHERE jHandle=?', array($this->jHandle));
+        $db->executeStatement('DELETE FROM Jobs WHERE jHandle=?', array($this->jHandle));
     }
 
     /**
@@ -438,7 +438,7 @@ abstract class Job extends ConcreteObject
     public static function clearLog()
     {
         $db = Loader::db();
-        $db->Execute("delete from JobsLog");
+        $db->executeStatement("delete from JobsLog");
     }
 
     public function isScheduledForNow()
@@ -484,7 +484,7 @@ abstract class Job extends ConcreteObject
         $this->scheduledValue = $value;
         if ($this->getJobID()) {
             $db = Loader::db();
-            $db->query("UPDATE Jobs SET isScheduled = ?, scheduledInterval = ?, scheduledValue = ? WHERE jID = ?",
+            $db->executeStatement("UPDATE Jobs SET isScheduled = ?, scheduledInterval = ?, scheduledValue = ? WHERE jID = ?",
             array($this->isScheduled, $this->scheduledInterval, $this->scheduledValue, $this->getJobID()));
 
             return true;

--- a/concrete/src/Job/Set.php
+++ b/concrete/src/Job/Set.php
@@ -26,7 +26,7 @@ class Set extends ConcreteObject
         } else {
             $q = "select jsID, pkgID, jsName, jDateLastRun, isScheduled, scheduledInterval, scheduledValue from JobSets order by jsName asc";
         }
-        $r = $db->Execute($q);
+        $r = $db->executeQuery($q);
         $list = array();
         while ($row = $r->fetch()) {
             $js = new JobSet();
@@ -65,7 +65,7 @@ class Set extends ConcreteObject
     {
         $db = Loader::db();
         $list = array();
-        $r = $db->Execute('select jsID from JobSets where pkgID = ? order by jsID asc', array($pkg->getPackageID()));
+        $r = $db->executeQuery('select jsID from JobSets where pkgID = ? order by jsID asc', array($pkg->getPackageID()));
         while ($row = $r->fetch()) {
             $list[] = JobSet::getByID($row['jsID']);
         }
@@ -118,7 +118,7 @@ class Set extends ConcreteObject
     {
         $this->jsName = Loader::helper('security')->sanitizeString($jsName);
         $db = Loader::db();
-        $db->Execute("update JobSets set jsName = ? where jsID = ?", array($this->jsName, $this->jsID));
+        $db->executeStatement("update JobSets set jsName = ? where jsID = ?", array($this->jsName, $this->jsID));
     }
 
     public function addJob(Job $j)
@@ -126,7 +126,7 @@ class Set extends ConcreteObject
         $db = Loader::db();
         $no = $db->GetOne("select count(jID) from JobSetJobs where jID = ? and jsID = ?", array($j->getJobID(), $this->getJobSetID()));
         if ($no < 1) {
-            $db->Execute('insert into JobSetJobs (jsID, jID) values (?, ?)', array($this->getJobSetID(), $j->getJobID()));
+            $db->executeStatement('insert into JobSetJobs (jsID, jID) values (?, ?)', array($this->getJobSetID(), $j->getJobID()));
         }
     }
 
@@ -138,7 +138,7 @@ class Set extends ConcreteObject
         if (is_object($pkg)) {
             $pkgID = $pkg->getPackageID();
         }
-        $db->Execute('insert into JobSets (jsName, pkgID) values (?,?)', array($jsName, $pkgID));
+        $db->executeStatement('insert into JobSets (jsName, pkgID) values (?,?)', array($jsName, $pkgID));
         $id = $db->Insert_ID();
         $js = JobSet::getByID($id);
 
@@ -148,7 +148,7 @@ class Set extends ConcreteObject
     public function clearJobs()
     {
         $db = Loader::db();
-        $db->Execute('delete from JobSetJobs where jsID = ?', array($this->jsID));
+        $db->executeStatement('delete from JobSetJobs where jsID = ?', array($this->jsID));
     }
 
     /**
@@ -157,7 +157,7 @@ class Set extends ConcreteObject
     public function getJobs()
     {
         $db = Loader::db();
-        $r = $db->Execute('select jID from JobSetJobs where jsID = ? order by jID asc', $this->getJobSetId());
+        $r = $db->executeQuery('select jID from JobSetJobs where jsID = ? order by jID asc', $this->getJobSetId());
         $jobs = array();
         while ($row = $r->fetch()) {
             $j = Job::getByID($row['jID']);
@@ -174,7 +174,7 @@ class Set extends ConcreteObject
         $db = Loader::db();
         $timestamp = date('Y-m-d H:i:s');
         $this->jDateLastRun = $timestamp;
-        $db->query("UPDATE JobSets SET jDateLastRun=? WHERE jsID=?", array($timestamp, $this->getJobSetID()));
+        $db->executeStatement("UPDATE JobSets SET jDateLastRun=? WHERE jsID=?", array($timestamp, $this->getJobSetID()));
     }
 
     public function contains(Job $j)
@@ -188,8 +188,8 @@ class Set extends ConcreteObject
     public function delete()
     {
         $db = Loader::db();
-        $db->Execute('delete from JobSets where jsID = ?', array($this->getJobSetID()));
-        $db->Execute('delete from JobSetJobs where jsID = ?', array($this->getJobSetID()));
+        $db->executeStatement('delete from JobSets where jsID = ?', array($this->getJobSetID()));
+        $db->executeStatement('delete from JobSetJobs where jsID = ?', array($this->getJobSetID()));
     }
 
     public function canDelete()
@@ -200,7 +200,7 @@ class Set extends ConcreteObject
     public function removeJob(Job $j)
     {
         $db = Loader::db();
-        $db->Execute('delete from JobSetJobs where jsID = ? and jID = ?', array($this->getJobSetID(), $j->getJobID()));
+        $db->executeStatement('delete from JobSetJobs where jsID = ? and jID = ?', array($this->getJobSetID(), $j->getJobID()));
     }
 
     public function isScheduledForNow()
@@ -244,7 +244,7 @@ class Set extends ConcreteObject
         $this->scheduledValue = $value;
         if ($this->getJobSetID()) {
             $db = Loader::db();
-            $db->query("UPDATE JobSets SET isScheduled = ?, scheduledInterval = ?, scheduledValue = ? WHERE jsID = ?",
+            $db->executeStatement("UPDATE JobSets SET isScheduled = ?, scheduledInterval = ?, scheduledValue = ? WHERE jsID = ?",
             array($this->isScheduled ? 1 : 0, $this->scheduledInterval, $this->scheduledValue, $this->getJobSetID()));
 
             return true;

--- a/concrete/src/Legacy/DatabaseItemList.php
+++ b/concrete/src/Legacy/DatabaseItemList.php
@@ -19,7 +19,7 @@ class DatabaseItemList extends ItemList
         if ($this->total == -1) {
             $db = Loader::db();
             $arr = $this->executeBase(); // returns an associated array of query/placeholder values
-            $r = $db->Execute($arr);
+            $r = $db->executeQuery($arr);
             $this->total = $r->rowCount();
         }
 

--- a/concrete/src/Mail/Importer/MailImporter.php
+++ b/concrete/src/Mail/Importer/MailImporter.php
@@ -91,7 +91,7 @@ class MailImporter extends ConcreteObject
     public function delete()
     {
         $db = Database::connection();
-        $db->Execute('delete from MailImporters where miID = ?', array($this->miID));
+        $db->executeStatement('delete from MailImporters where miID = ?', array($this->miID));
     }
 
     public static function getListByPackage($pkg)
@@ -193,7 +193,7 @@ class MailImporter extends ConcreteObject
 
         $pkgID = ($pkg == null) ? 0 : $pkg->getPackageID();
 
-        $db->Execute('insert into MailImporters (miHandle, miServer, miUsername, miPassword, miEncryption, miIsEnabled, miEmail, miPort, miConnectionMethod, pkgID) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+        $db->executeStatement('insert into MailImporters (miHandle, miServer, miUsername, miPassword, miEncryption, miIsEnabled, miEmail, miPort, miConnectionMethod, pkgID) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
             array(
                 $miHandle,
                 Core::make('helper/security')->sanitizeString($miServer),
@@ -229,7 +229,7 @@ class MailImporter extends ConcreteObject
             $miEncryption = null;
         }
 
-        $db->Execute('update MailImporters set miServer = ?, miUsername = ?, miPassword = ?, miEncryption = ?, miIsEnabled = ?, miEmail = ?, miPort = ?, miConnectionMethod = ? where miID = ?',
+        $db->executeStatement('update MailImporters set miServer = ?, miUsername = ?, miPassword = ?, miEncryption = ?, miIsEnabled = ?, miEmail = ?, miPort = ?, miConnectionMethod = ? where miID = ?',
             array(
                 Core::make('helper/security')->sanitizeString($miServer),
                 $miUsername,
@@ -259,7 +259,7 @@ class MailImporter extends ConcreteObject
         $h = Core::make('helper/validation/identifier');
         $hash = $h->generate('MailValidationHashes', 'mHash');
         $args = array($email, $this->miID, $hash, time(), serialize($dataObject));
-        $db->Execute("insert into MailValidationHashes (email, miID, mHash, mDateGenerated, data) values (?, ?, ?, ?, ?)", $args);
+        $db->executeStatement("insert into MailValidationHashes (email, miID, mHash, mDateGenerated, data) values (?, ?, ?, ?, ?)", $args);
         $this->validationHash = $hash;
 
         return $hash;
@@ -305,7 +305,7 @@ class MailImporter extends ConcreteObject
     public function cleanup(MailImportedMessage $me)
     {
         $db = Database::connection();
-        $db->query("update MailValidationHashes set mDateRedeemed = " . time() . " where mHash = ?", array($me->getValidationHash()));
+        $db->executeStatement("update MailValidationHashes set mDateRedeemed = " . time() . " where mHash = ?", array($me->getValidationHash()));
         $me->delete();
     }
 }

--- a/concrete/src/Multilingual/Page/Section/Section.php
+++ b/concrete/src/Multilingual/Page/Section/Section.php
@@ -339,7 +339,7 @@ class Section extends Page
 
                 // adding in a check to see if old page was part of a language section or neutral.
                 if (is_object($msx)) {
-                    $db->Execute(
+                    $db->executeStatement(
                         'insert into MultilingualPageRelations (mpRelationID, cID, mpLanguage, mpLocale) values (?, ?, ?, ?)',
                         [
                             $mpRelationID,
@@ -355,7 +355,7 @@ class Section extends Page
                 $cID = self::getCollectionIDForLocale($mpRelationID, $ms->getLocale());
 
                 if ($cID > 0) {
-                    $db->Execute(
+                    $db->executeStatement(
                         'delete from MultilingualPageRelations where mpRelationID = ? and mpLocale = ?',
                         [$mpRelationID, $ms->getLocale()]
                     );
@@ -369,7 +369,7 @@ class Section extends Page
                 $ms->getLanguage()
             ];
 
-            $db->Execute('insert into MultilingualPageRelations (mpRelationID, cID, mpLocale, mpLanguage) values (?, ?, ?, ?)', $v);
+            $db->executeStatement('insert into MultilingualPageRelations (mpRelationID, cID, mpLocale, mpLanguage) values (?, ?, ?, ?)', $v);
 
             $pde = new Event($newPage);
             $pde->setLocale($ms->getLocale());
@@ -498,7 +498,7 @@ class Section extends Page
             return;
         }
         $db = Database::get();
-        $db->Execute('delete from MultilingualPageRelations where cID = ?', [$page->getCollectionID()]);
+        $db->executeStatement('delete from MultilingualPageRelations where cID = ?', [$page->getCollectionID()]);
     }
 
     public static function registerPage($page)
@@ -526,7 +526,7 @@ class Section extends Page
                     ++$mpRelationID;
                 }
                 $v = [$mpRelationID, $page->getCollectionID(), $ms->getLanguage(), $ms->getLocale()];
-                $db->Execute(
+                $db->executeStatement(
                     'insert into MultilingualPageRelations (mpRelationID, cID, mpLanguage, mpLocale) values (?, ?, ?, ?)',
                     $v
                 );
@@ -569,12 +569,12 @@ class Section extends Page
                     ++$mpRelationID;
                 }
                 $v = [$mpRelationID, $page->getCollectionID(), $ms->getLanguage(), $ms->getLocale()];
-                $db->Execute(
+                $db->executeStatement(
                     'insert into MultilingualPageRelations (mpRelationID, cID, mpLanguage, mpLocale) values (?, ?, ?, ?)',
                     $v
                 );
             } else {
-                $db->Execute(
+                $db->executeStatement(
                     'update MultilingualPageRelations set mpLanguage = ? where cID = ?',
                     [$ms->getLanguage(), $page->getCollectionID()]
                 );
@@ -593,12 +593,12 @@ class Section extends Page
 
         if ($mpRelationID && $section) {
             $v = [$mpRelationID, $newPage->getCollectionID(), $section->getLocale(), $section->getLanguage()];
-            $db->Execute(
+            $db->executeStatement(
                 'delete from MultilingualPageRelations where mpRelationID = ? and mpLocale = ?',
                 [$mpRelationID, $section->getLocale()]
             );
-            $db->Execute('delete from MultilingualPageRelations where cID = ?', [$newPage->getCollectionID()]);
-            $db->Execute('insert into MultilingualPageRelations (mpRelationID, cID, mpLocale, mpLanguage) values (?, ?, ?, ?)', $v);
+            $db->executeStatement('delete from MultilingualPageRelations where cID = ?', [$newPage->getCollectionID()]);
+            $db->executeStatement('insert into MultilingualPageRelations (mpRelationID, cID, mpLocale, mpLanguage) values (?, ?, ?, ?)', $v);
             $pde = new Event($newPage);
             $pde->setLocale($locale);
             \Events::dispatch('on_multilingual_page_relate', $pde);
@@ -623,7 +623,7 @@ class Section extends Page
         $mpRelationID = static::registerPage($page);
 
         $v = [$mpRelationID, 0, $locale];
-        $db->Execute('insert into MultilingualPageRelations (mpRelationID, cID, mpLocale) values (?, ?, ?)', $v);
+        $db->executeStatement('insert into MultilingualPageRelations (mpRelationID, cID, mpLocale) values (?, ?, ?)', $v);
         $pde = new Event($page);
         $pde->setLocale($locale);
         \Events::dispatch('on_multilingual_page_ignore', $pde);
@@ -664,7 +664,7 @@ class Section extends Page
         $translations->setLanguage($this->getLocale());
         $translations->setPluralForms($this->getNumberOfPluralForms(), $this->getPluralsRule());
         $db = \Database::get();
-        $r = $db->query(
+        $r = $db->executeQuery(
             "select *
             from MultilingualTranslations
             where mtSectionID = ?

--- a/concrete/src/Multilingual/Page/Section/Translation.php
+++ b/concrete/src/Multilingual/Page/Section/Translation.php
@@ -85,7 +85,7 @@ class Translation extends \Gettext\Translation
     public static function getByString($msgid)
     {
         $db = \Database::get();
-        $r = $db->query('select mtID from MultilingualTranslations mt where msgid = ?', array($msgid));
+        $r = $db->executeQuery('select mtID from MultilingualTranslations mt where msgid = ?', array($msgid));
         $row = $r->fetch();
         if ($row && $row['mtID']) {
             return static::getByRecordID($row['mtID']);
@@ -96,7 +96,7 @@ class Translation extends \Gettext\Translation
     {
         $result = null;
         $db = \Database::get();
-        $r = $db->query('select  * from MultilingualTranslations where mtID = ?', array($mtID));
+        $r = $db->executeQuery('select  * from MultilingualTranslations where mtID = ?', array($mtID));
         $row = $r->fetch();
 
         return self::getByRow($row);

--- a/concrete/src/Multilingual/Service/Extractor.php
+++ b/concrete/src/Multilingual/Service/Extractor.php
@@ -101,7 +101,7 @@ class Extractor
     {
         $app = Application::getFacadeApplication();
         $db = $app->make('database')->connection();
-        $db->executeQuery('truncate table MultilingualTranslations');
+        $db->executeStatement('truncate table MultilingualTranslations');
     }
 
     public function deleteSectionTranslationFile(Section $section)

--- a/concrete/src/Package/Package.php
+++ b/concrete/src/Package/Package.php
@@ -1057,7 +1057,7 @@ abstract class Package implements LocalizablePackageInterface
         if ($saveQueries !== []) {
             $db->beginTransaction();
             foreach ($saveQueries as $query) {
-                $db->query($query);
+                $db->executeStatement($query);
             }
             if ($db->isTransactionActive() && !$db->isAutoCommit()) {
                 $db->commit();

--- a/concrete/src/Package/StartingPointPackage.php
+++ b/concrete/src/Package/StartingPointPackage.php
@@ -552,20 +552,20 @@ class StartingPointPackage extends Package
 
         // Add Group Type + Default Role and assign them to the groups
         $db = Database::get();
-        $db->executeQuery(
+        $db->executeStatement(
             'insert into GroupTypes (gtID, gtName, gtDefaultRoleID) values (?,?, ?)',
             [DEFAULT_GROUP_TYPE_ID, t("Group"), DEFAULT_GROUP_ROLE_ID]
         );
-        $db->executeQuery('insert into GroupRoles (grID, grName) values (?,?)', [DEFAULT_GROUP_ROLE_ID, t("Member")]);
-        $db->executeQuery(
+        $db->executeStatement('insert into GroupRoles (grID, grName) values (?,?)', [DEFAULT_GROUP_ROLE_ID, t("Member")]);
+        $db->executeStatement(
             'insert into GroupTypeSelectedRoles (gtID, grID) values (?,?)',
             [DEFAULT_GROUP_TYPE_ID, DEFAULT_GROUP_ROLE_ID]
         );
-        $db->executeQuery(
+        $db->executeStatement(
             'update `Groups` set gtID = ?, gDefaultRoleID = ?',
             [DEFAULT_GROUP_TYPE_ID, DEFAULT_GROUP_ROLE_ID]
         );
-        $db->executeQuery('update UserGroups set grID = ?', [DEFAULT_GROUP_ROLE_ID]);
+        $db->executeStatement('update UserGroups set grID = ?', [DEFAULT_GROUP_ROLE_ID]);
 
         $config = $this->app->make(Repository::class);
         if (!$config->get('concrete.email.default.address')) {

--- a/concrete/src/Page/Cloner.php
+++ b/concrete/src/Page/Cloner.php
@@ -625,6 +625,6 @@ EOT
         if (count($wheres) > 0) {
             $query .= ' where ' . implode(' and ', $wheres);
         }
-        $this->connection->executeQuery($query, array_merge($insertParams, $whereParams));
+        $this->connection->executeStatement($query, array_merge($insertParams, $whereParams));
     }
 }

--- a/concrete/src/Page/Collection/Version/Version.php
+++ b/concrete/src/Page/Collection/Version/Version.php
@@ -605,7 +605,7 @@ class Version extends ConcreteObject implements PermissionObjectInterface, Attri
         $app = Facade::getFacadeApplication();
         $db = $app->make('database')->connection();
         $q = "update CollectionVersions set cvComments = ? where cvID = ? and cID = ?";
-        $db->executeQuery($q, $v);
+        $db->executeStatement($q, $v);
         $this->cvComments = $comment;
     }
 
@@ -803,7 +803,7 @@ class Version extends ConcreteObject implements PermissionObjectInterface, Attri
             // we make sure to update the cInheritPermissionsFromCID value
             $pType = PageType::getByID($c->getPageTypeID());
             $masterC = $pType->getPageTypePageTemplateDefaultPageObject();
-            $db->executeQuery(
+            $db->executeStatement(
                 'update Pages set cInheritPermissionsFromCID = ? where cID = ?',
                 [(int) $masterC->getCollectionID(), $c->getCollectionID()]
             );
@@ -849,7 +849,7 @@ class Version extends ConcreteObject implements PermissionObjectInterface, Attri
                 if ($cnp->canApprovePageVersions()) {
                     $v = $cn->getVersionObject();
                     $v->delete();
-                    $db->executeQuery('delete from CollectionVersionRelatedEdits where cID = ? and cvID = ? and cRelationID = ? and cvRelationID = ?', array(
+                    $db->executeStatement('delete from CollectionVersionRelatedEdits where cID = ? and cvID = ? and cRelationID = ? and cvRelationID = ?', array(
                         $this->cID,
                         $this->cvID,
                         $row['cRelationID'],
@@ -891,7 +891,7 @@ class Version extends ConcreteObject implements PermissionObjectInterface, Attri
     {
         $app = Facade::getFacadeApplication();
         $db = $app->make('database')->connection();
-        $db->executeQuery("update CollectionVersions set cvIsNew = 0 where cID = ? and cvID = ?", array(
+        $db->executeStatement("update CollectionVersions set cvIsNew = 0 where cID = ? and cvID = ?", array(
             $this->cID,
             $this->cvID,
         ));
@@ -978,35 +978,35 @@ class Version extends ConcreteObject implements PermissionObjectInterface, Attri
             $category->deleteValue($attribute);
         }
 
-        $db->executeQuery('delete from CollectionVersionBlockStyles where cID = ? and cvID = ?', array(
+        $db->executeStatement('delete from CollectionVersionBlockStyles where cID = ? and cvID = ?', array(
             $cID,
             $cvID,
         ));
-        $db->executeQuery('delete from CollectionVersionThemeCustomStyles where cID = ? and cvID = ?', array(
+        $db->executeStatement('delete from CollectionVersionThemeCustomStyles where cID = ? and cvID = ?', array(
             $cID,
             $cvID,
         ));
-        $db->executeQuery('delete from CollectionVersionRelatedEdits where cID = ? and cvID = ?', array(
+        $db->executeStatement('delete from CollectionVersionRelatedEdits where cID = ? and cvID = ?', array(
             $cID,
             $cvID,
         ));
-        $db->executeQuery('delete from CollectionVersionAreaStyles where cID = ? and cvID = ?', array(
-            $cID,
-            $cvID,
-        ));
-
-        $db->executeQuery('delete from PageTypeComposerOutputBlocks where cID = ? and cvID = ?', array(
+        $db->executeStatement('delete from CollectionVersionAreaStyles where cID = ? and cvID = ?', array(
             $cID,
             $cvID,
         ));
 
-        $db->executeQuery('delete from CollectionVersionBlocks where cID = ? and cvID = ?', array(
+        $db->executeStatement('delete from PageTypeComposerOutputBlocks where cID = ? and cvID = ?', array(
+            $cID,
+            $cvID,
+        ));
+
+        $db->executeStatement('delete from CollectionVersionBlocks where cID = ? and cvID = ?', array(
             $cID,
             $cvID,
         ));
 
         $q = "delete from CollectionVersions where cID = '{$cID}' and cvID='{$cvID}'";
-        $db->executeQuery($q);
+        $db->executeStatement($q);
         $this->refreshCache();
 
         $ev = new Event($c);

--- a/concrete/src/Page/Command/CopyPageCommandHandler.php
+++ b/concrete/src/Page/Command/CopyPageCommandHandler.php
@@ -52,7 +52,7 @@ class CopyPageCommandHandler
             if ($nc->getCollectionPointerOriginalID() > 0) {
                 $ncID = $nc->getCollectionPointerOriginalID();
             }
-            $db->Execute('insert into QueuePageDuplicationRelations (cID, originalCID, queue_name) values (?, ?, ?)', array(
+            $db->executeStatement('insert into QueuePageDuplicationRelations (cID, originalCID, queue_name) values (?, ?, ?)', array(
                 $ncID, $ocID, $command->getCopyBatchID(),
             ));
         }

--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -2947,7 +2947,7 @@ EOT
                 //as well as all collections beneath it that are set to inherit from this parent
                 // first we do this one
                 $q = 'update Pages set cInheritPermissionsFromCID = ? where cID = ?';
-                $r = $db->executeStatement($q, [(int) $npID, $cID]);
+                $db->executeStatement($q, [(int) $npID, $cID]);
                 $this->updatePermissionsCollectionID($cID, $npID);
             }
         }

--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -621,7 +621,7 @@ class Page extends Collection implements CategoryMemberInterface,
     {
         $db = Database::connection();
         $q = 'update Pages set cIsCheckedOut = 0, cCheckedOutUID = null, cCheckedOutDatetime = null, cCheckedOutDatetimeLastEdit = null where cID = ?';
-        $db->executeQuery($q, [$this->cID]);
+        $db->executeStatement($q, [$this->cID]);
     }
 
     /**
@@ -633,7 +633,7 @@ class Page extends Collection implements CategoryMemberInterface,
     {
         $db = Database::connection();
         $q = 'update Pages set cIsCheckedOut = 0, cCheckedOutUID = null, cCheckedOutDatetime = null, cCheckedOutDatetimeLastEdit = null';
-        $db->executeQuery($q);
+        $db->executeStatement($q);
     }
 
     /**
@@ -734,9 +734,9 @@ class Page extends Collection implements CategoryMemberInterface,
         $db = Database::connection();
 
         // Remove the moved block from its old area, and all blocks from the destination area.
-        $db->executeQuery('UPDATE CollectionVersionBlockStyles SET arHandle = ?  WHERE cID = ? and cvID = ? and bID = ?',
+        $db->executeStatement('UPDATE CollectionVersionBlockStyles SET arHandle = ?  WHERE cID = ? and cvID = ? and bID = ?',
                      [$area_handle, $this->getCollectionID(), $this->getVersionID(), $moved_block_id]);
-        $db->executeQuery('UPDATE CollectionVersionBlocks SET arHandle = ?  WHERE cID = ? and cvID = ? and bID = ?',
+        $db->executeStatement('UPDATE CollectionVersionBlocks SET arHandle = ?  WHERE cID = ? and cvID = ? and bID = ?',
                      [$area_handle, $this->getCollectionID(), $this->getVersionID(), $moved_block_id]);
 
         $update_query = 'UPDATE CollectionVersionBlocks SET cbDisplayOrder = CASE bID';
@@ -753,7 +753,7 @@ class Page extends Collection implements CategoryMemberInterface,
         $values = array_merge($update_values, $block_order);
         $values = array_merge($values, [$this->getCollectionID(), $this->getVersionID()]);
 
-        $db->executeQuery($update_query, $values);
+        $db->executeStatement($update_query, $values);
     }
 
     /**
@@ -1195,8 +1195,8 @@ class Page extends Collection implements CategoryMemberInterface,
             }
             $cLink = app('helper/security')->sanitizeURL($cLink);
             $cName = app('helper/text')->sanitize($cName);
-            $db->executeQuery('update CollectionVersions set cvName = ? where cID = ?', [$cName, $this->cID]);
-            $db->executeQuery('update Pages set cPointerExternalLink = ?, cPointerExternalLinkNewWindow = ? where cID = ?', [$cLink, $newWindow, $this->cID]);
+            $db->executeStatement('update CollectionVersions set cvName = ? where cID = ?', [$cName, $this->cID]);
+            $db->executeStatement('update Pages set cPointerExternalLink = ?, cPointerExternalLinkNewWindow = ? where cID = ?', [$cLink, $newWindow, $this->cID]);
         }
     }
 
@@ -1339,16 +1339,16 @@ class Page extends Collection implements CategoryMemberInterface,
 
             $args = [$this->getCollectionPointerOriginalID()];
             $q = 'delete from Pages where cID = ?';
-            $db->executeQuery($q, $args);
+            $db->executeStatement($q, $args);
 
             $q = 'delete from Collections where cID = ?';
-            $db->executeQuery($q, $args);
+            $db->executeStatement($q, $args);
 
             $q = 'delete from CollectionVersions where cID = ?';
-            $db->executeQuery($q, $args);
+            $db->executeStatement($q, $args);
 
             $q = 'delete from PagePaths where cID = ?';
-            $db->executeQuery($q, $args);
+            $db->executeStatement($q, $args);
 
             return $cIDRedir;
         }
@@ -2125,7 +2125,7 @@ class Page extends Collection implements CategoryMemberInterface,
     public function setTheme($pl)
     {
         $db = Database::connection();
-        $db->executeQuery('update CollectionVersions set pThemeID = ? where cID = ? and cvID = ?', [$pl ? $pl->getThemeID() : 0, $this->cID, $this->vObj->getVersionID()]);
+        $db->executeStatement('update CollectionVersions set pThemeID = ? where cID = ? and cvID = ?', [$pl ? $pl->getThemeID() : 0, $this->cID, $this->vObj->getVersionID()]);
         $this->themeObject = $pl;
     }
 
@@ -2137,7 +2137,7 @@ class Page extends Collection implements CategoryMemberInterface,
     public function setThemeSkin(SkinInterface $skin)
     {
         $db = Database::connection();
-        $db->executeQuery('update CollectionVersions set pThemeSkinIdentifier = ? where cID = ? and cvID = ?', [$skin->getIdentifier(), $this->cID, $this->vObj->getVersionID()]);
+        $db->executeStatement('update CollectionVersions set pThemeSkinIdentifier = ? where cID = ? and cvID = ?', [$skin->getIdentifier(), $this->cID, $this->vObj->getVersionID()]);
     }
 
     /**
@@ -2152,7 +2152,7 @@ class Page extends Collection implements CategoryMemberInterface,
             $ptID = $type->getPageTypeID();
         }
         $db = Database::connection();
-        $db->executeQuery('update Pages set ptID = ? where cID = ?', [$ptID, $this->cID]);
+        $db->executeStatement('update Pages set ptID = ? where cID = ?', [$ptID, $this->cID]);
         $this->ptID = $ptID;
     }
 
@@ -2163,7 +2163,7 @@ class Page extends Collection implements CategoryMemberInterface,
     {
         $db = Database::connection();
         if ($this->cID) {
-            $db->executeQuery('update Pages set cOverrideTemplatePermissions = 0 where cID = ?', [$this->cID]);
+            $db->executeStatement('update Pages set cOverrideTemplatePermissions = 0 where cID = ?', [$this->cID]);
         }
     }
 
@@ -2174,7 +2174,7 @@ class Page extends Collection implements CategoryMemberInterface,
     {
         $db = Database::connection();
         if ($this->cID) {
-            $db->executeQuery('update Pages set cOverrideTemplatePermissions = 1 where cID = ?', [$this->cID]);
+            $db->executeStatement('update Pages set cOverrideTemplatePermissions = 1 where cID = ?', [$this->cID]);
         }
     }
 
@@ -2407,7 +2407,7 @@ EOT
             $app = Application::getFacadeApplication();
             $cHandle = $app->make(HandleGenerator::class)->generate($this, ['cName' => $name]);
 
-            $db->executeQuery('update CollectionVersions set cvName = ?, cvHandle = ? where cID = ? and cvID = ?', [$name, $cHandle, $this->getCollectionID(), $cvID]);
+            $db->executeStatement('update CollectionVersions set cvName = ?, cvHandle = ? where cID = ? and cvID = ?', [$name, $cHandle, $this->getCollectionID(), $cvID]);
 
             $cache = PageCache::getLibrary();
             $cache->purge($this);
@@ -2584,7 +2584,7 @@ EOT
                     }
 
                     // now, we default all blocks on the current version of the page.
-                    $db->executeQuery('delete from CollectionVersionBlocks where cID = ? and cvID = ?', [$this->getCollectionID(), $cvID]);
+                    $db->executeStatement('delete from CollectionVersionBlocks where cID = ? and cvID = ?', [$this->getCollectionID(), $cvID]);
 
                     // now, we go back and we alias blocks from the new master collection onto the page.
                     foreach ($newMCBlocks as $b) {
@@ -2604,7 +2604,7 @@ EOT
                     foreach ($currentPageBlocks as $b) {
                         if (!in_array($b->getBlockID(), $oldMCBlockIDs)) {
                             $newBlockDisplayOrder = $this->getCollectionAreaDisplayOrder($b->getAreaHandle());
-                            $db->executeQuery('insert into CollectionVersionBlocks (cID, cvID, bID, arHandle, cbRelationID, cbDisplayOrder, isOriginal, cbOverrideAreaPermissions, cbIncludeAll) values (?, ?, ?, ?, ?, ?, ?, ?, ?)', [
+                            $db->executeStatement('insert into CollectionVersionBlocks (cID, cvID, bID, arHandle, cbRelationID, cbDisplayOrder, isOriginal, cbOverrideAreaPermissions, cbIncludeAll) values (?, ?, ?, ?, ?, ?, ?, ?, ?)', [
                                 $this->getCollectionID(), $cvID, $b->getBlockID(), $b->getAreaHandle(), $b->getBlockRelationID(), $newBlockDisplayOrder, (int) ($b->isOriginal()), $b->overrideAreaPermissions(), $b->disableBlockVersioning(),
                             ]);
                         }
@@ -2624,7 +2624,7 @@ EOT
             $r->execute($v);
         }
 
-        $db->executeQuery('update Pages set ptID = ?, uID = ?, pkgID = ?, cFilename = ?, cCacheFullPageContent = ?, cCacheFullPageContentLifetimeCustom = ?, cCacheFullPageContentOverrideLifetime = ? where cID = ?', [$ptID, $uID, $pkgID, $cFilename, $cCacheFullPageContent, $cCacheFullPageContentLifetimeCustom, $cCacheFullPageContentOverrideLifetime, $this->cID]);
+        $db->executeStatement('update Pages set ptID = ?, uID = ?, pkgID = ?, cFilename = ?, cCacheFullPageContent = ?, cCacheFullPageContentLifetimeCustom = ?, cCacheFullPageContentOverrideLifetime = ? where cID = ?', [$ptID, $uID, $pkgID, $cFilename, $cCacheFullPageContent, $cCacheFullPageContentLifetimeCustom, $cCacheFullPageContentOverrideLifetime, $this->cID]);
 
         $cache = PageCache::getLibrary();
         $cache->purge($this);
@@ -2647,7 +2647,7 @@ EOT
     public function clearPagePermissions()
     {
         $db = Database::connection();
-        $db->executeQuery('delete from PagePermissionAssignments where cID = ?', [$this->cID]);
+        $db->executeStatement('delete from PagePermissionAssignments where cID = ?', [$this->cID]);
         $this->permissionAssignments = [];
     }
 
@@ -2661,7 +2661,7 @@ EOT
         $this->updatePermissionsCollectionID($this->cID, $cpID);
         $v = ['PARENT', (int) $cpID, $this->cID];
         $q = 'update Pages set cInheritPermissionsFrom = ?, cInheritPermissionsFromCID = ? where cID = ?';
-        $db->executeQuery($q, $v);
+        $db->executeStatement($q, $v);
         $this->cInheritPermissionsFrom = 'PARENT';
         $this->cInheritPermissionsFromCID = $cpID;
         $this->clearPagePermissions();
@@ -2682,7 +2682,7 @@ EOT
                 $this->updatePermissionsCollectionID($this->cID, $cpID);
                 $v = ['TEMPLATE', (int) $cpID, $this->cID];
                 $q = 'update Pages set cInheritPermissionsFrom = ?, cInheritPermissionsFromCID = ? where cID = ?';
-                $db->executeQuery($q, $v);
+                $db->executeStatement($q, $v);
                 $this->cInheritPermissionsFrom = 'TEMPLATE';
                 $this->cInheritPermissionsFromCID = $cpID;
                 $this->clearPagePermissions();
@@ -2705,7 +2705,7 @@ EOT
             $this->updatePermissionsCollectionID($this->cID, $cpID);
             $v = ['OVERRIDE', (int) $cpID, $this->cID];
             $q = 'update Pages set cInheritPermissionsFrom = ?, cInheritPermissionsFromCID = ? where cID = ?';
-            $db->executeQuery($q, $v);
+            $db->executeStatement($q, $v);
             $this->cInheritPermissionsFrom = 'OVERRIDE';
             $this->cInheritPermissionsFromCID = $cpID;
             $this->rescanAreaPermissions();
@@ -2735,7 +2735,7 @@ EOT
         $db = Database::connection();
         $v = [$cOverrideTemplatePermissions, $this->cID];
         $q = 'update Pages set cOverrideTemplatePermissions = ? where cID = ?';
-        $db->executeQuery($q, $v);
+        $db->executeStatement($q, $v);
         $this->cOverrideTemplatePermissions = $cOverrideTemplatePermissions;
     }
 
@@ -2752,7 +2752,7 @@ EOT
         $db = Database::connection();
         $pcID = $this->getPermissionsCollectionID();
         $q = "select cID from Pages where cParentID in ({$cParentIDString}) and cInheritPermissionsFromCID = {$pcID}";
-        $r = $db->query($q);
+        $r = $db->executeQuery($q);
         $cList = [];
         while ($row = $r->fetch()) {
             $cList[] = $row['cID'];
@@ -2760,7 +2760,7 @@ EOT
         if (count($cList) > 0) {
             $cParentIDString = implode(',', $cList);
             $q2 = "update Pages set cInheritPermissionsFromCID = {$npID} where cID in ({$cParentIDString})";
-            $db->query($q2);
+            $db->executeStatement($q2);
             $this->updatePermissionsCollectionID($cParentIDString, $npID);
         }
     }
@@ -2775,7 +2775,7 @@ EOT
         $v = [$this->cID];
         $db = Database::connection();
         $q = 'delete from AreaPermissionAssignments where cID = ?';
-        $db->executeQuery($q, $v);
+        $db->executeStatement($q, $v);
 
         // ack - we need to copy area permissions from that page as well
         $v = [$permissionsCollectionID];
@@ -2784,7 +2784,7 @@ EOT
         while ($row = $r->fetch()) {
             $v = [$this->cID, $row['arHandle'], $row['paID'], $row['pkID']];
             $q = 'insert into AreaPermissionAssignments (cID, arHandle, paID, pkID) values (?, ?, ?, ?)';
-            $db->executeQuery($q, $v);
+            $db->executeStatement($q, $v);
         }
 
         // any areas that were overriding permissions on the current page need to be overriding permissions
@@ -2795,7 +2795,7 @@ EOT
         while ($row = $r->fetch()) {
             $v = [$this->cID, $row['arHandle'], $row['arOverrideCollectionPermissions'], $row['arInheritPermissionsFromAreaOnCID'], $row['arIsGlobal']];
             $q = 'insert into Areas (cID, arHandle, arOverrideCollectionPermissions, arInheritPermissionsFromAreaOnCID, arIsGlobal) values (?, ?, ?, ?, ?)';
-            $db->executeQuery($q, $v);
+            $db->executeStatement($q, $v);
         }
     }
 
@@ -2809,7 +2809,7 @@ EOT
         $v = [$this->cID];
         $db = Database::connection();
         $q = 'delete from PagePermissionAssignments where cID = ?';
-        $db->executeQuery($q, $v);
+        $db->executeStatement($q, $v);
 
         $v = [$permissionsCollectionID];
         $q = 'select cID, paID, pkID from PagePermissionAssignments where cID = ?';
@@ -2817,7 +2817,7 @@ EOT
         while ($row = $r->fetch()) {
             $v = [$this->cID, $row['paID'], $row['pkID']];
             $q = 'insert into PagePermissionAssignments (cID, paID, pkID) values (?, ?, ?)';
-            $db->executeQuery($q, $v);
+            $db->executeStatement($q, $v);
         }
     }
 
@@ -2832,7 +2832,7 @@ EOT
         $db = Database::connection();
         $this->getPermissionsCollectionID();
         $q = "select cID from Pages where cParentID in ({$cParentIDString}) and cInheritPermissionsFrom = 'PARENT'";
-        $r = $db->query($q);
+        $r = $db->executeQuery($q);
         $cList = [];
         while ($row = $r->fetch()) {
             $cList[] = $row['cID'];
@@ -2840,7 +2840,7 @@ EOT
         if (count($cList) > 0) {
             $cParentIDString = implode(',', $cList);
             $q2 = "update Pages set cInheritPermissionsFromCID = {$this->cID} where cID in ({$cParentIDString})";
-            $db->query($q2);
+            $db->executeStatement($q2);
             $this->updateGroupsSubCollection($cParentIDString);
         }
     }
@@ -2947,14 +2947,14 @@ EOT
                 //as well as all collections beneath it that are set to inherit from this parent
                 // first we do this one
                 $q = 'update Pages set cInheritPermissionsFromCID = ? where cID = ?';
-                $r = $db->executeQuery($q, [(int) $npID, $cID]);
+                $r = $db->executeStatement($q, [(int) $npID, $cID]);
                 $this->updatePermissionsCollectionID($cID, $npID);
             }
         }
 
         $oldParent = self::getByID($this->getCollectionParentID(), 'RECENT');
 
-        $db->executeQuery('update Collections set cDateModified = ? where cID = ?', [$cDateModified, $cID]);
+        $db->executeStatement('update Collections set cDateModified = ? where cID = ?', [$cDateModified, $cID]);
         $v = [$newCParentID, $cID];
         $q = 'update Pages set cParentID = ? where cID = ?';
         $r = $db->prepare($q);
@@ -2967,18 +2967,18 @@ EOT
             if ($this->isInTrash()) {
                 $childPages = $this->populateRecursivePages([], ['cID' => $cID], $this->getCollectionParentID(), 0, false);
                 foreach ($childPages as $page) {
-                    $db->executeQuery('update Pages set cIsActive = 1 where cID = ?', [$page['cID']]);
+                    $db->executeStatement('update Pages set cIsActive = 1 where cID = ?', [$page['cID']]);
                 }
             }
         }
 
         if ($nc->getSiteTreeID() != $this->getSiteTreeID()) {
-            $db->executeQuery('update Pages set siteTreeID = ? where cID = ?', [$nc->getSiteTreeID(), $cID]);
+            $db->executeStatement('update Pages set siteTreeID = ? where cID = ?', [$nc->getSiteTreeID(), $cID]);
             if (!isset($childPages)) {
                 $childPages = $this->populateRecursivePages([], ['cID' => $cID], $this->getCollectionParentID(), 0, false);
             }
             foreach ($childPages as $page) {
-                $db->executeQuery('update Pages set siteTreeID = ? where cID = ?', [$nc->getSiteTreeID(), $page['cID']]);
+                $db->executeStatement('update Pages set siteTreeID = ? where cID = ?', [$nc->getSiteTreeID(), $page['cID']]);
             }
         }
 
@@ -3088,31 +3088,31 @@ EOT
 
         // Now that all versions are gone, we can delete the collection information
         $q = "delete from PagePaths where cID = '{$cID}'";
-        $r = $db->query($q);
+        $r = $db->executeQuery($q);
 
         // remove all pages where the pointer is this cID
         $r = $db->executeQuery('select cID from Pages where cPointerID = ?', [$cID]);
         while ($row = $r->fetch()) {
             PageStatistics::decrementParents($row['cID']);
-            $db->executeQuery('DELETE FROM PagePaths WHERE cID=?', [$row['cID']]);
+            $db->executeStatement('DELETE FROM PagePaths WHERE cID=?', [$row['cID']]);
         }
 
         // Update cChildren for cParentID
         PageStatistics::decrementParents($cID);
 
-        $db->executeQuery('delete from PagePermissionAssignments where cID = ?', [$cID]);
+        $db->executeStatement('delete from PagePermissionAssignments where cID = ?', [$cID]);
 
-        $db->executeQuery('delete from Pages where cID = ?', [$cID]);
+        $db->executeStatement('delete from Pages where cID = ?', [$cID]);
 
-        $db->executeQuery('delete from MultilingualPageRelations where cID = ?', [$cID]);
+        $db->executeStatement('delete from MultilingualPageRelations where cID = ?', [$cID]);
 
-        $db->executeQuery('delete from SiblingPageRelations where cID = ?', [$cID]);
+        $db->executeStatement('delete from SiblingPageRelations where cID = ?', [$cID]);
 
-        $db->executeQuery('delete from Pages where cPointerID = ?', [$cID]);
+        $db->executeStatement('delete from Pages where cPointerID = ?', [$cID]);
 
-        $db->executeQuery('delete from Areas WHERE cID = ?', [$cID]);
+        $db->executeStatement('delete from Areas WHERE cID = ?', [$cID]);
 
-        $db->executeQuery('delete from PageSearchIndex where cID = ?', [$cID]);
+        $db->executeStatement('delete from PageSearchIndex where cID = ?', [$cID]);
 
         $r = $db->executeQuery('select cID from Pages where cParentID = ?', [$cID]);
         if ($r) {
@@ -3171,7 +3171,7 @@ EOT
         $pages = $this->populateRecursivePages($pages, ['cID' => $cID], $this->getCollectionParentID(), 0, false);
         $db = Database::connection();
         foreach ($pages as $page) {
-            $db->executeQuery('update Pages set cIsActive = 0 where cID = ?', [$page['cID']]);
+            $db->executeStatement('update Pages set cIsActive = 0 where cID = ?', [$page['cID']]);
             $indexer->forget(Page::class, $page['cID']);
         }
     }
@@ -3190,7 +3190,7 @@ EOT
         $current_count = 0;
         foreach ($children_array as $newcID) {
             $q = 'update Pages set cDisplayOrder = ? where cID = ?';
-            $db->executeQuery($q, [$current_count, $newcID]);
+            $db->executeStatement($q, [$current_count, $newcID]);
             ++$current_count;
         }
     }
@@ -3401,7 +3401,7 @@ EOT
         }
 
         // Store the new display order.
-        $db->executeQuery('update Pages set cDisplayOrder = ? where cID = ?', [$displayOrder, $cID]);
+        $db->executeStatement('update Pages set cDisplayOrder = ? where cID = ?', [$displayOrder, $cID]);
 
         // Because the display order of another page can be changed,
         // the page object is retrieved first in order to pass it to the event.
@@ -3517,10 +3517,10 @@ EOT
         }
 
         if ($systemPage) {
-            $db->executeQuery('update Pages set cIsSystemPage = 1 where cID = ?', [$cID]);
+            $db->executeStatement('update Pages set cIsSystemPage = 1 where cID = ?', [$cID]);
             $this->cIsSystemPage = true;
         } else {
-            $db->executeQuery('update Pages set cIsSystemPage = 0 where cID = ?', [$cID]);
+            $db->executeStatement('update Pages set cIsSystemPage = 0 where cID = ?', [$cID]);
             $this->cIsSystemPage = false;
         }
     }
@@ -3541,7 +3541,7 @@ EOT
     public function moveToRoot()
     {
         $db = Database::connection();
-        $db->executeQuery('update Pages set cParentID = 0 where cID = ?', [$this->getCollectionID()]);
+        $db->executeStatement('update Pages set cParentID = 0 where cID = ?', [$this->getCollectionID()]);
         $this->cParentID = 0;
         $this->rescanSystemPageStatus();
     }
@@ -3552,7 +3552,7 @@ EOT
     public function deactivate()
     {
         $db = Database::connection();
-        $db->executeQuery('update Pages set cIsActive = 0 where cID = ?', [$this->getCollectionID()]);
+        $db->executeStatement('update Pages set cIsActive = 0 where cID = ?', [$this->getCollectionID()]);
     }
 
     /**
@@ -3561,7 +3561,7 @@ EOT
     public function setPageToDraft()
     {
         $db = Database::connection();
-        $db->executeQuery('update Pages set cIsDraft = 1 where cID = ?', [$this->getCollectionID()]);
+        $db->executeStatement('update Pages set cIsDraft = 1 where cID = ?', [$this->getCollectionID()]);
         $this->cIsDraft = true;
     }
 
@@ -3571,7 +3571,7 @@ EOT
     public function activate()
     {
         $db = Database::connection();
-        $db->executeQuery('update Pages set cIsActive = 1 where cID = ?', [$this->getCollectionID()]);
+        $db->executeStatement('update Pages set cIsActive = 1 where cID = ?', [$this->getCollectionID()]);
     }
 
     /**
@@ -4108,7 +4108,7 @@ EOT
         }
         $db = Database::connection();
         $cParentID = (int) $cParentID;
-        $db->executeQuery('update Pages set cDraftTargetParentPageID = ? where cID = ?', [$cParentID, $this->cID]);
+        $db->executeStatement('update Pages set cDraftTargetParentPageID = ? where cID = ?', [$cParentID, $this->cID]);
         $this->cDraftTargetParentPageID = $cParentID;
 
         Section::registerPage($this);
@@ -4195,7 +4195,7 @@ EOT
     {
         $db = Database::connection();
         $q = "select cID from Pages where cParentID = {$cID} and cIsTemplate = 0 order by {$sortColumn}";
-        $r = $db->query($q);
+        $r = $db->executeQuery($q);
         if ($r) {
             while ($row = $r->fetch()) {
                 if ($row['cID'] > 0) {
@@ -4320,7 +4320,7 @@ EOT
         //$q = "select CollectionBlocks.cbAreaName, Blocks.bID, Blocks.bName, Blocks.bFilename, Blocks.btID, Blocks.uID, BlockTypes.btClassname, BlockTypes.btTablename from CollectionBlocks left join BlockTypes on (Blocks.btID = BlockTypes.btID) inner join Blocks on (CollectionBlocks.bID = Blocks.bID) where CollectionBlocks.cID = '$masterCID' order by CollectionBlocks.cbDisplayOrder asc";
         //$q = "select CollectionVersionBlocks.cbAreaName, Blocks.bID, Blocks.bName, Blocks.bFilename, Blocks.btID, Blocks.uID, BlockTypes.btClassname, BlockTypes.btTablename from CollectionBlocks left join BlockTypes on (Blocks.btID = BlockTypes.btID) inner join Blocks on (CollectionBlocks.bID = Blocks.bID) where CollectionBlocks.cID = '$masterCID' order by CollectionBlocks.cbDisplayOrder asc";
 
-        $r = $db->query($q);
+        $r = $db->executeQuery($q);
 
         if ($r) {
             while ($row = $r->fetch()) {
@@ -4377,7 +4377,7 @@ EOT
             $q = 'select issID, arHandle from CollectionVersionAreaStyles where cID = ?';
             $r = $db->executeQuery($q, [$mc->getCollectionID()]);
             while ($row = $r->fetch()) {
-                $db->executeQuery(
+                $db->executeStatement(
                     'insert into CollectionVersionAreaStyles (cID, cvID, arHandle, issID) values (?, ?, ?, ?)',
                     [
                         $this->getCollectionID(),

--- a/concrete/src/Page/Search/Index/PageIndex.php
+++ b/concrete/src/Page/Search/Index/PageIndex.php
@@ -45,10 +45,10 @@ class PageIndex extends AbstractIndex implements ApplicationAwareInterface
         // Truncate the existing search index
         $database = $this->app['database']->connection();
         if ($database->tableExists('PageSearchIndex')) {
-            $database->Execute('truncate table PageSearchIndex');
+            $database->executeStatement('truncate table PageSearchIndex');
         }
         if ($database->tableExists('CollectionSearchIndexAttributes')) {
-            $database->Execute('truncate table CollectionSearchIndexAttributes');
+            $database->executeStatement('truncate table CollectionSearchIndexAttributes');
         }
     }
 

--- a/concrete/src/Page/Search/Index/PageIndexer.php
+++ b/concrete/src/Page/Search/Index/PageIndexer.php
@@ -56,7 +56,7 @@ class PageIndexer implements IndexingDriverInterface, ApplicationAwareInterface
 
             /** @var Connection $database */
             $database = $this->app['database']->connection();
-            $database->executeQuery('DELETE FROM PageSearchIndex WHERE cID=?', [$page->getCollectionID()]);
+            $database->executeStatement('DELETE FROM PageSearchIndex WHERE cID=?', [$page->getCollectionID()]);
         }
 
         return false;

--- a/concrete/src/Page/Search/IndexedSearch.php
+++ b/concrete/src/Page/Search/IndexedSearch.php
@@ -53,7 +53,7 @@ class IndexedSearch
     public static function clearSearchIndex()
     {
         $db = Loader::db();
-        $db->Execute('truncate table PageSearchIndex');
+        $db->executeStatement('truncate table PageSearchIndex');
     }
 
     public function matchesArea($arHandle)
@@ -105,7 +105,7 @@ class IndexedSearch
                 true
             );
         } else {
-            $db->Execute('delete from PageSearchIndex where cID = ?', [$page->getCollectionID()]);
+            $db->executeStatement('delete from PageSearchIndex where cID = ?', [$page->getCollectionID()]);
         }
     }
 
@@ -127,7 +127,7 @@ class IndexedSearch
         ];
         $blarray = [];
         $db = Loader::db();
-        $r = $db->Execute(
+        $r = $db->executeQuery(
             'SELECT `bID`, `arHandle` FROM `CollectionVersionBlocks` WHERE `cID` = ? AND `cvID` = ? ORDER BY `arHandle` ASC, `cbDisplayOrder` ASC',
             [$c->getCollectionID(), $c->getVersionID()]
         );

--- a/concrete/src/Page/Single.php
+++ b/concrete/src/Page/Single.php
@@ -27,7 +27,7 @@ class Single
     public static function getListByPackage($pkg)
     {
         $db = Loader::db();
-        $r = $db->Execute("select cID from Pages where cFilename is not null and pkgID = ?", array($pkg->getPackageID()));
+        $r = $db->executeQuery("select cID from Pages where cFilename is not null and pkgID = ?", array($pkg->getPackageID()));
         $singlePages = array();
         while ($row = $r->fetch()) {
             $singlePages[] = CorePage::getByID($row['cID']);
@@ -258,7 +258,7 @@ class Single
     public static function getList()
     {
         $db = Loader::db();
-        $r = $db->query("select Pages.cID from Pages inner join Collections on Pages.cID = Collections.cID where cFilename is not null order by cDateModified desc");
+        $r = $db->executeQuery("select Pages.cID from Pages inner join Collections on Pages.cID = Collections.cID where cFilename is not null order by cDateModified desc");
         $pages = array();
         while ($row = $r->fetch()) {
             $c = Page::getByID($row['cID']);

--- a/concrete/src/Page/Stack/Pile/Pile.php
+++ b/concrete/src/Page/Stack/Pile/Pile.php
@@ -86,7 +86,7 @@ class Pile extends ConcreteObject
         $u = $app->make(User::class);
         $v = array($u->getUserID(), 0, $name, 'READY');
         $q = "insert into Piles (uID, isDefault, name, state) values (?, ?, ?, ?)";
-        $r = $db->query($q, $v);
+        $r = $db->executeStatement($q, $v);
         if ($r) {
             $pID = $db->Insert_ID();
 
@@ -104,7 +104,7 @@ class Pile extends ConcreteObject
         $db = Loader::db();
         $v = array($pID);
         $q = "select pID, uID, isDefault, name, state from Piles where pID = ?";
-        $r = $db->query($q, $v);
+        $r = $db->executeQuery($q, $v);
         $row = $r->fetch();
 
         $p = new self();
@@ -137,7 +137,7 @@ class Pile extends ConcreteObject
 
         $v = array($u->getUserID(), 0, $name, 'READY');
         $q = "insert into Piles (uID, isDefault, name, state) values (?, ?, ?, ?)";
-        $r = $db->query($q, $v);
+        $r = $db->executeStatement($q, $v);
         if ($r) {
             $pID = $db->Insert_ID();
 
@@ -226,7 +226,7 @@ class Pile extends ConcreteObject
             // create a new one
             $v = array($u->getUserID(), 1, null, 'READY');
             $q = "insert into Piles (uID, isDefault, name, state) values (?, ?, ?, ?)";
-            $r = $db->query($q, $v);
+            $r = $db->executeStatement($q, $v);
             if ($r) {
                 $pID = $db->Insert_ID();
 
@@ -250,7 +250,7 @@ class Pile extends ConcreteObject
         }
 
         $piles = array();
-        $r = $db->query($q, $v);
+        $r = $db->executeQuery($q, $v);
         if ($r) {
             while ($row = $r->fetch()) {
                 $piles[] = self::get($row['pID']);
@@ -291,9 +291,9 @@ class Pile extends ConcreteObject
         $db = Loader::db();
         $v = array($this->pID);
         $q = "delete from Piles where pID = ?";
-        $db->query($q, $v);
+        $db->executeStatement($q, $v);
         $q2 = "delete from PileContents where pID = ?";
-        $db->query($q, $v);
+        $db->executeStatement($q, $v);
 
         return true;
     }
@@ -337,7 +337,7 @@ class Pile extends ConcreteObject
 
         $v = array($this->pID);
         $q = "select pcID from PileContents where pID = ? order by {$order}";
-        $r = $db->query($q, $v);
+        $r = $db->executeQuery($q, $v);
         while ($row = $r->fetch()) {
             $pc[] = PileContent::get($row['pcID']);
         }
@@ -362,7 +362,7 @@ class Pile extends ConcreteObject
         if (!$existingPCID) {
             $v = array($this->pID, $obj->getBlockID(), "BLOCK", $quantity, $displayOrder);
             $q = "insert into PileContents (pID, itemID, itemType, quantity, displayOrder) values (?, ?, ?, ?, ?)";
-            $r = $db->query($q, $v);
+            $r = $db->executeStatement($q, $v);
             if ($r) {
                 $pcID = $db->Insert_ID();
 
@@ -415,11 +415,11 @@ class Pile extends ConcreteObject
         $q = "select quantity from PileContents where pID = ? and itemID = ? and itemType = ?";
         $exQuantity = $db->getOne($q, $v);
         if ($exQuantity > $quantity) {
-            $db->query(
+            $db->executeStatement(
                "update PileContent set quantity = quantity - {$quantity} where pID = ? and itemID = ? and itemType = ?",
                $v);
         } else {
-            $db->query("delete from PileContents where pID = ? and itemID = ? and itemType = ?", $v);
+            $db->executeStatement("delete from PileContents where pID = ? and itemID = ? and itemType = ?", $v);
         }
     }
 
@@ -431,12 +431,12 @@ class Pile extends ConcreteObject
         $db = Loader::db();
         $v = array($this->pID);
         $q = "select pcID from PileContents where pID = ? order by displayOrder asc";
-        $r = $db->query($q, $v);
+        $r = $db->executeQuery($q, $v);
         $currentDisplayOrder = 0;
         while ($row = $r->fetch()) {
             $v1 = array($currentDisplayOrder, $row['pcID']);
             $q1 = "update PileContents set displayOrder = ? where pcID = ?";
-            $db->query($q1, $v1);
+            $db->executeStatement($q1, $v1);
             ++$currentDisplayOrder;
         }
 

--- a/concrete/src/Page/Stack/Pile/PileContent.php
+++ b/concrete/src/Page/Stack/Pile/PileContent.php
@@ -35,9 +35,7 @@ class PileContent extends ConcreteObject implements \JsonSerializable
 
     public function delete()
     {
-
         // it's assumed that we've already checked whether this user has access to this pile content object
-
         $db = Loader::db();
         $v = array($this->pcID);
         $q = "delete from PileContents where pcID = ?";

--- a/concrete/src/Page/Stack/Pile/PileContent.php
+++ b/concrete/src/Page/Stack/Pile/PileContent.php
@@ -41,7 +41,7 @@ class PileContent extends ConcreteObject implements \JsonSerializable
         $db = Loader::db();
         $v = array($this->pcID);
         $q = "delete from PileContents where pcID = ?";
-        $r = $db->query($q, $v);
+        $r = $db->executeStatement($q, $v);
         if ($r) {
             $this->p->rescanDisplayOrder();
 
@@ -64,10 +64,10 @@ class PileContent extends ConcreteObject implements \JsonSerializable
 
             $pcID = $db->getOne($q);
             $q = "update PileContents set displayOrder = {$targetDO} where pcID = {$this->pcID}";
-            $db->query($q);
+            $db->executeStatement($q);
 
             $q = "update PileContents set displayOrder = {$displayOrder} where pcID = {$pcID}";
-            $db->query($q);
+            $db->executeStatement($q);
         }
     }
 
@@ -88,10 +88,10 @@ class PileContent extends ConcreteObject implements \JsonSerializable
             $q = "select pcID from PileContents where displayOrder = {$targetDO}";
             $pcID = $db->getOne($q);
             $q = "update PileContents set displayOrder = {$targetDO} where pcID = {$this->pcID}";
-            $db->query($q);
+            $db->executeStatement($q);
 
             $q = "update PileContents set displayOrder = {$displayOrder} where pcID = {$pcID}";
-            $db->query($q);
+            $db->executeStatement($q);
         }
     }
 
@@ -100,7 +100,7 @@ class PileContent extends ConcreteObject implements \JsonSerializable
         $db = Loader::db();
         $v = array($pcID);
         $q = "select pID, pcID, itemID, itemType, displayOrder, quantity, timestamp from PileContents where pcID = ?";
-        $r = $db->query($q, $v);
+        $r = $db->executeQuery($q, $v);
         $row = $r->fetch();
 
         $pc = new self();

--- a/concrete/src/Page/Stack/Stack.php
+++ b/concrete/src/Page/Stack/Stack.php
@@ -240,7 +240,7 @@ class Stack extends Page
         //$siteTreeID = $parent->getSiteTreeObject()->getSiteTreeID();
         //$v = array($name, $stackCID, $type, $siteTreeID);
         $v = [$name, $stackCID, $type];
-        $db->Execute('insert into Stacks (stName, cID, stType) values (?, ?, ?)', $v);
+        $db->executeStatement('insert into Stacks (stName, cID, stType) values (?, ?, ?)', $v);
 
         $stack = static::getByID($stackCID);
 
@@ -326,7 +326,7 @@ class Stack extends Page
 
             $db = Database::connection();
             $stackName = $data['stackName'];
-            $db->Execute('update Stacks set stName = ? WHERE cID = ?', [$stackName, $this->getCollectionID()]);
+            $db->executeStatement('update Stacks set stName = ? WHERE cID = ?', [$stackName, $this->getCollectionID()]);
         }
 
         return $worked;
@@ -352,7 +352,7 @@ class Stack extends Page
         parent::delete();
         $db = Database::connection();
 
-        return $db->Execute('delete from Stacks where cID = ?', [$this->getCollectionID()]);
+        return $db->executeStatement('delete from Stacks where cID = ?', [$this->getCollectionID()]);
     }
 
     /**
@@ -441,7 +441,7 @@ class Stack extends Page
         public function updateMultilingualSection(Section $section)
         {
             $db = Database::connection();
-            $db->Execute('update Stacks set stMultilingualSection = ? where cID = ?', array($section->getCollectionID(), $this->getCollectionID()));
+            $db->executeStatement('update Stacks set stMultilingualSection = ? where cID = ?', array($section->getCollectionID(), $this->getCollectionID()));
         }
     */
 

--- a/concrete/src/Page/Statistics.php
+++ b/concrete/src/Page/Statistics.php
@@ -54,7 +54,7 @@ class Statistics
         $cpc = Page::getByID($cParentID);
         $cpc->refreshCache();
 
-        $r = $db->query($q, array($cParentID));
+        $r = $db->executeStatement($q, array($cParentID));
     }
 
     /**
@@ -75,7 +75,7 @@ class Statistics
         $cpc = Page::getByID($cParentID);
         $cpc->refreshCache();
 
-        $r = $db->query($q, array($cChildren, $cParentID));
+        $r = $db->executeStatement($q, array($cChildren, $cParentID));
     }
 
     /**

--- a/concrete/src/Page/Statistics.php
+++ b/concrete/src/Page/Statistics.php
@@ -54,7 +54,7 @@ class Statistics
         $cpc = Page::getByID($cParentID);
         $cpc->refreshCache();
 
-        $r = $db->executeStatement($q, array($cParentID));
+        $db->executeStatement($q, array($cParentID));
     }
 
     /**
@@ -75,7 +75,7 @@ class Statistics
         $cpc = Page::getByID($cParentID);
         $cpc->refreshCache();
 
-        $r = $db->executeStatement($q, array($cChildren, $cParentID));
+        $db->executeStatement($q, array($cChildren, $cParentID));
     }
 
     /**

--- a/concrete/src/Page/Theme/Theme.php
+++ b/concrete/src/Page/Theme/Theme.php
@@ -111,7 +111,7 @@ class Theme extends ConcreteObject implements \JsonSerializable
         }
 
         $db = Loader::db();
-        $r = $db->query('select pThemeID from PageThemes' . $where);
+        $r = $db->executeQuery('select pThemeID from PageThemes' . $where);
         $themes = [];
         while ($row = $r->fetch()) {
             $pl = static::getByID($row['pThemeID']);
@@ -860,7 +860,7 @@ class Theme extends ConcreteObject implements \JsonSerializable
             if (strlen($res->pError) === 0) {
                 $pThemeName = $res->pThemeName;
                 $pThemeDescription = $res->pThemeDescription;
-                $db->query(
+                $db->executeStatement(
                     'insert into PageThemes (pThemeHandle, pThemeName, pThemeDescription, pkgID) values (?, ?, ?, ?)',
                     [$pThemeHandle, $pThemeName, $pThemeDescription, $pkgID]
                 );
@@ -961,10 +961,10 @@ class Theme extends ConcreteObject implements \JsonSerializable
             $this->getPackageHandle()
         );
         if ($r->exists()) {
-            $db->Execute('update PageThemes set pThemeHasCustomClass = 1 where pThemeID = ?', [$this->pThemeID]);
+            $db->executeStatement('update PageThemes set pThemeHasCustomClass = 1 where pThemeID = ?', [$this->pThemeID]);
             $this->pThemeHasCustomClass = true;
         } else {
-            $db->Execute('update PageThemes set pThemeHasCustomClass = 0 where pThemeID = ?', [$this->pThemeID]);
+            $db->executeStatement('update PageThemes set pThemeHasCustomClass = 0 where pThemeID = ?', [$this->pThemeID]);
             $this->pThemeHasCustomClass = false;
         }
     }
@@ -1252,7 +1252,7 @@ class Theme extends ConcreteObject implements \JsonSerializable
         $treeIDs = implode(',', $treeIDs);
 
         $db = Loader::db();
-        $r = $db->query(
+        $r = $db->executeStatement(
             "update CollectionVersions inner join Pages on CollectionVersions.cID = Pages.cID left join Packages on Pages.pkgID = Packages.pkgID set CollectionVersions.pThemeID = ? where cIsTemplate = 0 and siteTreeID in ({$treeIDs}) and (Pages.ptID > 0 or CollectionVersions.pTemplateID > 0)",
             array($this->pThemeID)
         );
@@ -1277,7 +1277,7 @@ class Theme extends ConcreteObject implements \JsonSerializable
     {
         $db = Loader::db();
 
-        $db->query('delete from PageThemes where pThemeID = ?', [$this->pThemeID]);
+        $db->executeStatement('delete from PageThemes where pThemeID = ?', [$this->pThemeID]);
         $env = Environment::get();
         $env->clearOverrideCache();
     }

--- a/concrete/src/Page/Theme/Theme.php
+++ b/concrete/src/Page/Theme/Theme.php
@@ -1252,7 +1252,7 @@ class Theme extends ConcreteObject implements \JsonSerializable
         $treeIDs = implode(',', $treeIDs);
 
         $db = Loader::db();
-        $r = $db->executeStatement(
+        $db->executeStatement(
             "update CollectionVersions inner join Pages on CollectionVersions.cID = Pages.cID left join Packages on Pages.pkgID = Packages.pkgID set CollectionVersions.pThemeID = ? where cIsTemplate = 0 and siteTreeID in ({$treeIDs}) and (Pages.ptID > 0 or CollectionVersions.pTemplateID > 0)",
             array($this->pThemeID)
         );

--- a/concrete/src/Page/Type/Command/UpdatePageTypeDefaultsCommandHandler.php
+++ b/concrete/src/Page/Type/Command/UpdatePageTypeDefaultsCommandHandler.php
@@ -68,11 +68,11 @@ class UpdatePageTypeDefaultsCommandHandler
                 $pageCollectionID = $page->getCollectionID();
                 $pageVersionID = $page->getVersionID();
 
-                $db->executeQuery(
+                $db->executeStatement(
                     'UPDATE CollectionVersionBlockStyles SET arHandle = ?  WHERE cID = ? and cvID = ? and bID = ?',
                     [$actualArHandle, $pageCollectionID, $pageVersionID, $pageBlock->getBlockID()]
                 );
-                $db->executeQuery(
+                $db->executeStatement(
                     'UPDATE CollectionVersionBlocks SET arHandle = ?  WHERE cID = ? and cvID = ? and bID = ?',
                     [$actualArHandle, $pageCollectionID, $pageVersionID, $pageBlock->getBlockID()]
                 );

--- a/concrete/src/Page/Type/Composer/Control/BlockControl.php
+++ b/concrete/src/Page/Type/Composer/Control/BlockControl.php
@@ -348,7 +348,7 @@ class BlockControl extends Control
         $v = [$c->getVersionID(), $setControl->getPageTypeComposerFormLayoutSetControlID(), $c->getCollectionID(), $c->getVersionID()];
         $row = $db->fetchAssoc($q, $v);
         if ($row && $row['bID'] && $row['arHandle']) {
-            $db->executeQuery(
+            $db->executeStatement(
                 'delete from PageTypeComposerOutputBlocks where ptComposerFormLayoutSetControlID = ? and cID = ? and cvID = ?',
                 [$setControl->getPageTypeComposerFormLayoutSetControlID(), $c->getCollectionID(), $c->getVersionID()]
             );
@@ -384,7 +384,7 @@ class BlockControl extends Control
         $ocID = $oc->getCollectionID();
         $ovID = $oc->getVersionID();
 
-        $db->executeQuery(
+        $db->executeStatement(
             'insert into PageTypeComposerOutputBlocks (cID, cvID, arHandle, ptComposerFormLayoutSetControlID, cbDisplayOrder, bID) values (?, ?, ?, ?, ?, ?)',
             [
                 $ocID,

--- a/concrete/src/Page/Type/Composer/Control/Control.php
+++ b/concrete/src/Page/Type/Composer/Control/Control.php
@@ -210,7 +210,7 @@ abstract class Control extends ConcreteObject
         $controlType = $this->getPageTypeComposerControlTypeObject();
         $customLabel = $this->getPageTypeComposerControlCustomLabel();
         $description = $this->getPageTypeComposerControlDescription();
-        $db->Execute('insert into PageTypeComposerFormLayoutSetControls (ptComposerFormLayoutSetID, ptComposerControlTypeID, ptComposerControlObject, ptComposerFormLayoutSetControlDisplayOrder, ptComposerFormLayoutSetControlCustomLabel, ptComposerFormLayoutSetControlDescription, ptComposerFormLayoutSetControlRequired) values (?, ?, ?, ?, ?, ?, ?)', array(
+        $db->executeStatement('insert into PageTypeComposerFormLayoutSetControls (ptComposerFormLayoutSetID, ptComposerControlTypeID, ptComposerControlObject, ptComposerFormLayoutSetControlDisplayOrder, ptComposerFormLayoutSetControlCustomLabel, ptComposerFormLayoutSetControlDescription, ptComposerFormLayoutSetControlRequired) values (?, ?, ?, ?, ?, ?, ?)', array(
             $set->getPageTypeComposerFormLayoutSetID(), $controlType->getPageTypeComposerControlTypeID(), serialize($this), $displayOrder, $customLabel, $description, $ptComposerFormLayoutSetControlRequired,
         ));
 

--- a/concrete/src/Page/Type/Composer/Control/Type/Type.php
+++ b/concrete/src/Page/Type/Composer/Control/Type/Type.php
@@ -86,7 +86,7 @@ abstract class Type extends ConcreteObject
             $pkgID = $pkg->getPackageID();
         }
         $db = Loader::db();
-        $db->Execute('insert into PageTypeComposerControlTypes (ptComposerControlTypeHandle, ptComposerControlTypeName, pkgID) values (?, ?, ?)', array($ptComposerControlTypeHandle, $ptComposerControlTypeName, $pkgID));
+        $db->executeStatement('insert into PageTypeComposerControlTypes (ptComposerControlTypeHandle, ptComposerControlTypeName, pkgID) values (?, ?, ?)', array($ptComposerControlTypeHandle, $ptComposerControlTypeName, $pkgID));
 
         return static::getByHandle($ptComposerControlTypeHandle);
     }
@@ -94,7 +94,7 @@ abstract class Type extends ConcreteObject
     public function delete()
     {
         $db = Loader::db();
-        $db->Execute('delete from PageTypeComposerControlTypes where ptComposerControlTypeID = ?', array($this->ptComposerControlTypeID));
+        $db->executeStatement('delete from PageTypeComposerControlTypes where ptComposerControlTypeID = ?', array($this->ptComposerControlTypeID));
     }
 
     public static function getList()

--- a/concrete/src/Page/Type/Composer/FormLayoutSet.php
+++ b/concrete/src/Page/Type/Composer/FormLayoutSet.php
@@ -109,7 +109,7 @@ class FormLayoutSet extends ConcreteObject
     public function updateFormLayoutSetName($ptComposerFormLayoutSetName)
     {
         $db = Loader::db();
-        $db->Execute('update PageTypeComposerFormLayoutSets set ptComposerFormLayoutSetName = ? where ptComposerFormLayoutSetID = ?', array(
+        $db->executeStatement('update PageTypeComposerFormLayoutSets set ptComposerFormLayoutSetName = ? where ptComposerFormLayoutSetID = ?', array(
             $ptComposerFormLayoutSetName, $this->ptComposerFormLayoutSetID,
         ));
         $this->ptComposerFormLayoutSetName = $ptComposerFormLayoutSetName;
@@ -118,7 +118,7 @@ class FormLayoutSet extends ConcreteObject
     public function updateFormLayoutSetDescription($ptComposerFormLayoutSetDescription)
     {
         $db = Loader::db();
-        $db->Execute('update PageTypeComposerFormLayoutSets set ptComposerFormLayoutSetDescription = ? where ptComposerFormLayoutSetID = ?', array(
+        $db->executeStatement('update PageTypeComposerFormLayoutSets set ptComposerFormLayoutSetDescription = ? where ptComposerFormLayoutSetID = ?', array(
             $ptComposerFormLayoutSetDescription, $this->ptComposerFormLayoutSetID,
         ));
         $this->ptComposerFormLayoutSetDescription = $ptComposerFormLayoutSetDescription;
@@ -127,7 +127,7 @@ class FormLayoutSet extends ConcreteObject
     public function updateFormLayoutSetCollapseType($ptComposerFormLayoutSetCollapseType)
     {
         $db = Loader::db();
-        $db->Execute('update PageTypeComposerFormLayoutSets set ptComposerFormLayoutSetCollapseType = ? where ptComposerFormLayoutSetID = ?', array(
+        $db->executeStatement('update PageTypeComposerFormLayoutSets set ptComposerFormLayoutSetCollapseType = ? where ptComposerFormLayoutSetID = ?', array(
             $ptComposerFormLayoutSetCollapseType, $this->ptComposerFormLayoutSetID,
         ));
         $this->ptComposerFormLayoutSetCollapseType = $ptComposerFormLayoutSetCollapseType;
@@ -136,7 +136,7 @@ class FormLayoutSet extends ConcreteObject
     public function updateFormLayoutSetDisplayOrder($displayOrder)
     {
         $db = Loader::db();
-        $db->Execute('update PageTypeComposerFormLayoutSets set ptComposerFormLayoutSetDisplayOrder = ? where ptComposerFormLayoutSetID = ?', array(
+        $db->executeStatement('update PageTypeComposerFormLayoutSets set ptComposerFormLayoutSetDisplayOrder = ? where ptComposerFormLayoutSetID = ?', array(
             $displayOrder, $this->ptComposerFormLayoutSetID,
         ));
         $this->ptComposerFormLayoutSetDisplayOrder = $displayOrder;
@@ -149,7 +149,7 @@ class FormLayoutSet extends ConcreteObject
             $control->delete();
         }
         $db = Loader::db();
-        $db->Execute('delete from PageTypeComposerFormLayoutSets where ptComposerFormLayoutSetID = ?', array($this->ptComposerFormLayoutSetID));
+        $db->executeStatement('delete from PageTypeComposerFormLayoutSets where ptComposerFormLayoutSetID = ?', array($this->ptComposerFormLayoutSetID));
         $pagetype = $this->getPageTypeObject();
         $pagetype->rescanFormLayoutSetDisplayOrder();
     }

--- a/concrete/src/Page/Type/Composer/FormLayoutSetControl.php
+++ b/concrete/src/Page/Type/Composer/FormLayoutSetControl.php
@@ -202,7 +202,7 @@ class FormLayoutSetControl extends ConcreteObject
     {
         $app = Application::getFacadeApplication();
         $db = $app->make('database')->connection();
-        $db->executeQuery(
+        $db->executeStatement(
             'update PageTypeComposerFormLayoutSetControls set ptComposerFormLayoutSetControlDisplayOrder = ? where ptComposerFormLayoutSetControlID = ?',
             [$displayOrder, $this->ptComposerFormLayoutSetControlID]
         );
@@ -213,7 +213,7 @@ class FormLayoutSetControl extends ConcreteObject
     {
         $app = Application::getFacadeApplication();
         $db = $app->make('database')->connection();
-        $db->executeQuery(
+        $db->executeStatement(
             'update PageTypeComposerFormLayoutSetControls set ptComposerFormLayoutSetControlCustomLabel = ? where ptComposerFormLayoutSetControlID = ?',
             [$label, $this->ptComposerFormLayoutSetControlID]
         );
@@ -224,7 +224,7 @@ class FormLayoutSetControl extends ConcreteObject
     {
         $app = Application::getFacadeApplication();
         $db = $app->make('database')->connection();
-        $db->executeQuery(
+        $db->executeStatement(
             'update PageTypeComposerFormLayoutSetControls set ptComposerFormLayoutSetControlRequired = ? where ptComposerFormLayoutSetControlID = ?',
             [intval($required), $this->ptComposerFormLayoutSetControlID]
         );
@@ -235,7 +235,7 @@ class FormLayoutSetControl extends ConcreteObject
     {
         $app = Application::getFacadeApplication();
         $db = $app->make('database')->connection();
-        $db->executeQuery(
+        $db->executeStatement(
             'update PageTypeComposerFormLayoutSetControls set ptComposerFormLayoutSetControlCustomTemplate = ? where ptComposerFormLayoutSetControlID = ?',
             [$template, $this->ptComposerFormLayoutSetControlID]
         );
@@ -246,7 +246,7 @@ class FormLayoutSetControl extends ConcreteObject
     {
         $app = Application::getFacadeApplication();
         $db = $app->make('database')->connection();
-        $db->executeQuery('update PageTypeComposerFormLayoutSetControls set ptComposerFormLayoutSetControlDescription = ? where ptComposerFormLayoutSetControlID = ?',
+        $db->executeStatement('update PageTypeComposerFormLayoutSetControls set ptComposerFormLayoutSetControlDescription = ? where ptComposerFormLayoutSetControlID = ?',
             [$description, $this->ptComposerFormLayoutSetControlID]
         );
         $this->ptComposerFormLayoutSetControlDescription = $description;
@@ -288,8 +288,8 @@ class FormLayoutSetControl extends ConcreteObject
                 }
             }
         }
-        $db->executeQuery('delete from PageTypeComposerFormLayoutSetControls where ptComposerFormLayoutSetControlID = ?', [$this->ptComposerFormLayoutSetControlID]);
-        $db->executeQuery('delete from PageTypeComposerOutputControls where ptComposerFormLayoutSetControlID = ?', [$this->ptComposerFormLayoutSetControlID]);
+        $db->executeStatement('delete from PageTypeComposerFormLayoutSetControls where ptComposerFormLayoutSetControlID = ?', [$this->ptComposerFormLayoutSetControlID]);
+        $db->executeStatement('delete from PageTypeComposerOutputControls where ptComposerFormLayoutSetControlID = ?', [$this->ptComposerFormLayoutSetControlID]);
         $set = $this->getPageTypeComposerFormLayoutSetObject();
         $set->rescanFormLayoutSetControlDisplayOrder();
     }

--- a/concrete/src/Page/Type/Composer/OutputControl.php
+++ b/concrete/src/Page/Type/Composer/OutputControl.php
@@ -28,7 +28,7 @@ class OutputControl extends ConcreteObject
         $pagetype = $set->getPageTypeObject();
 
         $db = Loader::db();
-        $db->Execute('insert into PageTypeComposerOutputControls (ptID, pTemplateID, ptComposerFormLayoutSetControlID) values (?, ?, ?)', array(
+        $db->executeStatement('insert into PageTypeComposerOutputControls (ptID, pTemplateID, ptComposerFormLayoutSetControlID) values (?, ?, ?)', array(
             $pagetype->getPageTypeID(), $pt->getPageTemplateID(), $control->getPageTypeComposerFormLayoutSetControlID(),
         ));
         $ptComposerOutputControlID = $db->Insert_ID();
@@ -78,7 +78,7 @@ class OutputControl extends ConcreteObject
     public function delete()
     {
         $db = Loader::db();
-        $db->Execute('delete from PageTypeComposerOutputControls where ptComposerOutputControlID = ?', array($this->ptComposerOutputControlID));
+        $db->executeStatement('delete from PageTypeComposerOutputControls where ptComposerOutputControlID = ?', array($this->ptComposerOutputControlID));
     }
 
     public function getPageTypeComposerControlOutputLabel()

--- a/concrete/src/Page/Type/PublishTarget/Type/Type.php
+++ b/concrete/src/Page/Type/PublishTarget/Type/Type.php
@@ -147,7 +147,7 @@ abstract class Type extends ConcreteObject
             $pkgID = $pkg->getPackageID();
         }
         $db = Database::connection();
-        $db->executeQuery(
+        $db->executeStatement(
             'insert into PageTypePublishTargetTypes (ptPublishTargetTypeHandle, ptPublishTargetTypeName, pkgID)
             values (?, ?, ?)',
             array($ptPublishTargetTypeHandle, $ptPublishTargetTypeName, $pkgID)
@@ -159,7 +159,7 @@ abstract class Type extends ConcreteObject
     public function delete()
     {
         $db = Database::connection();
-        $db->executeQuery(
+        $db->executeStatement(
             'delete from PageTypePublishTargetTypes where ptPublishTargetTypeID = ?',
             array($this->ptPublishTargetTypeID)
         );

--- a/concrete/src/Page/Type/Type.php
+++ b/concrete/src/Page/Type/Type.php
@@ -204,7 +204,7 @@ class Type extends ConcreteObject implements \Concrete\Core\Permission\ObjectInt
             Section::registerPage($c);
             $c->move($parent);
             $db = \Database::connection();
-            $db->executeQuery('update Pages set cIsDraft = 0 where cID = ?', [$c->getCollectionID()]);
+            $db->executeStatement('update Pages set cIsDraft = 0 where cID = ?', [$c->getCollectionID()]);
             if (!$parent->overrideTemplatePermissions() && $c->getCollectionInheritance() === 'PARENT') {
                 // When the parent page's subpage permissions setting is "inherit page type default permissions",
                 // the permissions of this page should inherit from the default.
@@ -258,7 +258,7 @@ class Type extends ConcreteObject implements \Concrete\Core\Permission\ObjectInt
     {
         $templates = array();
         $db = Loader::db();
-        $r = $db->Execute(
+        $r = $db->executeQuery(
             'select pTemplateID from PageTypePageTemplates where ptID = ? order by pTemplateID asc',
             array($this->ptID)
         );
@@ -321,7 +321,7 @@ class Type extends ConcreteObject implements \Concrete\Core\Permission\ObjectInt
             $r2 = $db->prepare($q2);
             $res2 = $db->execute($r2, $v2);
 
-            $db->Execute(
+            $db->executeStatement(
                 'insert into PageTypePageTemplateDefaultPages (ptID, pTemplateID, cID) values (?, ?, ?)',
                 array(
                     $this->ptID,
@@ -655,7 +655,7 @@ class Type extends ConcreteObject implements \Concrete\Core\Permission\ObjectInt
 
         // now copy the master pages for defaults and attributes
         $db = \Database::get();
-        $r = $db->Execute('select cID from Pages where cIsTemplate = 1 and ptID = ?', array($this->getPageTypeID()));
+        $r = $db->executeQuery('select cID from Pages where cIsTemplate = 1 and ptID = ?', array($this->getPageTypeID()));
         $home = Page::getByID(Page::getHomePageID());
         while ($row = $r->fetch()) {
             $c = Page::getByID($row['cID']);
@@ -803,7 +803,7 @@ class Type extends ConcreteObject implements \Concrete\Core\Permission\ObjectInt
             $ptDisplayOrder = $count;
         }
 
-        $db->Execute(
+        $db->executeStatement(
             'insert into PageTypes (ptName, ptHandle, ptDefaultPageTemplateID, ptDefaultThemeID, ptAllowedPageTemplates, ptIsInternal, ptLaunchInComposer, ptDisplayOrder, ptIsFrequentlyAdded, siteTypeID, pkgID) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
             array(
                 $ptName,
@@ -825,7 +825,7 @@ class Type extends ConcreteObject implements \Concrete\Core\Permission\ObjectInt
                 if (!is_object($pt)){
                     $pt = PageTemplate::getByHandle($pt);
                 }
-                $db->Execute(
+                $db->executeStatement(
                     'insert into PageTypePageTemplates (ptID, pTemplateID) values (?, ?)',
                     array(
                         $ptID,
@@ -918,7 +918,7 @@ class Type extends ConcreteObject implements \Concrete\Core\Permission\ObjectInt
             $ptIsInternal = 1;
         }
         $db = Loader::db();
-        $db->Execute(
+        $db->executeStatement(
             'update PageTypes set ptName = ?, ptHandle = ?, ptDefaultPageTemplateID = ?, ptDefaultThemeID = ?, ptAllowedPageTemplates = ?, ptIsInternal = ?, ptLaunchInComposer = ?, ptIsFrequentlyAdded = ?, ptDisplayOrder = ? where ptID = ?',
             array(
                 $ptName,
@@ -933,13 +933,13 @@ class Type extends ConcreteObject implements \Concrete\Core\Permission\ObjectInt
                 $this->ptID,
             )
         );
-        $db->Execute('delete from PageTypePageTemplates where ptID = ?', array($this->ptID));
+        $db->executeStatement('delete from PageTypePageTemplates where ptID = ?', array($this->ptID));
         if ($ptAllowedPageTemplates != 'A') {
             foreach ($templates as $pt) {
                 if (!is_object($pt)) {
                     $pt = PageTemplate::getByHandle($pt);
                 }
-                $db->Execute(
+                $db->executeStatement(
                     'insert into PageTypePageTemplates (ptID, pTemplateID) values (?, ?)',
                     array(
                         $this->ptID,
@@ -970,7 +970,7 @@ class Type extends ConcreteObject implements \Concrete\Core\Permission\ObjectInt
                         $c->delete();
                     }
                 }
-                $db->Execute('delete from PageTypePageTemplateDefaultPages where pTemplateID = ? and ptID = ?', array($existingPageTemplateID, $this->getPageTypeID()));
+                $db->executeStatement('delete from PageTypePageTemplateDefaultPages where pTemplateID = ? and ptID = ?', array($existingPageTemplateID, $this->getPageTypeID()));
             }
         }
     }
@@ -1109,10 +1109,10 @@ class Type extends ConcreteObject implements \Concrete\Core\Permission\ObjectInt
             $set->delete();
         }
         $db = Loader::db();
-        $db->Execute('delete from PageTypes where ptID = ?', array($this->ptID));
-        $db->Execute('delete from PageTypePageTemplates where ptID = ?', array($this->ptID));
-        $db->Execute('delete from PageTypePageTemplateDefaultPages where ptID = ?', array($this->ptID));
-        $db->Execute('delete from PageTypeComposerOutputControls where ptID = ?', array($this->ptID));
+        $db->executeStatement('delete from PageTypes where ptID = ?', array($this->ptID));
+        $db->executeStatement('delete from PageTypePageTemplates where ptID = ?', array($this->ptID));
+        $db->executeStatement('delete from PageTypePageTemplateDefaultPages where ptID = ?', array($this->ptID));
+        $db->executeStatement('delete from PageTypeComposerOutputControls where ptID = ?', array($this->ptID));
 
         foreach ($this->getPageTypePageTemplateObjects() as $pt) {
             $c = $this->getPageTypePageTemplateDefaultPageObject($pt);
@@ -1124,7 +1124,7 @@ class Type extends ConcreteObject implements \Concrete\Core\Permission\ObjectInt
     {
         $db = Loader::db();
         if (is_object($configuredTarget)) {
-            $db->Execute(
+            $db->executeStatement(
                 'update PageTypes set ptPublishTargetTypeID = ?, ptPublishTargetObject = ? where ptID = ?',
                 array(
                     $configuredTarget->getPageTypePublishTargetTypeID(),
@@ -1155,7 +1155,7 @@ class Type extends ConcreteObject implements \Concrete\Core\Permission\ObjectInt
         if (!$displayOrder) {
             $displayOrder = 0;
         }
-        $db->Execute(
+        $db->executeStatement(
             'insert into PageTypeComposerFormLayoutSets (ptComposerFormLayoutSetName, ptComposerFormLayoutSetDescription, ptComposerFormLayoutSetCollapseType, ptID, ptComposerFormLayoutSetDisplayOrder) values (?, ?, ?, ?, ?)',
             array(
                 $ptComposerFormLayoutSetName,

--- a/concrete/src/Permission/Access/Access.php
+++ b/concrete/src/Permission/Access/Access.php
@@ -206,7 +206,7 @@ class Access extends ConcreteObject
     {
         $app = Application::getFacadeApplication();
         $db = $app->make(Connection::class);
-        $db->executeQuery('delete from PermissionAccessWorkflows where paID = ?', [$this->getPermissionAccessID()]);
+        $db->executeStatement('delete from PermissionAccessWorkflows where paID = ?', [$this->getPermissionAccessID()]);
     }
 
     /**
@@ -231,7 +231,7 @@ class Access extends ConcreteObject
     {
         $app = Application::getFacadeApplication();
         $db = $app->make(Connection::class);
-        $db->executeQuery(
+        $db->executeStatement(
             'delete from PermissionAccessWorkflows where paID = ? and wfID = ?',
             [$this->getPermissionAccessID(), $wf->getWorkflowID()]
         );
@@ -286,7 +286,7 @@ class Access extends ConcreteObject
     {
         $app = Application::getFacadeApplication();
         $db = $app->make(Connection::class);
-        $db->executeQuery('update PermissionAccess set paIsInUse = 1 where paID = ?', [$this->paID]);
+        $db->executeStatement('update PermissionAccess set paIsInUse = 1 where paID = ?', [$this->paID]);
         $this->paIsInUse = true;
 
         $logger = $app->make(Logger::class);
@@ -333,7 +333,7 @@ class Access extends ConcreteObject
     {
         $app = Application::getFacadeApplication();
         $db = $app->make(Connection::class);
-        $db->executeQuery(
+        $db->executeStatement(
             'delete from PermissionAccessList where peID = ? and paID = ?',
             [$pe->getAccessEntityID(), $this->getPermissionAccessID()]
         );
@@ -355,7 +355,7 @@ class Access extends ConcreteObject
     {
         $app = Application::getFacadeApplication();
         $db = $app->make(Connection::class);
-        $db->executeQuery('insert into PermissionAccess (paIsInUse) values (0)');
+        $db->executeStatement('insert into PermissionAccess (paIsInUse) values (0)');
 
         return static::getByID($db->lastInsertId(), $pk);
     }

--- a/concrete/src/Permission/Access/AddBlockBlockTypeAccess.php
+++ b/concrete/src/Permission/Access/AddBlockBlockTypeAccess.php
@@ -14,12 +14,12 @@ class AddBlockBlockTypeAccess extends BlockTypeAccess
         $r = $db->executeQuery('select * from BlockTypePermissionBlockTypeAccessList where paID = ?', array($this->getPermissionAccessID()));
         while ($row = $r->fetch()) {
             $v = array($row['peID'], $newPA->getPermissionAccessID(), $row['permission']);
-            $db->executeQuery('insert into BlockTypePermissionBlockTypeAccessList (peID, paID, permission) values (?, ?, ?)', $v);
+            $db->executeStatement('insert into BlockTypePermissionBlockTypeAccessList (peID, paID, permission) values (?, ?, ?)', $v);
         }
         $r = $db->executeQuery('select * from BlockTypePermissionBlockTypeAccessListCustom where paID = ?', array($this->getPermissionAccessID()));
         while ($row = $r->fetch()) {
             $v = array($row['peID'], $newPA->getPermissionAccessID(), $row['btID']);
-            $db->executeQuery('insert into BlockTypePermissionBlockTypeAccessListCustom  (peID, paID, btID) values (?, ?, ?)', $v);
+            $db->executeStatement('insert into BlockTypePermissionBlockTypeAccessListCustom  (peID, paID, btID) values (?, ?, ?)', $v);
         }
 
         return $newPA;
@@ -29,19 +29,19 @@ class AddBlockBlockTypeAccess extends BlockTypeAccess
     {
         parent::save();
         $db = Database::connection();
-        $db->executeQuery('delete from BlockTypePermissionBlockTypeAccessList where paID = ?', array($this->getPermissionAccessID()));
-        $db->executeQuery('delete from BlockTypePermissionBlockTypeAccessListCustom where paID = ?', array($this->getPermissionAccessID()));
+        $db->executeStatement('delete from BlockTypePermissionBlockTypeAccessList where paID = ?', array($this->getPermissionAccessID()));
+        $db->executeStatement('delete from BlockTypePermissionBlockTypeAccessListCustom where paID = ?', array($this->getPermissionAccessID()));
         if (!empty($args['blockTypesIncluded']) && is_array($args['blockTypesIncluded'])) {
             foreach ($args['blockTypesIncluded'] as $peID => $permission) {
                 $v = array($this->getPermissionAccessID(), $peID, $permission);
-                $db->executeQuery('insert into BlockTypePermissionBlockTypeAccessList (paID, peID, permission) values (?, ?, ?)', $v);
+                $db->executeStatement('insert into BlockTypePermissionBlockTypeAccessList (paID, peID, permission) values (?, ?, ?)', $v);
             }
         }
 
         if (!empty($args['blockTypesExcluded']) && is_array($args['blockTypesExcluded'])) {
             foreach ($args['blockTypesExcluded'] as $peID => $permission) {
                 $v = array($this->getPermissionAccessID(), $peID, $permission);
-                $db->executeQuery('insert into BlockTypePermissionBlockTypeAccessList (paID, peID, permission) values (?, ?, ?)', $v);
+                $db->executeStatement('insert into BlockTypePermissionBlockTypeAccessList (paID, peID, permission) values (?, ?, ?)', $v);
             }
         }
 
@@ -49,7 +49,7 @@ class AddBlockBlockTypeAccess extends BlockTypeAccess
             foreach ($args['btIDInclude'] as $peID => $btIDs) {
                 foreach ($btIDs as $btID) {
                     $v = array($this->getPermissionAccessID(), $peID, $btID);
-                    $db->executeQuery('insert into BlockTypePermissionBlockTypeAccessListCustom (paID, peID, btID) values (?, ?, ?)', $v);
+                    $db->executeStatement('insert into BlockTypePermissionBlockTypeAccessListCustom (paID, peID, btID) values (?, ?, ?)', $v);
                 }
             }
         }
@@ -58,7 +58,7 @@ class AddBlockBlockTypeAccess extends BlockTypeAccess
             foreach ($args['btIDExclude'] as $peID => $btIDs) {
                 foreach ($btIDs as $btID) {
                     $v = array($this->getPermissionAccessID(), $peID, $btID);
-                    $db->executeQuery('insert into BlockTypePermissionBlockTypeAccessListCustom (paID, peID, btID) values (?, ?, ?)', $v);
+                    $db->executeStatement('insert into BlockTypePermissionBlockTypeAccessListCustom (paID, peID, btID) values (?, ?, ?)', $v);
                 }
             }
         }

--- a/concrete/src/Permission/Access/AddBlockToAreaAreaAccess.php
+++ b/concrete/src/Permission/Access/AddBlockToAreaAreaAccess.php
@@ -102,19 +102,19 @@ class AddBlockToAreaAreaAccess extends AreaAccess
         $app = Application::getFacadeApplication();
         $db = $app->make(Connection::class);
         parent::save($args);
-        $db->executeQuery('delete from AreaPermissionBlockTypeAccessList where paID = ?', [$this->getPermissionAccessID()]);
-        $db->executeQuery('delete from AreaPermissionBlockTypeAccessListCustom where paID = ?', [$this->getPermissionAccessID()]);
+        $db->executeStatement('delete from AreaPermissionBlockTypeAccessList where paID = ?', [$this->getPermissionAccessID()]);
+        $db->executeStatement('delete from AreaPermissionBlockTypeAccessListCustom where paID = ?', [$this->getPermissionAccessID()]);
         if (isset($args['blockTypesIncluded']) && is_array($args['blockTypesIncluded'])) {
             foreach ($args['blockTypesIncluded'] as $peID => $permission) {
                 $v = [$this->getPermissionAccessID(), $peID, $permission];
-                $db->executeQuery('insert into AreaPermissionBlockTypeAccessList (paID, peID, permission) values (?, ?, ?)', $v);
+                $db->executeStatement('insert into AreaPermissionBlockTypeAccessList (paID, peID, permission) values (?, ?, ?)', $v);
             }
         }
 
         if (isset($args['blockTypesExcluded']) && is_array($args['blockTypesExcluded'])) {
             foreach ($args['blockTypesExcluded'] as $peID => $permission) {
                 $v = [$this->getPermissionAccessID(), $peID, $permission];
-                $db->executeQuery('insert into AreaPermissionBlockTypeAccessList (paID, peID, permission) values (?, ?, ?)', $v);
+                $db->executeStatement('insert into AreaPermissionBlockTypeAccessList (paID, peID, permission) values (?, ?, ?)', $v);
             }
         }
 
@@ -122,7 +122,7 @@ class AddBlockToAreaAreaAccess extends AreaAccess
             foreach ($args['btIDInclude'] as $peID => $btIDs) {
                 foreach ($btIDs as $btID) {
                     $v = [$this->getPermissionAccessID(), $peID, $btID];
-                    $db->executeQuery('insert into AreaPermissionBlockTypeAccessListCustom (paID, peID, btID) values (?, ?, ?)', $v);
+                    $db->executeStatement('insert into AreaPermissionBlockTypeAccessListCustom (paID, peID, btID) values (?, ?, ?)', $v);
                 }
             }
         }
@@ -131,7 +131,7 @@ class AddBlockToAreaAreaAccess extends AreaAccess
             foreach ($args['btIDExclude'] as $peID => $btIDs) {
                 foreach ($btIDs as $btID) {
                     $v = [$this->getPermissionAccessID(), $peID, $btID];
-                    $db->executeQuery('insert into AreaPermissionBlockTypeAccessListCustom (paID, peID, btID) values (?, ?, ?)', $v);
+                    $db->executeStatement('insert into AreaPermissionBlockTypeAccessListCustom (paID, peID, btID) values (?, ?, ?)', $v);
                 }
             }
         }

--- a/concrete/src/Permission/Access/AddConversationMessageConversationAccess.php
+++ b/concrete/src/Permission/Access/AddConversationMessageConversationAccess.php
@@ -10,12 +10,12 @@ class AddConversationMessageConversationAccess extends ConversationAccess
     {
         parent::save();
         $db = Database::connection();
-        $db->executeQuery('delete from ConversationPermissionAddMessageAccessList where paID = ?',
+        $db->executeStatement('delete from ConversationPermissionAddMessageAccessList where paID = ?',
             array($this->getPermissionAccessID()));
         if (isset($args['addMessageApproval']) && is_array($args['addMessageApproval'])) {
             foreach ($args['addMessageApproval'] as $peID => $permission) {
                 $v = array($this->getPermissionAccessID(), $peID, $permission);
-                $db->executeQuery('insert into ConversationPermissionAddMessageAccessList (paID, peID, permission) values (?, ?, ?)',
+                $db->executeStatement('insert into ConversationPermissionAddMessageAccessList (paID, peID, permission) values (?, ?, ?)',
                     $v);
             }
         }
@@ -29,7 +29,7 @@ class AddConversationMessageConversationAccess extends ConversationAccess
             array($this->getPermissionAccessID()));
         while ($row = $r->fetch()) {
             $v = array($row['peID'], $newPA->getPermissionAccessID(), $row['permission']);
-            $db->executeQuery('insert into ConversationPermissionAddMessageAccessList (peID, paID, permission) values (?, ?, ?)',
+            $db->executeStatement('insert into ConversationPermissionAddMessageAccessList (peID, paID, permission) values (?, ?, ?)',
                 $v);
         }
 

--- a/concrete/src/Permission/Access/AddFileFileFolderAccess.php
+++ b/concrete/src/Permission/Access/AddFileFileFolderAccess.php
@@ -41,7 +41,7 @@ class AddFileFileFolderAccess extends FileFolderAccess
             array($this->getPermissionAccessID()));
         while ($row = $r->fetch()) {
             $v = array($row['peID'], $newPA->getPermissionAccessID(), $row['permission']);
-            $db->executeQuery(
+            $db->executeStatement(
                 'INSERT INTO FilePermissionFileTypeAccessList (peID, paID, permission) VALUES (?, ?, ?)',
                 $v);
         }
@@ -50,7 +50,7 @@ class AddFileFileFolderAccess extends FileFolderAccess
             array($this->getPermissionAccessID()));
         while ($row = $r->fetch()) {
             $v = array($row['peID'], $newPA->getPermissionAccessID(), $row['extension']);
-            $db->executeQuery(
+            $db->executeStatement(
                 'INSERT INTO FilePermissionFileTypeAccessListCustom  (peID, paID, extension) VALUES (?, ?, ?)',
                 $v);
         }
@@ -62,16 +62,16 @@ class AddFileFileFolderAccess extends FileFolderAccess
     {
         parent::save();
         $db = Database::connection();
-        $db->executeQuery(
+        $db->executeStatement(
             'DELETE FROM FilePermissionFileTypeAccessList WHERE paID = ?',
             array($this->getPermissionAccessID()));
-        $db->executeQuery(
+        $db->executeStatement(
             'DELETE FROM FilePermissionFileTypeAccessListCustom WHERE paID = ?',
             array($this->getPermissionAccessID()));
         if (isset($args['fileTypesIncluded']) && is_array($args['fileTypesIncluded'])) {
             foreach ($args['fileTypesIncluded'] as $peID => $permission) {
                 $v = array($this->getPermissionAccessID(), $peID, $permission);
-                $db->executeQuery(
+                $db->executeStatement(
                     'INSERT INTO FilePermissionFileTypeAccessList (paID, peID, permission) VALUES (?, ?, ?)',
                     $v);
             }
@@ -80,7 +80,7 @@ class AddFileFileFolderAccess extends FileFolderAccess
         if (isset($args['fileTypesExcluded']) && is_array($args['fileTypesExcluded'])) {
             foreach ($args['fileTypesExcluded'] as $peID => $permission) {
                 $v = array($this->getPermissionAccessID(), $peID, $permission);
-                $db->executeQuery(
+                $db->executeStatement(
                     'INSERT INTO FilePermissionFileTypeAccessList (paID, peID, permission) VALUES (?, ?, ?)',
                     $v);
             }
@@ -90,7 +90,7 @@ class AddFileFileFolderAccess extends FileFolderAccess
             foreach ($args['extensionInclude'] as $peID => $extensions) {
                 foreach ($extensions as $extension) {
                     $v = array($this->getPermissionAccessID(), $peID, $extension);
-                    $db->executeQuery(
+                    $db->executeStatement(
                         'INSERT INTO FilePermissionFileTypeAccessListCustom (paID, peID, extension) VALUES (?, ?, ?)',
                         $v);
                 }
@@ -101,7 +101,7 @@ class AddFileFileFolderAccess extends FileFolderAccess
             foreach ($args['extensionExclude'] as $peID => $extensions) {
                 foreach ($extensions as $extension) {
                     $v = array($this->getPermissionAccessID(), $peID, $extension);
-                    $db->executeQuery(
+                    $db->executeStatement(
                         'INSERT INTO FilePermissionFileTypeAccessListCustom (paID, peID, extension) VALUES (?, ?, ?)',
                         $v);
                 }

--- a/concrete/src/Permission/Access/AddSubpagePageAccess.php
+++ b/concrete/src/Permission/Access/AddSubpagePageAccess.php
@@ -15,12 +15,12 @@ class AddSubpagePageAccess extends PageAccess
         $r = $db->executeQuery('select * from PagePermissionPageTypeAccessList where paID = ?', [$this->getPermissionAccessID()]);
         while ($row = $r->fetch()) {
             $v = [$row['peID'], $newPA->getPermissionAccessID(), $row['permission'], $row['externalLink']];
-            $db->executeQuery('insert into PagePermissionPageTypeAccessList (peID, paID, permission, externalLink) values (?, ?, ?, ?)', $v);
+            $db->executeStatement('insert into PagePermissionPageTypeAccessList (peID, paID, permission, externalLink) values (?, ?, ?, ?)', $v);
         }
         $r = $db->executeQuery('select * from PagePermissionPageTypeAccessListCustom where paID = ?', [$this->getPermissionAccessID()]);
         while ($row = $r->fetch()) {
             $v = [$row['peID'], $newPA->getPermissionAccessID(), $row['ptID']];
-            $db->executeQuery('insert into PagePermissionPageTypeAccessListCustom  (peID, paID, ptID) values (?, ?, ?)', $v);
+            $db->executeStatement('insert into PagePermissionPageTypeAccessListCustom  (peID, paID, ptID) values (?, ?, ?)', $v);
         }
 
         return $newPA;
@@ -30,16 +30,16 @@ class AddSubpagePageAccess extends PageAccess
     {
         parent::removeListItem($pe);
         $db = Database::connection();
-        $db->executeQuery('delete from PagePermissionPageTypeAccessList where peID = ? and paID = ?', [$pe->getAccessEntityID(), $this->getPermissionAccessID()]);
-        $db->executeQuery('delete from PagePermissionPageTypeAccessListCustom where peID = ? and paID = ?', [$pe->getAccessEntityID(), $this->getPermissionAccessID()]);
+        $db->executeStatement('delete from PagePermissionPageTypeAccessList where peID = ? and paID = ?', [$pe->getAccessEntityID(), $this->getPermissionAccessID()]);
+        $db->executeStatement('delete from PagePermissionPageTypeAccessListCustom where peID = ? and paID = ?', [$pe->getAccessEntityID(), $this->getPermissionAccessID()]);
     }
 
     public function save($args = [])
     {
         parent::save();
         $db = Database::connection();
-        $db->executeQuery('delete from PagePermissionPageTypeAccessList where paID = ?', [$this->getPermissionAccessID()]);
-        $db->executeQuery('delete from PagePermissionPageTypeAccessListCustom where paID = ?', [$this->getPermissionAccessID()]);
+        $db->executeStatement('delete from PagePermissionPageTypeAccessList where paID = ?', [$this->getPermissionAccessID()]);
+        $db->executeStatement('delete from PagePermissionPageTypeAccessListCustom where paID = ?', [$this->getPermissionAccessID()]);
         if (isset($args['pageTypesIncluded']) && is_array($args['pageTypesIncluded'])) {
             foreach ($args['pageTypesIncluded'] as $peID => $permission) {
                 $ext = 0;
@@ -47,7 +47,7 @@ class AddSubpagePageAccess extends PageAccess
                     $ext = $args['allowExternalLinksIncluded'][$peID];
                 }
                 $v = [$this->getPermissionAccessID(), $peID, $permission, $ext];
-                $db->executeQuery('insert into PagePermissionPageTypeAccessList (paID, peID, permission, externalLink) values (?, ?, ?, ?)', $v);
+                $db->executeStatement('insert into PagePermissionPageTypeAccessList (paID, peID, permission, externalLink) values (?, ?, ?, ?)', $v);
             }
         }
 
@@ -58,7 +58,7 @@ class AddSubpagePageAccess extends PageAccess
                     $ext = $args['allowExternalLinksExcluded'][$peID];
                 }
                 $v = [$this->getPermissionAccessID(), $peID, $permission, $ext];
-                $db->executeQuery('insert into PagePermissionPageTypeAccessList (paID, peID, permission, externalLink) values (?, ?, ?, ?)', $v);
+                $db->executeStatement('insert into PagePermissionPageTypeAccessList (paID, peID, permission, externalLink) values (?, ?, ?, ?)', $v);
             }
         }
 
@@ -66,7 +66,7 @@ class AddSubpagePageAccess extends PageAccess
             foreach ($args['ptIDInclude'] as $peID => $ptIDs) {
                 foreach ($ptIDs as $ptID) {
                     $v = [$this->getPermissionAccessID(), $peID, $ptID];
-                    $db->executeQuery('insert into PagePermissionPageTypeAccessListCustom (paID, peID, ptID) values (?, ?, ?)', $v);
+                    $db->executeStatement('insert into PagePermissionPageTypeAccessListCustom (paID, peID, ptID) values (?, ?, ?)', $v);
                 }
             }
         }
@@ -75,7 +75,7 @@ class AddSubpagePageAccess extends PageAccess
             foreach ($args['ptIDExclude'] as $peID => $ptIDs) {
                 foreach ($ptIDs as $ptID) {
                     $v = [$this->getPermissionAccessID(), $peID, $ptID];
-                    $db->executeQuery('insert into PagePermissionPageTypeAccessListCustom (paID, peID, ptID) values (?, ?, ?)', $v);
+                    $db->executeStatement('insert into PagePermissionPageTypeAccessListCustom (paID, peID, ptID) values (?, ?, ?)', $v);
                 }
             }
         }

--- a/concrete/src/Permission/Access/EditPagePropertiesPageAccess.php
+++ b/concrete/src/Permission/Access/EditPagePropertiesPageAccess.php
@@ -23,12 +23,12 @@ class EditPagePropertiesPageAccess extends PageAccess
                 $row['description'],
                 $row['paths'],
             );
-            $db->executeQuery('insert into PagePermissionPropertyAccessList (peID, paID, attributePermission, name, publicDateTime, uID, description, paths) values (?, ?, ?, ?, ?, ?, ?, ?)', $v);
+            $db->executeStatement('insert into PagePermissionPropertyAccessList (peID, paID, attributePermission, name, publicDateTime, uID, description, paths) values (?, ?, ?, ?, ?, ?, ?, ?)', $v);
         }
         $r = $db->executeQuery('select * from PagePermissionPropertyAttributeAccessListCustom where paID = ?', array($this->getPermissionAccessID()));
         while ($row = $r->fetch()) {
             $v = array($row['peID'], $newPA->getPermissionAccessID(), $row['akID']);
-            $db->executeQuery('insert into PagePermissionPropertyAttributeAccessListCustom  (peID, paID, akID) values (?, ?, ?)', $v);
+            $db->executeStatement('insert into PagePermissionPropertyAttributeAccessListCustom  (peID, paID, akID) values (?, ?, ?)', $v);
         }
 
         return $newPA;
@@ -38,8 +38,8 @@ class EditPagePropertiesPageAccess extends PageAccess
     {
         parent::save();
         $db = Database::connection();
-        $db->executeQuery('delete from PagePermissionPropertyAccessList where paID = ?', array($this->getPermissionAccessID()));
-        $db->executeQuery('delete from PagePermissionPropertyAttributeAccessListCustom where paID = ?', array($this->getPermissionAccessID()));
+        $db->executeStatement('delete from PagePermissionPropertyAccessList where paID = ?', array($this->getPermissionAccessID()));
+        $db->executeStatement('delete from PagePermissionPropertyAttributeAccessListCustom where paID = ?', array($this->getPermissionAccessID()));
         if (isset($args['propertiesIncluded']) && is_array($args['propertiesIncluded'])) {
             foreach ($args['propertiesIncluded'] as $peID => $attributePermission) {
                 $allowEditName = 0;
@@ -63,7 +63,7 @@ class EditPagePropertiesPageAccess extends PageAccess
                     $allowEditPaths = $args['allowEditPaths'][$peID];
                 }
                 $v = array($this->getPermissionAccessID(), $peID, $attributePermission, $allowEditName, $allowEditDateTime, $allowEditUID, $allowEditDescription, $allowEditPaths);
-                $db->executeQuery('insert into PagePermissionPropertyAccessList (paID, peID, attributePermission, name, publicDateTime, uID, description, paths) values (?, ?, ?, ?, ?, ?, ?, ?)', $v);
+                $db->executeStatement('insert into PagePermissionPropertyAccessList (paID, peID, attributePermission, name, publicDateTime, uID, description, paths) values (?, ?, ?, ?, ?, ?, ?, ?)', $v);
             }
         }
 
@@ -90,7 +90,7 @@ class EditPagePropertiesPageAccess extends PageAccess
                     $allowEditPathsExcluded = $args['allowEditPathsExcluded'][$peID];
                 }
                 $v = array($this->getPermissionAccessID(), $peID, $attributePermission, $allowEditNameExcluded, $allowEditDateTimeExcluded, $allowEditUIDExcluded, $allowEditDescriptionExcluded, $allowEditPathsExcluded);
-                $db->executeQuery('insert into PagePermissionPropertyAccessList (paID, peID, attributePermission, name, publicDateTime, uID, description, paths) values (?, ?, ?, ?, ?, ?, ?, ?)', $v);
+                $db->executeStatement('insert into PagePermissionPropertyAccessList (paID, peID, attributePermission, name, publicDateTime, uID, description, paths) values (?, ?, ?, ?, ?, ?, ?, ?)', $v);
             }
         }
 
@@ -98,7 +98,7 @@ class EditPagePropertiesPageAccess extends PageAccess
             foreach ($args['akIDInclude'] as $peID => $akIDs) {
                 foreach ($akIDs as $akID) {
                     $v = array($this->getPermissionAccessID(), $peID, $akID);
-                    $db->executeQuery('insert into PagePermissionPropertyAttributeAccessListCustom (paID, peID, akID) values (?, ?, ?)', $v);
+                    $db->executeStatement('insert into PagePermissionPropertyAttributeAccessListCustom (paID, peID, akID) values (?, ?, ?)', $v);
                 }
             }
         }
@@ -107,7 +107,7 @@ class EditPagePropertiesPageAccess extends PageAccess
             foreach ($args['akIDExclude'] as $peID => $akIDs) {
                 foreach ($akIDs as $akID) {
                     $v = array($this->getPermissionAccessID(), $peID, $akID);
-                    $db->executeQuery('insert into PagePermissionPropertyAttributeAccessListCustom (paID, peID, akID) values (?, ?, ?)', $v);
+                    $db->executeStatement('insert into PagePermissionPropertyAttributeAccessListCustom (paID, peID, akID) values (?, ?, ?)', $v);
                 }
             }
         }

--- a/concrete/src/Permission/Access/EditPageThemePageAccess.php
+++ b/concrete/src/Permission/Access/EditPageThemePageAccess.php
@@ -14,12 +14,12 @@ class EditPageThemePageAccess extends PageAccess
         $r = $db->executeQuery('select * from PagePermissionThemeAccessList where paID = ?', [$this->getPermissionAccessID()]);
         while ($row = $r->fetch()) {
             $v = [$row['peID'], $newPA->getPermissionAccessID(), $row['permission']];
-            $db->executeQuery('insert into PagePermissionThemeAccessList (peID, paID, permission) values (?, ?, ?)', $v);
+            $db->executeStatement('insert into PagePermissionThemeAccessList (peID, paID, permission) values (?, ?, ?)', $v);
         }
         $r = $db->executeQuery('select * from PagePermissionThemeAccessListCustom where paID = ?', [$this->getPermissionAccessID()]);
         while ($row = $r->fetch()) {
             $v = [$row['peID'], $newPA->getPermissionAccessID(), $row['pThemeID']];
-            $db->executeQuery('insert into PagePermissionThemeAccessListCustom  (peID, paID, pThemeID) values (?, ?, ?)', $v);
+            $db->executeStatement('insert into PagePermissionThemeAccessListCustom  (peID, paID, pThemeID) values (?, ?, ?)', $v);
         }
 
         return $newPA;
@@ -29,19 +29,19 @@ class EditPageThemePageAccess extends PageAccess
     {
         parent::save();
         $db = Database::connection();
-        $db->executeQuery('delete from PagePermissionThemeAccessList where paID = ?', [$this->getPermissionAccessID()]);
-        $db->executeQuery('delete from PagePermissionThemeAccessListCustom where paID = ?', [$this->getPermissionAccessID()]);
+        $db->executeStatement('delete from PagePermissionThemeAccessList where paID = ?', [$this->getPermissionAccessID()]);
+        $db->executeStatement('delete from PagePermissionThemeAccessListCustom where paID = ?', [$this->getPermissionAccessID()]);
         if (isset($args['themesIncluded']) && is_array($args['themesIncluded'])) {
             foreach ($args['themesIncluded'] as $peID => $permission) {
                 $v = [$this->getPermissionAccessID(), $peID, $permission];
-                $db->executeQuery('insert into PagePermissionThemeAccessList (paID, peID, permission) values (?, ?, ?)', $v);
+                $db->executeStatement('insert into PagePermissionThemeAccessList (paID, peID, permission) values (?, ?, ?)', $v);
             }
         }
 
         if (isset($args['themesExcluded']) && is_array($args['themesExcluded'])) {
             foreach ($args['themesExcluded'] as $peID => $permission) {
                 $v = [$this->getPermissionAccessID(), $peID, $permission];
-                $db->executeQuery('insert into PagePermissionThemeAccessList (paID, peID, permission) values (?, ?, ?)', $v);
+                $db->executeStatement('insert into PagePermissionThemeAccessList (paID, peID, permission) values (?, ?, ?)', $v);
             }
         }
 
@@ -49,7 +49,7 @@ class EditPageThemePageAccess extends PageAccess
             foreach ($args['pThemeIDInclude'] as $peID => $pThemeIDs) {
                 foreach ($pThemeIDs as $pThemeID) {
                     $v = [$this->getPermissionAccessID(), $peID, $pThemeID];
-                    $db->executeQuery('insert into PagePermissionThemeAccessListCustom (paID, peID, pThemeID) values (?, ?, ?)', $v);
+                    $db->executeStatement('insert into PagePermissionThemeAccessListCustom (paID, peID, pThemeID) values (?, ?, ?)', $v);
                 }
             }
         }
@@ -58,7 +58,7 @@ class EditPageThemePageAccess extends PageAccess
             foreach ($args['pThemeIDExclude'] as $peID => $pThemeIDs) {
                 foreach ($pThemeIDs as $pThemeID) {
                     $v = [$this->getPermissionAccessID(), $peID, $pThemeID];
-                    $db->executeQuery('insert into PagePermissionThemeAccessListCustom (paID, peID, pThemeID) values (?, ?, ?)', $v);
+                    $db->executeStatement('insert into PagePermissionThemeAccessListCustom (paID, peID, pThemeID) values (?, ?, ?)', $v);
                 }
             }
         }

--- a/concrete/src/Permission/Access/EditUserPropertiesUserAccess.php
+++ b/concrete/src/Permission/Access/EditUserPropertiesUserAccess.php
@@ -24,12 +24,12 @@ class EditUserPropertiesUserAccess extends UserAccess
             $row['uDefaultLanguage'],
             $row['uHomeFileManagerFolderID'],
             ];
-            $db->executeQuery('insert into UserPermissionEditPropertyAccessList (paID, peID, attributePermission, uName, uEmail, uPassword, uAvatar, uTimezone, uDefaultLanguage, uHomeFileManagerFolderID) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)', $v);
+            $db->executeStatement('insert into UserPermissionEditPropertyAccessList (paID, peID, attributePermission, uName, uEmail, uPassword, uAvatar, uTimezone, uDefaultLanguage, uHomeFileManagerFolderID) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)', $v);
         }
         $r = $db->executeQuery('select * from UserPermissionEditPropertyAttributeAccessListCustom where paID = ?', [$this->getPermissionAccessID()]);
         while ($row = $r->fetch()) {
             $v = [$row['peID'], $newPA->getPermissionAccessID(), $row['akID']];
-            $db->executeQuery('insert into UserPermissionEditPropertyAttributeAccessListCustom (peID, paID, akID) values (?, ?, ?)', $v);
+            $db->executeStatement('insert into UserPermissionEditPropertyAttributeAccessListCustom (peID, paID, akID) values (?, ?, ?)', $v);
         }
 
         return $newPA;
@@ -39,8 +39,8 @@ class EditUserPropertiesUserAccess extends UserAccess
     {
         parent::save();
         $db = Database::connection();
-        $db->executeQuery('delete from UserPermissionEditPropertyAccessList where paID = ?', [$this->getPermissionAccessID()]);
-        $db->executeQuery('delete from UserPermissionEditPropertyAttributeAccessListCustom where paID = ?', [$this->getPermissionAccessID()]);
+        $db->executeStatement('delete from UserPermissionEditPropertyAccessList where paID = ?', [$this->getPermissionAccessID()]);
+        $db->executeStatement('delete from UserPermissionEditPropertyAttributeAccessListCustom where paID = ?', [$this->getPermissionAccessID()]);
         if (isset($args['propertiesIncluded']) && is_array($args['propertiesIncluded'])) {
             foreach ($args['propertiesIncluded'] as $peID => $attributePermission) {
                 $allowEditUName = 0;
@@ -72,7 +72,7 @@ class EditUserPropertiesUserAccess extends UserAccess
                     $allowEditUHomeFileManagerFolderID = $args['allowEditUHomeFileManagerFolderID'][$peID];
                 }
                 $v = [$this->getPermissionAccessID(), $peID, $attributePermission, $allowEditUName, $allowEditUEmail, $allowEditUPassword, $allowEditUAvatar, $allowEditUTimezone, $allowEditUDefaultLanguage, $allowEditUHomeFileManagerFolderID];
-                $db->executeQuery('insert into UserPermissionEditPropertyAccessList (paID, peID, attributePermission, uName, uEmail, uPassword, uAvatar, uTimezone, uDefaultLanguage, uHomeFileManagerFolderID) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)', $v);
+                $db->executeStatement('insert into UserPermissionEditPropertyAccessList (paID, peID, attributePermission, uName, uEmail, uPassword, uAvatar, uTimezone, uDefaultLanguage, uHomeFileManagerFolderID) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)', $v);
             }
         }
 
@@ -107,7 +107,7 @@ class EditUserPropertiesUserAccess extends UserAccess
                     $allowEditUHomeFileManagerFolderIDExcluded = $args['allowEditUHomeFileManagerFolderIDExcluded'][$peID];
                 }
                 $v = [$this->getPermissionAccessID(), $peID, $attributePermission, $allowEditUNameExcluded, $allowEditUEmailExcluded, $allowEditUPasswordExcluded, $allowEditUAvatarExcluded, $allowEditUTimezoneExcluded, $allowEditUDefaultLanguageExcluded, $allowEditUHomeFileManagerFolderIDExcluded];
-                $db->executeQuery('insert into UserPermissionEditPropertyAccessList (paID, peID, attributePermission, uName, uEmail, uPassword, uAvatar, uTimezone, uDefaultLanguage, uHomeFileManagerFolderID) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)', $v);
+                $db->executeStatement('insert into UserPermissionEditPropertyAccessList (paID, peID, attributePermission, uName, uEmail, uPassword, uAvatar, uTimezone, uDefaultLanguage, uHomeFileManagerFolderID) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)', $v);
             }
         }
 
@@ -115,7 +115,7 @@ class EditUserPropertiesUserAccess extends UserAccess
             foreach ($args['akIDInclude'] as $peID => $akIDs) {
                 foreach ($akIDs as $akID) {
                     $v = [$this->getPermissionAccessID(), $peID, $akID];
-                    $db->executeQuery('insert into UserPermissionEditPropertyAttributeAccessListCustom (paID, peID, akID) values (?, ?, ?)', $v);
+                    $db->executeStatement('insert into UserPermissionEditPropertyAttributeAccessListCustom (paID, peID, akID) values (?, ?, ?)', $v);
                 }
             }
         }
@@ -124,7 +124,7 @@ class EditUserPropertiesUserAccess extends UserAccess
             foreach ($args['akIDExclude'] as $peID => $akIDs) {
                 foreach ($akIDs as $akID) {
                     $v = [$this->getPermissionAccessID(), $peID, $akID];
-                    $db->executeQuery('insert into UserPermissionEditPropertyAttributeAccessListCustom (paID, peID, akID) values (?, ?, ?)', $v);
+                    $db->executeStatement('insert into UserPermissionEditPropertyAttributeAccessListCustom (paID, peID, akID) values (?, ?, ?)', $v);
                 }
             }
         }

--- a/concrete/src/Permission/Access/Entity/FileUploaderEntity.php
+++ b/concrete/src/Permission/Access/Entity/FileUploaderEntity.php
@@ -68,7 +68,7 @@ class FileUploaderEntity extends Entity
         $peID = $db->GetOne('select peID from PermissionAccessEntities where petID = ?',
             array($petID));
         if (!$peID) {
-            $db->Execute("insert into PermissionAccessEntities (petID) values(?)", array($petID));
+            $db->executeStatement("insert into PermissionAccessEntities (petID) values(?)", array($petID));
             $peID = $db->Insert_ID();
             Config::save('concrete.misc.access_entity_updated', time());
         }

--- a/concrete/src/Permission/Access/Entity/GroupEntity.php
+++ b/concrete/src/Permission/Access/Entity/GroupEntity.php
@@ -95,10 +95,10 @@ class GroupEntity extends Entity
         $peID = $db->GetOne('select pae.peID from PermissionAccessEntities pae inner join PermissionAccessEntityGroups paeg on pae.peID = paeg.peID where petID = ? and paeg.gID = ?',
             array($petID, $g->getGroupID()));
         if (!$peID) {
-            $db->Execute("insert into PermissionAccessEntities (petID) values(?)", array($petID));
+            $db->executeStatement("insert into PermissionAccessEntities (petID) values(?)", array($petID));
             $peID = $db->Insert_ID();
             Config::save('concrete.misc.access_entity_updated', time());
-            $db->Execute('insert into PermissionAccessEntityGroups (peID, gID) values (?, ?)',
+            $db->executeStatement('insert into PermissionAccessEntityGroups (peID, gID) values (?, ?)',
                 array($peID, $g->getGroupID()));
         }
 

--- a/concrete/src/Permission/Access/Entity/GroupSetEntity.php
+++ b/concrete/src/Permission/Access/Entity/GroupSetEntity.php
@@ -62,7 +62,7 @@ class GroupSetEntity extends Entity
             $ingids[] = $group->getGroupID();
         }
         $instr = implode(',', $ingids);
-        $r = $db->Execute('select uID from UserGroups where gID in (' . $instr . ')');
+        $r = $db->executeQuery('select uID from UserGroups where gID in (' . $instr . ')');
         $users = array();
         while ($row = $r->fetch()) {
             $ui = UserInfo::getByID($row['uID']);
@@ -81,10 +81,10 @@ class GroupSetEntity extends Entity
         $peID = $db->GetOne('select pae.peID from PermissionAccessEntities pae inner join PermissionAccessEntityGroupSets paeg on pae.peID = paeg.peID where petID = ? and paeg.gsID = ?',
             array($petID, $gs->getGroupSetID()));
         if (!$peID) {
-            $db->Execute("insert into PermissionAccessEntities (petID) values(?)", array($petID));
+            $db->executeStatement("insert into PermissionAccessEntities (petID) values(?)", array($petID));
             Config::save('concrete.misc.access_entity_updated', time());
             $peID = $db->Insert_ID();
-            $db->Execute('insert into PermissionAccessEntityGroupSets (peID, gsID) values (?, ?)', array($peID, $gs->getGroupSetID()));
+            $db->executeStatement('insert into PermissionAccessEntityGroupSets (peID, gsID) values (?, ?)', array($peID, $gs->getGroupSetID()));
         }
 
         return \Concrete\Core\Permission\Access\Entity\Entity::getByID($peID);

--- a/concrete/src/Permission/Access/Entity/PageOwnerEntity.php
+++ b/concrete/src/Permission/Access/Entity/PageOwnerEntity.php
@@ -78,7 +78,7 @@ class PageOwnerEntity extends Entity
         $petID = $db->fetchColumn('select petID from PermissionAccessEntityTypes where petHandle = \'page_owner\'');
         $peID = $db->fetchColumn('select peID from PermissionAccessEntities where petID = ?', array($petID));
         if (!$peID) {
-            $db->executeQuery("insert into PermissionAccessEntities (petID) values(?)", array($petID));
+            $db->executeStatement("insert into PermissionAccessEntities (petID) values(?)", array($petID));
             $peID = $db->lastInsertId();
             Config::save('concrete.misc.access_entity_updated', time());
         }

--- a/concrete/src/Permission/Access/Entity/SiteGroupEntity.php
+++ b/concrete/src/Permission/Access/Entity/SiteGroupEntity.php
@@ -134,7 +134,7 @@ class SiteGroupEntity extends Entity
         $siteGroupEntity = $r->findOneByGroup($siteGroup);
 
         if (!$siteGroupEntity) {
-            $db->Execute('insert into PermissionAccessEntities (petID) values(?)', [$petID]);
+            $db->executeStatement('insert into PermissionAccessEntities (petID) values(?)', [$petID]);
             $peID = $db->Insert_ID();
             \Config::save('concrete.misc.access_entity_updated', time());
 

--- a/concrete/src/Permission/Access/Entity/Type.php
+++ b/concrete/src/Permission/Access/Entity/Type.php
@@ -80,10 +80,10 @@ class Type extends ConcreteObject
         $db = Loader::db();
         $list = array();
         if ($category instanceof Category) {
-            $r = $db->Execute('select pet.petID from PermissionAccessEntityTypes pet inner join PermissionAccessEntityTypeCategories petc on pet.petID = petc.petID where petc.pkCategoryID = ? order by pet.petID asc',
+            $r = $db->executeQuery('select pet.petID from PermissionAccessEntityTypes pet inner join PermissionAccessEntityTypeCategories petc on pet.petID = petc.petID where petc.pkCategoryID = ? order by pet.petID asc',
                 array($category->getPermissionKeyCategoryID()));
         } else {
-            $r = $db->Execute('select petID from PermissionAccessEntityTypes order by petID asc');
+            $r = $db->executeQuery('select petID from PermissionAccessEntityTypes order by petID asc');
         }
 
         while ($row = $r->fetch()) {
@@ -129,14 +129,14 @@ class Type extends ConcreteObject
     public function delete()
     {
         $db = Loader::db();
-        $db->Execute("delete from PermissionAccessEntityTypes where petID = ?", array($this->petID));
+        $db->executeStatement("delete from PermissionAccessEntityTypes where petID = ?", array($this->petID));
     }
 
     public static function getListByPackage($pkg)
     {
         $db = Loader::db();
         $list = array();
-        $r = $db->Execute('select petID from PermissionAccessEntityTypes where pkgID = ? order by petID asc',
+        $r = $db->executeQuery('select petID from PermissionAccessEntityTypes where pkgID = ? order by petID asc',
             array($pkg->getPackageID()));
         while ($row = $r->fetch()) {
             $list[] = static::getByID($row['petID']);
@@ -162,7 +162,7 @@ class Type extends ConcreteObject
             $pkgID = $pkg->getPackageID();
         }
         $db = Loader::db();
-        $db->Execute('insert into PermissionAccessEntityTypes (petHandle, petName, pkgID) values (?, ?, ?)',
+        $db->executeStatement('insert into PermissionAccessEntityTypes (petHandle, petName, pkgID) values (?, ?, ?)',
             array($petHandle, $petName, $pkgID));
         $id = $db->Insert_ID();
         $est = static::getByID($id);

--- a/concrete/src/Permission/Access/Entity/UserEntity.php
+++ b/concrete/src/Permission/Access/Entity/UserEntity.php
@@ -39,10 +39,10 @@ class UserEntity extends Entity
             'SELECT pae.peID FROM PermissionAccessEntities pae INNER JOIN PermissionAccessEntityUsers paeg ON pae.peID = paeg.peID WHERE petID = ? AND paeg.uID = ?',
             [$petID, $ui->getUserID()]);
         if (!$peID) {
-            $db->Execute('INSERT INTO PermissionAccessEntities (petID) VALUES(?)', [$petID]);
+            $db->executeStatement('INSERT INTO PermissionAccessEntities (petID) VALUES(?)', [$petID]);
             $peID = $db->Insert_ID();
             Config::save('concrete.misc.access_entity_updated', time());
-            $db->Execute(
+            $db->executeStatement(
                 'INSERT INTO PermissionAccessEntityUsers (peID, uID) VALUES (?, ?)',
                 [$peID, $ui->getUserID()]);
         }

--- a/concrete/src/Permission/Access/NotifyInNotificationCenterNotificationAccess.php
+++ b/concrete/src/Permission/Access/NotifyInNotificationCenterNotificationAccess.php
@@ -14,12 +14,12 @@ class NotifyInNotificationCenterNotificationAccess extends NotificationAccess
         $r = $db->executeQuery('select * from NotificationPermissionSubscriptionList where paID = ?', [$this->getPermissionAccessID()]);
         while ($row = $r->fetch()) {
             $v = [$row['peID'], $newPA->getPermissionAccessID(), $row['permission']];
-            $db->executeQuery('insert into NotificationPermissionSubscriptionList (peID, paID, permission) values (?, ?, ?)', $v);
+            $db->executeStatement('insert into NotificationPermissionSubscriptionList (peID, paID, permission) values (?, ?, ?)', $v);
         }
         $r = $db->executeQuery('select * from NotificationPermissionSubscriptionListCustom where paID = ?', [$this->getPermissionAccessID()]);
         while ($row = $r->fetch()) {
             $v = [$row['peID'], $newPA->getPermissionAccessID(), $row['nSubscriptionIdentifier']];
-            $db->executeQuery('insert into NotificationPermissionSubscriptionListCustom  (peID, paID, nSubscriptionIdentifier) values (?, ?, ?)', $v);
+            $db->executeStatement('insert into NotificationPermissionSubscriptionListCustom  (peID, paID, nSubscriptionIdentifier) values (?, ?, ?)', $v);
         }
 
         return $newPA;
@@ -29,19 +29,19 @@ class NotifyInNotificationCenterNotificationAccess extends NotificationAccess
     {
         parent::save();
         $db = Database::connection();
-        $db->executeQuery('delete from NotificationPermissionSubscriptionList where paID = ?', [$this->getPermissionAccessID()]);
-        $db->executeQuery('delete from NotificationPermissionSubscriptionListCustom where paID = ?', [$this->getPermissionAccessID()]);
+        $db->executeStatement('delete from NotificationPermissionSubscriptionList where paID = ?', [$this->getPermissionAccessID()]);
+        $db->executeStatement('delete from NotificationPermissionSubscriptionListCustom where paID = ?', [$this->getPermissionAccessID()]);
         if (isset($args['subscriptionsIncluded']) && is_array($args['subscriptionsIncluded'])) {
             foreach ($args['subscriptionsIncluded'] as $peID => $permission) {
                 $v = [$this->getPermissionAccessID(), $peID, $permission];
-                $db->executeQuery('insert into NotificationPermissionSubscriptionList (paID, peID, permission) values (?, ?, ?)', $v);
+                $db->executeStatement('insert into NotificationPermissionSubscriptionList (paID, peID, permission) values (?, ?, ?)', $v);
             }
         }
 
         if (isset($args['subscriptionsExcluded']) && is_array($args['subscriptionsExcluded'])) {
             foreach ($args['subscriptionsExcluded'] as $peID => $permission) {
                 $v = [$this->getPermissionAccessID(), $peID, $permission];
-                $db->executeQuery('insert into NotificationPermissionSubscriptionList (paID, peID, permission) values (?, ?, ?)', $v);
+                $db->executeStatement('insert into NotificationPermissionSubscriptionList (paID, peID, permission) values (?, ?, ?)', $v);
             }
         }
 
@@ -49,7 +49,7 @@ class NotifyInNotificationCenterNotificationAccess extends NotificationAccess
             foreach ($args['subscriptionIdentifierInclude'] as $peID => $pThemeIDs) {
                 foreach ($pThemeIDs as $pThemeID) {
                     $v = [$this->getPermissionAccessID(), $peID, $pThemeID];
-                    $db->executeQuery('insert into NotificationPermissionSubscriptionListCustom (paID, peID, nSubscriptionIdentifier) values (?, ?, ?)', $v);
+                    $db->executeStatement('insert into NotificationPermissionSubscriptionListCustom (paID, peID, nSubscriptionIdentifier) values (?, ?, ?)', $v);
                 }
             }
         }
@@ -58,7 +58,7 @@ class NotifyInNotificationCenterNotificationAccess extends NotificationAccess
             foreach ($args['subscriptionIdentifierExclude'] as $peID => $pThemeIDs) {
                 foreach ($pThemeIDs as $pThemeID) {
                     $v = [$this->getPermissionAccessID(), $peID, $pThemeID];
-                    $db->executeQuery('insert into NotificationPermissionSubscriptionListCustom (paID, peID, nSubscriptionIdentifier) values (?, ?, ?)', $v);
+                    $db->executeStatement('insert into NotificationPermissionSubscriptionListCustom (paID, peID, nSubscriptionIdentifier) values (?, ?, ?)', $v);
                 }
             }
         }

--- a/concrete/src/Permission/Access/ViewUserAttributesUserAccess.php
+++ b/concrete/src/Permission/Access/ViewUserAttributesUserAccess.php
@@ -10,19 +10,19 @@ class ViewUserAttributesUserAccess extends UserAccess
     {
         parent::save();
         $db = Database::connection();
-        $db->executeQuery('delete from UserPermissionViewAttributeAccessList where paID = ?', array($this->getPermissionAccessID()));
-        $db->executeQuery('delete from UserPermissionViewAttributeAccessListCustom where paID = ?', array($this->getPermissionAccessID()));
+        $db->executeStatement('delete from UserPermissionViewAttributeAccessList where paID = ?', array($this->getPermissionAccessID()));
+        $db->executeStatement('delete from UserPermissionViewAttributeAccessListCustom where paID = ?', array($this->getPermissionAccessID()));
         if (isset($args['viewAttributesIncluded']) && is_array($args['viewAttributesIncluded'])) {
             foreach ($args['viewAttributesIncluded'] as $peID => $permission) {
                 $v = array($this->getPermissionAccessID(), $peID, $permission);
-                $db->executeQuery('insert into UserPermissionViewAttributeAccessList (paID, peID, permission) values (?, ?, ?)', $v);
+                $db->executeStatement('insert into UserPermissionViewAttributeAccessList (paID, peID, permission) values (?, ?, ?)', $v);
             }
         }
 
         if (isset($args['viewAttributesExcluded']) && is_array($args['viewAttributesExcluded'])) {
             foreach ($args['viewAttributesExcluded'] as $peID => $permission) {
                 $v = array($this->getPermissionAccessID(), $peID, $permission);
-                $db->executeQuery('insert into UserPermissionViewAttributeAccessList (paID, peID, permission) values (?, ?, ?)', $v);
+                $db->executeStatement('insert into UserPermissionViewAttributeAccessList (paID, peID, permission) values (?, ?, ?)', $v);
             }
         }
 
@@ -30,7 +30,7 @@ class ViewUserAttributesUserAccess extends UserAccess
             foreach ($args['akIDInclude'] as $peID => $akIDs) {
                 foreach ($akIDs as $akID) {
                     $v = array($this->getPermissionAccessID(), $peID, $akID);
-                    $db->executeQuery('insert into UserPermissionViewAttributeAccessListCustom (paID, peID, akID) values (?, ?, ?)', $v);
+                    $db->executeStatement('insert into UserPermissionViewAttributeAccessListCustom (paID, peID, akID) values (?, ?, ?)', $v);
                 }
             }
         }
@@ -39,7 +39,7 @@ class ViewUserAttributesUserAccess extends UserAccess
             foreach ($args['akIDExclude'] as $peID => $akIDs) {
                 foreach ($akIDs as $akID) {
                     $v = array($this->getPermissionAccessID(), $peID, $akID);
-                    $db->executeQuery('insert into UserPermissionViewAttributeAccessListCustom (paID, peID, akID) values (?, ?, ?)', $v);
+                    $db->executeStatement('insert into UserPermissionViewAttributeAccessListCustom (paID, peID, akID) values (?, ?, ?)', $v);
                 }
             }
         }
@@ -52,12 +52,12 @@ class ViewUserAttributesUserAccess extends UserAccess
         $r = $db->executeQuery('select * from UserPermissionViewAttributeAccessList where paID = ?', array($this->getPermissionAccessID()));
         while ($row = $r->fetch()) {
             $v = array($row['peID'], $newPA->getPermissionAccessID(), $row['permission']);
-            $db->executeQuery('insert into UserPermissionViewAttributeAccessList (peID, paID, permission) values (?, ?, ?)', $v);
+            $db->executeStatement('insert into UserPermissionViewAttributeAccessList (peID, paID, permission) values (?, ?, ?)', $v);
         }
         $r = $db->executeQuery('select * from UserPermissionViewAttributeAccessListCustom where paID = ?', array($this->getPermissionAccessID()));
         while ($row = $r->fetch()) {
             $v = array($row['peID'], $newPA->getPermissionAccessID(), $row['akID']);
-            $db->executeQuery('insert into UserPermissionViewAttributeAccessListCustom  (peID, paID, akID) values (?, ?, ?)', $v);
+            $db->executeStatement('insert into UserPermissionViewAttributeAccessListCustom  (peID, paID, akID) values (?, ?, ?)', $v);
         }
 
         return $newPA;

--- a/concrete/src/Permission/Assignment/AreaAssignment.php
+++ b/concrete/src/Permission/Assignment/AreaAssignment.php
@@ -212,7 +212,7 @@ class AreaAssignment extends Assignment
         $db = $app->make(Connection::class);
         $area = $this->getPermissionObject();
         $c = $area->getAreaCollectionObject();
-        $db->executeQuery('update AreaPermissionAssignments set paID = 0 where pkID = ? and cID = ? and arHandle = ?', [$this->pk->getPermissionKeyID(), $c->getCollectionID(), $area->getAreaHandle()]);
+        $db->executeStatement('update AreaPermissionAssignments set paID = 0 where pkID = ? and cID = ? and arHandle = ?', [$this->pk->getPermissionKeyID(), $c->getCollectionID(), $area->getAreaHandle()]);
     }
 
     /**

--- a/concrete/src/Permission/Assignment/Assignment.php
+++ b/concrete/src/Permission/Assignment/Assignment.php
@@ -76,7 +76,7 @@ class Assignment
     {
         $app = Application::getFacadeApplication();
         $db = $app->make(Connection::class);
-        $db->executeQuery('update PermissionAssignments set paID = 0 where pkID = ?', [$this->pk->getPermissionKeyID()]);
+        $db->executeStatement('update PermissionAssignments set paID = 0 where pkID = ?', [$this->pk->getPermissionKeyID()]);
     }
 
     /**

--- a/concrete/src/Permission/Assignment/BasicWorkflowAssignment.php
+++ b/concrete/src/Permission/Assignment/BasicWorkflowAssignment.php
@@ -19,7 +19,7 @@ class BasicWorkflowAssignment extends Assignment
     public function clearPermissionAssignment()
     {
         $db = Loader::db();
-        $db->Execute('update BasicWorkflowPermissionAssignments set paID = 0 where pkID = ? and wfID = ?', array($this->pk->getPermissionKeyID(), $this->getPermissionObject()->getWorkflowID()));
+        $db->executeStatement('update BasicWorkflowPermissionAssignments set paID = 0 where pkID = ? and wfID = ?', array($this->pk->getPermissionKeyID(), $this->getPermissionObject()->getWorkflowID()));
     }
 
     public function assignPermissionAccess(Access $pa)

--- a/concrete/src/Permission/Assignment/BlockAssignment.php
+++ b/concrete/src/Permission/Assignment/BlockAssignment.php
@@ -98,7 +98,7 @@ class BlockAssignment extends Assignment
     {
         $db = Database::connection();
         $co = $this->permissionObject->getBlockCollectionObject();
-        $db->Execute('update BlockPermissionAssignments set paID = 0 where pkID = ? and bID = ? and cvID = ? and cID = ?', array($this->pk->getPermissionKeyID(), $this->permissionObject->getBlockID(), $co->getVersionID(), $co->getCollectionID()));
+        $db->executeStatement('update BlockPermissionAssignments set paID = 0 where pkID = ? and bID = ? and cvID = ? and cID = ?', array($this->pk->getPermissionKeyID(), $this->permissionObject->getBlockID(), $co->getVersionID(), $co->getCollectionID()));
     }
 
     public function assignPermissionAccess(Access $pa)

--- a/concrete/src/Permission/Assignment/BoardAssignment.php
+++ b/concrete/src/Permission/Assignment/BoardAssignment.php
@@ -72,7 +72,7 @@ class BoardAssignment extends Assignment
     {
         $db = \Database::connection();
         $board = $this->getPermissionObject();
-        $db->Execute('update BoardPermissionAssignments set paID = 0 where pkID = ? and boardID = ?', array($this->pk->getPermissionKeyID(), $board->getBoardID()));
+        $db->executeStatement('update BoardPermissionAssignments set paID = 0 where pkID = ? and boardID = ?', array($this->pk->getPermissionKeyID(), $board->getBoardID()));
     }
 
     public function assignPermissionAccess(Access $pa)

--- a/concrete/src/Permission/Assignment/CalendarAssignment.php
+++ b/concrete/src/Permission/Assignment/CalendarAssignment.php
@@ -76,7 +76,7 @@ class CalendarAssignment extends Assignment
     {
         $db = \Database::connection();
         $calendar = $this->getPermissionObject();
-        $db->Execute('update CalendarPermissionAssignments set paID = 0 where pkID = ? and caID = ?', array($this->pk->getPermissionKeyID(), $calendar->getID()));
+        $db->executeStatement('update CalendarPermissionAssignments set paID = 0 where pkID = ? and caID = ?', array($this->pk->getPermissionKeyID(), $calendar->getID()));
     }
 
     public function assignPermissionAccess(Access $pa)

--- a/concrete/src/Permission/Assignment/ConversationAssignment.php
+++ b/concrete/src/Permission/Assignment/ConversationAssignment.php
@@ -50,7 +50,7 @@ class ConversationAssignment extends Assignment
         }
 
         $db = Database::connection();
-        $db->Execute(
+        $db->executeStatement(
             'update ConversationPermissionAssignments set paID = 0 where pkID = ? and cnvID = ?',
             array($this->pk->getPermissionKeyID(), $cnvID)
         );

--- a/concrete/src/Permission/Assignment/FileAssignment.php
+++ b/concrete/src/Permission/Assignment/FileAssignment.php
@@ -85,7 +85,7 @@ class FileAssignment extends TreeNodeAssignment
     public function clearPermissionAssignment()
     {
         $db = Database::connection();
-        $db->Execute('update FilePermissionAssignments set paID = 0 where pkID = ? and fID = ?', array($this->pk->getPermissionKeyID(), $this->permissionObject->getFileID()));
+        $db->executeStatement('update FilePermissionAssignments set paID = 0 where pkID = ? and fID = ?', array($this->pk->getPermissionKeyID(), $this->permissionObject->getFileID()));
     }
 
     public function assignPermissionAccess(Access $pa)

--- a/concrete/src/Permission/Assignment/PageAssignment.php
+++ b/concrete/src/Permission/Assignment/PageAssignment.php
@@ -80,7 +80,7 @@ class PageAssignment extends Assignment
     {
         $app = Application::getFacadeApplication();
         $db = $app->make(Connection::class);
-        $db->executeQuery('update PagePermissionAssignments set paID = 0 where pkID = ? and cID = ?', [$this->pk->getPermissionKeyID(), $this->getPermissionObject()->getPermissionsCollectionID()]);
+        $db->executeStatement('update PagePermissionAssignments set paID = 0 where pkID = ? and cID = ?', [$this->pk->getPermissionKeyID(), $this->getPermissionObject()->getPermissionsCollectionID()]);
 
         $cache = $app->make('cache/request');
         $identifier = sprintf(

--- a/concrete/src/Permission/Assignment/PageTypeAssignment.php
+++ b/concrete/src/Permission/Assignment/PageTypeAssignment.php
@@ -19,7 +19,7 @@ class PageTypeAssignment extends Assignment
     public function clearPermissionAssignment()
     {
         $db = Loader::db();
-        $db->Execute('update PageTypePermissionAssignments set paID = 0 where pkID = ? and ptID = ?', array($this->pk->getPermissionKeyID(), $this->permissionObject->getPageTypeID()));
+        $db->executeStatement('update PageTypePermissionAssignments set paID = 0 where pkID = ? and ptID = ?', array($this->pk->getPermissionKeyID(), $this->permissionObject->getPageTypeID()));
     }
 
     public function assignPermissionAccess(Access $pa)

--- a/concrete/src/Permission/Assignment/TreeNodeAssignment.php
+++ b/concrete/src/Permission/Assignment/TreeNodeAssignment.php
@@ -30,7 +30,7 @@ class TreeNodeAssignment extends Assignment
     public function clearPermissionAssignment()
     {
         $db = Loader::db();
-        $db->Execute('update TreeNodePermissionAssignments set paID = 0 where pkID = ? and treeNodeID = ?', array($this->pk->getPermissionKeyID(), $this->permissionObject->getTreeNodeID()));
+        $db->executeStatement('update TreeNodePermissionAssignments set paID = 0 where pkID = ? and treeNodeID = ?', array($this->pk->getPermissionKeyID(), $this->permissionObject->getTreeNodeID()));
     }
 
     public function assignPermissionAccess(Access $pa)

--- a/concrete/src/Permission/Category.php
+++ b/concrete/src/Permission/Category.php
@@ -171,7 +171,7 @@ class Category extends ConcreteObject
     public function clearAccessEntityTypeCategories()
     {
         $db = Database::get();
-        $db->executeStatement('delete from PermissionAccessEntityTypeCategories where pkCategoryID = ?', $this->pkCategoryID);
+        $db->executeStatement('delete from PermissionAccessEntityTypeCategories where pkCategoryID = ?', [$this->pkCategoryID]);
     }
 
     public static function getList()

--- a/concrete/src/Permission/Category.php
+++ b/concrete/src/Permission/Category.php
@@ -25,7 +25,7 @@ class Category extends ConcreteObject
     {
         $db = Database::get();
         self::$categories = array();
-        $r = $db->Execute('select pkCategoryID, pkCategoryHandle, pkgID from PermissionKeyCategories');
+        $r = $db->executeQuery('select pkCategoryID, pkCategoryHandle, pkgID from PermissionKeyCategories');
         while ($row = $r->fetch()) {
             $pkc = new static();
             $pkc->setPropertiesFromArray($row);
@@ -66,7 +66,7 @@ class Category extends ConcreteObject
     {
         $db = Database::get();
         $list = array();
-        $r = $db->Execute('select pkCategoryID from PermissionKeyCategories where pkgID = ? order by pkCategoryID asc', array($pkg->getPackageID()));
+        $r = $db->executeQuery('select pkCategoryID from PermissionKeyCategories where pkgID = ? order by pkCategoryID asc', array($pkg->getPackageID()));
         while ($row = $r->fetch()) {
             $list[] = static::getByID($row['pkCategoryID']);
         }
@@ -146,7 +146,7 @@ class Category extends ConcreteObject
     public function delete()
     {
         $db = Database::get();
-        $db->Execute('delete from PermissionKeyCategories where pkCategoryID = ?', array($this->pkCategoryID));
+        $db->executeStatement('delete from PermissionKeyCategories where pkCategoryID = ?', array($this->pkCategoryID));
     }
 
     public function associateAccessEntityType(\Concrete\Core\Permission\Access\Entity\Type $pt)
@@ -156,7 +156,7 @@ class Category extends ConcreteObject
             $pt->getAccessEntityTypeID(), $this->pkCategoryID,
         ));
         if (!$r) {
-            $db->Execute('insert into PermissionAccessEntityTypeCategories (petID, pkCategoryID) values (?, ?)', array(
+            $db->executeStatement('insert into PermissionAccessEntityTypeCategories (petID, pkCategoryID) values (?, ?)', array(
                 $pt->getAccessEntityTypeID(), $this->pkCategoryID,
             ));
         }
@@ -171,14 +171,14 @@ class Category extends ConcreteObject
     public function clearAccessEntityTypeCategories()
     {
         $db = Database::get();
-        $db->Execute('delete from PermissionAccessEntityTypeCategories where pkCategoryID = ?', $this->pkCategoryID);
+        $db->executeStatement('delete from PermissionAccessEntityTypeCategories where pkCategoryID = ?', $this->pkCategoryID);
     }
 
     public static function getList()
     {
         $db = Database::get();
         $cats = array();
-        $r = $db->Execute('select pkCategoryID from PermissionKeyCategories order by pkCategoryID asc');
+        $r = $db->executeQuery('select pkCategoryID from PermissionKeyCategories order by pkCategoryID asc');
         while ($row = $r->fetch()) {
             $cats[] = static::getByID($row['pkCategoryID']);
         }
@@ -194,7 +194,7 @@ class Category extends ConcreteObject
         } else {
             $pkgID = null;
         }
-        $db->Execute('insert into PermissionKeyCategories (pkCategoryHandle, pkgID) values (?, ?)', array($pkCategoryHandle, $pkgID));
+        $db->executeStatement('insert into PermissionKeyCategories (pkCategoryHandle, pkgID) values (?, ?)', array($pkCategoryHandle, $pkgID));
         $id = $db->Insert_ID();
 
         self::$categories = array();

--- a/concrete/src/Permission/Duration.php
+++ b/concrete/src/Permission/Duration.php
@@ -141,11 +141,11 @@ class Duration extends AbstractRepetition
         if (!$this->pdID) {
             $pd = new self();
             $pdObject = serialize($pd);
-            $db->executeQuery('INSERT INTO PermissionDurationObjects (pdObject) VALUES (?)', [$pdObject]);
+            $db->executeStatement('INSERT INTO PermissionDurationObjects (pdObject) VALUES (?)', [$pdObject]);
             $this->pdID = $db->lastInsertId();
         }
         $pdObject = serialize($this);
-        $db->executeQuery(
+        $db->executeStatement(
             'UPDATE PermissionDurationObjects SET pdObject = ? WHERE pdID = ?',
             [$pdObject, $this->pdID]
         );

--- a/concrete/src/Permission/Key/AddBlockToAreaAreaKey.php
+++ b/concrete/src/Permission/Key/AddBlockToAreaAreaKey.php
@@ -65,7 +65,7 @@ class AddBlockToAreaAreaKey extends AreaKey
                     true
                 );
             }
-            $db->executeQuery('delete from AreaPermissionBlockTypeAccessListCustom where paID = ?', [$row['paID']]);
+            $db->executeStatement('delete from AreaPermissionBlockTypeAccessListCustom where paID = ?', [$row['paID']]);
             $rx = $db->executeQuery('select btID from BlockTypePermissionBlockTypeAccessListCustom where paID = ? and peID = ?', [$row['paID'], $row['peID']]);
             while (($rowx = $rx->fetch(PDO::FETCH_ASSOC)) !== false) {
                 $db->replace(

--- a/concrete/src/Permission/Key/Key.php
+++ b/concrete/src/Permission/Key/Key.php
@@ -530,7 +530,7 @@ EOT
     {
         $app = Application::getFacadeApplication();
         $db = $app->make(Connection::class);
-        $db->executeQuery('update PermissionKeys set pkHasCustomClass = ? where pkID = ?', [$pkHasCustomClass ? 1 : 0, $this->getPermissionKeyID()]);
+        $db->executeStatement('update PermissionKeys set pkHasCustomClass = ? where pkID = ?', [$pkHasCustomClass ? 1 : 0, $this->getPermissionKeyID()]);
         self::loadAll();
     }
 
@@ -584,7 +584,7 @@ EOT
     {
         $app = Application::getFacadeApplication();
         $db = $app->make(Connection::class);
-        $db->executeQuery('delete from PermissionKeys where pkID = ?', [$this->getPermissionKeyID()]);
+        $db->executeStatement('delete from PermissionKeys where pkID = ?', [$this->getPermissionKeyID()]);
         self::loadAll();
     }
 

--- a/concrete/src/Permission/Response/PageResponse.php
+++ b/concrete/src/Permission/Response/PageResponse.php
@@ -243,7 +243,7 @@ class PageResponse extends Response
     {
         $db = Loader::db();
         $assignments = [];
-        $r = $db->Execute(
+        $r = $db->executeQuery(
             'select peID, pkID, pdID from PagePermissionAssignments ppa inner join PermissionAccessList pal on ppa.paID = pal.paID where cID = ?',
             [$this->object->getCollectionID()]
         );
@@ -257,12 +257,12 @@ class PageResponse extends Response
             $ppc->setPermissionKeyObject($pk);
             $assignments[] = $ppc;
         }
-        $r = $db->Execute(
+        $r = $db->executeQuery(
             'select arHandle from Areas where cID = ? and arOverrideCollectionPermissions = 1',
             [$this->object->getCollectionID()]
         );
         while ($row = $r->fetch()) {
-            $r2 = $db->Execute(
+            $r2 = $db->executeQuery(
                 'select peID, pdID, pkID from AreaPermissionAssignments apa inner join PermissionAccessList pal on apa.paID = pal.paID where cID = ? and arHandle = ?',
                 [$this->object->getCollectionID(), $row['arHandle']]
             );
@@ -279,7 +279,7 @@ class PageResponse extends Response
                 $assignments[] = $ppc;
             }
         }
-        $r = $db->Execute(
+        $r = $db->executeQuery(
             'select peID, cvb.cvID, cvb.bID, pdID, pkID from BlockPermissionAssignments bpa
                     inner join PermissionAccessList pal on bpa.paID = pal.paID inner join CollectionVersionBlocks cvb on cvb.cID = bpa.cID and cvb.cvID = bpa.cvID and cvb.bID = bpa.bID
                     where cvb.cID = ? and cvb.cvID = ? and cvb.cbOverrideAreaPermissions = 1',

--- a/concrete/src/Site/Locale/Listener.php
+++ b/concrete/src/Site/Locale/Listener.php
@@ -40,8 +40,8 @@ EOT
     private function fixMultilingualPageRelations(Connection $cn, $updateMultilingualRelation, array $pageIDs)
     {
         $pageIDsJoined = implode(',', $pageIDs);
-        $cn->query(str_replace(':cIDs:', $pageIDsJoined, $updateMultilingualRelation));
-        $childPageIDs = $cn->query('SELECT cID FROM Pages WHERE cParentID IN (' . $pageIDsJoined . ')')->fetchAll();
+        $cn->executeStatement(str_replace(':cIDs:', $pageIDsJoined, $updateMultilingualRelation));
+        $childPageIDs = $cn->executeQuery('SELECT cID FROM Pages WHERE cParentID IN (' . $pageIDsJoined . ')')->fetchAll();
         if (!empty($childPageIDs)) {
             $tempChildPageIDs = array();
             foreach ($childPageIDs as $oneChildPage) {

--- a/concrete/src/Tree/Node/Node.php
+++ b/concrete/src/Tree/Node/Node.php
@@ -106,7 +106,7 @@ abstract class Node extends ConcreteObject implements \Concrete\Core\Permission\
     public function setTreeNodeName($treeNodeName)
     {
         $db = app(Connection::class);
-        $db->executeQuery('update TreeNodes set treeNodeName = ? where treeNodeID = ?', [$treeNodeName, $this->treeNodeID]);
+        $db->executeStatement('update TreeNodes set treeNodeName = ? where treeNodeID = ?', [$treeNodeName, $this->treeNodeID]);
         $this->treeNodeName = $treeNodeName;
     }
 
@@ -361,8 +361,8 @@ abstract class Node extends ConcreteObject implements \Concrete\Core\Permission\
             $db = app(Connection::class);
             $parentNode = $this->getTreeNodeParentObject();
             if (is_object($parentNode)) {
-                $db->executeQuery('delete from TreeNodePermissionAssignments where treeNodeID = ?', [$this->treeNodeID]);
-                $db->executeQuery('update TreeNodes set treeNodeOverridePermissions = 0, inheritPermissionsFromTreeNodeID = ? where treeNodeID = ?', [$parentNode->getTreeNodePermissionsNodeID(), $this->treeNodeID]);
+                $db->executeStatement('delete from TreeNodePermissionAssignments where treeNodeID = ?', [$this->treeNodeID]);
+                $db->executeStatement('update TreeNodes set treeNodeOverridePermissions = 0, inheritPermissionsFromTreeNodeID = ? where treeNodeID = ?', [$parentNode->getTreeNodePermissionsNodeID(), $this->treeNodeID]);
                 $this->updateTreeNodePermissionsID([$this->getTreeNodeID()], $parentNode->getTreeNodePermissionsNodeID());
 
                 $this->treeNodeOverridePermissions = false;
@@ -381,7 +381,7 @@ abstract class Node extends ConcreteObject implements \Concrete\Core\Permission\
             $this->populateChildren();
             $childNodeIDs = $this->getAllChildNodeIDs();
 
-            $db->executeQuery('delete from TreeNodePermissionAssignments where treeNodeID = ?', [$this->treeNodeID]);
+            $db->executeStatement('delete from TreeNodePermissionAssignments where treeNodeID = ?', [$this->treeNodeID]);
             // copy permissions
             $permissions = Key::getList($this->getPermissionObjectKeyCategoryHandle());
             foreach ($permissions as $pk) {
@@ -389,7 +389,7 @@ abstract class Node extends ConcreteObject implements \Concrete\Core\Permission\
                 $pk->copyFromParentNodeToCurrentNode();
             }
 
-            $db->executeQuery('update TreeNodes set treeNodeOverridePermissions = 1, inheritPermissionsFromTreeNodeID = ? where treeNodeID = ?', [$this->treeNodeID, $this->treeNodeID]);
+            $db->executeStatement('update TreeNodes set treeNodeOverridePermissions = 1, inheritPermissionsFromTreeNodeID = ? where treeNodeID = ?', [$this->treeNodeID, $this->treeNodeID]);
 
             $this->updateTreeNodePermissionsID([$this->getTreeNodeID()], $this->treeNodeID);
 
@@ -455,7 +455,7 @@ abstract class Node extends ConcreteObject implements \Concrete\Core\Permission\
     public function setTreeNodeTreeID($treeID)
     {
         $db = app(Connection::class);
-        $db->executeQuery('update TreeNodes set treeID = ? where treeNodeID = ?', [$treeID, $this->treeNodeID]);
+        $db->executeStatement('update TreeNodes set treeID = ? where treeNodeID = ?', [$treeID, $this->treeNodeID]);
         $this->treeID = $treeID;
     }
 
@@ -502,12 +502,12 @@ abstract class Node extends ConcreteObject implements \Concrete\Core\Permission\
             $db = app(Connection::class);
             $existingDisplayOrder = $this->treeNodeDisplayOrder;
             $treeNodeDisplayOrder = (int) $db->fetchColumn('select count(treeNodeDisplayOrder) from TreeNodes where treeNodeParentID = ?', [$newParent->getTreeNodeID()]);
-            $db->executeQuery('update TreeNodes set treeNodeParentID = ?, treeNodeDisplayOrder = ? where treeNodeID = ?', [$newParent->getTreeNodeID(), $treeNodeDisplayOrder, $this->treeNodeID]);
+            $db->executeStatement('update TreeNodes set treeNodeParentID = ?, treeNodeDisplayOrder = ? where treeNodeID = ?', [$newParent->getTreeNodeID(), $treeNodeDisplayOrder, $this->treeNodeID]);
             if (!$this->overrideParentTreeNodePermissions()) {
                 $newParentPermissionsNodeID = $newParent->getTreeNodePermissionsNodeID();
                 if ($newParentPermissionsNodeID != $this->getTreeNodePermissionsNodeID()) {
                     // first we do this one
-                    $db->executeQuery('update TreeNodes set inheritPermissionsFromTreeNodeID = ? where treeNodeID = ?', [$newParentPermissionsNodeID, $this->treeNodeID]);
+                    $db->executeStatement('update TreeNodes set inheritPermissionsFromTreeNodeID = ? where treeNodeID = ?', [$newParentPermissionsNodeID, $this->treeNodeID]);
                     // Now let's do it recursively down the tree
                     $this->updateTreeNodePermissionsID([$this->treeNodeID], $newParentPermissionsNodeID);
                 }
@@ -517,7 +517,7 @@ abstract class Node extends ConcreteObject implements \Concrete\Core\Permission\
                 // Instead of just rescanning all the nodes (which could take a long time),
                 // let's just update all the nodes with display order above this one to be their current
                 // order - 1
-                $db->executeQuery(
+                $db->executeStatement(
                     'update TreeNodes set treeNodeDisplayOrder = (treeNodeDisplayOrder - 1) 
 where treeNodeDisplayOrder > ? and treeNodeParentID = ?',
                     [$existingDisplayOrder, $oldParent->getTreeNodeID()]
@@ -548,7 +548,7 @@ where treeNodeDisplayOrder > ? and treeNodeParentID = ?',
         if (is_array($orderedIDs)) {
             $displayOrder = 0;
             foreach ($orderedIDs as $treeNodeID) {
-                $db->executeQuery('update TreeNodes set treeNodeDisplayOrder = ? where treeNodeID = ?', [$displayOrder, $treeNodeID]);
+                $db->executeStatement('update TreeNodes set treeNodeDisplayOrder = ? where treeNodeID = ?', [$displayOrder, $treeNodeID]);
                 ++$displayOrder;
             }
         }
@@ -584,7 +584,7 @@ where treeNodeDisplayOrder > ? and treeNodeParentID = ?',
         $dateCreated = app('date')->toDB();
 
         $type = TreeNodeType::getByHandle($treeNodeTypeHandle);
-        $db->executeQuery(
+        $db->executeStatement(
             'insert into TreeNodes (treeNodeTypeID, treeNodeParentID, treeNodeDisplayOrder, inheritPermissionsFromTreeNodeID, dateModified, dateCreated, treeID) values (?, ?, ?, ?, ?, ?, ?)',
             [
                 $type->getTreeNodeTypeID(),
@@ -687,7 +687,7 @@ where treeNodeDisplayOrder > ? and treeNodeParentID = ?',
         while ($row = $r->fetch()) {
             $node = self::getByID($row['treeNodeID']);
             $parentNode = $node->getTreeNodeParentObject();
-            $db->executeQuery('update TreeNodes set inheritPermissionsFromTreeNodeID = ? where treeNodeID = ?', [$parentNode->getTreeNodePermissionsNodeID(), $node->getTreeNodeID()]);
+            $db->executeStatement('update TreeNodes set inheritPermissionsFromTreeNodeID = ? where treeNodeID = ?', [$parentNode->getTreeNodePermissionsNodeID(), $node->getTreeNodeID()]);
         }
         $r->closeCursor();
 
@@ -706,8 +706,8 @@ where treeNodeDisplayOrder > ? and treeNodeParentID = ?',
         }
 
         $this->deleteDetails();
-        $db->executeQuery('delete from TreeNodes where treeNodeID = ?', [$this->treeNodeID]);
-        $db->executeQuery('delete from TreeNodePermissionAssignments where treeNodeID = ?', [$this->treeNodeID]);
+        $db->executeStatement('delete from TreeNodes where treeNodeID = ?', [$this->treeNodeID]);
+        $db->executeStatement('delete from TreeNodePermissionAssignments where treeNodeID = ?', [$this->treeNodeID]);
     }
 
     /**
@@ -833,7 +833,7 @@ where treeNodeDisplayOrder > ? and treeNodeParentID = ?',
         $r = $db->executeQuery('select treeNodeID from TreeNodes WHERE treeNodeParentID = ? order by treeNodeDisplayOrder asc', [$this->getTreeNodeID()]);
         $displayOrder = 0;
         while ($row = $r->fetch()) {
-            $db->executeQuery('update TreeNodes set treeNodeDisplayOrder = ? where treeNodeID = ?', [$displayOrder, $row['treeNodeID']]);
+            $db->executeStatement('update TreeNodes set treeNodeDisplayOrder = ? where treeNodeID = ?', [$displayOrder, $row['treeNodeID']]);
             ++$displayOrder;
         }
         $r->closeCursor();

--- a/concrete/src/Tree/Node/NodeType.php
+++ b/concrete/src/Tree/Node/NodeType.php
@@ -39,7 +39,7 @@ class NodeType extends ConcreteObject
             $pkgID = $pkg->getPackageID();
         }
 
-        $r = $db->query("insert into TreeNodeTypes (treeNodeTypeHandle, pkgID) values (?, ?)", array(
+        $r = $db->executeStatement("insert into TreeNodeTypes (treeNodeTypeHandle, pkgID) values (?, ?)", array(
             $treeNodeTypeHandle, $pkgID,
         ));
 
@@ -51,7 +51,7 @@ class NodeType extends ConcreteObject
     public function delete()
     {
         $db = Database::connection();
-        $db->Execute('delete from TreeNodeTypes where treeNodeTypeID = ?', array($this->treeNodeTypeID));
+        $db->executeStatement('delete from TreeNodeTypes where treeNodeTypeID = ?', array($this->treeNodeTypeID));
     }
 
     public static function getByID($treeNodeTypeID)
@@ -107,7 +107,7 @@ class NodeType extends ConcreteObject
     {
         $db = Database::connection();
         $list = array();
-        $r = $db->Execute('select treeNodeTypeID from TreeNodeTypes where pkgID = ? order by treeNodeTypeID asc', array($pkg->getPackageID()));
+        $r = $db->executeQuery('select treeNodeTypeID from TreeNodeTypes where pkgID = ? order by treeNodeTypeID asc', array($pkg->getPackageID()));
         while ($row = $r->fetch()) {
             $list[] = TreeNodeType::getByID($row['treeNodeTypeID']);
         }
@@ -120,7 +120,7 @@ class NodeType extends ConcreteObject
     {
         $db = Database::connection();
         $list = array();
-        $r = $db->Execute('select treeNodeTypeID from TreeNodeTypes order by treeNodeTypeID asc');
+        $r = $db->executeQuery('select treeNodeTypeID from TreeNodeTypes order by treeNodeTypeID asc');
         while ($row = $r->fetch()) {
             $list[] = TreeNodeType::getByID($row['treeNodeTypeID']);
         }

--- a/concrete/src/Tree/Node/NodeType.php
+++ b/concrete/src/Tree/Node/NodeType.php
@@ -39,7 +39,7 @@ class NodeType extends ConcreteObject
             $pkgID = $pkg->getPackageID();
         }
 
-        $r = $db->executeStatement("insert into TreeNodeTypes (treeNodeTypeHandle, pkgID) values (?, ?)", array(
+        $db->executeStatement("insert into TreeNodeTypes (treeNodeTypeHandle, pkgID) values (?, ?)", array(
             $treeNodeTypeHandle, $pkgID,
         ));
 

--- a/concrete/src/Tree/Node/Type/File.php
+++ b/concrete/src/Tree/Node/Type/File.php
@@ -82,7 +82,7 @@ class File extends TreeNode
     public function deleteDetails()
     {
         $db = Loader::db();
-        $db->Execute('delete from TreeFileNodes where treeNodeID = ?', array($this->treeNodeID));
+        $db->executeStatement('delete from TreeFileNodes where treeNodeID = ?', array($this->treeNodeID));
     }
 
     public function getDateLastModified()

--- a/concrete/src/Tree/Node/Type/FileFolder.php
+++ b/concrete/src/Tree/Node/Type/FileFolder.php
@@ -133,10 +133,10 @@ class FileFolder extends TreeNode
     {
         $app = Application::getFacadeApplication();
         $db = $app->make(Connection::class);
-        $db->executeQuery('DELETE FROM TreeFileFolderNodes WHERE treeNodeID = ?', [
+        $db->executeStatement('DELETE FROM TreeFileFolderNodes WHERE treeNodeID = ?', [
             $this->treeNodeID,
         ]);
-        $db->executeQuery('DELETE FROM UserFavoriteFolders WHERE treeNodeFolderId = ?', [
+        $db->executeStatement('DELETE FROM UserFavoriteFolders WHERE treeNodeFolderId = ?', [
             $this->treeNodeID,
         ]);
     }

--- a/concrete/src/Tree/Node/Type/GroupFolder.php
+++ b/concrete/src/Tree/Node/Type/GroupFolder.php
@@ -71,7 +71,7 @@ class GroupFolder extends TreeNode
         /** @var Connection $db */
         $db = $app->make(Connection::class);
 
-        $db->executeQuery('DELETE FROM TreeGroupFolderNodeSelectedGroupTypes WHERE treeNodeID = ?', [
+        $db->executeStatement('DELETE FROM TreeGroupFolderNodeSelectedGroupTypes WHERE treeNodeID = ?', [
             $this->treeNodeID,
         ]);
 
@@ -151,10 +151,10 @@ class GroupFolder extends TreeNode
     {
         $app = Application::getFacadeApplication();
         $db = $app->make(Connection::class);
-        $db->executeQuery('DELETE FROM TreeGroupFolderNodes WHERE treeNodeID = ?', [
+        $db->executeStatement('DELETE FROM TreeGroupFolderNodes WHERE treeNodeID = ?', [
             $this->treeNodeID,
         ]);
-        $db->executeQuery('DELETE FROM TreeGroupFolderNodeSelectedGroupTypes WHERE treeNodeID = ?', [
+        $db->executeStatement('DELETE FROM TreeGroupFolderNodeSelectedGroupTypes WHERE treeNodeID = ?', [
             $this->treeNodeID,
         ]);
     }

--- a/concrete/src/Tree/Node/Type/SearchPreset.php
+++ b/concrete/src/Tree/Node/Type/SearchPreset.php
@@ -70,7 +70,7 @@ class SearchPreset extends Node
     public function deleteDetails()
     {
         $db = Loader::db();
-        $db->Execute('delete from TreeSearchQueryNodes where treeNodeID = ?', array($this->treeNodeID));
+        $db->executeStatement('delete from TreeSearchQueryNodes where treeNodeID = ?', array($this->treeNodeID));
         $search = $this->getSavedSearchObject();
         if (is_object($search)) {
             $em = \Database::connection()->getEntityManager();

--- a/concrete/src/Tree/Tree.php
+++ b/concrete/src/Tree/Tree.php
@@ -182,7 +182,7 @@ abstract class Tree extends ConcreteObject
             $node->delete();
         }
         $this->deleteDetails();
-        $db->executeQuery('delete from Trees where treeID = ?', [$this->treeID]);
+        $db->executeStatement('delete from Trees where treeID = ?', [$this->treeID]);
     }
 
     public function duplicate()
@@ -195,7 +195,7 @@ abstract class Tree extends ConcreteObject
         $db = $app->make('database')->connection();
         $nodes = $newRoot->getAllChildNodeIDs();
         foreach ($nodes as $nodeID) {
-            $db->executeQuery('update TreeNodes set treeID = ? where treeNodeID = ?', [$tree->getTreeID(), $nodeID]);
+            $db->executeStatement('update TreeNodes set treeID = ? where treeNodeID = ?', [$tree->getTreeID(), $nodeID]);
         }
 
         return $tree;
@@ -225,7 +225,7 @@ abstract class Tree extends ConcreteObject
         $date = $app->make('date')->getOverridableNow();
         $treeTypeHandle = uncamelcase(strrchr(get_called_class(), '\\'));
         $type = TreeType::getByHandle($treeTypeHandle);
-        $db->executeQuery(
+        $db->executeStatement(
             'insert into Trees (treeDateAdded, rootTreeNodeID, treeTypeID) values (?, ?, ?)',
             [$date, $rootNode->getTreeNodeID(), $type->getTreeTypeID()]
         );

--- a/concrete/src/Tree/TreeType.php
+++ b/concrete/src/Tree/TreeType.php
@@ -36,7 +36,7 @@ class TreeType extends ConcreteObject
             $pkgID = $pkg->getPackageID();
         }
 
-        $r = $db->executeStatement("insert into TreeTypes (treeTypeHandle, pkgID) values (?, ?)", array(
+        $db->executeStatement("insert into TreeTypes (treeTypeHandle, pkgID) values (?, ?)", array(
             $treeTypeHandle, $pkgID,
         ));
 

--- a/concrete/src/Tree/TreeType.php
+++ b/concrete/src/Tree/TreeType.php
@@ -36,7 +36,7 @@ class TreeType extends ConcreteObject
             $pkgID = $pkg->getPackageID();
         }
 
-        $r = $db->query("insert into TreeTypes (treeTypeHandle, pkgID) values (?, ?)", array(
+        $r = $db->executeStatement("insert into TreeTypes (treeTypeHandle, pkgID) values (?, ?)", array(
             $treeTypeHandle, $pkgID,
         ));
 
@@ -48,7 +48,7 @@ class TreeType extends ConcreteObject
     public function delete()
     {
         $db = Database::connection();
-        $db->Execute('delete from TreeTypes where treeTypeID = ?', array($this->treeTypeID));
+        $db->executeStatement('delete from TreeTypes where treeTypeID = ?', array($this->treeTypeID));
     }
 
     public static function getByID($treeTypeID)
@@ -87,7 +87,7 @@ class TreeType extends ConcreteObject
     {
         $db = Database::connection();
         $list = array();
-        $r = $db->Execute('select treeTypeID from TreeTypes where pkgID = ? order by treeTypeID asc', array($pkg->getPackageID()));
+        $r = $db->executeQuery('select treeTypeID from TreeTypes where pkgID = ? order by treeTypeID asc', array($pkg->getPackageID()));
         while ($row = $r->fetch()) {
             $list[] = self::getByID($row['treeTypeID']);
         }
@@ -101,7 +101,7 @@ class TreeType extends ConcreteObject
     {
         $db = Database::connection();
         $list = array();
-        $r = $db->Execute('select treeTypeID from TreeTypes order by treeTypeID asc');
+        $r = $db->executeQuery('select treeTypeID from TreeTypes order by treeTypeID asc');
         while ($row = $r->fetch()) {
             $list[] = self::getByID($row['treeTypeID']);
         }

--- a/concrete/src/Tree/Type/Topic.php
+++ b/concrete/src/Tree/Type/Topic.php
@@ -48,7 +48,7 @@ class Topic extends Tree
     protected function deleteDetails()
     {
         $db = Database::connection();
-        $db->Execute('delete from TopicTrees where treeID = ?', array($this->treeID));
+        $db->executeStatement('delete from TopicTrees where treeID = ?', array($this->treeID));
     }
 
     public static function getByName($name)

--- a/concrete/src/Updater/Migrations/AbstractMigration.php
+++ b/concrete/src/Updater/Migrations/AbstractMigration.php
@@ -155,7 +155,7 @@ abstract class AbstractMigration extends DoctrineAbstractMigration
         $sqlField = $platform->quoteSingleIdentifier($field);
         $sqlLinkedTable = $platform->quoteSingleIdentifier($linkedTable);
         $sqlLinkedField = $platform->quoteSingleIdentifier($linkedField);
-        $this->connection->executeQuery("
+        $this->connection->executeStatement("
             update {$sqlTable}
             left join {$sqlLinkedTable} on {$sqlTable}.{$sqlField} = {$sqlLinkedTable}.{$sqlLinkedField}
             set {$sqlTable}.{$sqlField} = null
@@ -178,7 +178,7 @@ abstract class AbstractMigration extends DoctrineAbstractMigration
         $sqlField = $platform->quoteSingleIdentifier($field);
         $sqlLinkedTable = $platform->quoteSingleIdentifier($linkedTable);
         $sqlLinkedField = $platform->quoteSingleIdentifier($linkedField);
-        $this->connection->executeQuery("
+        $this->connection->executeStatement("
             delete {$sqlTable}
             from {$sqlTable}
             left join {$sqlLinkedTable} on {$sqlTable}.{$sqlField} = {$sqlLinkedTable}.{$sqlLinkedField}

--- a/concrete/src/Updater/Migrations/Migrations/Version20141113000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20141113000000.php
@@ -45,18 +45,18 @@ class Version20141113000000 extends AbstractMigration implements RepeatableMigra
         $sm = $db->getSchemaManager();
         $schemaTables = $sm->listTableNames();
         if (in_array('signuprequests', $schemaTables)) {
-            $db->query('alter table signuprequests rename SignupRequestsTmp');
-            $db->query('alter table SignupRequestsTmp rename SignupRequests');
+            $db->executeStatement('alter table signuprequests rename SignupRequestsTmp');
+            $db->executeStatement('alter table SignupRequestsTmp rename SignupRequests');
         }
         if (in_array('userbannedips', $schemaTables)) {
-            $db->query('alter table userbannedips rename UserBannedIPsTmp');
-            $db->query('alter table UserBannedIPsTmp rename UserBannedIPs');
+            $db->executeStatement('alter table userbannedips rename UserBannedIPsTmp');
+            $db->executeStatement('alter table UserBannedIPsTmp rename UserBannedIPs');
         }
 
         // Clean up File stupidity
-        $r = $db->Execute('select Files.fID from Files left join FileVersions on (Files.fID = FileVersions.fID) where FileVersions.fID is null');
+        $r = $db->executeQuery('select Files.fID from Files left join FileVersions on (Files.fID = FileVersions.fID) where FileVersions.fID is null');
         while ($row = $r->fetch()) {
-            $db->Execute('delete from Files where fID = ?', [$row['fID']]);
+            $db->executeStatement('delete from Files where fID = ?', [$row['fID']]);
         }
     }
 }

--- a/concrete/src/Updater/Migrations/Migrations/Version20141219000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20141219000000.php
@@ -113,7 +113,7 @@ class Version20141219000000 extends AbstractMigration implements RepeatableMigra
             $ptk = PermissionKey::add('page', 'edit_page_page_type', 'Edit Page Type', 'Change the type of an existing page.', false, false);
         }
         $db = \Database::get();
-        $r = $db->Execute('select cID from Pages where cInheritPermissionsFrom = "OVERRIDE" order by cID asc');
+        $r = $db->executeQuery('select cID from Pages where cInheritPermissionsFrom = "OVERRIDE" order by cID asc');
         while ($row = $r->fetch()) {
             $c = Page::getByID($row['cID']);
             if (is_object($c) && !$c->isError()) {

--- a/concrete/src/Updater/Migrations/Migrations/Version20150504000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20150504000000.php
@@ -119,7 +119,7 @@ class Version20150504000000 extends AbstractMigration implements RepeatableMigra
         }
 
         $db = \Database::get();
-        $db->Execute('DROP TABLE IF EXISTS PageStatistics');
+        $db->executeStatement('DROP TABLE IF EXISTS PageStatistics');
 
         $this->refreshBlockType('page_list');
 
@@ -142,7 +142,7 @@ class Version20150504000000 extends AbstractMigration implements RepeatableMigra
         $pkx->associateAccessEntityType(Type::getByHandle('user'));
         $pkx->associateAccessEntityType(Type::getByHandle('group_combination'));
 
-        $db->Execute('alter table QueueMessages modify column body longtext not null');
+        $db->executeStatement('alter table QueueMessages modify column body longtext not null');
 
         $this->updatePermissionDurationObjects();
 
@@ -155,7 +155,7 @@ class Version20150504000000 extends AbstractMigration implements RepeatableMigra
 
         $db = \Database::get();
         if ($this->updateSectionPlurals) {
-            $rs = $db->Execute('select cID, msLanguage, msCountry from MultilingualSections');
+            $rs = $db->executeQuery('select cID, msLanguage, msCountry from MultilingualSections');
             while ($row = $rs->fetch()) {
                 $locale = $row['msLanguage'];
                 if ($row['msCountry']) {
@@ -180,14 +180,14 @@ class Version20150504000000 extends AbstractMigration implements RepeatableMigra
             }
         }
         if ($this->updateMultilingualTranslations) {
-            $db->Execute("UPDATE MultilingualTranslations SET comments = REPLACE(comments, ':', '\\n') WHERE comments IS NOT NULL");
+            $db->executeStatement("UPDATE MultilingualTranslations SET comments = REPLACE(comments, ':', '\\n') WHERE comments IS NOT NULL");
         }
     }
 
     protected function updatePermissionDurationObjects()
     {
         $db = \Database::get();
-        $r = $db->Execute('select pdID from PermissionDurationObjects order by pdID asc');
+        $r = $db->executeQuery('select pdID from PermissionDurationObjects order by pdID asc');
         while ($row = $r->fetch()) {
             $pd = Duration::getByID($row['pdID']);
             if (isset($pd->error)) {

--- a/concrete/src/Updater/Migrations/Migrations/Version20150713000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20150713000000.php
@@ -25,6 +25,6 @@ class Version20150713000000 extends AbstractMigration implements RepeatableMigra
     public function upgradeDatabase()
     {
         $db = \Database::connection();
-        $db->Execute("update UserPointActions set upaHasCustomClass = 1 where upaHandle = 'won_badge'");
+        $db->executeStatement("update UserPointActions set upaHasCustomClass = 1 where upaHandle = 'won_badge'");
     }
 }

--- a/concrete/src/Updater/Migrations/Migrations/Version20150731000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20150731000000.php
@@ -41,10 +41,10 @@ class Version20150731000000 extends AbstractMigration implements RepeatableMigra
     public function upgradeDatabase()
     {
         $db = \Database::connection();
-        $db->executeQuery('DELETE FROM FileSetFiles WHERE fID NOT IN (SELECT fID FROM Files)');
-        $db->executeQuery('DELETE FROM FileSearchIndexAttributes WHERE fID NOT IN (SELECT fID FROM Files)');
-        $db->executeQuery('DELETE FROM DownloadStatistics WHERE fID NOT IN (SELECT fID FROM Files)');
-        $db->executeQuery('DELETE FROM FilePermissionAssignments WHERE fID NOT IN (SELECT fID FROM Files)');
+        $db->executeStatement('DELETE FROM FileSetFiles WHERE fID NOT IN (SELECT fID FROM Files)');
+        $db->executeStatement('DELETE FROM FileSearchIndexAttributes WHERE fID NOT IN (SELECT fID FROM Files)');
+        $db->executeStatement('DELETE FROM DownloadStatistics WHERE fID NOT IN (SELECT fID FROM Files)');
+        $db->executeStatement('DELETE FROM FilePermissionAssignments WHERE fID NOT IN (SELECT fID FROM Files)');
 
         $this->refreshBlockType('page_list');
     }

--- a/concrete/src/Updater/Migrations/Migrations/Version20160725000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20160725000000.php
@@ -175,59 +175,59 @@ class Version20160725000000 extends AbstractMigration implements LongRunningMigr
     {
         $this->output(t('Renaming problematic tables...'));
         if (!$this->connection->tableExists('_AttributeKeys')) {
-            $this->connection->Execute('alter table AttributeKeys rename _AttributeKeys');
+            $this->connection->executeStatement('alter table AttributeKeys rename _AttributeKeys');
         }
         if (!$this->connection->tableExists('_AttributeValues')) {
-            $this->connection->Execute('alter table AttributeValues rename _AttributeValues');
+            $this->connection->executeStatement('alter table AttributeValues rename _AttributeValues');
         }
         if (!$this->connection->tableExists('_atAddressSettings')) {
-            $this->connection->Execute('alter table atAddressSettings rename _atAddressSettings');
-            $this->connection->Execute('alter table _atAddressSettings drop primary key, add primary key (akID)');
+            $this->connection->executeStatement('alter table atAddressSettings rename _atAddressSettings');
+            $this->connection->executeStatement('alter table _atAddressSettings drop primary key, add primary key (akID)');
         }
         if (!$this->connection->tableExists('_atAddressCustomCountries')) {
-            $this->connection->Execute('alter table atAddressCustomCountries rename _atAddressCustomCountries');
+            $this->connection->executeStatement('alter table atAddressCustomCountries rename _atAddressCustomCountries');
         }
         if (!$this->connection->tableExists('_atSelectSettings')) {
-            $this->connection->Execute('alter table atSelectSettings rename _atSelectSettings');
-            $this->connection->Execute('alter table _atSelectSettings drop primary key, add primary key (akID)');
+            $this->connection->executeStatement('alter table atSelectSettings rename _atSelectSettings');
+            $this->connection->executeStatement('alter table _atSelectSettings drop primary key, add primary key (akID)');
         }
         if (!$this->connection->tableExists('_atSelectOptions')) {
-            $this->connection->Execute('alter table atSelectOptions rename _atSelectOptions');
+            $this->connection->executeStatement('alter table atSelectOptions rename _atSelectOptions');
         }
         if (!$this->connection->tableExists('_atSocialLinks')) {
-            $this->connection->Execute('alter table atSocialLinks rename _atSocialLinks');
+            $this->connection->executeStatement('alter table atSocialLinks rename _atSocialLinks');
         }
         if (!$this->connection->tableExists('_atSelectOptionsSelected')) {
-            $this->connection->Execute('alter table atSelectOptionsSelected rename _atSelectOptionsSelected');
+            $this->connection->executeStatement('alter table atSelectOptionsSelected rename _atSelectOptionsSelected');
         }
         if (!$this->connection->tableExists('_atSelectedTopics')) {
-            $this->connection->Execute('alter table atSelectedTopics rename _atSelectedTopics');
+            $this->connection->executeStatement('alter table atSelectedTopics rename _atSelectedTopics');
         }
         if (!$this->connection->tableExists('_TreeTopicNodes')) {
-            $this->connection->Execute('alter table TreeTopicNodes rename _TreeTopicNodes');
+            $this->connection->executeStatement('alter table TreeTopicNodes rename _TreeTopicNodes');
         }
     }
 
     protected function migrateOldPermissions()
     {
         $this->output(t('Migrating old permissions...'));
-        $this->connection->Execute('update PermissionKeys set pkHandle = ? where pkHandle = ?', [
+        $this->connection->executeStatement('update PermissionKeys set pkHandle = ? where pkHandle = ?', [
             'view_category_tree_node', 'view_topic_category_tree_node',
         ]);
-        $this->connection->Execute('update PermissionKeyCategories set pkCategoryHandle = ? where pkCategoryHandle = ?', [
+        $this->connection->executeStatement('update PermissionKeyCategories set pkCategoryHandle = ? where pkCategoryHandle = ?', [
             'category_tree_node', 'topic_category_tree_node',
         ]);
         $folderCategoryID = $this->connection->fetchColumn('select pkCategoryID from PermissionKeyCategories where pkCategoryHandle = ?', ['file_folder']);
         if (!$folderCategoryID) {
-            $this->connection->Execute('update PermissionKeys set pkHandle = ? where pkHandle = ?', [
+            $this->connection->executeStatement('update PermissionKeys set pkHandle = ? where pkHandle = ?', [
                 '_add_file', 'add_file',
             ]);
         }
         if (!$this->connection->tableExists('FilePermissionFileTypeAccessList') && $this->connection->tableExists('FileSetPermissionFileTypeAccessList')) {
-            $this->connection->Execute('alter table FileSetPermissionFileTypeAccessList rename FilePermissionFileTypeAccessList ');
+            $this->connection->executeStatement('alter table FileSetPermissionFileTypeAccessList rename FilePermissionFileTypeAccessList ');
         }
         if (!$this->connection->tableExists('FilePermissionFileTypeAccessListCustom') && $this->connection->tableExists('FileSetPermissionFileTypeAccessListCustom')) {
-            $this->connection->Execute('alter table FileSetPermissionFileTypeAccessListCustom  rename FilePermissionFileTypeAccessListCustom');
+            $this->connection->executeStatement('alter table FileSetPermissionFileTypeAccessListCustom  rename FilePermissionFileTypeAccessListCustom');
         }
     }
 
@@ -281,7 +281,7 @@ class Version20160725000000 extends AbstractMigration implements LongRunningMigr
         ]);
         if (!$count) {
             $folder->setTreeNodePermissionsToOverride();
-            $this->connection->executeQuery('delete from TreeNodePermissionAssignments where treeNodeID = ?', [
+            $this->connection->executeStatement('delete from TreeNodePermissionAssignments where treeNodeID = ?', [
                 $folder->getTreeNodeID(),
             ]);
 
@@ -289,7 +289,7 @@ class Version20160725000000 extends AbstractMigration implements LongRunningMigr
                 $mapped = isset($permissionsMap[$row['pkHandle']]) ? $permissionsMap[$row['pkHandle']] : $row['pkHandle'];
                 $newPKID = $this->connection->fetchColumn('select pkID from PermissionKeys where pkHandle = ?', [$mapped]);
                 $v = [$folder->getTreeNodeID(), $newPKID, $row['paID']];
-                $this->connection->executeQuery(
+                $this->connection->executeStatement(
                     'insert into TreeNodePermissionAssignments (treeNodeID, pkID, paID) values (?, ?, ?)', $v
                 );
             }
@@ -332,7 +332,7 @@ class Version20160725000000 extends AbstractMigration implements LongRunningMigr
     {
         $this->output(t('Preparing problematic entity database tables...'));
         // Remove the weird primary keys from the Files table
-        $this->connection->executeQuery('alter table Files drop primary key, add primary key (fID)');
+        $this->connection->executeStatement('alter table Files drop primary key, add primary key (fID)');
     }
 
     protected function installOtherEntities()
@@ -817,13 +817,13 @@ class Version20160725000000 extends AbstractMigration implements LongRunningMigr
     protected function addTreeNodeTypes()
     {
         $this->output(t('Adding tree node types...'));
-        $this->connection->Execute('update TreeNodeTypes set treeNodeTypeHandle = ? where treeNodeTypeHandle = ?', [
+        $this->connection->executeStatement('update TreeNodeTypes set treeNodeTypeHandle = ? where treeNodeTypeHandle = ?', [
             'category', 'topic_category',
         ]);
-        $this->connection->Execute('update PermissionKeys set pkHandle = ? where pkHandle = ?', [
+        $this->connection->executeStatement('update PermissionKeys set pkHandle = ? where pkHandle = ?', [
             'view_category_tree_node', 'view_topic_category_tree_node',
         ]);
-        $this->connection->Execute('update PermissionKeyCategories set pkCategoryHandle = ? where pkCategoryHandle = ?', [
+        $this->connection->executeStatement('update PermissionKeyCategories set pkCategoryHandle = ? where pkCategoryHandle = ?', [
             'category_tree_node', 'topic_category_tree_node',
         ]);
         $results = NodeType::getByHandle('express_entry_results');
@@ -966,8 +966,8 @@ class Version20160725000000 extends AbstractMigration implements LongRunningMigr
         }
 
         $site = $service->getDefault();
-        $this->connection->executeQuery('update Pages set siteTreeID = ? where cIsSystemPage = 0', [$site->getSiteTreeID()]);
-        $this->connection->executeQuery('update PageTypes set siteTypeID = ? where ptIsInternal = 0', [$type->getSiteTypeID()]);
+        $this->connection->executeStatement('update Pages set siteTreeID = ? where cIsSystemPage = 0', [$site->getSiteTreeID()]);
+        $this->connection->executeStatement('update PageTypes set siteTypeID = ? where ptIsInternal = 0', [$type->getSiteTypeID()]);
         // migrate social links
         $links = $em->getRepository('Concrete\Core\Entity\Sharing\SocialNetwork\Link')
             ->findAll();
@@ -1089,7 +1089,7 @@ class Version20160725000000 extends AbstractMigration implements LongRunningMigr
     protected function cleanupOldPermissions()
     {
         $this->output(t('Cleaning old permissions...'));
-        $this->connection->Execute('delete from PermissionKeys where pkHandle = ?', ['_add_file']);
+        $this->connection->executeStatement('delete from PermissionKeys where pkHandle = ?', ['_add_file']);
     }
 
     protected function updateTopics()
@@ -1097,7 +1097,7 @@ class Version20160725000000 extends AbstractMigration implements LongRunningMigr
         $this->output(t('Updating topics...'));
         $r = $this->connection->executeQuery('select * from _TreeTopicNodes');
         while ($row = $r->fetch()) {
-            $this->connection->executeQuery(
+            $this->connection->executeStatement(
                 'update TreeNodes set treeNodeName = ? where treeNodeID = ? and treeNodeName = \'\'', [
                     $row['treeNodeTopicName'], $row['treeNodeID'], ]
             );
@@ -1154,7 +1154,7 @@ class Version20160725000000 extends AbstractMigration implements LongRunningMigr
             ['/page_not_found.php', $siteTreeID, 0],
         ];
         foreach ($pages as $record) {
-            $this->connection->executeQuery('update Pages set siteTreeID = ?, cParentID = ? where cFilename = ?', [$record[1], $record[2], $record[0]]);
+            $this->connection->executeStatement('update Pages set siteTreeID = ?, cParentID = ? where cFilename = ?', [$record[1], $record[2], $record[0]]);
         }
 
         // Delete members page if profiles not enabled
@@ -1208,7 +1208,7 @@ class Version20160725000000 extends AbstractMigration implements LongRunningMigr
         if (!$sectionsIncludeHome && $redirectToDefaultLocale) {
             // Move the home page outside site trees.
             $this->output(t('Moving home page to outside of site trees...'));
-            $this->connection->executeQuery('update Pages set siteTreeID = 0 where cID = ' . $homeCID);
+            $this->connection->executeStatement('update Pages set siteTreeID = 0 where cID = ' . $homeCID);
         }
 
         foreach ($sections as $section) {
@@ -1240,13 +1240,13 @@ class Version20160725000000 extends AbstractMigration implements LongRunningMigr
                     $tree->setSiteHomePageID($section['cID']);
                     $em->persist($tree);
                     $em->flush();
-                    $this->connection->executeQuery('update Pages set cParentID = 0, siteTreeID = ? where cID = ?', [
+                    $this->connection->executeStatement('update Pages set cParentID = 0, siteTreeID = ? where cID = ?', [
                         $tree->getSiteTreeID(), $section['cID'],
                     ]);
                     // Now we set all pages in this site tree to the new site tree ID.
                     $children = $sectionPage->getCollectionChildrenArray();
                     foreach ($children as $cID) {
-                        $this->connection->executeQuery('update Pages set siteTreeID = ? where cID = ?', [
+                        $this->connection->executeStatement('update Pages set siteTreeID = ? where cID = ?', [
                             $tree->getSiteTreeID(), $cID,
                         ]);
                     }
@@ -1261,7 +1261,7 @@ class Version20160725000000 extends AbstractMigration implements LongRunningMigr
     protected function fixStacks()
     {
         $this->output(t('Updating Stacks and Global Areas...'));
-        $this->connection->executeQuery('update Pages inner join Stacks on Pages.cID = Stacks.cID set Pages.siteTreeID = 0');
+        $this->connection->executeStatement('update Pages inner join Stacks on Pages.cID = Stacks.cID set Pages.siteTreeID = 0');
         $app = Application::getFacadeApplication();
         $site = \Site::getSite();
         if ((int) $this->connection->fetchColumn('select count(*) from SiteLocales where siteID = ?', [$site->getSiteID()]) > 1) {
@@ -1298,14 +1298,14 @@ class Version20160725000000 extends AbstractMigration implements LongRunningMigr
             }
         } else {
             // Consider all the stacks and global areas as "neutral version"
-            $this->connection->executeQuery('update Stacks set stMultilingualSection = 0');
+            $this->connection->executeStatement('update Stacks set stMultilingualSection = 0');
         }
     }
 
     protected function fixMultilingualPageRelations()
     {
         // Delete records in MultilingualPageRelations with invalid locales
-        $this->connection->query(<<<'EOT'
+        $this->connection->executeStatement(<<<'EOT'
 DELETE MultilingualPageRelations
 FROM MultilingualPageRelations
 LEFT JOIN MultilingualSections ON (
@@ -1317,13 +1317,13 @@ WHERE MultilingualSections.cID IS NULL
 EOT
         );
         // Set the mpLanguage field where it's missing
-        $this->connection->query(<<<'EOT'
+        $this->connection->executeStatement(<<<'EOT'
 UPDATE MultilingualPageRelations
 SET mpLanguage = mpLocale
 WHERE mpLanguage = '' AND LOCATE('_', mpLocale) = 0
 EOT
         );
-        $this->connection->query(<<<'EOT'
+        $this->connection->executeStatement(<<<'EOT'
 UPDATE MultilingualPageRelations
 SET mpLanguage = LEFT(mpLocale, LOCATE('_', mpLocale) - 1)
 WHERE mpLanguage = '' AND LOCATE('_', mpLocale) > 1
@@ -1331,7 +1331,7 @@ EOT
         );
         // Determine the map between locale and cID
         $locales = [];
-        $rs = $this->connection->query('SELECT cID, msLanguage, msCountry FROM MultilingualSections');
+        $rs = $this->connection->executeQuery('SELECT cID, msLanguage, msCountry FROM MultilingualSections');
         while (false !== ($row = $rs->fetch())) {
             $locales[$row['msLanguage'] . '_' . $row['msCountry']] = (int) $row['cID'];
             if ((string) $row['msLanguage'] === '') {
@@ -1339,7 +1339,7 @@ EOT
             }
         }
         // Delete duplicated relations p
-        $rs = $this->connection->query(<<<'EOT'
+        $rs = $this->connection->executeQuery(<<<'EOT'
 SELECT
     mpRelationID, cID, GROUP_CONCAT(mpLocale SEPARATOR '|') as mpLocales
 FROM
@@ -1367,7 +1367,7 @@ EOT
                     $delete = !in_array($locales[$locale], $trail, true);
                 }
                 if ($delete) {
-                    $this->connection->executeQuery('DELETE FROM MultilingualPageRelations WHERE mpRelationID = ? AND cID = ? AND mpLocale = ?', [$row['mpRelationID'], $cID, $locale]);
+                    $this->connection->executeStatement('DELETE FROM MultilingualPageRelations WHERE mpRelationID = ? AND cID = ? AND mpLocale = ?', [$row['mpRelationID'], $cID, $locale]);
                 }
             }
         }

--- a/concrete/src/Updater/Migrations/Migrations/Version20161203000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20161203000000.php
@@ -43,7 +43,7 @@ class Version20161203000000 extends AbstractMigration implements RepeatableMigra
                 'select treeNodeID from TreeFileNodes where fID = ?', [$row['fID']]
             );
             if ($properFolderID) {
-                $this->connection->executeQuery(
+                $this->connection->executeStatement(
                     'update Files set folderTreeNodeID = ? where fID = ?', [$properFolderID, $row['fID']]
                 );
             }
@@ -53,7 +53,7 @@ class Version20161203000000 extends AbstractMigration implements RepeatableMigra
     protected function fixWorkflows()
     {
         $this->output(t('Updating permission keys to trigger workflows'));
-        $this->connection->executeQuery(
+        $this->connection->executeStatement(
             "update PermissionKeys set pkCanTriggerWorkflow = 1 where pkHandle in ('delete_user', 'activate_user')"
         );
     }

--- a/concrete/src/Updater/Migrations/Migrations/Version20161208000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20161208000000.php
@@ -52,6 +52,6 @@ class Version20161208000000 extends AbstractMigration implements RepeatableMigra
     protected function updateEmptyFileAttributes()
     {
         $this->output(t('Updating old empty file attributes.'));
-        $this->connection->executeQuery('update atFile set fID = null where fID = 0');
+        $this->connection->executeStatement('update atFile set fID = null where fID = 0');
     }
 }

--- a/concrete/src/Updater/Migrations/Migrations/Version20161216100000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20161216100000.php
@@ -49,7 +49,7 @@ class Version20161216100000 extends AbstractMigration implements RepeatableMigra
         while ($row = $r->fetch()) {
             $control = FormLayoutSetControl::getByID($row['ptComposerFormLayoutSetControlID']);
             $object = $control->getPageTypeComposerControlObject();
-            $this->connection->executeQuery('update PageTypeComposerFormLayoutSetControls set ptComposerControlObject = ? where ptComposerFormLayoutSetControlID = ?', [serialize($object), $row['ptComposerFormLayoutSetControlID']]);
+            $this->connection->executeStatement('update PageTypeComposerFormLayoutSetControls set ptComposerControlObject = ? where ptComposerFormLayoutSetControlID = ?', [serialize($object), $row['ptComposerFormLayoutSetControlID']]);
         }
     }
 }

--- a/concrete/src/Updater/Migrations/Migrations/Version20170313000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170313000000.php
@@ -15,7 +15,7 @@ class Version20170313000000 extends AbstractMigration implements RepeatableMigra
     public function upgradeDatabase()
     {
         // Move all stacks to the root. Putting them in a site was a mistake.
-        $this->connection->executeQuery('
+        $this->connection->executeStatement('
             update Pages
             left join PageTypes on Pages.ptID = PageTypes.ptID
             set Pages.siteTreeID = 0

--- a/concrete/src/Updater/Migrations/Migrations/Version20170407000001.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170407000001.php
@@ -14,11 +14,11 @@ class Version20170407000001 extends AbstractMigration implements RepeatableMigra
      */
     public function upgradeDatabase()
     {
-        $this->connection->executeQuery('set foreign_key_checks = 0');
+        $this->connection->executeStatement('set foreign_key_checks = 0');
         $this->refreshEntities([
             'Concrete\Core\Entity\File\File',
             'Concrete\Core\Entity\User\User',
         ]);
-        $this->connection->executeQuery('set foreign_key_checks = 1');
+        $this->connection->executeStatement('set foreign_key_checks = 1');
     }
 }

--- a/concrete/src/Updater/Migrations/Migrations/Version20170412000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170412000000.php
@@ -15,7 +15,7 @@ class Version20170412000000 extends AbstractMigration implements RepeatableMigra
      */
     public function upgradeDatabase()
     {
-        $this->connection->Execute('set foreign_key_checks = 0');
+        $this->connection->executeStatement('set foreign_key_checks = 0');
         $this->refreshEntities([
             'Concrete\Core\Entity\Attribute\Value\Value\AbstractValue',
             'Concrete\Core\Entity\Attribute\Value\Value\AddressValue',
@@ -32,6 +32,6 @@ class Version20170412000000 extends AbstractMigration implements RepeatableMigra
             'Concrete\Core\Entity\File\File',
             'Concrete\Core\Entity\Attribute\Key\Key',
         ]);
-        $this->connection->Execute('set foreign_key_checks = 1');
+        $this->connection->executeStatement('set foreign_key_checks = 1');
     }
 }

--- a/concrete/src/Updater/Migrations/Migrations/Version20170609100000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170609100000.php
@@ -18,8 +18,8 @@ class Version20170609100000 extends AbstractMigration implements RepeatableMigra
             'FailedLoginAttempts',
             'LoginControlIpRanges',
         ]);
-        $this->connection->executeQuery('DROP TABLE IF EXISTS SignupRequests');
-        $this->connection->executeQuery('DROP TABLE IF EXISTS UserBannedIPs');
+        $this->connection->executeStatement('DROP TABLE IF EXISTS SignupRequests');
+        $this->connection->executeStatement('DROP TABLE IF EXISTS UserBannedIPs');
 
         // Add the new dashboard page to show IP ranges
         $this->createSinglePage('/dashboard/system/permissions/blacklist/range', 'IP Range', ['exclude_nav' => true]);

--- a/concrete/src/Updater/Migrations/Migrations/Version20170613000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170613000000.php
@@ -19,7 +19,7 @@ class Version20170613000000 extends AbstractMigration implements RepeatableMigra
         $filesystem = new Filesystem();
         $folder = $filesystem->getRootFolder();
         if ($folder) {
-            $this->connection->executeQuery(
+            $this->connection->executeStatement(
                 'update btExpressForm set addFilesToFolder = ? where addFilesToFolder IS NULL or addFilesToFolder = 0', [$folder->getTreeNodeID()]
             );
         }

--- a/concrete/src/Updater/Migrations/Migrations/Version20170802000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170802000000.php
@@ -45,7 +45,7 @@ class Version20170802000000 extends AbstractMigration implements RepeatableMigra
         }
 
         foreach ($delete as $deleteRow) {
-            $this->connection->executeQuery('delete from btExpressEntryDetail where bID = ? and exEntityID = ? and exSpecificEntryID = ? and exFormID = ?', $deleteRow);
+            $this->connection->executeStatement('delete from btExpressEntryDetail where bID = ? and exEntityID = ? and exSpecificEntryID = ? and exFormID = ?', $deleteRow);
         }
 
         // Now that we have removed problematic duplicate rows, rescan the table and remove the primary keys.

--- a/concrete/src/Updater/Migrations/Migrations/Version20170926000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20170926000000.php
@@ -15,14 +15,14 @@ class Version20170926000000 extends AbstractMigration implements RepeatableMigra
      */
     public function upgradeDatabase()
     {
-        $this->connection->executeQuery("UPDATE btSearch SET postTo_cID = NULL WHERE postTo_cID IS NOT NULL AND postTo_cID = ''");
+        $this->connection->executeStatement("UPDATE btSearch SET postTo_cID = NULL WHERE postTo_cID IS NOT NULL AND postTo_cID = ''");
         foreach ([
             "postTo_cID NOT REGEXP '^[1-9][0-9]*$'",
             'IFNULL(postTo_cID + 0, 0) < 1',
             'IFNULL(CAST(postTo_cID AS SIGNED), 0) < 1',
         ] as $try) {
             try {
-                $this->connection->executeQuery('UPDATE btSearch SET postTo_cID = NULL WHERE postTo_cID IS NOT NULL AND ' . $try);
+                $this->connection->executeStatement('UPDATE btSearch SET postTo_cID = NULL WHERE postTo_cID IS NOT NULL AND ' . $try);
                 break;
             } catch (Exception $foo) {
             }

--- a/concrete/src/Updater/Migrations/Migrations/Version20171025000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20171025000000.php
@@ -20,7 +20,7 @@ class Version20171025000000 extends AbstractMigration implements RepeatableMigra
         if ($pkg) {
             // First, we update the block type record that we have from the document library
             // add-on so that it's using the core code base.
-            $this->connection->executeQuery('update BlockTypes set pkgID = 0 where pkgID = ?', [$pkg->getPackageID()]);
+            $this->connection->executeStatement('update BlockTypes set pkgID = 0 where pkgID = ?', [$pkg->getPackageID()]);
 
             // Now we uninstall the package.
             $pkg->uninstall();

--- a/concrete/src/Updater/Migrations/Migrations/Version20171110032423.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20171110032423.php
@@ -47,7 +47,7 @@ class Version20171110032423 extends AbstractMigration implements RepeatableMigra
         // first, let's see whether the concrete5 calendar is installed.
         $pkg = Package::getByHandle('calendar');
         if ($pkg) {
-            $this->connection->Execute('set foreign_key_checks = 0');
+            $this->connection->executeStatement('set foreign_key_checks = 0');
 
             // let's uninstall the package.
             $this->uninstallLegacyCalendar($pkg);
@@ -63,7 +63,7 @@ class Version20171110032423 extends AbstractMigration implements RepeatableMigra
 
             // leaving data in backup tables so that we can use the dashboard import to migrate it.
 
-            $this->connection->Execute('set foreign_key_checks = 1');
+            $this->connection->executeStatement('set foreign_key_checks = 1');
         } else {
             $this->addCalendarFunctionality();
         }
@@ -133,11 +133,11 @@ class Version20171110032423 extends AbstractMigration implements RepeatableMigra
             }
         }
         $this->output('Updating attribute categories...');
-        $this->connection->executeQuery('delete from AttributeKeyCategories where pkgID = ?', [$pkg->getPackageID()]);
+        $this->connection->executeStatement('delete from AttributeKeyCategories where pkgID = ?', [$pkg->getPackageID()]);
         $this->output('Updating block types...');
-        $this->connection->executeQuery('delete from BlockTypes where pkgID = ?', [$pkg->getPackageID()]);
+        $this->connection->executeStatement('delete from BlockTypes where pkgID = ?', [$pkg->getPackageID()]);
         $this->output(t('Uninstalling calendar package (ID %s)', $pkg->getPackageID()));
-        $this->connection->executeQuery('delete from Packages where pkgID = ?', [$pkg->getPackageID()]);
+        $this->connection->executeStatement('delete from Packages where pkgID = ?', [$pkg->getPackageID()]);
     }
 
     protected function updateAttributeKeys($pkg)
@@ -148,8 +148,8 @@ class Version20171110032423 extends AbstractMigration implements RepeatableMigra
         while ($row = $r->fetch()) {
             $cnt = $this->connection->fetchColumn('select count(akID) from CalendarEventAttributeKeys where akID = ?', [$row['akID']]);
             if (!$cnt) {
-                $this->connection->executeQuery('delete from LegacyAttributeKeys where akID = ?', [$row['akID']]);
-                $this->connection->executeQuery('update AttributeKeys set pkgID = null, akCategoryID = ?, akCategory = ? where akID = ?',
+                $this->connection->executeStatement('delete from LegacyAttributeKeys where akID = ?', [$row['akID']]);
+                $this->connection->executeStatement('update AttributeKeys set pkgID = null, akCategoryID = ?, akCategory = ? where akID = ?',
                     [$category->getAttributeKeyCategoryID(), 'eventkey', $row['akID']]
                 );
                 $this->connection->insert('CalendarEventAttributeKeys', ['akID' => $row['akID']]);
@@ -158,7 +158,7 @@ class Version20171110032423 extends AbstractMigration implements RepeatableMigra
 
         $r = $this->connection->executeQuery('select asID from AttributeSets ats left join AttributeKeyCategories akc on ats.akCategoryID = akc.akCategoryID where akc.akCategoryID is null');
         while ($row = $r->fetch()) {
-            $this->connection->executeQuery('update AttributeSets set pkgID = null, akCategoryID = ? where asID = ?',
+            $this->connection->executeStatement('update AttributeSets set pkgID = null, akCategoryID = ? where asID = ?',
                 [$category->getAttributeKeyCategoryID(), $row['asID']]
             );
         }

--- a/concrete/src/Updater/Migrations/Migrations/Version20171121000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20171121000000.php
@@ -48,7 +48,7 @@ class Version20171121000000 extends AbstractMigration implements RepeatableMigra
     public function upgradeDatabase()
     {
         $db = $this->connection;
-        $db->executeQuery("UPDATE FileImageThumbnailPaths SET thumbnailFormat = ? WHERE thumbnailFormat = '' AND (path LIKE '%.jpg' OR path LIKE '%.jpeg' OR path LIKE '%.pjpg' OR path LIKE '%.pjpeg')", [BitmapFormat::FORMAT_JPEG]);
-        $db->executeQuery("UPDATE FileImageThumbnailPaths SET thumbnailFormat = ? WHERE thumbnailFormat = ''", [BitmapFormat::FORMAT_PNG]);
+        $db->executeStatement("UPDATE FileImageThumbnailPaths SET thumbnailFormat = ? WHERE thumbnailFormat = '' AND (path LIKE '%.jpg' OR path LIKE '%.jpeg' OR path LIKE '%.pjpg' OR path LIKE '%.pjpeg')", [BitmapFormat::FORMAT_JPEG]);
+        $db->executeStatement("UPDATE FileImageThumbnailPaths SET thumbnailFormat = ? WHERE thumbnailFormat = ''", [BitmapFormat::FORMAT_PNG]);
     }
 }

--- a/concrete/src/Updater/Migrations/Migrations/Version20180328215345.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20180328215345.php
@@ -13,7 +13,7 @@ class Version20180328215345 extends AbstractMigration implements RepeatableMigra
         $c = Page::getByPath('/page_not_found');
         if ($c && !$c->isError()) {
             $db = $this->connection;
-            $db->executeQuery('update Pages set siteTreeID = ? where cID = ?', [
+            $db->executeStatement('update Pages set siteTreeID = ? where cID = ?', [
                 0, $c->getCollectionID(),
             ]);
         }

--- a/concrete/src/Updater/Migrations/Migrations/Version20180518153531.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20180518153531.php
@@ -11,6 +11,6 @@ class Version20180518153531 extends AbstractMigration implements RepeatableMigra
 
     public function upgradeDatabase()
     {
-        $this->connection->executeQuery('alter table Sessions modify column sessionValue longtext null');
+        $this->connection->executeStatement('alter table Sessions modify column sessionValue longtext null');
     }
 }

--- a/concrete/src/Updater/Migrations/Migrations/Version20180621222449.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20180621222449.php
@@ -13,7 +13,7 @@ class Version20180621222449 extends AbstractMigration implements RepeatableMigra
         if ($db->tableExists('atPageSelector')) {
             // This is the name of the page selector attribute table in some implementations of the page selector attribute
             // We need to take this data and place it into atNumber.
-            $db->query(<<<EOT
+            $db->executeStatement(<<<EOT
 insert into atNumber (avID, value)
     select
         atPageSelector.avID, atPageSelector.value

--- a/concrete/src/Updater/Migrations/Migrations/Version20180910000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20180910000000.php
@@ -29,13 +29,13 @@ class Version20180910000000 extends AbstractMigration implements RepeatableMigra
         // Migrate data from old entries table to new
         if ($this->connection->tableExists('ExpressEntityAssociationSelectedEntries')) {
             $this->connection->transactional(function ($db) {
-                $r = $db->query('select * from ExpressEntityAssociationSelectedEntries');
+                $r = $db->executeQuery('select * from ExpressEntityAssociationSelectedEntries');
                 while ($row = $r->fetch()) {
                     $db->insert('ExpressEntityAssociationEntries', [
                         'association_id' => $row['id'], 'exEntryID' => $row['exSelectedEntryID']
                     ]);
                 }
-                $this->connection->Execute('alter table ExpressEntityAssociationSelectedEntries rename _ExpressEntityAssociationSelectedEntries');
+                $this->connection->executeStatement('alter table ExpressEntityAssociationSelectedEntries rename _ExpressEntityAssociationSelectedEntries');
             });
         }
 

--- a/concrete/src/Updater/Migrations/Migrations/Version20180926000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20180926000000.php
@@ -59,7 +59,7 @@ class Version20180926000000 extends AbstractMigration implements RepeatableMigra
         if ($db->tableExists('atUserSelector')) {
             // This is the name of the user selector attribute table in some implementations of the user selector attribute
             // We need to take this data and place it into atNumber.
-            $db->query(<<<EOT
+            $db->executeStatement(<<<EOT
 insert into atNumber (avID, value)
     select
         atUserSelector.avID, atUserSelector.value

--- a/concrete/src/Updater/Migrations/Migrations/Version20190309000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20190309000000.php
@@ -41,7 +41,7 @@ class Version20190309000000 extends AbstractMigration implements RepeatableMigra
             $folderTreeNodeTypeID
         ]);
         foreach ($folders as $folder) {
-            $db->executeQuery('INSERT INTO TreeFileFolderNodes (treeNodeID, fslID) VALUES (?, ?)', [
+            $db->executeStatement('INSERT INTO TreeFileFolderNodes (treeNodeID, fslID) VALUES (?, ?)', [
                 $folder['treeNodeID'],
                 $defaultStorageLocationID
             ]);

--- a/concrete/src/Updater/Migrations/Migrations/Version20190422235040.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20190422235040.php
@@ -79,7 +79,7 @@ final class Version20190422235040 extends AbstractMigration implements Repeatabl
 
         // for sites with the private multisite addon installed:
         if ($this->connection->tableExists('SiteAttributeValueValues')) {
-            $this->connection->query('alter table SiteAttributeValueValues rename atSite');
+            $this->connection->executeStatement('alter table SiteAttributeValueValues rename atSite');
         }
 
     }

--- a/concrete/src/Updater/Migrations/Migrations/Version20190708000000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20190708000000.php
@@ -69,7 +69,7 @@ class Version20190708000000 extends AbstractMigration implements RepeatableMigra
             return;
         }
         $site = $this->app->make('site')->getSite();
-        $this->connection->executeQuery(
+        $this->connection->executeStatement(
             '
 INSERT INTO IpAccessControlRanges
     (
@@ -103,7 +103,7 @@ INSERT INTO IpAccessControlRanges
             return;
         }
         $site = $this->app->make('site')->getSite();
-        $this->connection->executeQuery(
+        $this->connection->executeStatement(
             '
 INSERT INTO IpAccessControlEvents
     (

--- a/concrete/src/Updater/Migrations/Migrations/Version20200523051311.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20200523051311.php
@@ -89,7 +89,7 @@ final class Version20200523051311 extends AbstractMigration implements Repeatabl
          * @var $db Connection
          */
         foreach($list->findAll() as $entity) {
-            $db->executeQuery(
+            $db->executeStatement(
                 'update ExpressEntityEntries set resultsNodeID = ? 
                 where exEntryEntityID = ? and (resultsNodeID = 0 or resultsNodeID is null)',
             [$entity->getEntityResultsNodeId(), $entity->getId()]

--- a/concrete/src/Updater/Migrations/Migrations/Version20200903201537.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20200903201537.php
@@ -13,6 +13,6 @@ final class Version20200903201537 extends AbstractMigration implements Repeatabl
     public function upgradeDatabase()
     {
         $this->refreshEntities([SavedExpressSearch::class]);
-        $this->connection->executeQuery('delete from SavedExpressSearchQueries where exEntityID is null');
+        $this->connection->executeStatement('delete from SavedExpressSearchQueries where exEntityID is null');
     }
 }

--- a/concrete/src/Updater/Migrations/Migrations/Version20201028143317.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20201028143317.php
@@ -15,6 +15,6 @@ final class Version20201028143317 extends AbstractMigration implements Repeatabl
             User::class
         ]);
 
-        $this->connection->executeQuery("ALTER Table UserPermissionEditPropertyAccessList ADD COLUMN uHomeFileManagerFolderID tinyint(1) DEFAULT '0'");
+        $this->connection->executeStatement("ALTER Table UserPermissionEditPropertyAccessList ADD COLUMN uHomeFileManagerFolderID tinyint(1) DEFAULT '0'");
     }
 }

--- a/concrete/src/Updater/Migrations/Migrations/Version20210216184000.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20210216184000.php
@@ -114,11 +114,11 @@ final class Version20210216184000 extends AbstractMigration implements Repeatabl
         try {
             /** @var Connection $db */
             $db = $this->app->make(Connection::class);
-            $db->executeQuery('insert into GroupTypes (gtID, gtName, gtDefaultRoleID) values (?,?, ?)', [DEFAULT_GROUP_TYPE_ID, t("Group"), DEFAULT_GROUP_ROLE_ID]);
-            $db->executeQuery('insert into GroupRoles (grID, grName) values (?,?)', [DEFAULT_GROUP_ROLE_ID, t("Member")]);
-            $db->executeQuery('insert into GroupTypeSelectedRoles (gtID, grID) values (?,?)', [DEFAULT_GROUP_TYPE_ID, DEFAULT_GROUP_ROLE_ID]);
-            $db->executeQuery('update `Groups` set gtID = ?, gDefaultRoleID = ?', [DEFAULT_GROUP_TYPE_ID, DEFAULT_GROUP_ROLE_ID]);
-            $db->executeQuery('update UserGroups set grID = ?', [DEFAULT_GROUP_ROLE_ID]);
+            $db->executeStatement('insert into GroupTypes (gtID, gtName, gtDefaultRoleID) values (?,?, ?)', [DEFAULT_GROUP_TYPE_ID, t("Group"), DEFAULT_GROUP_ROLE_ID]);
+            $db->executeStatement('insert into GroupRoles (grID, grName) values (?,?)', [DEFAULT_GROUP_ROLE_ID, t("Member")]);
+            $db->executeStatement('insert into GroupTypeSelectedRoles (gtID, grID) values (?,?)', [DEFAULT_GROUP_TYPE_ID, DEFAULT_GROUP_ROLE_ID]);
+            $db->executeStatement('update `Groups` set gtID = ?, gDefaultRoleID = ?', [DEFAULT_GROUP_TYPE_ID, DEFAULT_GROUP_ROLE_ID]);
+            $db->executeStatement('update UserGroups set grID = ?', [DEFAULT_GROUP_ROLE_ID]);
         } catch (Exception $e) {
             // The group type + role was already created
         }

--- a/concrete/src/Updater/Migrations/Migrations/Version20210712110100.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20210712110100.php
@@ -17,6 +17,6 @@ final class Version20210712110100 extends AbstractMigration implements Repeatabl
         /** @var Connection $db */
         $db = $this->app->make(Connection::class);
         /** @noinspection PhpUnhandledExceptionInspection */
-        $db->executeQuery("UPDATE btContentImage SET sizingOption = 'constrain_size' WHERE maxWidth > 0 OR maxHeight > 0");
+        $db->executeStatement("UPDATE btContentImage SET sizingOption = 'constrain_size' WHERE maxWidth > 0 OR maxHeight > 0");
     }
 }

--- a/concrete/src/Updater/Migrations/Migrations/Version20210910234801.php
+++ b/concrete/src/Updater/Migrations/Migrations/Version20210910234801.php
@@ -28,28 +28,28 @@ final class Version20210910234801 extends AbstractMigration implements Repeatabl
             $bt->delete();
         }
 
-        $this->connection->executeQuery('DROP TABLE IF EXISTS Gatherings');
-        $this->connection->executeQuery('DROP TABLE IF EXISTS GatheringItemSelectedTemplates');
-        $this->connection->executeQuery('DROP TABLE IF EXISTS GatheringItems');
-        $this->connection->executeQuery('DROP TABLE IF EXISTS GatheringPermissionAssignments');
-        $this->connection->executeQuery('DROP TABLE IF EXISTS GatheringItemFeatureAssignments');
-        $this->connection->executeQuery('DROP TABLE IF EXISTS GatheringItemTemplateTypes');
-        $this->connection->executeQuery('DROP TABLE IF EXISTS GatheringItemTemplates');
-        $this->connection->executeQuery('DROP TABLE IF EXISTS GatheringItemTemplateFeatures');
-        $this->connection->executeQuery('DROP TABLE IF EXISTS GatheringDataSources');
-        $this->connection->executeQuery('DROP TABLE IF EXISTS GatheringConfiguredDataSources');
+        $this->connection->executeStatement('DROP TABLE IF EXISTS Gatherings');
+        $this->connection->executeStatement('DROP TABLE IF EXISTS GatheringItemSelectedTemplates');
+        $this->connection->executeStatement('DROP TABLE IF EXISTS GatheringItems');
+        $this->connection->executeStatement('DROP TABLE IF EXISTS GatheringPermissionAssignments');
+        $this->connection->executeStatement('DROP TABLE IF EXISTS GatheringItemFeatureAssignments');
+        $this->connection->executeStatement('DROP TABLE IF EXISTS GatheringItemTemplateTypes');
+        $this->connection->executeStatement('DROP TABLE IF EXISTS GatheringItemTemplates');
+        $this->connection->executeStatement('DROP TABLE IF EXISTS GatheringItemTemplateFeatures');
+        $this->connection->executeStatement('DROP TABLE IF EXISTS GatheringDataSources');
+        $this->connection->executeStatement('DROP TABLE IF EXISTS GatheringConfiguredDataSources');
 
-        $this->connection->executeQuery("delete from PermissionKeyCategories where pkCategoryHandle = 'gathering'");
-        $this->connection->executeQuery("delete from PermissionKeys where pkHandle in ('edit_gatherings', 'edit_gathering_items')");
+        $this->connection->executeStatement("delete from PermissionKeyCategories where pkCategoryHandle = 'gathering'");
+        $this->connection->executeStatement("delete from PermissionKeys where pkHandle in ('edit_gatherings', 'edit_gathering_items')");
 
         // Drop features
         // Note: other tables related to this functionality were dropped in a previous migration.
-        $this->connection->executeQuery('DROP TABLE IF EXISTS Features');
-        $this->connection->executeQuery('DROP TABLE IF EXISTS FeatureCategories');
-        $this->connection->executeQuery('DROP TABLE IF EXISTS FeatureAssignments');
-        $this->connection->executeQuery('DROP TABLE IF EXISTS gaPage');
+        $this->connection->executeStatement('DROP TABLE IF EXISTS Features');
+        $this->connection->executeStatement('DROP TABLE IF EXISTS FeatureCategories');
+        $this->connection->executeStatement('DROP TABLE IF EXISTS FeatureAssignments');
+        $this->connection->executeStatement('DROP TABLE IF EXISTS gaPage');
 
         // Other Old Things
-        $this->connection->executeQuery('DROP TABLE IF EXISTS ConversationDiscussions');
+        $this->connection->executeStatement('DROP TABLE IF EXISTS ConversationDiscussions');
     }
 }

--- a/concrete/src/User/Command/RemoveOldFileAttachmentsCommandHandler.php
+++ b/concrete/src/User/Command/RemoveOldFileAttachmentsCommandHandler.php
@@ -59,7 +59,7 @@ SQL;
                 $file->delete();
             }
 
-            $this->connection->executeQuery("DELETE FROM UserPrivateMessagesAttachments WHERE msgID = ? AND fID = ?", [$row["msgID"], $row["fID"]]);
+            $this->connection->executeStatement("DELETE FROM UserPrivateMessagesAttachments WHERE msgID = ? AND fID = ?", [$row["msgID"], $row["fID"]]);
 
             $removedItemsCounter++;
         }

--- a/concrete/src/User/Group/Command/DeleteGroupCommandHandler.php
+++ b/concrete/src/User/Group/Command/DeleteGroupCommandHandler.php
@@ -240,9 +240,9 @@ class DeleteGroupCommandHandler
         }
         $this->entityManager->flush();
         $table = $this->connection->getDatabasePlatform()->quoteSingleIdentifier('Groups');
-        $this->connection->query('DELETE FROM UserGroups WHERE gID = ?', [$groupID]);
-        $this->connection->query('DELETE FROM ' . $table . ' WHERE gID = ?', [$groupID]);
-        $this->connection->query('delete from GroupSelectedRoles where gID = ?', [$groupID]);
+        $this->connection->executeStatement('DELETE FROM UserGroups WHERE gID = ?', [$groupID]);
+        $this->connection->executeStatement('DELETE FROM ' . $table . ' WHERE gID = ?', [$groupID]);
+        $this->connection->executeStatement('delete from GroupSelectedRoles where gID = ?', [$groupID]);
         $this->requestCache->delete('tree/node');
     }
 }

--- a/concrete/src/User/Group/FolderManager.php
+++ b/concrete/src/User/Group/FolderManager.php
@@ -32,7 +32,7 @@ class FolderManager
         /** @var Connection $db */
         $db = $app->make(Connection::class);
 
-        $db->executeQuery("UPDATE TreeNodes n SET n.treeNodeTypeID = ? WHERE n.treeNodeID = ?", [
+        $db->executeStatement("UPDATE TreeNodes n SET n.treeNodeTypeID = ? WHERE n.treeNodeID = ?", [
             $type->getTreeNodeTypeID(),
             $groupTree->getRootTreeNodeID()
         ]);

--- a/concrete/src/User/Group/Group.php
+++ b/concrete/src/User/Group/Group.php
@@ -129,7 +129,7 @@ class Group extends ConcreteObject implements \Concrete\Core\Permission\ObjectIn
         $path .= '/' . $this->gName;
         $this->gPath = $path;
 
-        $db->executeQuery('update ' . $db->getDatabasePlatform()->quoteSingleIdentifier('Groups') . ' set gPath = ? where gID = ?', [$path, $this->getGroupID()]);
+        $db->executeStatement('update ' . $db->getDatabasePlatform()->quoteSingleIdentifier('Groups') . ' set gPath = ? where gID = ?', [$path, $this->getGroupID()]);
     }
 
     public function rescanGroupPathRecursive()
@@ -212,7 +212,7 @@ class Group extends ConcreteObject implements \Concrete\Core\Permission\ObjectIn
                 $app = Application::getFacadeApplication();
                 /** @var Connection $db */
                 $db = $app->make(Connection::class);
-                $db->executeQuery("UPDATE UserGroups SET grID = ? WHERE gID = ? AND uID = ?", [$userRole->getId(), $this->getGroupID(), $user->getUserID()]);
+                $db->executeStatement("UPDATE UserGroups SET grID = ? WHERE gID = ? AND uID = ?", [$userRole->getId(), $this->getGroupID(), $user->getUserID()]);
 
                 /** @noinspection PhpUnhandledExceptionInspection */
                 $subject = new GroupRoleChange($this, $user, $userRole);
@@ -247,7 +247,7 @@ class Group extends ConcreteObject implements \Concrete\Core\Permission\ObjectIn
             $db = $app->make(Connection::class);
             $dt = $app->make('helper/date');
 
-            $db->executeQuery("DELETE FROM GroupJoinRequests WHERE gID = ? AND uID = ?", [$this->getGroupID(), $user->getUserID()]);
+            $db->executeStatement("DELETE FROM GroupJoinRequests WHERE gID = ? AND uID = ?", [$this->getGroupID(), $user->getUserID()]);
             $db->insert("GroupJoinRequests", [
                 "gID" => $this->getGroupID(),
                 "uID" => $user->getUserID(),
@@ -306,7 +306,7 @@ class Group extends ConcreteObject implements \Concrete\Core\Permission\ObjectIn
         $this->gOverrideGroupTypeSettings = $gOverrideGroupTypeSettings;
 
         try {
-            $db->executeQuery("update `Groups` set gOverrideGroupTypeSettings = ? where gID = ?", [(int)$gOverrideGroupTypeSettings, $this->getGroupID()]);
+            $db->executeStatement("update `Groups` set gOverrideGroupTypeSettings = ? where gID = ?", [(int)$gOverrideGroupTypeSettings, $this->getGroupID()]);
 
             return true;
         } catch (Exception $e) {
@@ -346,7 +346,7 @@ class Group extends ConcreteObject implements \Concrete\Core\Permission\ObjectIn
         $this->gtID = $groupType->getId();
 
         try {
-            $db->executeQuery("update `Groups` set gtID = ? where gID = ?", [$this->gtID, $this->getGroupID()]);
+            $db->executeStatement("update `Groups` set gtID = ? where gID = ?", [$this->gtID, $this->getGroupID()]);
 
             return true;
         } catch (Exception $e) {
@@ -391,7 +391,7 @@ class Group extends ConcreteObject implements \Concrete\Core\Permission\ObjectIn
         $this->gDefaultRoleID = $role->getId();
 
         try {
-            $db->executeQuery("update `Groups` set gDefaultRoleID = ? where gID = ?", [(int)$this->gDefaultRoleID, (int)$this->getGroupID()]);
+            $db->executeStatement("update `Groups` set gDefaultRoleID = ? where gID = ?", [(int)$this->gDefaultRoleID, (int)$this->getGroupID()]);
 
             return true;
         } catch (Exception $e) {
@@ -423,7 +423,7 @@ class Group extends ConcreteObject implements \Concrete\Core\Permission\ObjectIn
         $db = $app->make(Connection::class);
 
         try {
-            $db->executeQuery("update `Groups` set gThumbnailFID = ? where gID = ?", [0, $this->getGroupID()]);
+            $db->executeStatement("update `Groups` set gThumbnailFID = ? where gID = ?", [0, $this->getGroupID()]);
 
             return true;
         } catch (Exception $e) {
@@ -444,7 +444,7 @@ class Group extends ConcreteObject implements \Concrete\Core\Permission\ObjectIn
         $this->gThumbnailFID = $file->getFileID();
 
         try {
-            $db->executeQuery("update `Groups` set gThumbnailFID = ? where gID = ?", [$this->gThumbnailFID, $this->getGroupID()]);
+            $db->executeStatement("update `Groups` set gThumbnailFID = ? where gID = ?", [$this->gThumbnailFID, $this->getGroupID()]);
 
             return true;
         } catch (Exception $e) {
@@ -470,7 +470,7 @@ class Group extends ConcreteObject implements \Concrete\Core\Permission\ObjectIn
         $this->gPetitionForPublicEntry = $gPetitionForPublicEntry;
 
         try {
-            $db->executeQuery("update `Groups` set gPetitionForPublicEntry = ? where gID = ?", [(int)$gPetitionForPublicEntry, $this->getGroupID()]);
+            $db->executeStatement("update `Groups` set gPetitionForPublicEntry = ? where gID = ?", [(int)$gPetitionForPublicEntry, $this->getGroupID()]);
 
             return true;
         } catch (Exception $e) {
@@ -539,7 +539,7 @@ class Group extends ConcreteObject implements \Concrete\Core\Permission\ObjectIn
         $db = $app->make(Connection::class);
 
         try {
-            $db->executeQuery('insert into GroupSelectedRoles (grID, gID) values (?,?)', [(int)$role->getId(), (int)$this->getGroupID()]);
+            $db->executeStatement('insert into GroupSelectedRoles (grID, gID) values (?,?)', [(int)$role->getId(), (int)$this->getGroupID()]);
         } catch (Exception $e) {
             return false;
         }
@@ -843,8 +843,10 @@ class Group extends ConcreteObject implements \Concrete\Core\Permission\ObjectIn
         if ($gID) {
             CacheLocal::delete('group', $gID);
             $v = [$gName, $gDescription, $gID];
-            $r = $db->prepare('update ' . $db->getDatabasePlatform()->quoteSingleIdentifier('Groups') . ' set gName = ?, gDescription = ? where gID = ?');
-            $db->Execute($r, $v);
+            $db->executeStatement(
+                'update ' . $db->getDatabasePlatform()->quoteSingleIdentifier('Groups') . ' set gName = ?, gDescription = ? where gID = ?',
+                $v
+            );
             $group = static::getByID($gID);
             $group->rescanGroupPathRecursive();
 
@@ -962,7 +964,7 @@ class Group extends ConcreteObject implements \Concrete\Core\Permission\ObjectIn
     public function clearBadgeOptions()
     {
         $db = Database::connection();
-        $db->executeQuery(
+        $db->executeStatement(
             'update ' . $db->getDatabasePlatform()->quoteSingleIdentifier('Groups') . ' set gIsBadge = 0, gBadgeFID = 0, gBadgeDescription = null, gBadgeCommunityPointValue = 0 where gID = ?',
             [$this->getGroupID()]
         );
@@ -971,7 +973,7 @@ class Group extends ConcreteObject implements \Concrete\Core\Permission\ObjectIn
     public function clearAutomationOptions()
     {
         $db = Database::connection();
-        $db->executeQuery(
+        $db->executeStatement(
             'update ' . $db->getDatabasePlatform()->quoteSingleIdentifier('Groups') . ' set gIsAutomated = 0, gCheckAutomationOnRegister = 0, gCheckAutomationOnLogin = 0, gCheckAutomationOnJobRun = 0 where gID = ?',
             [$this->getGroupID()]
         );
@@ -980,7 +982,7 @@ class Group extends ConcreteObject implements \Concrete\Core\Permission\ObjectIn
     public function removeGroupExpiration()
     {
         $db = Database::connection();
-        $db->executeQuery(
+        $db->executeStatement(
             'update ' . $db->getDatabasePlatform()->quoteSingleIdentifier('Groups') . ' set gUserExpirationIsEnabled = 0, gUserExpirationMethod = null, gUserExpirationSetDateTime = null, gUserExpirationInterval = 0, gUserExpirationAction = null where gID = ?',
             [$this->getGroupID()]
         );
@@ -995,7 +997,7 @@ class Group extends ConcreteObject implements \Concrete\Core\Permission\ObjectIn
     public function setBadgeOptions($gBadgeFID, $gBadgeDescription, $gBadgeCommunityPointValue)
     {
         $db = Database::connection();
-        $db->executeQuery(
+        $db->executeStatement(
             'update ' . $db->getDatabasePlatform()->quoteSingleIdentifier('Groups') . ' set gIsBadge = 1, gBadgeFID = ?, gBadgeDescription = ?, gBadgeCommunityPointValue = ? where gID = ?',
             [intval($gBadgeFID), $gBadgeDescription, $gBadgeCommunityPointValue, $this->getGroupID()]
         );
@@ -1008,7 +1010,7 @@ class Group extends ConcreteObject implements \Concrete\Core\Permission\ObjectIn
     )
     {
         $db = Database::connection();
-        $db->executeQuery(
+        $db->executeStatement(
             'update ' . $db->getDatabasePlatform()->quoteSingleIdentifier('Groups') . ' set gIsAutomated = 1, gCheckAutomationOnRegister = ?, gCheckAutomationOnLogin = ?, gCheckAutomationOnJobRun = ? where gID = ?',
             [
                 intval($gCheckAutomationOnRegister),
@@ -1022,7 +1024,7 @@ class Group extends ConcreteObject implements \Concrete\Core\Permission\ObjectIn
     public function setGroupExpirationByDateTime($datetime, $action)
     {
         $db = Database::connection();
-        $db->executeQuery(
+        $db->executeStatement(
             'update ' . $db->getDatabasePlatform()->quoteSingleIdentifier('Groups') . ' set gUserExpirationIsEnabled = 1, gUserExpirationMethod = \'SET_TIME\', gUserExpirationInterval = 0, gUserExpirationSetDateTime = ?, gUserExpirationAction = ? where gID = ?',
             [$datetime, $action, $this->getGroupID()]
         );
@@ -1032,7 +1034,7 @@ class Group extends ConcreteObject implements \Concrete\Core\Permission\ObjectIn
     {
         $db = Database::connection();
         $interval = $minutes + ($hours * 60) + ($days * 1440);
-        $db->executeQuery(
+        $db->executeStatement(
             'update ' . $db->getDatabasePlatform()->quoteSingleIdentifier('Groups') . ' set gUserExpirationIsEnabled = 1, gUserExpirationMethod = \'INTERVAL\', gUserExpirationSetDateTime = null, gUserExpirationInterval = ?, gUserExpirationAction = ? where gID = ?',
             [$interval, $action, $this->getGroupID()]
         );

--- a/concrete/src/User/Group/GroupJoinRequest.php
+++ b/concrete/src/User/Group/GroupJoinRequest.php
@@ -57,7 +57,7 @@ class GroupJoinRequest extends ConcreteObject implements SubjectInterface
 
             $this->user->enterGroup($this->group);
 
-            $db->executeQuery("DELETE FROM GroupJoinRequests WHERE uID = ? AND gID = ?", [$this->user->getUserID(), $this->group->getGroupID()]);
+            $db->executeStatement("DELETE FROM GroupJoinRequests WHERE uID = ? AND gID = ?", [$this->user->getUserID(), $this->group->getGroupID()]);
 
             /** @noinspection PhpUnhandledExceptionInspection */
             $subject = new GroupSignupRequestAccept($this->group, $this->user, $activeUser);
@@ -86,7 +86,7 @@ class GroupJoinRequest extends ConcreteObject implements SubjectInterface
             $app = Application::getFacadeApplication();
             /** @var Connection $db */
             $db = $app->make(Connection::class);
-            $db->executeQuery("DELETE FROM GroupJoinRequests WHERE uID = ? AND gID = ?", [$this->user->getUserID(), $this->group->getGroupID()]);
+            $db->executeStatement("DELETE FROM GroupJoinRequests WHERE uID = ? AND gID = ?", [$this->user->getUserID(), $this->group->getGroupID()]);
 
             /** @noinspection PhpUnhandledExceptionInspection */
             $subject = new GroupSignupRequestDecline($this->group, $this->user, $activeUser);

--- a/concrete/src/User/Group/GroupRole.php
+++ b/concrete/src/User/Group/GroupRole.php
@@ -48,7 +48,7 @@ class GroupRole extends ConcreteObject implements JsonSerializable
         $this->grName = $grName;
 
         try {
-            $db->executeQuery("update GroupRoles set grName = ? where grID = ?", [$grName, $this->grID]);
+            $db->executeStatement("update GroupRoles set grName = ? where grID = ?", [$grName, $this->grID]);
 
             return true;
         } catch (Exception $e) {
@@ -77,7 +77,7 @@ class GroupRole extends ConcreteObject implements JsonSerializable
         $this->grIsManager = $grIsManager;
 
         try {
-            $db->executeQuery("update GroupRoles set grIsManager = ? where grID = ?", [(int)$grIsManager, $this->grID]);
+            $db->executeStatement("update GroupRoles set grIsManager = ? where grID = ?", [(int)$grIsManager, $this->grID]);
 
             return true;
         } catch (Exception $e) {
@@ -194,7 +194,7 @@ class GroupRole extends ConcreteObject implements JsonSerializable
         $db = $app->make(Connection::class);
 
         try {
-            $db->executeQuery('insert into GroupRoles (grName, grIsManager) values (?,?)', [$grName, (int)$grIsManager]);
+            $db->executeStatement('insert into GroupRoles (grName, grIsManager) values (?,?)', [$grName, (int)$grIsManager]);
         } catch (Exception $e) {
             return false;
         }
@@ -219,9 +219,9 @@ class GroupRole extends ConcreteObject implements JsonSerializable
         $db = $app->make(Connection::class);
 
         try {
-            $db->executeQuery('delete from GroupRoles where grID = ?', [$this->getId()]);
-            $db->executeQuery('delete from GroupSelectedRoles where grID = ?', [$this->getId()]);
-            $db->executeQuery('delete from GroupTypeSelectedRoles where grID = ?', [$this->getId()]);
+            $db->executeStatement('delete from GroupRoles where grID = ?', [$this->getId()]);
+            $db->executeStatement('delete from GroupSelectedRoles where grID = ?', [$this->getId()]);
+            $db->executeStatement('delete from GroupTypeSelectedRoles where grID = ?', [$this->getId()]);
 
             // update Group Type or Group => set new default role
         } catch (Exception $e) {

--- a/concrete/src/User/Group/GroupSet.php
+++ b/concrete/src/User/Group/GroupSet.php
@@ -10,7 +10,7 @@ class GroupSet extends ConcreteObject
     public static function getList()
     {
         $db = Loader::db();
-        $r = $db->Execute('select gsID from GroupSets order by gsName asc');
+        $r = $db->executeQuery('select gsID from GroupSets order by gsName asc');
         $list = array();
         while ($row = $r->fetch()) {
             $list[] = static::getByID($row['gsID']);
@@ -47,7 +47,7 @@ class GroupSet extends ConcreteObject
     {
         $db = Loader::db();
         $list = array();
-        $r = $db->Execute('select gsID from GroupSets where pkgID = ? order by gsID asc', array($pkg->getPackageID()));
+        $r = $db->executeQuery('select gsID from GroupSets where pkgID = ? order by gsID asc', array($pkg->getPackageID()));
         while ($row = $r->fetch()) {
             $list[] = static::getByID($row['gsID']);
         }
@@ -92,7 +92,7 @@ class GroupSet extends ConcreteObject
     {
         $this->gsName = $gsName;
         $db = Loader::db();
-        $db->Execute("update GroupSets set gsName = ? where gsID = ?", array($gsName, $this->gsID));
+        $db->executeStatement("update GroupSets set gsName = ? where gsID = ?", array($gsName, $this->gsID));
     }
 
     public function addGroup(Group $g)
@@ -100,7 +100,7 @@ class GroupSet extends ConcreteObject
         $db = Loader::db();
         $no = $db->GetOne("select count(gID) from GroupSetGroups where gID = ? and gsID = ?", array($g->getGroupID(), $this->getGroupSetID()));
         if ($no < 1) {
-            $db->Execute('insert into GroupSetGroups (gsID, gID) values (?, ?)', array($this->getGroupSetID(), $g->getGroupID()));
+            $db->executeStatement('insert into GroupSetGroups (gsID, gID) values (?, ?)', array($this->getGroupSetID(), $g->getGroupID()));
         }
     }
 
@@ -111,7 +111,7 @@ class GroupSet extends ConcreteObject
         if (is_object($pkg)) {
             $pkgID = $pkg->getPackageID();
         }
-        $db->Execute('insert into GroupSets (gsName, pkgID) values (?,?)', array($gsName, $pkgID));
+        $db->executeStatement('insert into GroupSets (gsName, pkgID) values (?,?)', array($gsName, $pkgID));
         $id = $db->Insert_ID();
         $gs = self::getByID($id);
 
@@ -121,13 +121,13 @@ class GroupSet extends ConcreteObject
     public function clearGroups()
     {
         $db = Loader::db();
-        $db->Execute('delete from GroupSetGroups where gsID = ?', array($this->gsID));
+        $db->executeStatement('delete from GroupSetGroups where gsID = ?', array($this->gsID));
     }
 
     public function getGroups()
     {
         $db = Loader::db();
-        $r = $db->Execute('select gID from GroupSetGroups where gsID = ? order by gID asc', $this->getGroupSetId());
+        $r = $db->executeQuery('select gID from GroupSetGroups where gsID = ? order by gID asc', $this->getGroupSetId());
         $groups = array();
         while ($row = $r->fetch()) {
             $g = Group::getByID($row['gID']);
@@ -150,14 +150,14 @@ class GroupSet extends ConcreteObject
     public function delete()
     {
         $db = Loader::db();
-        $db->Execute('delete from GroupSets where gsID = ?', array($this->getGroupSetID()));
-        $db->Execute('delete from GroupSetGroups where gsID = ?', array($this->getGroupSetID()));
+        $db->executeStatement('delete from GroupSets where gsID = ?', array($this->getGroupSetID()));
+        $db->executeStatement('delete from GroupSetGroups where gsID = ?', array($this->getGroupSetID()));
     }
 
     public function removeGroup(Group $g)
     {
         $db = Loader::db();
-        $db->Execute('delete from GroupSetGroups where gsID = ? and gID = ?', array($this->getGroupSetID(), $g->getGroupID()));
+        $db->executeStatement('delete from GroupSetGroups where gsID = ? and gID = ?', array($this->getGroupSetID(), $g->getGroupID()));
     }
 
     public static function exportTranslations()

--- a/concrete/src/User/Group/GroupSet.php
+++ b/concrete/src/User/Group/GroupSet.php
@@ -127,7 +127,7 @@ class GroupSet extends ConcreteObject
     public function getGroups()
     {
         $db = Loader::db();
-        $r = $db->executeQuery('select gID from GroupSetGroups where gsID = ? order by gID asc', $this->getGroupSetId());
+        $r = $db->executeQuery('select gID from GroupSetGroups where gsID = ? order by gID asc', [$this->getGroupSetId()]);
         $groups = array();
         while ($row = $r->fetch()) {
             $g = Group::getByID($row['gID']);

--- a/concrete/src/User/Group/GroupType.php
+++ b/concrete/src/User/Group/GroupType.php
@@ -53,7 +53,7 @@ class GroupType extends ConcreteObject implements JsonSerializable
         $this->gtName = $gtName;
 
         try {
-            $db->executeQuery("update GroupTypes set gtName = ? where gtID = ?", [$gtName, $this->gtID]);
+            $db->executeStatement("update GroupTypes set gtName = ? where gtID = ?", [$gtName, $this->gtID]);
 
             return true;
         } catch (Exception $e) {
@@ -82,7 +82,7 @@ class GroupType extends ConcreteObject implements JsonSerializable
         $this->gtPetitionForPublicEntry = $gtPetitionForPublicEntry;
 
         try {
-            $db->executeQuery("update GroupTypes set gtPetitionForPublicEntry = ? where gtID = ?", [(int)$gtPetitionForPublicEntry, $this->gtID]);
+            $db->executeStatement("update GroupTypes set gtPetitionForPublicEntry = ? where gtID = ?", [(int)$gtPetitionForPublicEntry, $this->gtID]);
 
             return true;
         } catch (Exception $e) {
@@ -173,7 +173,7 @@ class GroupType extends ConcreteObject implements JsonSerializable
         $db = $app->make(Connection::class);
 
         try {
-            $db->executeQuery('insert into GroupTypes (gtName, gtPetitionForPublicEntry) values (?,?)', [$gtName, (int)$gtPetitionForPublicEntry]);
+            $db->executeStatement('insert into GroupTypes (gtName, gtPetitionForPublicEntry) values (?,?)', [$gtName, (int)$gtPetitionForPublicEntry]);
         } catch (Exception $e) {
             return false;
         }
@@ -196,7 +196,7 @@ class GroupType extends ConcreteObject implements JsonSerializable
         $this->gtDefaultRoleID = $role->getId();
 
         try {
-            $db->executeQuery("update GroupTypes set gtDefaultRoleID = ? where gtID = ?", [(int)$this->gtDefaultRoleID, $this->gtID]);
+            $db->executeStatement("update GroupTypes set gtDefaultRoleID = ? where gtID = ?", [(int)$this->gtDefaultRoleID, $this->gtID]);
 
             return true;
         } catch (Exception $e) {
@@ -223,9 +223,9 @@ class GroupType extends ConcreteObject implements JsonSerializable
         $db = $app->make(Connection::class);
 
         try {
-            $db->executeQuery('delete from GroupTypes where gtID = ?', [$this->getId()]);
-            $db->executeQuery("update `Groups` set gtID = ? where gtID = ?", [DEFAULT_GROUP_TYPE_ID, $this->getId()]);
-            $db->executeQuery("update UserGroups set gtID = ? where gtID = ?", [DEFAULT_GROUP_TYPE_ID, $this->getId()]);
+            $db->executeStatement('delete from GroupTypes where gtID = ?', [$this->getId()]);
+            $db->executeStatement("update `Groups` set gtID = ? where gtID = ?", [DEFAULT_GROUP_TYPE_ID, $this->getId()]);
+            $db->executeStatement("update UserGroups set gtID = ? where gtID = ?", [DEFAULT_GROUP_TYPE_ID, $this->getId()]);
         } catch (Exception $e) {
             return false;
         }
@@ -253,7 +253,7 @@ class GroupType extends ConcreteObject implements JsonSerializable
         $db = $app->make(Connection::class);
 
         try {
-            $db->executeQuery('insert into GroupTypeSelectedRoles (grID, gtID) values (?,?)', [(int)$role->getId(), (int)$this->getId()]);
+            $db->executeStatement('insert into GroupTypeSelectedRoles (grID, gtID) values (?,?)', [(int)$role->getId(), (int)$this->getId()]);
         } catch (Exception $e) {
             return false;
         }

--- a/concrete/src/User/PrivateMessage/Mailbox.php
+++ b/concrete/src/User/PrivateMessage/Mailbox.php
@@ -40,7 +40,7 @@ class Mailbox extends ConcreteObject
         $ue = new \Concrete\Core\User\Event\UserInfo($user);
         Events::dispatch('on_private_message_marked_not_new', $ue);
 
-        $db->Execute('update UserPrivateMessagesTo set msgIsNew = 0 where msgMailboxID = ? and uID = ?', array($this->msgMailboxID, $user->getUserID()));
+        $db->executeStatement('update UserPrivateMessagesTo set msgIsNew = 0 where msgMailboxID = ? and uID = ?', array($this->msgMailboxID, $user->getUserID()));
     }
 
     public function removeMessageNewStatus($messageId)
@@ -51,7 +51,7 @@ class Mailbox extends ConcreteObject
         $ue = new \Concrete\Core\User\Event\UserInfo($user);
         Events::dispatch('on_private_message_marked_not_new', $ue);
 
-        $db->Execute('update UserPrivateMessagesTo set msgIsNew = 0 where msgMailboxID = ? and uID = ? and msgID = ?', [$this->msgMailboxID, $user->getUserID(), $messageId ]);
+        $db->executeStatement('update UserPrivateMessagesTo set msgIsNew = 0 where msgMailboxID = ? and uID = ? and msgID = ?', [$this->msgMailboxID, $user->getUserID(), $messageId ]);
     }
 
     public function getTotalMessages()

--- a/concrete/src/User/PrivateMessage/PrivateMessage.php
+++ b/concrete/src/User/PrivateMessage/PrivateMessage.php
@@ -104,7 +104,7 @@ class PrivateMessage extends ConcreteObject implements SubjectInterface
         $db = Loader::db();
         $ue = new Event($this);
         Events::dispatch('on_private_message_marked_as_read', $ue);
-        $db->Execute('update UserPrivateMessagesTo set msgIsUnread = 0 where msgID = ? and msgMailboxID = ? and uID = ?', array($this->msgID, $this->msgMailboxID, $this->uID));
+        $db->executeStatement('update UserPrivateMessagesTo set msgIsUnread = 0 where msgID = ? and msgMailboxID = ? and uID = ?', array($this->msgID, $this->msgMailboxID, $this->uID));
     }
 
     public function getMessageAuthorID()
@@ -192,7 +192,7 @@ class PrivateMessage extends ConcreteObject implements SubjectInterface
             return;
         }
 
-        $db->Execute('delete from UserPrivateMessagesTo where uID = ? and msgID = ?', array($this->uID, $this->msgID));
+        $db->executeStatement('delete from UserPrivateMessagesTo where uID = ? and msgID = ?', array($this->uID, $this->msgID));
     }
 
     public function getMessageRelevantUserObject()

--- a/concrete/src/User/User.php
+++ b/concrete/src/User/User.php
@@ -835,7 +835,7 @@ class User extends ConcreteObject
             $app['director']->dispatch('on_user_exit_group', $ue);
 
             $q = 'delete from UserGroups where uID = ? and gID = ?';
-            $r = $db->executeStatement($q, [$this->uID, $gID]);
+            $db->executeStatement($q, [$this->uID, $gID]);
         }
     }
 

--- a/concrete/src/User/User.php
+++ b/concrete/src/User/User.php
@@ -55,7 +55,7 @@ class User extends ConcreteObject
 
         $v = [$uID];
         $q = 'SELECT uID, uName, uIsActive, uLastOnline, uTimezone, uDefaultLanguage, uLastPasswordChange FROM Users WHERE uID = ? LIMIT 1';
-        $r = $db->query($q, $v);
+        $r = $db->executeQuery($q, $v);
         $row = $r ? $r->fetch() : null;
         $nu = null;
         if ($row) {
@@ -205,7 +205,7 @@ class User extends ConcreteObject
 
             $hasher = $app->make(PasswordHasher::class);
             $db = $app->make('Concrete\Core\Database\Connection\Connection');
-            $r = $db->query($q, $v);
+            $r = $db->executeQuery($q, $v);
             if ($r) {
                 $row = $r->fetch();
                 if ($row) {
@@ -339,7 +339,7 @@ class User extends ConcreteObject
         /** @var \Concrete\Core\Permission\IPService $iph */
         $iph = $app->make('helper/validation/ip');
         $ip = $iph->getRequestIP();
-        $db->query('update Users set uLastIP = ?, uLastLogin = ?, uPreviousLogin = ?, uNumLogins = uNumLogins + 1 where uID = ?', [($ip === false) ? ('') : ($ip->getIp()), time(), $uLastLogin, $this->uID]);
+        $db->executeStatement('update Users set uLastIP = ?, uLastLogin = ?, uPreviousLogin = ?, uNumLogins = uNumLogins + 1 where uID = ?', [($ip === false) ? ('') : ($ip->getIp()), time(), $uLastLogin, $this->uID]);
     }
 
     /**
@@ -457,7 +457,7 @@ class User extends ConcreteObject
     {
         $app = Application::getFacadeApplication();
         $db = $app['database']->connection();
-        $db->Execute('UPDATE Users SET uLastAuthTypeID=? WHERE uID=?', [$at->getAuthenticationTypeID(), $this->getUserID()]);
+        $db->executeStatement('UPDATE Users SET uLastAuthTypeID=? WHERE uID=?', [$at->getAuthenticationTypeID(), $this->getUserID()]);
     }
 
     /**
@@ -597,7 +597,7 @@ class User extends ConcreteObject
 
         $this->uDefaultLanguage = $lang;
         $session->set('uDefaultLanguage', $lang);
-        $db->Execute('update Users set uDefaultLanguage = ? where uID = ?', [$lang, $this->getUserID()]);
+        $db->executeStatement('update Users set uDefaultLanguage = ? where uID = ?', [$lang, $this->getUserID()]);
     }
 
     /**
@@ -723,7 +723,7 @@ class User extends ConcreteObject
 
                 $uID = $this->uID;
                 $q = 'select gID from UserGroups where uID = ?';
-                $r = $db->query($q, [$uID]);
+                $r = $db->executeQuery($q, [$uID]);
                 while ($row = $r->fetch()) {
                     $g = Group::getByID($row['gID']);
                     if ($g->isUserExpired($this)) {
@@ -835,7 +835,7 @@ class User extends ConcreteObject
             $app['director']->dispatch('on_user_exit_group', $ue);
 
             $q = 'delete from UserGroups where uID = ? and gID = ?';
-            $r = $db->executeQuery($q, [$this->uID, $gID]);
+            $r = $db->executeStatement($q, [$this->uID, $gID]);
         }
     }
 
@@ -948,7 +948,7 @@ class User extends ConcreteObject
                 $dh = $app->make('helper/date');
                 $datetime = $dh->getOverridableNow();
                 $q2 = 'update Pages set cIsCheckedOut = ?, cCheckedOutUID = ?, cCheckedOutDatetime = ?, cCheckedOutDatetimeLastEdit = ? where cID = ?';
-                $r2 = $db->executeQuery($q2, [1, $uID, $datetime, $datetime, $cID]);
+                $r2 = $db->executeStatement($q2, [1, $uID, $datetime, $datetime, $cID]);
 
                 $c->cIsCheckedOut = 1;
                 $c->cCheckedOutUID = $uID;
@@ -978,7 +978,7 @@ class User extends ConcreteObject
             }
 
             $q = 'update Pages set cIsCheckedOut = 0, cCheckedOutUID = null, cCheckedOutDatetime = null, cCheckedOutDatetimeLastEdit = null where cCheckedOutUID = ?';
-            $db->query($q, [$this->getUserID()]);
+            $db->executeStatement($q, [$this->getUserID()]);
         }
     }
 
@@ -1044,14 +1044,14 @@ class User extends ConcreteObject
             $datetime = $dh->getOverridableNow();
 
             $q = 'update Pages set cCheckedOutDatetimeLastEdit = ? where cID = ?';
-            $db->executeQuery($q, [$datetime, $cID]);
+            $db->executeStatement($q, [$datetime, $cID]);
 
             $c->cCheckedOutDatetimeLastEdit = $datetime;
         }
     }
 
     /**
-     * @return \Doctrine\DBAL\Driver\Statement
+     * @return int
      */
     public function forceCollectionCheckInAll()
     {
@@ -1060,7 +1060,7 @@ class User extends ConcreteObject
         $db = $app['database']->connection();
 
         $q = 'update Pages set cIsCheckedOut = 0, cCheckedOutUID = null, cCheckedOutDatetime = null, cCheckedOutDatetimeLastEdit = null';
-        $r = $db->query($q);
+        $r = $db->executeStatement($q);
 
         return $r;
     }

--- a/concrete/src/User/UserInfo.php
+++ b/concrete/src/User/UserInfo.php
@@ -241,23 +241,23 @@ class UserInfo extends ConcreteObject implements AttributeObjectInterface, Permi
             $this->attributeCategory->deleteValue($attribute);
         }
 
-        $this->connection->executeQuery('DELETE FROM OauthUserMap WHERE user_id = ?', [(int)$this->getUserID()]);
-        $this->connection->executeQuery('DELETE FROM Logs WHERE uID = ?', [(int)$this->getUserID()]);
-        $this->connection->executeQuery('DELETE FROM UserSearchIndexAttributes WHERE uID = ?', [(int)$this->getUserID()]);
-        $this->connection->executeQuery('DELETE FROM UserGroups WHERE uID = ?', [(int)$this->getUserID()]);
-        $this->connection->executeQuery('DELETE FROM UserValidationHashes WHERE uID = ?', [(int)$this->getUserID()]);
-        $this->connection->executeQuery('DELETE FROM Piles WHERE uID = ?', [(int)$this->getUserID()]);
-        $this->connection->executeQuery('DELETE FROM ConfigStore WHERE uID = ?', [(int)$this->getUserID()]);
-        $this->connection->executeQuery('DELETE FROM ConversationSubscriptions WHERE uID = ?', [(int)$this->getUserID()]);
-        $this->connection->executeQuery('DELETE FROM PermissionAccessEntityUsers WHERE uID = ?', [(int)$this->getUserID()]);
-        $this->connection->executeQuery('DELETE FROM authTypeConcreteCookieMap WHERE uID = ?', [(int)$this->getUserID()]);
+        $this->connection->executeStatement('DELETE FROM OauthUserMap WHERE user_id = ?', [(int)$this->getUserID()]);
+        $this->connection->executeStatement('DELETE FROM Logs WHERE uID = ?', [(int)$this->getUserID()]);
+        $this->connection->executeStatement('DELETE FROM UserSearchIndexAttributes WHERE uID = ?', [(int)$this->getUserID()]);
+        $this->connection->executeStatement('DELETE FROM UserGroups WHERE uID = ?', [(int)$this->getUserID()]);
+        $this->connection->executeStatement('DELETE FROM UserValidationHashes WHERE uID = ?', [(int)$this->getUserID()]);
+        $this->connection->executeStatement('DELETE FROM Piles WHERE uID = ?', [(int)$this->getUserID()]);
+        $this->connection->executeStatement('DELETE FROM ConfigStore WHERE uID = ?', [(int)$this->getUserID()]);
+        $this->connection->executeStatement('DELETE FROM ConversationSubscriptions WHERE uID = ?', [(int)$this->getUserID()]);
+        $this->connection->executeStatement('DELETE FROM PermissionAccessEntityUsers WHERE uID = ?', [(int)$this->getUserID()]);
+        $this->connection->executeStatement('DELETE FROM authTypeConcreteCookieMap WHERE uID = ?', [(int)$this->getUserID()]);
 
         // Conversation messages and ratings should be detached from the user
-        $this->connection->executeQuery('UPDATE ConversationMessages SET uID = 0, cnvMessageAuthorName = NULL, cnvMessageAuthorEmail = NULL, cnvMessageAuthorWebsite = NULL, cnvMessageSubmitIP = NULL, cnvMessageSubmitUserAgent = NULL WHERE uID = ?', [(int)$this->getUserID()]);
-        $this->connection->executeQuery('UPDATE ConversationMessageRatings SET cnvMessageRatingIP = NULL, uID = 0 WHERE uID = ?', [(int)$this->getUserID()]);
+        $this->connection->executeStatement('UPDATE ConversationMessages SET uID = 0, cnvMessageAuthorName = NULL, cnvMessageAuthorEmail = NULL, cnvMessageAuthorWebsite = NULL, cnvMessageSubmitIP = NULL, cnvMessageSubmitUserAgent = NULL WHERE uID = ?', [(int)$this->getUserID()]);
+        $this->connection->executeStatement('UPDATE ConversationMessageRatings SET cnvMessageRatingIP = NULL, uID = 0 WHERE uID = ?', [(int)$this->getUserID()]);
 
         // Public file sets should be detached from the user
-        $this->connection->executeQuery('UPDATE FileSets SET uID = 0 WHERE uID = ? AND fsType = ?', [
+        $this->connection->executeStatement('UPDATE FileSets SET uID = 0 WHERE uID = ? AND fsType = ?', [
             (int)$this->getUserID(),
             Set::TYPE_PUBLIC,
         ]);
@@ -267,8 +267,8 @@ class UserInfo extends ConcreteObject implements AttributeObjectInterface, Permi
             $set->delete();
         }
 
-        $this->connection->executeQuery('UPDATE Blocks set uID = ? WHERE uID = ?', [(int)USER_SUPER_ID, (int)$this->getUserID()]);
-        $this->connection->executeQuery('UPDATE Pages set uID = ? WHERE uID = ?', [(int)USER_SUPER_ID, (int)$this->getUserID()]);
+        $this->connection->executeStatement('UPDATE Blocks set uID = ? WHERE uID = ?', [(int)USER_SUPER_ID, (int)$this->getUserID()]);
+        $this->connection->executeStatement('UPDATE Pages set uID = ? WHERE uID = ?', [(int)USER_SUPER_ID, (int)$this->getUserID()]);
         $this->entityManager->createQueryBuilder()
             ->update(DownloadStatistics::class, 'ds')
             ->set('ds.downloaderID', ':null')
@@ -347,7 +347,7 @@ class UserInfo extends ConcreteObject implements AttributeObjectInterface, Permi
             ]
         );
 
-        $this->connection->executeQuery('update Users set uHasAvatar = 1, uDateLastUpdated = NOW() where uID = ? limit 1', [$this->getUserID()]);
+        $this->connection->executeStatement('update Users set uHasAvatar = 1, uDateLastUpdated = NOW() where uID = ? limit 1', [$this->getUserID()]);
 
         // run any internal event we have for user update
         $ui = $this->application->make(UserInfoRepository::class)->getByID($this->getUserID());
@@ -362,7 +362,7 @@ class UserInfo extends ConcreteObject implements AttributeObjectInterface, Permi
     {
         $ue = new UserInfoEvent($this);
         $this->getDirector()->dispatch('on_user_reset_password', $ue);
-        $this->connection->executeQuery('UPDATE Users SET uIsPasswordReset = 1 WHERE uID = ? limit 1', [$this->getUserID()]);
+        $this->connection->executeStatement('UPDATE Users SET uIsPasswordReset = 1 WHERE uID = ? limit 1', [$this->getUserID()]);
     }
 
     /**
@@ -401,29 +401,29 @@ class UserInfo extends ConcreteObject implements AttributeObjectInterface, Permi
         $dt = $this->application->make('date');
         $msgDateCreated = $dt->getOverridableNow();
         $v = [$this->getUserID(), $msgDateCreated, $subject, $text, $recipient->getUserID()];
-        $this->connection->executeQuery('insert into UserPrivateMessages (uAuthorID, msgDateCreated, msgSubject, msgBody, uToID) values (?, ?, ?, ?, ?)', $v);
+        $this->connection->executeStatement('insert into UserPrivateMessages (uAuthorID, msgDateCreated, msgSubject, msgBody, uToID) values (?, ?, ?, ?, ?)', $v);
 
         $msgID = $this->connection->lastInsertId();
 
         if ($msgID) {
             // we add the private message to the sent box of the sender, and the inbox of the recipient
-            $this->connection->executeQuery(
+            $this->connection->executeStatement(
                 'insert into UserPrivateMessagesTo (msgID, uID, uAuthorID, msgMailboxID, msgIsNew, msgIsUnread) values (?, ?, ?, ?, ?, ?)',
                 [$msgID, $this->getUserID(), $this->getUserID(), UserPrivateMessageMailbox::MBTYPE_SENT, 0, 1]
             );
-            $this->connection->executeQuery(
+            $this->connection->executeStatement(
                 'insert into UserPrivateMessagesTo (msgID, uID, uAuthorID, msgMailboxID, msgIsNew, msgIsUnread) values (?, ?, ?, ?, ?, ?)',
                 [$msgID, $recipient->getUserID(), $this->getUserID(), UserPrivateMessageMailbox::MBTYPE_INBOX, 1, 1]
             );
             // add file attachments
             foreach ($attachments as $attachment) {
-                $this->connection->executeQuery('insert into UserPrivateMessagesAttachments (msgID, fID) values (?, ?)', [$msgID, $attachment->getFileID()]);
+                $this->connection->executeStatement('insert into UserPrivateMessagesAttachments (msgID, fID) values (?, ?)', [$msgID, $attachment->getFileID()]);
             }
         }
 
         // If the message is in reply to another message, we make a note of that here
         if (is_object($inReplyTo)) {
-            $this->connection->executeQuery(
+            $this->connection->executeStatement(
                 'update UserPrivateMessagesTo set msgIsReplied = 1 where uID = ? and msgID = ?',
                 [$this->getUserID(), $inReplyTo->getMessageID()]
             );
@@ -556,7 +556,7 @@ class UserInfo extends ConcreteObject implements AttributeObjectInterface, Permi
                 $values[] = (new SimpleArrayType())->convertToDatabaseValue($data['ignoredIPMismatches'], $this->connection->getDatabasePlatform());
             }
             if ($result === true && !empty($fields)) {
-                $this->connection->executeQuery(
+                $this->connection->executeStatement(
                     'update Users set  ' . implode(', ', $fields) . ' where uID = ? limit 1',
                     array_merge($values, [$uID])
                 );
@@ -566,10 +566,10 @@ class UserInfo extends ConcreteObject implements AttributeObjectInterface, Permi
                         $nullFieldsStr .= (strlen($nullFieldsStr) > 0 ? ", " : "") . $nullField . " = NULL";
                     }
                     $nullQuery = sprintf('update Users set %s where uID = ? limit 1', $nullFieldsStr);
-                    $this->connection->executeQuery($nullQuery, [$uID]);
+                    $this->connection->executeStatement($nullQuery, [$uID]);
                 }
                 if ($emailChanged) {
-                    $this->connection->executeQuery('DELETE FROM UserValidationHashes WHERE uID = ?', [$uID]);
+                    $this->connection->executeStatement('DELETE FROM UserValidationHashes WHERE uID = ?', [$uID]);
                     $h = $this->application->make('helper/validation/identifier');
                     $h->deleteKey('UserValidationHashes', 'uID', $uID);
                 }
@@ -658,7 +658,7 @@ class UserInfo extends ConcreteObject implements AttributeObjectInterface, Permi
             }
             if (!empty($groupObjects)) {
                 $inStr = implode(',', array_keys($groupObjects));
-                $this->connection->executeQuery(
+                $this->connection->executeStatement(
                     "delete from UserGroups where uID = ? and gID in ($inStr)",
                     [$this->getUserID()]
                 );
@@ -682,7 +682,7 @@ class UserInfo extends ConcreteObject implements AttributeObjectInterface, Permi
         if (!$result) {
             $h = $this->application->make('helper/validation/identifier');
             $result = $h->generate('UserValidationHashes', 'uHash');
-            $this->connection->executeQuery(
+            $this->connection->executeStatement(
                 'insert into UserValidationHashes (uID, uHash, uDateGenerated) values (?, ?, ?)',
                 [$this->getUserID(), $result, time()]
             );
@@ -697,8 +697,8 @@ class UserInfo extends ConcreteObject implements AttributeObjectInterface, Permi
     public function markValidated()
     {
         $v = [$this->getUserID()];
-        $this->connection->executeQuery('update Users set uIsValidated = 1, uIsFullRecord = 1 where uID = ? limit 1', $v);
-        $this->connection->executeQuery('update UserValidationHashes set uDateRedeemed = ' . time() . ' where uID = ?', $v);
+        $this->connection->executeStatement('update Users set uIsValidated = 1, uIsFullRecord = 1 where uID = ? limit 1', $v);
+        $this->connection->executeStatement('update UserValidationHashes set uDateRedeemed = ' . time() . ' where uID = ?', $v);
 
         $this->uIsValidated = 1;
         $ue = new UserInfoEvent($this);
@@ -758,7 +758,7 @@ class UserInfo extends ConcreteObject implements AttributeObjectInterface, Permi
 
     public function activate()
     {
-        $this->connection->executeQuery(
+        $this->connection->executeStatement(
             'update Users set uIsActive = 1 where uID = ? limit 1',
             [$this->getUserID()]
         );
@@ -796,7 +796,7 @@ class UserInfo extends ConcreteObject implements AttributeObjectInterface, Permi
 
     public function deactivate()
     {
-        $this->connection->executeQuery(
+        $this->connection->executeStatement(
             'update Users set uIsActive = 0 where uID = ? limit 1',
             [$this->getUserID()]
         );

--- a/concrete/src/User/ValidationHash.php
+++ b/concrete/src/User/ValidationHash.php
@@ -37,7 +37,7 @@ class ValidationHash
                 break;
         }
         $db = Database::connection();
-        $db->executeQuery('DELETE FROM UserValidationHashes WHERE type = ? AND uDateGenerated <= ?', array($type, time() - $lifetime));
+        $db->executeStatement('DELETE FROM UserValidationHashes WHERE type = ? AND uDateGenerated <= ?', array($type, time() - $lifetime));
     }
 
     /**
@@ -56,9 +56,9 @@ class ValidationHash
         $hash = self::generate($hashLength);
         $db = Database::connection();
         if ($singeHashAllowed) {
-            $db->executeQuery("DELETE FROM UserValidationHashes WHERE uID = ? AND type = ?", array($uID, $type));
+            $db->executeStatement("DELETE FROM UserValidationHashes WHERE uID = ? AND type = ?", array($uID, $type));
         }
-        $db->executeQuery("insert into UserValidationHashes (uID, uHash, uDateGenerated, type) values (?, ?, ?, ?)", array($uID, $hash, time(), intval($type)));
+        $db->executeStatement("insert into UserValidationHashes (uID, uHash, uDateGenerated, type) values (?, ?, ?, ?)", array($uID, $hash, time(), intval($type)));
 
         return $hash;
     }

--- a/concrete/src/Utility/Service/Identifier.php
+++ b/concrete/src/Utility/Service/Identifier.php
@@ -104,6 +104,6 @@ class Identifier
     public function deleteKey($table, $keyCol, $uHash)
     {
         $db = Application::make(Connection::class);
-        $db->Execute("DELETE FROM " . $table . " WHERE " . $keyCol . "=?", array($uHash));
+        $db->executeStatement("DELETE FROM " . $table . " WHERE " . $keyCol . "=?", array($uHash));
     }
 }

--- a/concrete/src/Workflow/BasicWorkflow.php
+++ b/concrete/src/Workflow/BasicWorkflow.php
@@ -126,7 +126,7 @@ class BasicWorkflow extends \Concrete\Core\Workflow\Workflow implements Assignab
     public function delete()
     {
         $db = Core::make('database')->connection();
-        $db->executeQuery('DELETE FROM BasicWorkflowPermissionAssignments WHERE wfID = ?', [$this->wfID]);
+        $db->executeStatement('DELETE FROM BasicWorkflowPermissionAssignments WHERE wfID = ?', [$this->wfID]);
         parent::delete();
     }
 
@@ -141,7 +141,7 @@ class BasicWorkflow extends \Concrete\Core\Workflow\Workflow implements Assignab
                 return new SkippedResponse();
             } else {
                 $db = Core::make('database')->connection();
-                $db->executeQuery(
+                $db->executeStatement(
                     'INSERT INTO BasicWorkflowProgressData (wpID, uIDStarted) VALUES (?, ?)',
                     [$wp->getWorkflowProgressID(), $req->getRequesterUserID()]);
 

--- a/concrete/src/Workflow/Progress/CalendarEventProgress.php
+++ b/concrete/src/Workflow/Progress/CalendarEventProgress.php
@@ -46,7 +46,7 @@ class CalendarEventProgress extends Progress implements SiteProgressInterface
     {
         parent::delete();
         $db = \Database::connection();
-        $db->Execute('delete from CalendarEventWorkflowProgress where wpID = ?', array($this->wpID));
+        $db->executeStatement('delete from CalendarEventWorkflowProgress where wpID = ?', array($this->wpID));
     }
 
     /*
@@ -59,7 +59,7 @@ class CalendarEventProgress extends Progress implements SiteProgressInterface
             $filter .= ' and ' . $key . ' = ' . $value . ' ';
         }
         $filter .= ' order by ' . $sortBy;
-        $r = $db->Execute('select wp.wpID from PageWorkflowProgress pwp inner join WorkflowProgress wp on pwp.wpID = wp.wpID where cID = ? ' . $filter, array($c->getCollectionID()));
+        $r = $db->executeQuery('select wp.wpID from PageWorkflowProgress pwp inner join WorkflowProgress wp on pwp.wpID = wp.wpID where cID = ? ' . $filter, array($c->getCollectionID()));
         $list = array();
         while ($row = $r->fetch()) {
             $wp = static::getByID($row['wpID']);

--- a/concrete/src/Workflow/Progress/Category.php
+++ b/concrete/src/Workflow/Progress/Category.php
@@ -46,7 +46,7 @@ class Category extends ConcreteObject
     {
         $db = Loader::db();
         $list = array();
-        $r = $db->Execute('select wpCategoryID from WorkflowProgressCategories where pkgID = ? order by wpCategoryID asc', array($pkg->getPackageID()));
+        $r = $db->executeQuery('select wpCategoryID from WorkflowProgressCategories where pkgID = ? order by wpCategoryID asc', array($pkg->getPackageID()));
         while ($row = $r->fetch()) {
             $list[] = static::getByID($row['wpCategoryID']);
         }
@@ -97,14 +97,14 @@ class Category extends ConcreteObject
     public function delete()
     {
         $db = Loader::db();
-        $db->Execute('delete from WorkflowProgressCategories where wpCategoryID = ?', array($this->wpCategoryID));
+        $db->executeStatement('delete from WorkflowProgressCategories where wpCategoryID = ?', array($this->wpCategoryID));
     }
 
     public static function getList()
     {
         $db = Loader::db();
         $cats = array();
-        $r = $db->Execute('select wpCategoryID from WorkflowProgressCategories order by wpCategoryID asc');
+        $r = $db->executeQuery('select wpCategoryID from WorkflowProgressCategories order by wpCategoryID asc');
         while ($row = $r->fetch()) {
             $cats[] = static::getByID($row['wpCategoryID']);
         }
@@ -120,7 +120,7 @@ class Category extends ConcreteObject
         } else {
             $pkgID = $pkg ?: null;
         }
-        $db->Execute('insert into WorkflowProgressCategories (wpCategoryHandle, pkgID) values (?, ?)', array($wpCategoryHandle, $pkgID));
+        $db->executeStatement('insert into WorkflowProgressCategories (wpCategoryHandle, pkgID) values (?, ?)', array($wpCategoryHandle, $pkgID));
         $id = $db->Insert_ID();
 
         return static::getByID($id);

--- a/concrete/src/Workflow/Progress/History.php
+++ b/concrete/src/Workflow/Progress/History.php
@@ -61,7 +61,7 @@ class History extends ConcreteObject
     public static function getList(Progress $wp)
     {
         $db = Loader::db();
-        $r = $db->Execute('select wphID from WorkflowProgressHistory where wpID = ? order by timestamp desc', [$wp->getWorkflowProgressID()]);
+        $r = $db->executeQuery('select wphID from WorkflowProgressHistory where wpID = ? order by timestamp desc', [$wp->getWorkflowProgressID()]);
         $list = [];
         while ($row = $r->fetch()) {
             $obj = $wp->getWorkflowProgressHistoryObjectByID($row['wphID']);

--- a/concrete/src/Workflow/Progress/PageProgress.php
+++ b/concrete/src/Workflow/Progress/PageProgress.php
@@ -40,7 +40,7 @@ class PageProgress extends Progress implements SiteProgressInterface
     {
         parent::delete();
         $db = Database::connection();
-        $db->Execute('delete from PageWorkflowProgress where wpID = ?', array($this->wpID));
+        $db->executeStatement('delete from PageWorkflowProgress where wpID = ?', array($this->wpID));
     }
 
     public static function getList(Page $c, $filters = array('wpIsCompleted' => 0), $sortBy = 'wpDateAdded asc')
@@ -51,7 +51,7 @@ class PageProgress extends Progress implements SiteProgressInterface
             $filter .= ' and ' . $key . ' = ' . $value . ' ';
         }
         $filter .= ' order by ' . $sortBy;
-        $r = $db->Execute('select wp.wpID from PageWorkflowProgress pwp inner join WorkflowProgress wp on pwp.wpID = wp.wpID where cID = ? ' . $filter, array($c->getCollectionID()));
+        $r = $db->executeQuery('select wp.wpID from PageWorkflowProgress pwp inner join WorkflowProgress wp on pwp.wpID = wp.wpID where cID = ? ' . $filter, array($c->getCollectionID()));
         $list = array();
         while ($row = $r->fetch()) {
             $wp = static::getByID($row['wpID']);

--- a/concrete/src/Workflow/Progress/Progress.php
+++ b/concrete/src/Workflow/Progress/Progress.php
@@ -153,7 +153,7 @@ abstract class Progress extends ConcreteObject implements SubjectInterface
         $db = Database::connection();
         $wpDateAdded = Core::make('helper/date')->getOverridableNow();
         $wpCategoryID = $db->fetchColumn('select wpCategoryID from WorkflowProgressCategories where wpCategoryHandle = ?', array($wpCategoryHandle));
-        $db->executeQuery('insert into WorkflowProgress (wfID, wrID, wpDateAdded, wpCategoryID) values (?, ?, ?, ?)', array(
+        $db->executeStatement('insert into WorkflowProgress (wfID, wrID, wpDateAdded, wpCategoryID) values (?, ?, ?, ?)', array(
             $wf->getWorkflowID(), $wr->getWorkflowRequestID(), $wpDateAdded, $wpCategoryID,
         ));
         $wp = self::getByID($db->lastInsertId());
@@ -177,7 +177,7 @@ abstract class Progress extends ConcreteObject implements SubjectInterface
     {
         $db = Database::connection();
         $wr = $this->getWorkflowRequestObject();
-        $db->executeQuery('delete from WorkflowProgress where wpID = ?', array($this->wpID));
+        $db->executeStatement('delete from WorkflowProgress where wpID = ?', array($this->wpID));
         // now we clean up any WorkflowRequests that aren't in use any longer
         $cnt = $db->fetchColumn('select count(wpID) from WorkflowProgress where wrID = ?', array($this->wrID));
         if ($cnt == 0) {
@@ -248,7 +248,7 @@ abstract class Progress extends ConcreteObject implements SubjectInterface
         $db = Database::connection();
         $num = $wf->getWorkflowProgressCurrentStatusNum($this);
         $time = Core::make('helper/date')->getOverridableNow();
-        $db->executeQuery('update WorkflowProgress set wpDateLastAction = ?, wpCurrentStatus = ? where wpID = ?', array($time, $num, $this->wpID));
+        $db->executeStatement('update WorkflowProgress set wpDateLastAction = ?, wpCurrentStatus = ? where wpID = ?', array($time, $num, $this->wpID));
     }
 
     /**
@@ -310,7 +310,7 @@ abstract class Progress extends ConcreteObject implements SubjectInterface
     public function addWorkflowProgressHistoryObject($obj)
     {
         $db = Database::connection();
-        $db->executeQuery('insert into WorkflowProgressHistory (wpID, object) values (?, ?)', array($this->wpID, serialize($obj)));
+        $db->executeStatement('insert into WorkflowProgressHistory (wpID, object) values (?, ?)', array($this->wpID, serialize($obj)));
     }
 
     public function markCompleted()
@@ -318,7 +318,7 @@ abstract class Progress extends ConcreteObject implements SubjectInterface
         $wf = $this->getWorkflowObject();
 
         $db = Database::connection();
-        $db->executeQuery('update WorkflowProgress set wpIsCompleted = 1 where wpID = ?', array($this->wpID));
+        $db->executeStatement('update WorkflowProgress set wpIsCompleted = 1 where wpID = ?', array($this->wpID));
 
         if (!($wf instanceof EmptyWorkflow)) {
             $application = \Core::getFacadeApplication();

--- a/concrete/src/Workflow/Progress/UserProgress.php
+++ b/concrete/src/Workflow/Progress/UserProgress.php
@@ -73,7 +73,7 @@ class UserProgress extends Progress
 
 
         $r = $db->executeQuery('SELECT wp.wpID FROM UserWorkflowProgress uwp INNER JOIN WorkflowProgress wp ON wp.wpID = uwp.wpID WHERE uwp.uID = ? ' . $filter,
-            $requestedUID);
+            [$requestedUID]);
         $list = array();
         while ($row = $r->fetch()) {
             $wp = UserProgress::getByID($row['wpID']);

--- a/concrete/src/Workflow/Progress/UserProgress.php
+++ b/concrete/src/Workflow/Progress/UserProgress.php
@@ -24,7 +24,7 @@ class UserProgress extends Progress
     {
         parent::delete();
         $db = Loader::db();
-        $db->Execute('delete from UserWorkflowProgress where wpID = ?', array($this->wpID));
+        $db->executeStatement('delete from UserWorkflowProgress where wpID = ?', array($this->wpID));
     }
 
     public static function add(Workflow $wf, UserRequest $wr)
@@ -72,7 +72,7 @@ class UserProgress extends Progress
         $filter .= ' order by ' . $sortBy;
 
 
-        $r = $db->Execute('SELECT wp.wpID FROM UserWorkflowProgress uwp INNER JOIN WorkflowProgress wp ON wp.wpID = uwp.wpID WHERE uwp.uID = ? ' . $filter,
+        $r = $db->executeQuery('SELECT wp.wpID FROM UserWorkflowProgress uwp INNER JOIN WorkflowProgress wp ON wp.wpID = uwp.wpID WHERE uwp.uID = ? ' . $filter,
             $requestedUID);
         $list = array();
         while ($row = $r->fetch()) {

--- a/concrete/src/Workflow/Request/Request.php
+++ b/concrete/src/Workflow/Request/Request.php
@@ -83,7 +83,7 @@ abstract class Request extends ConcreteObject
     public function delete()
     {
         $db = Database::connection();
-        $db->Execute('delete from WorkflowRequestObjects where wrID = ?', array($this->wrID));
+        $db->executeStatement('delete from WorkflowRequestObjects where wrID = ?', array($this->wrID));
     }
 
     public function save()
@@ -91,11 +91,11 @@ abstract class Request extends ConcreteObject
         $db = Database::connection();
         if (!$this->wrID) {
             $wrObject = '';
-            $db->Execute('insert into WorkflowRequestObjects (wrObject) values (?)', array($wrObject));
+            $db->executeStatement('insert into WorkflowRequestObjects (wrObject) values (?)', array($wrObject));
             $this->wrID = $db->Insert_ID();
         }
         $wrObject = serialize($this);
-        $db->Execute('update WorkflowRequestObjects set wrObject = ? where wrID = ?', array($wrObject, $this->wrID));
+        $db->executeStatement('update WorkflowRequestObjects set wrObject = ? where wrID = ?', array($wrObject, $this->wrID));
     }
 
     /**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -54,8 +54,8 @@ $cn->connect();
 if (!$cn->isConnected()) {
     throw new Exception('Unable to connect to test database, please create a user "ccm_test" with no password with full privileges to a database "ccm_tests"');
 }
-$cn->query('DROP DATABASE IF EXISTS ccm_tests');
-$cn->query('CREATE DATABASE ccm_tests');
+$cn->executeStatement('DROP DATABASE IF EXISTS ccm_tests');
+$cn->executeStatement('CREATE DATABASE ccm_tests');
 $cn->close();
 
 // Unset variables, so that PHPUnit won't consider them as global variables.

--- a/tests/helpers/Attribute/AttributeTestCase.php
+++ b/tests/helpers/Attribute/AttributeTestCase.php
@@ -162,7 +162,7 @@ abstract class AttributeTestCase extends ConcreteDatabaseTestCase
         $object->reindex();
 
         $db = Database::get();
-        $r = $db->query($this->indexQuery);
+        $r = $db->executeQuery($this->indexQuery);
         $row = $r->fetch();
         foreach ($columns as $column => $value) {
             $this->assertTrue(isset($row[$column]));

--- a/tests/helpers/Database/ConcreteDatabaseTestCase.php
+++ b/tests/helpers/Database/ConcreteDatabaseTestCase.php
@@ -195,21 +195,21 @@ abstract class ConcreteDatabaseTestCase extends TestCase
         $connection = $this->connection();
 
         // Get all existing tables
-        $tables = $connection->query('show tables')->fetchAllAssociative();
+        $tables = $connection->executeQuery('show tables')->fetchAllAssociative();
         $tables = array_map(function($tableSet) {
             return array_shift($tableSet);
         }, $tables);
 
         // Turn off foreign key checks
-        $connection->query('SET FOREIGN_KEY_CHECKS = 0');
+        $connection->executeStatement('SET FOREIGN_KEY_CHECKS = 0');
 
         foreach ($tables as $table) {
             // Drop tables
-            $connection->query("DROP TABLE `{$table}`");
+            $connection->executeStatement("DROP TABLE `{$table}`");
         }
 
         // Reset foreign key checks on
-        $connection->query('SET FOREIGN_KEY_CHECKS = 1');
+        $connection->executeStatement('SET FOREIGN_KEY_CHECKS = 1');
 
         // Clear exists cache
         static::$existingTables = [];
@@ -262,7 +262,7 @@ abstract class ConcreteDatabaseTestCase extends TestCase
 
         // Run queries
         foreach ($queries as $query) {
-            $connection->query($query);
+            $connection->executeStatement($query);
         }
     }
 
@@ -293,7 +293,7 @@ abstract class ConcreteDatabaseTestCase extends TestCase
         if ($xml->database && $xml->database->table_data) {
             foreach ($xml->database->table_data as $tableData) {
                 $name = $tableData['name']->__toString();
-                $connection->executeQuery("DELETE FROM " .$connection->quoteIdentifier($name));
+                $connection->executeStatement("DELETE FROM " .$connection->quoteIdentifier($name));
                 foreach ($tableData->row as $rowData) {
                     $queryBuilder = $connection->createQueryBuilder();
                     $queryBuilder->insert($name);
@@ -407,7 +407,7 @@ abstract class ConcreteDatabaseTestCase extends TestCase
 
         if ($tables === null) {
             // Get all existing tables
-            $tables = $connection->query('show tables')->fetchAllAssociative();
+            $tables = $connection->executeQuery('show tables')->fetchAllAssociative();
             $tables = array_map(function ($table) {
                 return array_shift($table);
             }, $tables);

--- a/tests/tests/Attribute/Value/NumberValue2Test.php
+++ b/tests/tests/Attribute/Value/NumberValue2Test.php
@@ -53,9 +53,9 @@ class NumberValue2Test extends ConcreteDatabaseTestCase
         static::$lastID = $avID;
 
         $db = Database::connection();
-        $db->executeQuery('insert into AttributeValues (avID) values (?)', [$avID]);
+        $db->executeStatement('insert into AttributeValues (avID) values (?)', [$avID]);
         $avID = $db->lastInsertId();
-        $db->executeQuery('insert into atNumber (avID, value) values (?, ?)', [$avID, $value]);
+        $db->executeStatement('insert into atNumber (avID, value) values (?, ?)', [$avID, $value]);
         $em = ORM::entityManager();
         $repo = $em->getRepository(NumberValue::class);
         $entity = $repo->find($avID);

--- a/tests/tests/Block/FormTest.php
+++ b/tests/tests/Block/FormTest.php
@@ -27,6 +27,6 @@ class FormTest extends BlockTypeTestCase
     {
         parent::tearDown();
         $db = Database::get();
-        $db->Execute('drop table if exists btForm');
+        $db->executeStatement('drop table if exists btForm');
     }
 }

--- a/tests/tests/Database/DatabaseTest.php
+++ b/tests/tests/Database/DatabaseTest.php
@@ -3,6 +3,8 @@
 namespace Concrete\Tests\Database;
 
 use Concrete\Core\Database\Connection\Connection;
+use Concrete\Core\Database\EntityManagerFactory;
+use Doctrine\DBAL\Connections\PrimaryReadReplicaConnection;
 use Concrete\TestHelpers\Database\ConcreteDatabaseTestCase;
 use Database;
 use PDOException;
@@ -73,7 +75,7 @@ class DatabaseTest extends ConcreteDatabaseTestCase
     public function testFetchRowsDoctrineAPI()
     {
         $db = Database::connection();
-        $r = $db->query('SELECT * FROM Users');
+        $r = $db->executeQuery('SELECT * FROM Users');
         $results = [];
         while ($row = $r->fetch()) {
             $results[] = $row;
@@ -177,4 +179,139 @@ class DatabaseTest extends ConcreteDatabaseTestCase
         $uName = $db->GetOne('SELECT uName FROM Users WHERE uEmail = ?', ["testuser5'@concrete5.org"]);
         $this->assertTrue($uName == "test'der");
     }
+    private function createPrimaryReplicaConnection(bool $keepReplica = false): Connection
+    {
+        $database = \Config::get('database');
+        $config = $database['connections'][$database['default-connection']];
+        $config['replica'] = [
+            ['server' => $config['server'], 'replicaName' => 'test-reader'],
+        ];
+        $config['keepReplica'] = $keepReplica;
+
+        /** @var Connection $connection */
+        $connection = Database::getFactory()->createConnection($config);
+        $connection->close();
+
+        return $connection;
+    }
+
+    public function testFlatConfigurationUsesConcretePrimaryReplicaConnection()
+    {
+        $database = \Config::get('database');
+        $config = $database['connections'][$database['default-connection']];
+
+        $connection = Database::getFactory()->createConnection($config);
+        $params = $connection->getParams();
+
+        $this->assertInstanceOf(PrimaryReadReplicaConnection::class, $connection);
+        $this->assertSame($params['primary'], $params['replica'][0]);
+
+        $connection->close();
+        $connection->executeQuery('SELECT 1')->fetchOne();
+        $this->assertTrue($connection->isConnectedToPrimary());
+        $connection->close();
+    }
+
+    public function testPrimaryAndReplicaConfigurationIsNormalized()
+    {
+        $database = \Config::get('database');
+        $flatConfig = $database['connections'][$database['default-connection']];
+        $config = [
+            'driver' => $flatConfig['driver'],
+            'primary' => [
+                'host' => $flatConfig['server'],
+                'user' => $flatConfig['username'],
+                'password' => $flatConfig['password'],
+                'dbname' => $flatConfig['database'],
+            ],
+            'replica' => [
+                ['server' => $flatConfig['server']],
+                ['host' => $flatConfig['server']],
+            ],
+        ];
+
+        $connection = Database::getFactory()->createConnection($config);
+        $params = $connection->getParams();
+
+        $this->assertSame($flatConfig['server'], $params['primary']['host']);
+        $this->assertSame($flatConfig['username'], $params['primary']['user']);
+        $this->assertSame($flatConfig['database'], $params['primary']['database']);
+        $this->assertSame($flatConfig['database'], $params['primary']['dbname']);
+        $this->assertCount(2, $params['replica']);
+        $this->assertSame($params['primary']['password'], $params['replica'][0]['password']);
+        $this->assertSame($flatConfig['server'], $params['replica'][0]['host']);
+        $connection->close();
+    }
+
+    public function testDbalReadWriteRoutingAndStickyPrimary()
+    {
+        $connection = $this->createPrimaryReplicaConnection();
+
+        $connection->executeQuery('SELECT 1')->fetchOne();
+        $this->assertFalse($connection->isConnectedToPrimary());
+
+        $connection->executeStatement('SET @concrete_primary_replica_test = 1');
+        $this->assertTrue($connection->isConnectedToPrimary());
+
+        $connection->executeQuery('SELECT 1')->fetchOne();
+        $this->assertTrue($connection->isConnectedToPrimary());
+        $connection->close();
+    }
+
+    public function testLegacyApisAlwaysUsePrimary()
+    {
+        $connection = $this->createPrimaryReplicaConnection();
+        $connection->query('SELECT 1');
+        $this->assertTrue($connection->isConnectedToPrimary());
+        $connection->close();
+
+        $connection = $this->createPrimaryReplicaConnection();
+        $connection->Execute('SELECT 1');
+        $this->assertTrue($connection->isConnectedToPrimary());
+        $connection->close();
+    }
+
+    public function testKeepReplicaAllowsExplicitSwitchBack()
+    {
+        $connection = $this->createPrimaryReplicaConnection(true);
+
+        $connection->executeQuery('SELECT 1')->fetchOne();
+        $this->assertFalse($connection->isConnectedToPrimary());
+
+        $connection->executeStatement('SET @concrete_primary_replica_test = 1');
+        $this->assertTrue($connection->isConnectedToPrimary());
+
+        $connection->ensureConnectedToReplica();
+        $this->assertFalse($connection->isConnectedToPrimary());
+        $connection->close();
+    }
+
+    public function testDoctrineOrmUsesTheSameReadWriteRouting()
+    {
+        $connection = $this->createPrimaryReplicaConnection();
+        $entityManager = app(EntityManagerFactory::class)->create($connection);
+
+        $entityManager
+            ->createQuery('SELECT u.uID FROM Concrete\\Core\\Entity\\User\\User u')
+            ->setMaxResults(1)
+            ->getScalarResult()
+        ;
+        $this->assertFalse($connection->isConnectedToPrimary());
+
+        $entityManager
+            ->createQuery('UPDATE Concrete\\Core\\Entity\\User\\User u SET u.uName = u.uName WHERE u.uID = -1')
+            ->execute()
+        ;
+        $this->assertTrue($connection->isConnectedToPrimary());
+
+        $entityManager
+            ->createQuery('SELECT u.uID FROM Concrete\\Core\\Entity\\User\\User u')
+            ->setMaxResults(1)
+            ->getScalarResult()
+        ;
+        $this->assertTrue($connection->isConnectedToPrimary());
+
+        $entityManager->close();
+    }
+
 }

--- a/tests/tests/Database/ReadWriteMethodUsageTest.php
+++ b/tests/tests/Database/ReadWriteMethodUsageTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Concrete\Tests\Database;
+
+use Concrete\Tests\TestCase;
+use FilesystemIterator;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+
+class ReadWriteMethodUsageTest extends TestCase
+{
+    public function testFirstPartyCodeUsesExplicitReadWriteMethods()
+    {
+        $root = dirname(__DIR__, 3);
+        $ignoredFiles = [
+            realpath($root . '/concrete/src/Database/Connection/Connection.php'),
+            realpath($root . '/tests/tests/Database/DatabaseTest.php'),
+            realpath(__FILE__),
+        ];
+        $violations = [];
+
+        foreach (['concrete', 'application', 'packages', 'tests'] as $directory) {
+            $iterator = new RecursiveIteratorIterator(
+                new RecursiveDirectoryIterator($root . '/' . $directory, FilesystemIterator::SKIP_DOTS)
+            );
+            foreach ($iterator as $file) {
+                $path = $file->getPathname();
+                if ($file->getExtension() !== 'php'
+                    || strpos($path, $root . '/concrete/vendor/') === 0
+                    || in_array(realpath($path), $ignoredFiles, true)
+                ) {
+                    continue;
+                }
+
+                $source = $this->stripComments(file_get_contents($path));
+                $writePattern = '/->(?:executeQuery|fetchAllAssociative|fetchAssociative|fetchOne|fetchFirstColumn|fetchColumn)' .
+                    '\\s*\\(\\s*([\'"])\\s*(?:INSERT|UPDATE|DELETE|REPLACE|TRUNCATE|ALTER|CREATE|DROP|RENAME|' .
+                    'GRANT|REVOKE|CALL|SET\\b|LOCK|UNLOCK)/i';
+                $legacyPattern = '/(?:\\$(?:db|connection|conn|cn|database)|\\$this->connection)' .
+                    '\\s*->\\s*(?:query|Execute)\\s*\\(/';
+
+                $this->collectViolations($violations, $path, $source, $writePattern, 'write SQL passed to a read API');
+                $this->collectViolations($violations, $path, $source, $legacyPattern, 'deprecated mixed-purpose database API');
+            }
+        }
+
+        $this->assertSame([], $violations, implode("\n", $violations));
+    }
+
+    private function stripComments($source)
+    {
+        $result = '';
+        foreach (token_get_all($source) as $token) {
+            if (is_array($token) && in_array($token[0], [T_COMMENT, T_DOC_COMMENT], true)) {
+                $result .= preg_replace('/[^\\r\\n]/', ' ', $token[1]);
+            } else {
+                $result .= is_array($token) ? $token[1] : $token;
+            }
+        }
+
+        return $result;
+    }
+
+    private function collectViolations(array &$violations, $path, $source, $pattern, $description)
+    {
+        if (!preg_match_all($pattern, $source, $matches, PREG_OFFSET_CAPTURE)) {
+            return;
+        }
+        foreach ($matches[0] as $match) {
+            $line = substr_count(substr($source, 0, $match[1]), "\n") + 1;
+            $violations[] = $path . ':' . $line . ': ' . $description;
+        }
+    }
+}
+


### PR DESCRIPTION
These changes were generated by Codex running GPT 5.6 high, so the conversion might not be fully complete.

This change:
1. Adds support for `PrimaryReadReplicaConnection` allowing reads to go to fast read replicas, and writes to go to slow writers. This is particularly helpful when deploying in geographically distinct locations, writing to the database might be extremely slow in those cases.
2. Updates calls in many many places to use the correct `->executeStatement` or `->executeQuery` method depending on whether a write or a read is taking place.