### PR TITLE
ApplicationServiceProvider: Allow using class names with dependency injection

### DIFF
--- a/concrete/src/Application/ApplicationServiceProvider.php
+++ b/concrete/src/Application/ApplicationServiceProvider.php
@@ -36,13 +36,13 @@ class ApplicationServiceProvider extends ServiceProvider
             // deprecated
             'helper/concrete/avatar' => 'Concrete\Core\Legacy\Avatar',
         ];
+        foreach ($singletons as $alias => $class) {
+            $this->app->singleton($class);
+            $this->app->alias($class, $alias);
+        }
 
         $this->app->singleton('Concrete\Core\ConcreteCms\ActivityService');
         $this->app->singleton('Concrete\Core\Block\Menu\Manager');
-
-        foreach ($singletons as $key => $value) {
-            $this->app->singleton($key, $value);
-        }
 
         $this->app->bind('error', 'Concrete\Core\Error\ErrorList\ErrorList');
 

--- a/concrete/src/Application/ApplicationServiceProvider.php
+++ b/concrete/src/Application/ApplicationServiceProvider.php
@@ -28,12 +28,13 @@ class ApplicationServiceProvider extends ServiceProvider
             'helper/concrete/validation' => 'Concrete\Core\Application\Service\Validation',
             'helper/rating' => 'Concrete\Attribute\Rating\Service',
             'helper/pagination' => 'Concrete\Core\Legacy\Pagination',
-
             'help' => 'Concrete\Core\Application\Service\UserInterface\Help',
             'help/core' => 'Concrete\Core\Application\Service\UserInterface\Help\CoreManager',
             'help/dashboard' => 'Concrete\Core\Application\Service\UserInterface\Help\DashboardManager',
             'help/block_type' => 'Concrete\Core\Application\Service\UserInterface\Help\BlockTypeManager',
             'help/panel' => 'Concrete\Core\Application\Service\UserInterface\Help\PanelManager',
+            // deprecated
+            'helper/concrete/avatar' => 'Concrete\Core\Legacy\Avatar',
         ];
 
         $this->app->singleton('Concrete\Core\ConcreteCms\ActivityService');
@@ -52,11 +53,6 @@ class ApplicationServiceProvider extends ServiceProvider
         $this->app->bind(ContainerInterface::class, function() {
             return $this->app;
         });
