### PR TITLE
Keep the dashboard panel closed by default

### DIFF
--- a/concrete/src/Page/Controller/DashboardPageController.php
+++ b/concrete/src/Page/Controller/DashboardPageController.php
@@ -89,7 +89,9 @@ class DashboardPageController extends PageController
         $this->elementManager = $this->app->make(ElementManager::class);
         $this->set('interface', $this->app->make('helper/concrete/ui'));
         $this->set('dashboard', $this->app->make('helper/concrete/dashboard'));
-        $this->set('hideDashboardPanel', $cookieJar->get('dashboardPanelStatus') === 'closed');
+        // The dashboard navigation is closed by default and stays open only when
+        // the user explicitly opened it during the current authenticated session.
+        $this->set('hideDashboardPanel', $cookieJar->get('dashboardPanelStatus') !== 'open');
 
         $favorites = $this->app->make(FavoritesNavigationFactory::class)->createNavigation();
         if ($favorites->has(new PageItem($this->getPageObject()))) {

--- a/concrete/src/User/User.php
+++ b/concrete/src/User/User.php
@@ -535,6 +535,9 @@ class User extends ConcreteObject
         if ($cookie->has('ConcreteSitemapTreeID')) {
             $cookie->clear('ConcreteSitemapTreeID');
         }
+        if ($cookie->has('dashboardPanelStatus')) {
+            $cookie->clear('dashboardPanelStatus');
+        }
 
         $app->make(PersistentAuthentication\CookieService::class)->deleteCookie();
 

--- a/concrete/themes/dashboard/elements/footer.php
+++ b/concrete/themes/dashboard/elements/footer.php
@@ -51,13 +51,13 @@ if (!empty($showPrivacyPolicyNotice)) { ?>
     var savePanelStatus = false;
     ConcreteEvent.subscribe('PanelOpen', function(e, data) {
         if (savePanelStatus && data.panel === panel) {
-            $.cookie('dashboardPanelStatus', null, {path: '<?=DIR_REL?>/'});
+            $.cookie('dashboardPanelStatus', 'open', {path: '<?=DIR_REL?>/'});
             savePanelStatus = false;
         }
     });
     ConcreteEvent.subscribe('PanelClose', function(e, data) {
         if (savePanelStatus && data.panel === panel) {
-            $.cookie('dashboardPanelStatus', 'closed', {path: '<?=DIR_REL?>/'});
+            $.cookie('dashboardPanelStatus', null, {path: '<?=DIR_REL?>/'});
             savePanelStatus = false;
         }
     });

--- a/concrete/themes/dashboard/elements/header.php
+++ b/concrete/themes/dashboard/elements/header.php
@@ -17,7 +17,7 @@ $config = $app->make('config');
 
 $sitemapHelper = $app->make('helper/concrete/dashboard/sitemap');
 if (!isset($hideDashboardPanel)) {
-    $hideDashboardPanel = false;
+    $hideDashboardPanel = true;
 }
 
 $view->addFooterItem('<script type="text/javascript">$(function() { ConcreteToolbar.start(); });</script>');


### PR DESCRIPTION
Fixes #12995

## Issue

The Dashboard navigation panel opens automatically after login whenever the `dashboardPanelStatus` cookie is missing. Closing it is remembered only temporarily and inconsistently, which makes the panel appear to reopen unexpectedly.

## Fix

- Keep the Dashboard panel closed by default.
- Store an explicit session cookie when the user opens the panel.
- Preserve the open state while navigating or reloading Dashboard pages.
- Remove the preference when the user explicitly closes the panel.
- Clear the preference when the authenticated session is invalidated.
- Keep indirect panel closures from changing the user's preference.

## Testing

- PHP lint passed for all four changed files.
- `git diff --check` passed.
- Verified login starts with the panel closed.
- Verified opening the panel persists across Dashboard navigation.
- Verified closing the panel persists across Dashboard navigation.
- Verified the panel can be reopened and remains open after another navigation.
- Verified logout clears the preference and the next login starts closed.
- Verified the deployed test instance returns HTTP 200.