### PR TITLE
Correctly pass body HTML to the conversation subscription email

### DIFF
--- a/concrete/mail/new_conversation_message.php
+++ b/concrete/mail/new_conversation_message.php
@@ -2,6 +2,7 @@
 
 defined('C5_EXECUTE') or die("Access Denied.");
 $subject = t('New Message on Conversation: %s', $title);
+$message = $body;
 $body = t("
 %s has posted a new message to the conversation \"%s\":
 
@@ -11,4 +12,13 @@ You can view the whole conversation at
 
 %s
 
-", $poster, $title, $body, $link);
+", $poster, $title, $message, $link);
+
+$bodyHTML = t(
+    '%s has posted a new message to the conversation "%s":<br /><br />%s<br /><br />You can view the whole conversation at<br /><br /><a href="%s">%s</a>',
+    $posterHTML,
+    h($title),
+    nl2br(h($message)),
+    $link,
+    h($link)
+);

--- a/concrete/src/Conversation/Command/SendEmailsToConversationMessageSubscribersCommandHandler.php
+++ b/concrete/src/Conversation/Command/SendEmailsToConversationMessageSubscribersCommandHandler.php
@@ -43,7 +43,9 @@ class SendEmailsToConversationMessageSubscribersCommandHandler
                     $this->mailService->to($ui->getUserEmail());
                     $this->mailService->addParameter('title', $c->getCollectionName());
                     $this->mailService->addParameter('link', $c->getCollectionLink(true));
-                    $this->mailService->addParameter('poster', $formatter->getDisplayName());
+                    $posterHTML = $formatter->getDisplayName();
+                    $this->mailService->addParameter('poster', strip_tags($posterHTML));
+                    $this->mailService->addParameter('posterHTML', $posterHTML);
                     $this->mailService->addParameter('body', $this->textService->prettyStripTags($cnvMessageBody));
                     $this->mailService->load('new_conversation_message');
                     $this->mailService->sendMail();


### PR DESCRIPTION
## Summary

Fixes the malformed user profile link in conversation notification emails.

Previously, the HTML anchor surrounding the username was displayed incorrectly in the email. This change ensures that the username is rendered as a valid link to the user's profile.

## Related issue

Partially addresses #11387.

This PR fixes the user profile link described in the issue. It does not address the separate problem where the conversation link at the bottom of the email may lead to an error page.

## Testing

1. Subscribe to a conversation.
2. Add a new message to trigger a notification email.
3. Confirm that the username is displayed correctly.
4. Confirm that clicking the username opens the appropriate user profile.

