### PR TITLE
Fix toolbar tooltips remaining visible after panel launch

### DIFF
--- a/concrete/elements/page_controls_footer.php
+++ b/concrete/elements/page_controls_footer.php
@@ -187,7 +187,7 @@ if (isset($cp) && $cp->canViewToolbar() && (!$dh->inDashboard()) && !$view->isEd
                 if ($dh->canRead()) {
                     ?>
                     <li data-guide-toolbar-action="dashboard" class="float-end d-none d-md-block ">
-                        <a <?php if ($show_tooltips) { ?>class="launch-tooltip"<?php } ?> data-bs-toggle="tooltip" data-bs-placement="bottom" href="<?= URL::to('/dashboard') ?>" data-launch-panel="dashboard" title="<?= t('Dashboard – Change Site-wide Settings') ?>">
+                        <a <?php if ($show_tooltips) { ?>class="launch-tooltip"<?php } ?> data-bs-toggle="tooltip" data-bs-trigger="hover" data-bs-placement="bottom" href="<?= URL::to('/dashboard') ?>" data-launch-panel="dashboard" title="<?= t('Dashboard – Change Site-wide Settings') ?>">
                             <svg><use xlink:href="#icon-dashboard" /></svg><span class="ccm-toolbar-accessibility-title ccm-toolbar-accessibility-title-site-settings"><?= tc('toolbar', 'Dashboard') ?></span>
                         </a>
                     </li>
@@ -205,7 +205,7 @@ if (isset($cp) && $cp->canViewToolbar() && (!$dh->inDashboard()) && !$view->isEd
                 if ($sh->canViewSitemapPanel()) {
                     ?>
                     <li data-guide-toolbar-action="sitemap" class="float-end d-none d-md-block">
-                        <a <?php if ($show_tooltips) { ?>class="launch-tooltip"<?php } ?> data-bs-toggle="tooltip"
+                        <a <?php if ($show_tooltips) { ?>class="launch-tooltip"<?php } ?> data-bs-toggle="tooltip" data-bs-trigger="hover"
                            data-bs-placement="bottom" href="#"
                            data-panel-url="<?= URL::to('/ccm/system/panels/sitemap') ?>"
                            title="<?= t('Add Pages and Navigate Your Site') ?>" data-launch-panel="sitemap">
@@ -228,7 +228,7 @@ if (isset($cp) && $cp->canViewToolbar() && (!$dh->inDashboard()) && !$view->isEd
                 }
                 ?>
                 <li data-guide-toolbar-action="help" class="float-end d-none d-md-block">
-                    <a <?php if ($show_tooltips) { ?>class="launch-tooltip"<?php } ?> data-bs-toggle="tooltip"
+                    <a <?php if ($show_tooltips) { ?>class="launch-tooltip"<?php } ?> data-bs-toggle="tooltip" data-bs-trigger="hover"
                        data-launch="help-modal"
                        data-bs-placement="bottom"
                        href="<?= URL::to('/ccm/system/dialogs/help/help') ?>?ccm_token=<?=$valt->generate('view_help')?>"

--- a/concrete/themes/dashboard/elements/header.php
+++ b/concrete/themes/dashboard/elements/header.php
@@ -94,7 +94,7 @@ $colorScheme = $config->get('concrete.appearance.color_scheme');
                     }
                     $dashboardPanelClass = implode(' ', $dashboardPanelClasses);
                     ?>
-                    <a class="<?=$dashboardPanelClass; ?>" data-bs-placement="bottom" href="<?= URL::to('/dashboard'); ?>" title="<?= t('Dashboard – Change Site-wide Settings'); ?>"
+                    <a class="<?=$dashboardPanelClass; ?>" data-bs-trigger="hover" data-bs-placement="bottom" href="<?= URL::to('/dashboard'); ?>" title="<?= t('Dashboard – Change Site-wide Settings'); ?>"
                         data-launch-panel="dashboard"
                         data-panel-url="<?=URL::to('/system/panels/dashboard'); ?>"
                     >
@@ -107,7 +107,7 @@ $colorScheme = $config->get('concrete.appearance.color_scheme');
                     <li class="float-end d-none d-sm-none d-md-block">
                         <a <?php if ($show_tooltips) {
                             ?>class="launch-tooltip"<?php
-                        } ?>  data-bs-toggle="tooltip" data-bs-placement="bottom" href="#" data-panel-url="<?= URL::to('/ccm/system/panels/sitemap'); ?>" title="<?= t('Add Pages and Navigate Your Site'); ?>" data-launch-panel="sitemap">
+                        } ?>  data-bs-toggle="tooltip" data-bs-trigger="hover" data-bs-placement="bottom" href="#" data-panel-url="<?= URL::to('/ccm/system/panels/sitemap'); ?>" title="<?= t('Add Pages and Navigate Your Site'); ?>" data-launch-panel="sitemap">
                             <svg><use xlink:href="#icon-sitemap" /></svg>
                             <span class="ccm-toolbar-accessibility-title ccm-toolbar-accessibility-title-add-page"><?= tc('toolbar', 'Pages'); ?></span>
                         </a>
@@ -127,7 +127,7 @@ $colorScheme = $config->get('concrete.appearance.color_scheme');
                 <li data-guide-toolbar-action="help" class="float-end d-none d-sm-block">
                     <a <?php if ($show_tooltips) {
                         ?>class="launch-tooltip"<?php
-                    } ?> data-bs-toggle="tooltip"
+                    } ?> data-bs-toggle="tooltip" data-bs-trigger="hover"
                        data-bs-placement="bottom" href="#"
                        data-panel-url="<?= URL::to('/ccm/system/panels/help'); ?>"
                        title="<?= t('View help about the CMS.'); ?>" data-launch-panel="help">


### PR DESCRIPTION
## Summary

This patch prevents the Dashboard, Sitemap, and Help tooltips from remaining visible after a pointer click opens the corresponding interface.

Bootstrap's default tooltip trigger is `hover focus`. Clicking a toolbar link leaves it focused, so the tooltip remains visible after the pointer moves away and may obscure the opened side panel.

## Implementation

The fix explicitly sets `data-bs-trigger="hover"` on Dashboard, Sitemap, and Help in both toolbar implementations:

- `concrete/elements/page_controls_footer.php`
- `concrete/themes/dashboard/elements/header.php`

This updates all six toolbar controls. In both site and Dashboard contexts, the tooltip now appears on hover and disappears when the pointer leaves, even when the clicked link remains focused.

The patch uses Bootstrap's existing tooltip configuration and requires no custom JavaScript or rebuilt bundles. Toolbar actions, tooltip text, placement, accessible control labels, and panel behavior remain unchanged.

## Testing

- PHP syntax checks passed for both modified files.
- `git diff --check` passed.
- Tested Dashboard, Sitemap, and Help on regular site pages.
- Tested Dashboard, Sitemap, and Help from `Dashboard > Welcome`.
- Confirmed that each tooltip appears on hover.
- Confirmed that each tooltip disappears after clicking and moving the pointer away.
- Confirmed that the Dashboard link may remain focused while its tooltip is hidden.

Fixes #12987
