### PR TITLE
Append group folder names to the group path value

### DIFF
--- a/concrete/src/User/Group/Group.php
+++ b/concrete/src/User/Group/Group.php
@@ -116,12 +116,16 @@ class Group extends ConcreteObject implements \Concrete\Core\Permission\ObjectIn
         if (is_object($node)) {
             $parents = $node->getTreeNodeParentArray();
             $parents = array_reverse($parents);
+            // Remove the top level node because it's always "All Groups"
+            array_shift($parents);
             foreach ($parents as $node) {
                 if ($node instanceof \Concrete\Core\Tree\Node\Type\Group) {
                     $g = $node->getTreeNodeGroupObject();
                     if (is_object($g)) {
                         $path .= '/' . $g->getGroupName();
                     }
+                } elseif ($node instanceof GroupFolder) {
+                    $path .= '/' . $node->getTreeNodeName();
                 }
             }
         }


### PR DESCRIPTION
Append group folder names to group path in same format as group names. Ensure that the base "All Groups" parent is removed before checking for the group folders.

Note this won't adjust existing group paths but will prevent the issue occurring on future group folders.

Fixes: #12997 