### PR TITLE
Fix package directory removal during package uninstall

### DIFF
--- a/concrete/controllers/single_page/dashboard/extend/install.php
+++ b/concrete/controllers/single_page/dashboard/extend/install.php
@@ -131,18 +131,24 @@ class Install extends DashboardPageController implements LoggerAwareInterface
                     if ($r instanceof ErrorList) {
                         $this->error->add(t('The package has been uninstalled, but its directory could not be removed from the installation directory.'));
                         $this->error->add($r);
-                        $this->view();
+                        $this->flash('error', $this->error->toText());
 
-                        return;
+                        return $this->buildRedirect('/dashboard/extend/install');
                     }
                     $packageDirectoryRemoved = true;
                 }
                 if (!$this->error->has()) {
                     if ($packageDirectoryRemoved) {
-                        $this->redirect('/dashboard/extend/install', 'package_uninstalled', 'directory_removed');
+                        $message = t(
+                            'The package has been uninstalled and its directory has been moved to the package backup directory on the server: %s.',
+                            $this->getPackageBackupDirectoryDisplayPath()
+                        );
                     } else {
-                        $this->redirect('/dashboard/extend/install', 'package_uninstalled');
+                        $message = t('The package has been uninstalled.');
                     }
+                    $this->flash('success', $message);
+
+                    return $this->buildRedirect('/dashboard/extend/install');
                 }
             } else {
                 $this->error->add($test);
@@ -168,20 +174,10 @@ class Install extends DashboardPageController implements LoggerAwareInterface
         }
     }
 
-    public function package_uninstalled($status = null)
+    public function package_uninstalled()
     {
         $this->view();
-        $packageRemovedMessage = t('The package has been uninstalled.');
-        if ($status === 'directory_removed') {
-            $packageRemovedMessage = t(
-                'The package has been uninstalled and its directory has been moved to the package backup directory on the server: %s.',
-                $this->getPackageBackupDirectoryDisplayPath()
-            );
-        }
-        $this->set(
-            'message',
-            $packageRemovedMessage
-        );
+        $this->set('message', t('The package has been uninstalled.'));
     }
 
     private function getPackageBackupDirectoryDisplayPath(): string

--- a/concrete/controllers/single_page/dashboard/extend/install.php
+++ b/concrete/controllers/single_page/dashboard/extend/install.php
@@ -93,6 +93,7 @@ class Install extends DashboardPageController implements LoggerAwareInterface
         $manager = $this->app->make(Manager::class, ['application' => $this->app]);
         $this->set('text', Loader::helper('text'));
         $this->set('pkg', $pkg);
+        $this->set('packageBackupErrors', $pkg->getController()->getBackupErrors());
         $this->set('categories', $manager->getPackageItemCategories());
     }
 
@@ -123,15 +124,25 @@ class Install extends DashboardPageController implements LoggerAwareInterface
             $test = $p->testForUninstall();
 
             if (!is_object($test)) {
-                $r = Package::uninstall($p);
+                Package::uninstall($p);
+                $packageDirectoryRemoved = false;
                 if ($this->post('pkgMoveToTrash')) {
-                    $r = $pkg->backup();
+                    $r = $p->backup();
                     if ($r instanceof ErrorList) {
+                        $this->error->add(t('The package has been uninstalled, but its directory could not be removed from the installation directory.'));
                         $this->error->add($r);
+                        $this->view();
+
+                        return;
                     }
+                    $packageDirectoryRemoved = true;
                 }
                 if (!$this->error->has()) {
-                    $this->redirect('/dashboard/extend/install', 'package_uninstalled');
+                    if ($packageDirectoryRemoved) {
+                        $this->redirect('/dashboard/extend/install', 'package_uninstalled', 'directory_removed');
+                    } else {
+                        $this->redirect('/dashboard/extend/install', 'package_uninstalled');
+                    }
                 }
             } else {
                 $this->error->add($test);
@@ -157,10 +168,25 @@ class Install extends DashboardPageController implements LoggerAwareInterface
         }
     }
 