-
-        /*
-         * @deprecated
-         */
-        $this->app->singleton('helper/concrete/avatar', 'Concrete\Core\Legacy\Avatar');
 
         $this->app->singleton(JsonSerializer::class, function($app) {
             $serializer = new JsonSerializer([

--- a/concrete/src/Application/ApplicationServiceProvider.php
+++ b/concrete/src/Application/ApplicationServiceProvider.php
@@ -46,7 +46,7 @@ class ApplicationServiceProvider extends ServiceProvider
 
         $this->app->bind('error', 'Concrete\Core\Error\ErrorList\ErrorList');
 
-        $this->app->bindShared('environment', static function ($app) {
+        $this->app->singleton('environment', static function ($app) {
             return Environment::get();
         });
 

--- a/concrete/src/Application/ApplicationServiceProvider.php
+++ b/concrete/src/Application/ApplicationServiceProvider.php
@@ -14,26 +14,26 @@ class ApplicationServiceProvider extends ServiceProvider
     public function register()
     {
         $singletons = [
-            'helper/concrete/asset_library' => '\Concrete\Core\Application\Service\FileManager',
-            'helper/concrete/file_manager' => '\Concrete\Core\Application\Service\FileManager',
-            'helper/concrete/composer' => '\Concrete\Core\Application\Service\Composer',
-            'helper/concrete/dashboard' => '\Concrete\Core\Application\Service\Dashboard',
-            'helper/concrete/dashboard/sitemap' => '\Concrete\Core\Application\Service\Dashboard\Sitemap',
-            'helper/concrete/ui' => '\Concrete\Core\Application\Service\UserInterface',
-            'helper/concrete/ui/menu' => '\Concrete\Core\Application\Service\UserInterface\Menu',
-            'helper/concrete/ui/help' => '\Concrete\Core\Application\Service\UserInterface\Help',
-            'helper/concrete/upgrade' => '\Concrete\Core\Application\Service\Upgrade',
-            'helper/concrete/urls' => '\Concrete\Core\Application\Service\Urls',
-            'helper/concrete/user' => '\Concrete\Core\Application\Service\User',
-            'helper/concrete/validation' => '\Concrete\Core\Application\Service\Validation',
-            'helper/rating' => '\Concrete\Attribute\Rating\Service',
-            'helper/pagination' => '\Concrete\Core\Legacy\Pagination',
+            'helper/concrete/asset_library' => 'Concrete\Core\Application\Service\FileManager',
+            'helper/concrete/file_manager' => 'Concrete\Core\Application\Service\FileManager',
+            'helper/concrete/composer' => 'Concrete\Core\Application\Service\Composer',
+            'helper/concrete/dashboard' => 'Concrete\Core\Application\Service\Dashboard',
+            'helper/concrete/dashboard/sitemap' => 'Concrete\Core\Application\Service\Dashboard\Sitemap',
+            'helper/concrete/ui' => 'Concrete\Core\Application\Service\UserInterface',
+            'helper/concrete/ui/menu' => 'Concrete\Core\Application\Service\UserInterface\Menu',
+            'helper/concrete/ui/help' => 'Concrete\Core\Application\Service\UserInterface\Help',
+            'helper/concrete/upgrade' => 'Concrete\Core\Application\Service\Upgrade',
+            'helper/concrete/urls' => 'Concrete\Core\Application\Service\Urls',
+            'helper/concrete/user' => 'Concrete\Core\Application\Service\User',
+            'helper/concrete/validation' => 'Concrete\Core\Application\Service\Validation',
+            'helper/rating' => 'Concrete\Attribute\Rating\Service',
+            'helper/pagination' => 'Concrete\Core\Legacy\Pagination',
 
-            'help' => '\Concrete\Core\Application\Service\UserInterface\Help',
-            'help/core' => '\Concrete\Core\Application\Service\UserInterface\Help\CoreManager',
-            'help/dashboard' => '\Concrete\Core\Application\Service\UserInterface\Help\DashboardManager',
-            'help/block_type' => '\Concrete\Core\Application\Service\UserInterface\Help\BlockTypeManager',
-            'help/panel' => '\Concrete\Core\Application\Service\UserInterface\Help\PanelManager',
+            'help' => 'Concrete\Core\Application\Service\UserInterface\Help',
+            'help/core' => 'Concrete\Core\Application\Service\UserInterface\Help\CoreManager',
+            'help/dashboard' => 'Concrete\Core\Application\Service\UserInterface\Help\DashboardManager',
+            'help/block_type' => 'Concrete\Core\Application\Service\UserInterface\Help\BlockTypeManager',
+            'help/panel' => 'Concrete\Core\Application\Service\UserInterface\Help\PanelManager',
         ];
 
         $this->app->singleton('Concrete\Core\ConcreteCms\ActivityService');
@@ -56,7 +56,7 @@ class ApplicationServiceProvider extends ServiceProvider
         /*
          * @deprecated
          */
-        $this->app->singleton('helper/concrete/avatar', '\Concrete\Core\Legacy\Avatar');
+        $this->app->singleton('helper/concrete/avatar', 'Concrete\Core\Legacy\Avatar');
 
         $this->app->singleton(JsonSerializer::class, function($app) {
             $serializer = new JsonSerializer([

--- a/concrete/src/Application/ApplicationServiceProvider.php
+++ b/concrete/src/Application/ApplicationServiceProvider.php
@@ -13,7 +13,7 @@ class ApplicationServiceProvider extends ServiceProvider
 {
     public function register()
     {
-        $singletons = array(
+        $singletons = [
             'helper/concrete/asset_library' => '\Concrete\Core\Application\Service\FileManager',
             'helper/concrete/file_manager' => '\Concrete\Core\Application\Service\FileManager',
             'helper/concrete/composer' => '\Concrete\Core\Application\Service\Composer',
@@ -34,7 +34,7 @@ class ApplicationServiceProvider extends ServiceProvider
             'help/dashboard' => '\Concrete\Core\Application\Service\UserInterface\Help\DashboardManager',
             'help/block_type' => '\Concrete\Core\Application\Service\UserInterface\Help\BlockTypeManager',
             'help/panel' => '\Concrete\Core\Application\Service\UserInterface\Help\PanelManager',
-        );
+        ];
 
         $this->app->singleton('Concrete\Core\ConcreteCms\ActivityService');
         $this->app->singleton('Concrete\Core\Block\Menu\Manager');
@@ -45,10 +45,8 @@ class ApplicationServiceProvider extends ServiceProvider
 
         $this->app->bind('error', 'Concrete\Core\Error\ErrorList\ErrorList');
 
-        $this->app->bindShared('environment', function ($app) {
-            $env = Environment::get();
-
-            return $env;
+        $this->app->bindShared('environment', static function ($app) {
+            return Environment::get();
         });
 
         $this->app->bind(ContainerInterface::class, function() {

--- a/concrete/src/Application/ApplicationServiceProvider.php
+++ b/concrete/src/Application/ApplicationServiceProvider.php
@@ -33,6 +33,7 @@ class ApplicationServiceProvider extends ServiceProvider
             'help/dashboard' => 'Concrete\Core\Application\Service\UserInterface\Help\DashboardManager',
             'help/block_type' => 'Concrete\Core\Application\Service\UserInterface\Help\BlockTypeManager',
             'help/panel' => 'Concrete\Core\Application\Service\UserInterface\Help\PanelManager',
+            'environment' => Environment::class,
             // deprecated
             'helper/concrete/avatar' => 'Concrete\Core\Legacy\Avatar',
         ];
@@ -45,10 +46,6 @@ class ApplicationServiceProvider extends ServiceProvider
         $this->app->singleton('Concrete\Core\Block\Menu\Manager');
 
         $this->app->bind('error', 'Concrete\Core\Error\ErrorList\ErrorList');
-
-        $this->app->singleton('environment', static function ($app) {
-            return Environment::get();
-        });
 
         $this->app->bind(ContainerInterface::class, function() {
             return $this->app;


### PR DESCRIPTION
We currently have that stuff like

```php
$app->make('helper/concrete/asset_library')
```

returns a singleton, but stuff like

```php
$app->make(\Concrete\Core\Application\Service\FileManager::class)
```

always creates a new instance of the classes.

This prevents writing code that uses dependency injection, for example

```php
class MyClass
{
    public function __construct(
        \Concrete\Core\Application\Service\FileManager $fileManager
    ) {
    }
)

$app->make(MyClass::class);
```

Let's make it work.

