### PR TITLE
Add a new timezone field to the add user dashboard page

### DIFF
--- a/concrete/controllers/single_page/dashboard/users/add.php
+++ b/concrete/controllers/single_page/dashboard/users/add.php
@@ -30,6 +30,7 @@ class Add extends DashboardPageController
         $this->set('ih', $this->app->make('helper/concrete/ui'));
         $this->set('av', $this->app->make('helper/concrete/avatar'));
         $this->set('dtt', $this->app->make('helper/form/date_time'));
+        $this->set('dh', $this->app->make('helper/date'));
         $this->set('gArray', $gArray);
         $this->set('assignment', $assignment);
         $this->set('locales', $locales);
@@ -77,6 +78,9 @@ class Add extends DashboardPageController
         if (!$this->error->has()) {
             // do the registration
             $data = ['uName' => $username, 'uPassword' => $password, 'uEmail' => $postRequest->get('uEmail'), 'uDefaultLanguage' => $postRequest->get('uDefaultLanguage',''), 'uHomeFileManagerFolderID' => ($postRequest->get('uHomeFileManagerFolderID', 0) == 0 ? '' : $postRequest->get('uHomeFileManagerFolderID'))];
+            if ($this->app->make('config')->get('concrete.misc.user_timezones') && $assignment->allowEditTimezone()) {
+                $data['uTimezone'] = $postRequest->get('uTimezone');
+            }
             $uo = $this->app['user/registration']->create($data);
             if (is_object($uo)) {
                 if ($assignment->allowEditAvatar()) {

--- a/concrete/single_pages/dashboard/users/add.php
+++ b/concrete/single_pages/dashboard/users/add.php
@@ -9,6 +9,7 @@ use Concrete\Core\Support\Facade\Application;
  * @var Concrete\Core\Permission\Access\ListItem\EditUserPropertiesUserListItem $assignment
  * @var Concrete\Controller\SinglePage\Dashboard\Users\Add $controller
  * @var Concrete\Core\Form\Service\Form $form
+ * @var Concrete\Core\Localization\Service\Date $dh
  * @var Concrete\Core\Validation\CSRF\Token $token
  */
 $app = Application::getFacadeApplication();
@@ -72,6 +73,17 @@ $fileFolderSelector = $app->make(FileFolderSelector::class);
                 </div>
             </div>
 		<?php } ?>
+
+        <?php
+        if ($assignment->allowEditTimezone() && $app->make('config')->get('concrete.misc.user_timezones')) {
+            ?>
+            <div class="form-group">
+                <?= $form->label('uTimezone', t('Time Zone')) ?>
+                <?= $form->select('uTimezone', $dh->getTimezones(), date_default_timezone_get()) ?>
+            </div>
+            <?php
+        }
+        ?>
 
         <div class="form-group">
             <?php echo $form->label('uHomeFileManagerFolderID', t('Home Folder')); ?>

--- a/concrete/src/User/RegistrationService.php
+++ b/concrete/src/User/RegistrationService.php
@@ -103,6 +103,11 @@ class RegistrationService implements RegistrationServiceInterface
             $uHomeFileManagerFolderID = $data['uHomeFileManagerFolderID'];
         }
 
+        $uTimezone = null;
+        if (isset($data['uTimezone']) && $data['uTimezone'] != '') {
+            $uTimezone = $data['uTimezone'];
+        }
+
         $entity = new UserEntity();
         $entity->setUserName($data['uName']);
         $entity->setUserEmail($data['uEmail']);
@@ -111,6 +116,7 @@ class RegistrationService implements RegistrationServiceInterface
         $entity->setUserIsFullRecord($uIsFullRecord);
         $entity->setUserDefaultLanguage($uDefaultLanguage);
         $entity->setHomeFileManagerFolderID($uHomeFileManagerFolderID);
+        $entity->setUserTimezone($uTimezone);
         $entity->setUserIsActive(true);
 
         $this->entityManager->persist($entity);


### PR DESCRIPTION
Creates a new timezone field to the add user dashboard page if individual user timezone setting is enabled. 

Fixes: #5169