-    public function package_uninstalled()
+    public function package_uninstalled($status = null)
     {
         $this->view();
-        $this->set('message', t('The package has been uninstalled.'));
+        $packageRemovedMessage = t('The package has been uninstalled.');
+        if ($status === 'directory_removed') {
+            $packageRemovedMessage = t(
+                'The package has been uninstalled and its directory has been moved to the package backup directory on the server: %s.',
+                $this->getPackageBackupDirectoryDisplayPath()
+            );
+        }
+        $this->set(
+            'message',
+            $packageRemovedMessage
+        );
+    }
+
+    private function getPackageBackupDirectoryDisplayPath(): string
+    {
+        return str_replace('\\', '/', $this->app->make('config')->get('concrete.misc.package_backup_directory'));
     }
 
     public function install_package($package)

--- a/concrete/single_pages/dashboard/extend/install.php
+++ b/concrete/single_pages/dashboard/extend/install.php
@@ -80,6 +80,7 @@ if ($this->controller->getTask() == 'install_package' && isset($showInstallOptio
     <?php
 } elseif (isset($pkg) && is_object($pkg) && $this->controller->getTask() == 'uninstall' && $tp->canUninstallPackages()) {
     $pkgID = $pkg->getPackageID();
+    $canMovePackageToTrash = !isset($packageBackupErrors) || !$packageBackupErrors->has();
     ?>
     <form method="post" class="form-stacked" id="ccm-uninstall-form" action="<?= $view->action('do_uninstall_package'); ?>">
         <?= $token->output('uninstall'); ?>
@@ -103,9 +104,28 @@ if ($this->controller->getTask() == 'install_package' && isset($showInstallOptio
             <div class="form-group">
                 <label class="control-label form-label"><?= t('Move package to trash directory on server?'); ?></label>
                 <div class="form-check">
-                    <?= $app->make('helper/form')->checkbox('pkgMoveToTrash', 1); ?>
+                    <?= $app->make('helper/form')->checkbox('pkgMoveToTrash', 1, false, $canMovePackageToTrash ? [] : ['disabled' => 'disabled']); ?>
                     <label for="pkgMoveToTrash" class="form-check-label"><?= t('Yes, remove the package\'s directory from the installation directory.'); ?></label>
                 </div>
+                <?php
+                if (!$canMovePackageToTrash) {
+                    ?>
+                    <div class="alert alert-warning">
+                        <p><?= t('If you click "Uninstall", the package will be uninstalled, but the checkbox option above cannot be selected because Concrete CMS cannot move this package directory to the trash directory. Package files will remain on the server.'); ?></p>
+                        <p class="mb-1"><?= t('Reason:'); ?></p>
+                        <ul class="mb-0">
+                            <?php
+                            foreach ($packageBackupErrors->getList() as $error) {
+                                ?>
+                                <li><?= h((string) $error); ?></li>
+                                <?php
+                            }
+                            ?>
+                        </ul>
+                    </div>
+                    <?php
+                }
+                ?>
             </div>
         </fieldset>
         <div class="ccm-dashboard-form-actions-wrapper">

--- a/concrete/src/Package/Package.php
+++ b/concrete/src/Package/Package.php
@@ -919,17 +919,12 @@ abstract class Package implements LocalizablePackageInterface
      */
     public function backup()
     {
-        $config = $this->app->make('config');
-        $trash = $config->get('concrete.misc.package_backup_directory');
-        if (!is_dir($trash)) {
-            @mkdir($trash, $config->get('concrete.filesystem.permissions.directory'));
-        }
-
         $errors = $this->getBackupErrors();
         if ($errors->has()) {
             return $errors;
         }
 
+        $trash = $this->app->make('config')->get('concrete.misc.package_backup_directory');
         $packageHandle = $this->getPackageHandle();
         $packagePath = DIR_PACKAGES . '/' . $packageHandle;
         $trashName = $trash . '/' . $packageHandle . '_' . date('YmdHis');
@@ -1003,7 +998,7 @@ abstract class Package implements LocalizablePackageInterface
     }
 
     /**
-     * Check whether the current package directory can be moved to the trash directory.
+     * Create the trash directory if needed and check whether the current package directory can be moved there.
      */
     public function getBackupErrors(): ErrorList
     {
@@ -1015,19 +1010,31 @@ abstract class Package implements LocalizablePackageInterface
         } else {
             $config = $this->app->make('config');
             $trash = $config->get('concrete.misc.package_backup_directory');
-            if (!is_dir($trash)) {
-                $trashParent = dirname($trash);
-                if (!is_dir($trashParent) || !is_writable($trashParent)) {
+            if (!is_string($trash) || trim($trash) === '') {
+                $this->addPackageFilesystemError(
+                    $errors,
+                    t('The package trash directory is not configured.')
+                );
+            } elseif ((file_exists($trash) || is_link($trash)) && !is_dir($trash)) {
+                $this->addPackageFilesystemError(
+                    $errors,
+                    t('The configured package trash path "%s" exists but is not a directory.', $trash)
+                );
+            } else {
+                if (!is_dir($trash)) {
+                    @mkdir($trash, $config->get('concrete.filesystem.permissions.directory'), true);
+                }
+                if (!is_dir($trash)) {
                     $this->addPackageFilesystemError(
                         $errors,
                         t('Unable to create the package trash directory "%s". Check write permissions for the parent directory.', $trash)
                     );
+                } elseif (!is_writable($trash)) {
+                    $this->addPackageFilesystemError(
+                        $errors,
+                        t('Unable to write to the package trash directory "%s".', $trash)
+                    );
                 }
-            } elseif (!is_writable($trash)) {
-                $this->addPackageFilesystemError(
-                    $errors,
-                    t('Unable to write to the package trash directory "%s".', $trash)
-                );
             }
             if (!is_writable(DIR_PACKAGES)) {
                 $this->addPackageFilesystemError(

--- a/concrete/src/Package/Package.php
+++ b/concrete/src/Package/Package.php
@@ -15,13 +15,16 @@ use Concrete\Core\Database\EntityManager\Driver\CoreDriver;
 use Concrete\Core\Database\EntityManager\Provider\PackageProviderFactory;
 use Concrete\Core\Database\Schema\Schema;
 use Concrete\Core\Entity\Package as PackageEntity;
+use Concrete\Core\Error\ErrorList\ErrorList;
 use Concrete\Core\Events\EventDispatcher;
+use Concrete\Core\File\Service\File as FileService;
 use Concrete\Core\Package\Dependency\DependencyChecker;
 use Concrete\Core\Package\Event\PackageEvent;
 use Concrete\Core\Package\Event\UninstallEvent;
 use Concrete\Core\Package\Event\UpgradeEvent;
 use Concrete\Core\Package\ItemCategory\Manager;
 use Concrete\Core\Page\Theme\Theme;
+use Concrete\Core\System\SystemUser;
 use Doctrine\Common\Proxy\ProxyGenerator;
 use Doctrine\DBAL\Schema\Comparator as SchemaComparator;
 use Doctrine\ORM\EntityManager;
@@ -916,29 +919,141 @@ abstract class Package implements LocalizablePackageInterface
      */
     public function backup()
     {
+        $config = $this->app->make('config');
+        $trash = $config->get('concrete.misc.package_backup_directory');
+        if (!is_dir($trash)) {
+            @mkdir($trash, $config->get('concrete.filesystem.permissions.directory'));
+        }
+
+        $errors = $this->getBackupErrors();
+        if ($errors->has()) {
+            return $errors;
+        }
+
+        $packageHandle = $this->getPackageHandle();
+        $packagePath = DIR_PACKAGES . '/' . $packageHandle;
+        $trashName = $trash . '/' . $packageHandle . '_' . date('YmdHis');
+        if (!$this->movePackageDirectoryToTrash($packagePath, $trashName)) {
+            $this->addPackageFilesystemError(
+                $errors,
+                t(
+                    'Unable to move the package directory from "%1$s" to "%2$s". Check write permissions on the package directory and trash directory.',
+                    $packagePath,
+                    $trashName
+                )
+            );
+        }
+
+        return $errors->has() ? $errors : $this;
+    }
+
+    private function movePackageDirectoryToTrash(
+        string $packagePath,
+        string $trashName
+    ): bool {
+        if (@rename($packagePath, $trashName)) {
+            $this->backedUpFname = $trashName;
+
+            return true;
+        }
+
+        $fileService = $this->app->make(FileService::class);
+        @$fileService->copyAll($packagePath, $trashName);
+        if (!$this->packageDirectoryWasCopied($packagePath, $trashName)) {
+            if (is_dir($trashName)) {
+                @$fileService->removeAll($trashName, true);
+            }
+
+            return false;
+        }
+        if (!$fileService->removeAll($packagePath, true)) {
+            return false;
+        }
+
+        $this->backedUpFname = $trashName;
+
+        return true;
+    }
+
+    private function packageDirectoryWasCopied(
+        string $packagePath,
+        string $trashName
+    ): bool {
+        if (!is_dir($packagePath) || !is_dir($trashName)) {
+            return false;
+        }
+
+        $files = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($packagePath, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::SELF_FIRST
+        );
+        foreach ($files as $file) {
+            $relativePath = substr($file->getPathname(), strlen($packagePath) + 1);
+            $copiedPath = $trashName . '/' . $relativePath;
+            if ($file->isDir()) {
+                if (!is_dir($copiedPath)) {
+                    return false;
+                }
+            } elseif (!is_file($copiedPath) || filesize($file->getPathname()) !== filesize($copiedPath)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Check whether the current package directory can be moved to the trash directory.
+     */
+    public function getBackupErrors(): ErrorList
+    {
         $packageHandle = $this->getPackageHandle();
         $errors = $this->app->make('error');
-        if ($packageHandle === '' || !is_dir(DIR_PACKAGES . '/' . $packageHandle)) {
+        $packagePath = DIR_PACKAGES . '/' . $packageHandle;
+        if ($packageHandle === '' || !is_dir($packagePath)) {
             $errors->add($this->getErrorText(self::E_PACKAGE_NOT_FOUND));
         } else {
             $config = $this->app->make('config');
             $trash = $config->get('concrete.misc.package_backup_directory');
             if (!is_dir($trash)) {
-                @mkdir($trash, $config->get('concrete.filesystem.permissions.directory'));
-            }
-            if (!is_dir($trash)) {
-                $errors->add($this->getErrorText(self::E_PACKAGE_MIGRATE_BACKUP));
-            } else {
-                $trashName = $trash . '/' . $packageHandle . '_' . date('YmdHis');
-                if (!@rename(DIR_PACKAGES . '/' . $this->getPackageHandle(), $trashName)) {
-                    $errors->add($this->getErrorText(self::E_PACKAGE_MIGRATE_BACKUP));
-                } else {
-                    $this->backedUpFname = $trashName;
+                $trashParent = dirname($trash);
+                if (!is_dir($trashParent) || !is_writable($trashParent)) {
+                    $this->addPackageFilesystemError(
+                        $errors,
+                        t('Unable to create the package trash directory "%s". Check write permissions for the parent directory.', $trash)
+                    );
                 }
+            } elseif (!is_writable($trash)) {
+                $this->addPackageFilesystemError(
+                    $errors,
+                    t('Unable to write to the package trash directory "%s".', $trash)
+                );
+            }
+            if (!is_writable(DIR_PACKAGES)) {
+                $this->addPackageFilesystemError(
+                    $errors,
+                    t('Unable to move the package directory because the package installation directory "%s" is not writable.', DIR_PACKAGES)
+                );
             }
         }
 
-        return $errors->has() ? $errors : $this;
+        return $errors;
+    }
+
+    private function addPackageFilesystemError(
+        ErrorList $errors,
+        string $message
+    ): void {
+        $username = $this->app->make(SystemUser::class)->getCurrentUserName();
+        if ($username === '') {
+            $username = t('unknown');
+        }
+
+        $errors->add(t(
+            '%1$s PHP process user: %2$s.',
+            $message,
+            $username
+        ));
     }
 
     /**

--- a/tests/tests/Package/PackageBackupTest.php
+++ b/tests/tests/Package/PackageBackupTest.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace Concrete\Core\Package {
+    if (!function_exists(__NAMESPACE__ . '\rename')) {
+        function rename($old, $new)
+        {
+            if (!empty($GLOBALS['PACKAGE_BACKUP_TEST_FORCE_RENAME_FAILURE'])) {
+                return false;
+            }
+
+            return \rename($old, $new);
+        }
+    }
+}
+
+namespace Concrete\Tests\Package {
+    use Concrete\Core\Application\Application;
+    use Concrete\Core\Error\ErrorList\ErrorList;
+    use Concrete\Core\File\Service\File;
+    use Concrete\Core\Package\Package;
+    use Concrete\Tests\TestCase;
+
+    class PackageBackupTest extends TestCase
+    {
+        public function testBackupReportsPackageDirectoryNotWritable(): void
+        {
+            if (DIRECTORY_SEPARATOR === '\\') {
+                $this->markTestSkipped('Changing directory writability is not reliable on Windows.');
+            }
+
+            $handle = 'package_backup_not_writable_test';
+            $packagePath = DIR_PACKAGES . '/' . $handle;
+            $trash = app('config')->get('concrete.misc.package_backup_directory');
+            $createdTrash = false;
+
+            if (is_dir($packagePath)) {
+                app(File::class)->removeAll($packagePath, true);
+            }
+            if (!is_dir($packagePath) && !@mkdir($packagePath, 0777, true)) {
+                $this->markTestSkipped('Unable to create the test package directory.');
+            }
+            if (!is_dir($trash)) {
+                $createdTrash = @mkdir($trash, app('config')->get('concrete.filesystem.permissions.directory'), true);
+            }
+            if (!is_dir($trash) || !is_writable($trash)) {
+                $this->markTestSkipped('Package trash directory is not writable in this environment.');
+            }
+
+            $originalPermissions = fileperms(DIR_PACKAGES) & 0777;
+            $result = null;
+            $package = new class(app(), $handle) extends Package {
+                protected $pkgHandle;
+
+                public function __construct(Application $app, string $handle)
+                {
+                    parent::__construct($app);
+                    $this->pkgHandle = $handle;
+                }
+            };
+
+            try {
+                if (!@chmod(DIR_PACKAGES, 0555)) {
+                    $this->markTestSkipped('Unable to change package directory permissions.');
+                }
+
+                clearstatcache(true, DIR_PACKAGES);
+                if (is_writable(DIR_PACKAGES)) {
+                    $this->markTestSkipped('The current process can still write to the package directory.');
+                }
+
+                $result = $package->backup();
+            } finally {
+                @chmod(DIR_PACKAGES, $originalPermissions);
+                if (is_dir($packagePath)) {
+                    app(File::class)->removeAll($packagePath, true);
+                }
+                if ($createdTrash && is_dir($trash)) {
+                    @rmdir($trash);
+                }
+            }
+
+            $this->assertInstanceOf(ErrorList::class, $result);
+            $message = (string) $result;
+            $this->assertStringContainsString('Unable to move the package directory because the package installation directory', $message);
+            $this->assertStringContainsString(DIR_PACKAGES, $message);
+            $this->assertStringContainsString('not writable', $message);
+            $this->assertStringContainsString('PHP process user:', $message);
+        }
+
+        public function testBackupFallsBackToCopyAndRemoveWhenRenameFails(): void
+        {
+            $handle = 'package_backup_rename_fallback_test';
+            $packagePath = DIR_PACKAGES . '/' . $handle;
+            $trash = app('config')->get('concrete.misc.package_backup_directory');
+            $fileService = app(File::class);
+            $result = null;
+            $sourceExists = true;
+            $backupContent = null;
+
+            if (is_dir($packagePath)) {
+                $fileService->removeAll($packagePath, true);
+            }
+            foreach (glob($trash . '/' . $handle . '_*') ?: [] as $backupPath) {
+                if (is_dir($backupPath)) {
+                    $fileService->removeAll($backupPath, true);
+                }
+            }
+            if (!is_dir($trash) && !@mkdir($trash, app('config')->get('concrete.filesystem.permissions.directory'), true)) {
+                $this->markTestSkipped('Unable to create the package trash directory.');
+            }
+            if (!@mkdir($packagePath, 0777, true)) {
+                $this->markTestSkipped('Unable to create the test package directory.');
+            }
+            file_put_contents($packagePath . '/probe.txt', 'ok');
+
+            $package = new class(app(), $handle) extends Package {
+                protected $pkgHandle;
+
+                public function __construct(Application $app, string $handle)
+                {
+                    parent::__construct($app);
+                    $this->pkgHandle = $handle;
+                }
+            };
+
+            try {
+                $GLOBALS['PACKAGE_BACKUP_TEST_FORCE_RENAME_FAILURE'] = true;
+                $result = $package->backup();
+                $sourceExists = is_dir($packagePath);
+                $backupFiles = glob($trash . '/' . $handle . '_*/probe.txt') ?: [];
+                if (count($backupFiles) === 1) {
+                    $backupContent = file_get_contents($backupFiles[0]);
+                }
+            } finally {
+                unset($GLOBALS['PACKAGE_BACKUP_TEST_FORCE_RENAME_FAILURE']);
+                if (is_dir($packagePath)) {
+                    $fileService->removeAll($packagePath, true);
+                }
+                foreach (glob($trash . '/' . $handle . '_*') ?: [] as $backupPath) {
+                    if (is_dir($backupPath)) {
+                        $fileService->removeAll($backupPath, true);
+                    }
+                }
+            }
+
+            $this->assertInstanceOf(Package::class, $result);
+            $this->assertFalse($sourceExists);
+            $this->assertSame('ok', $backupContent);
+        }
+    }
+}

--- a/tests/tests/Package/PackageBackupTest.php
+++ b/tests/tests/Package/PackageBackupTest.php
@@ -147,5 +147,98 @@ namespace Concrete\Tests\Package {
             $this->assertFalse($sourceExists);
             $this->assertSame('ok', $backupContent);
         }
+
+        public function testBackupPreflightCreatesNestedTrashDirectory(): void
+        {
+            $handle = 'package_backup_nested_trash_' . uniqid();
+            $packagePath = DIR_PACKAGES . '/' . $handle;
+            $testRoot = DIR_FILES_UPLOADED_STANDARD . '/' . $handle;
+            $trash = $testRoot . '/first/second/trash';
+            $config = app('config');
+            $originalTrash = $config->get('concrete.misc.package_backup_directory');
+            $fileService = app(File::class);
+            $preflight = null;
+            $result = null;
+            $trashCreatedByPreflight = false;
+
+            try {
+                if (!@mkdir($testRoot, 0777, true) || !@mkdir($packagePath, 0777, true)) {
+                    $this->markTestSkipped('Unable to create the test directories.');
+                }
+                file_put_contents($packagePath . '/probe.txt', 'nested');
+                $config->set('concrete.misc.package_backup_directory', $trash);
+                $package = $this->createPackage($handle);
+
+                $preflight = $package->getBackupErrors();
+                $trashCreatedByPreflight = is_dir($trash);
+                $result = $package->backup();
+            } finally {
+                $config->set('concrete.misc.package_backup_directory', $originalTrash);
+                if (is_dir($packagePath)) {
+                    $fileService->removeAll($packagePath, true);
+                }
+                if (is_dir($testRoot)) {
+                    $fileService->removeAll($testRoot, true);
+                }
+            }
+
+            $this->assertInstanceOf(ErrorList::class, $preflight);
+            $this->assertFalse($preflight->has(), (string) $preflight);
+            $this->assertTrue($trashCreatedByPreflight);
+            $this->assertInstanceOf(Package::class, $result);
+        }
+
+        public function testBackupRejectsTrashPathThatIsAFile(): void
+        {
+            $handle = 'package_backup_file_trash_' . uniqid();
+            $packagePath = DIR_PACKAGES . '/' . $handle;
+            $testRoot = DIR_FILES_UPLOADED_STANDARD . '/' . $handle;
+            $trash = $testRoot . '/trash';
+            $config = app('config');
+            $originalTrash = $config->get('concrete.misc.package_backup_directory');
+            $fileService = app(File::class);
+            $result = null;
+            $sourceStillExists = false;
+            $trashContent = null;
+
+            try {
+                if (!@mkdir($testRoot, 0777, true) || !@mkdir($packagePath, 0777, true)) {
+                    $this->markTestSkipped('Unable to create the test directories.');
+                }
+                file_put_contents($trash, 'sentinel');
+                file_put_contents($packagePath . '/probe.txt', 'source');
+                $config->set('concrete.misc.package_backup_directory', $trash);
+
+                $result = $this->createPackage($handle)->backup();
+                $sourceStillExists = is_file($packagePath . '/probe.txt');
+                $trashContent = file_get_contents($trash);
+            } finally {
+                $config->set('concrete.misc.package_backup_directory', $originalTrash);
+                if (is_dir($packagePath)) {
+                    $fileService->removeAll($packagePath, true);
+                }
+                if (is_dir($testRoot)) {
+                    $fileService->removeAll($testRoot, true);
+                }
+            }
+
+            $this->assertInstanceOf(ErrorList::class, $result);
+            $this->assertStringContainsString('exists but is not a directory', (string) $result);
+            $this->assertTrue($sourceStillExists);
+            $this->assertSame('sentinel', $trashContent);
+        }
+
+        private function createPackage(string $handle): Package
+        {
+            return new class(app(), $handle) extends Package {
+                protected $pkgHandle;
+
+                public function __construct(Application $app, string $handle)
+                {
+                    parent::__construct($app);
+                    $this->pkgHandle = $handle;
+                }
+            };
+        }
     }
 }


### PR DESCRIPTION
## Summary

This fixes the package uninstall flow when the optional package directory move cannot be completed.

The affected uninstall flow is shared across the Concrete CMS 9.x series, where the directory move is attempted only after the package has been uninstalled.

Previously, Concrete CMS attempted to move the package directory only after uninstalling the package. When the filesystem operation failed, the Dashboard displayed a generic error without clearly explaining that the package had already been uninstalled and its files were still present on the server.

## Changes

- Check the package installation and backup directories before displaying the uninstall option.
- Create missing package trash directories recursively during preflight.
- Reject empty, invalid, and non-directory package trash paths before enabling directory removal.
- Disable the directory-removal checkbox when the operation cannot be completed.
- Show an actionable warning with the affected directory and current PHP process user.
- Keep late filesystem failures recoverable and clearly distinguish them from the completed package uninstall.
- Try the existing direct `rename()` first, then fall back to the Concrete CMS file service for copy and removal.
- Verify copied package contents before removing the original directory.
- Distinguish between uninstall-only and uninstall-with-directory-move success messages.

The default uninstall behavior is unchanged when the directory-removal checkbox is not selected.

## Screenshots

Before and after screenshots are included in #12985.

## Testing

### Automated regression coverage

`PackageBackupTest` covers:

- reporting an actionable error when the package installation directory is not writable;
- falling back to copy, verification, and source removal when `rename()` fails;
- recursively creating a configured package trash directory with multiple missing path segments;
- rejecting a package trash path that already exists as a file while preserving both the package source and existing file.

At head `cf0efb8e93`, all 22 GitHub Actions checks completed successfully.

Additional local checks:

```text
php -l on all changed PHP files
git diff --check
```

### Dashboard smoke test

A browser-driven Dashboard smoke test was completed against Concrete CMS 9.5.2 with PHP-FPM 8.2, using `Simple Audio Player` as a disposable package.

The negative preflight flow confirmed that when `/app/packages` was not writable by the PHP process:

- the directory-removal checkbox was disabled;
- the warning identified `/app/packages`;
- the warning identified the PHP process user as `www-data`.

Write access was then granted temporarily and verified as `www-data`. After refreshing the uninstall page:

- the directory-removal checkbox was enabled;
- uninstalling with directory removal selected succeeded;
- the package source directory was removed;
- the package directory was moved to `/app/application/files/trash`;
- the Dashboard displayed the uninstall-with-directory-move success message.

The original `/app/packages` mode (`775`) was restored and verified, and all temporary package and trash artifacts were removed after testing.

Fixes #12985