### PR TITLE
Add sorting options to the folder tree

### DIFF
--- a/concrete/src/Form/Service/Widget/FileFolderSelector.php
+++ b/concrete/src/Form/Service/Widget/FileFolderSelector.php
@@ -28,16 +28,30 @@ class FileFolderSelector
         }
 
         $rootTreeNodeID = $filesystem->getRootFolder()->getTreeNodeID();
+        $sortByLabel = h(t('Sort by'));
+        $systemOrderLabel = h(t('System order'));
+        $nameAscendingLabel = h(t('Name (A-Z)'));
+        $nameDescendingLabel = h(t('Name (Z-A)'));
 
         $html = <<<EOL
         <input type="hidden" name="{$field}" value="{$selected}">
+        <div class="d-flex align-items-center gap-2 mb-2">
+            <label for="file-folder-selector-sort-{$identifier}" class="form-label mb-0">{$sortByLabel}</label>
+            <select id="file-folder-selector-sort-{$identifier}" class="form-select form-select-sm w-auto" data-file-folder-selector-sort="{$identifier}">
+                <option value="">{$systemOrderLabel}</option>
+                <option value="name_asc">{$nameAscendingLabel}</option>
+                <option value="name_desc">{$nameDescendingLabel}</option>
+            </select>
+        </div>
         <div data-file-folder-selector="{$identifier}"></div>
         <script type="text/javascript">
         $(function() {
-            $('[data-file-folder-selector={$identifier}]').concreteTree({
-                    ajaxData: {
-                        displayOnly: 'file_folder'
-                    },
+            var ajaxData = {
+                displayOnly: 'file_folder'
+            };
+            var treeElement = $('[data-file-folder-selector={$identifier}]');
+            treeElement.concreteTree({
+                    ajaxData: ajaxData,
                     treeNodeParentID: {$rootTreeNodeID},
                     selectNodesByKey: [{$selected}],
                     onSelect : function(nodes) {
@@ -48,6 +62,18 @@ class FileFolderSelector
                         }
                     },
                     chooseNodeInForm: 'single'
+            });
+            $('[data-file-folder-selector-sort={$identifier}]').on('change', function() {
+                var orderBy = $(this).val();
+                if (orderBy) {
+                    ajaxData.orderBy = orderBy;
+                } else {
+                    delete ajaxData.orderBy;
+                }
+                var tree = $.ui.fancytree.getTree(treeElement);
+                tree.reload($.extend({}, tree.options.source, {
+                    data: ajaxData
+                }));
             });
         });
         </script>

--- a/concrete/src/Tree/Node/Node.php
+++ b/concrete/src/Tree/Node/Node.php
@@ -640,10 +640,21 @@ where treeNodeDisplayOrder > ? and treeNodeParentID = ?',
             $db = app(Connection::class);
             $tree = $this->getTreeObject();
             $data = $tree ? $tree->getRequestData() : [];
+            switch ($data['orderBy'] ?? null) {
+                case 'name_asc':
+                    $orderBy = 'treeNodeName asc, treeNodeDisplayOrder asc';
+                    break;
+                case 'name_desc':
+                    $orderBy = 'treeNodeName desc, treeNodeDisplayOrder asc';
+                    break;
+                default:
+                    $orderBy = 'treeNodeDisplayOrder asc';
+                    break;
+            }
             if (isset($data['displayOnly']) && $data['displayOnly']) {
-                $rows = $db->fetchAll('select treeNodeID from TreeNodes tn inner join TreeNodeTypes tnt on tn.treeNodeTypeID = tnt.treeNodeTypeID where treeNodeParentID = ? and treeNodeTypeHandle = ? order by treeNodeDisplayOrder asc', [$this->treeNodeID, $data['displayOnly']]);
+                $rows = $db->fetchAll("select treeNodeID from TreeNodes tn inner join TreeNodeTypes tnt on tn.treeNodeTypeID = tnt.treeNodeTypeID where treeNodeParentID = ? and treeNodeTypeHandle = ? order by {$orderBy}", [$this->treeNodeID, $data['displayOnly']]);
             } else {
-                $rows = $db->fetchAll('select treeNodeID from TreeNodes where treeNodeParentID = ? order by treeNodeDisplayOrder asc', [$this->treeNodeID]);
+                $rows = $db->fetchAll("select treeNodeID from TreeNodes where treeNodeParentID = ? order by {$orderBy}", [$this->treeNodeID]);
             }
 
             foreach ($rows as $row) {

--- a/tests/tests/File/FilesystemTest.php
+++ b/tests/tests/File/FilesystemTest.php
@@ -46,6 +46,31 @@ class FilesystemTest extends ConcreteDatabaseTestCase
         $this->assertEquals('Test Sub Folder', $folder->getTreeNodeDisplayName());
     }
 
+    public function testPopulateDirectChildrenOnlyCanSortByName()
+    {
+        $rootFolder = $this->filesystem->getRootFolder();
+        $this->filesystem->addFolder($rootFolder, 'Zulu');
+        $this->filesystem->addFolder($rootFolder, 'Alpha');
+        $this->filesystem->addFolder($rootFolder, 'Bravo');
+
+        $rootFolder->populateDirectChildrenOnly();
+        $this->assertSame(['Zulu', 'Alpha', 'Bravo'], array_map(function ($folder) {
+            return $folder->getTreeNodeName();
+        }, $rootFolder->getChildNodes()));
+
+        $rootFolder->getTreeObject()->setRequest(['orderBy' => 'name_asc']);
+        $rootFolder->clearLoadedChildren()->populateDirectChildrenOnly();
+        $this->assertSame(['Alpha', 'Bravo', 'Zulu'], array_map(function ($folder) {
+            return $folder->getTreeNodeName();
+        }, $rootFolder->getChildNodes()));
+
+        $rootFolder->getTreeObject()->setRequest(['orderBy' => 'name_desc']);
+        $rootFolder->clearLoadedChildren()->populateDirectChildrenOnly();
+        $this->assertSame(['Zulu', 'Bravo', 'Alpha'], array_map(function ($folder) {
+            return $folder->getTreeNodeName();
+        }, $rootFolder->getChildNodes()));
+    }
+
     public function testGetFolderByName()
     {
         $rootFolder = $this->filesystem->getRootFolder();


### PR DESCRIPTION
## Summary

Add a **Sort by** dropdown above the folder tree in the **Move to Folder** dialog.

The dropdown provides three options:

- **System order**
- **Name (A-Z)**
- **Name (Z-A)**

## Cause

Folder nodes were always loaded using `treeNodeDisplayOrder`. This usually reflects the order in which folders were added or moved, making it difficult to locate a folder when many folders are present.

The File Manager can display folders alphabetically, but the folder tree used when choosing a destination had no equivalent sorting control.

## Fix

- Pass the selected ordering to the tree loading endpoints.
- Support ascending and descending name ordering.
- Preserve the existing system order as the default.
- Preserve the selected folder when the tree reloads.
- Apply the selected ordering to lazily loaded child folders.
- Restrict accepted ordering values to known options, falling back to the existing system order.

Other tree components retain their existing behavior unless they explicitly request a name-based order.

## Tests

- Reproduced the original unsorted folder tree.
- Verified that **System order** retains the stored tree order.
- Verified that **Name (A-Z)** sorts folders alphabetically.
- Verified that **Name (Z-A)** sorts folders in reverse alphabetical order.
- Verified switching between all three options without reopening the dialog.
- Verified that the selected folder remains selected after every reload.
- Verified folder selection and moving a file still work.
- Added regression coverage for default, ascending, and descending ordering.
- Verified PHP syntax for all modified PHP files.
- Verified the patch with `git diff --check`.

Fixes #11531