### PR TITLE
Fix #13009: Group ID search column crash and guard against unwired column callbacks

### DIFF
--- a/concrete/src/Search/Column/Column.php
+++ b/concrete/src/Search/Column/Column.php
@@ -24,6 +24,11 @@ class Column implements ColumnInterface
     public function getColumnValue($obj)
     {
         $callback = $this->getColumnCallback();
+        if (empty($callback)) {
+            // No callback configured for this column: degrade to an empty
+            // value rather than fataling the entire search results page.
+            return '';
+        }
         if (is_array($callback)) {
             // PHP 8.0 only allows static functions with call_user_func
             // So institate the callback if its not callable

--- a/concrete/src/User/Group/Search/ColumnSet/Available.php
+++ b/concrete/src/User/Group/Search/ColumnSet/Available.php
@@ -63,7 +63,7 @@ class Available extends DefaultSet
      * @param Node $node
      * @return mixed
      */
-    public function getGroupID($node)
+    public static function getGroupID($node)
     {
         if ($node->getTreeNodeTypeHandle() == 'group_folder') {
             return '';

--- a/concrete/src/User/Group/Search/ColumnSet/Column/GroupIdColumn.php
+++ b/concrete/src/User/Group/Search/ColumnSet/Column/GroupIdColumn.php
@@ -23,6 +23,7 @@ class GroupIdColumn extends Column implements PagerColumnInterface
 
     public function getColumnCallback()
     {
+        return ['\Concrete\Core\User\Group\Search\ColumnSet\Available', 'getGroupID'];
     }
 
     public function filterListAtOffset(PagerProviderInterface $itemList, $mixed)

--- a/tests/tests/Search/Column/ColumnTest.php
+++ b/tests/tests/Search/Column/ColumnTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace Concrete\Tests\Search\Column;
+
+use Concrete\Core\Search\Column\Column;
+use Concrete\Tests\TestCase;
+
+class ColumnTest extends TestCase
+{
+    /**
+     * Regression test: a column with no callback configured (an empty
+     * getColumnCallback(), which returns null) must degrade to an empty value
+     * instead of throwing a TypeError from call_user_func([$obj, null]) and
+     * fataling the entire search results page.
+     *
+     * @see https://github.com/concretecms/concretecms/issues/12961
+     */
+    public function testNullCallbackReturnsEmptyString()
+    {
+        $column = new Column('someKey', 'Some Name', null);
+        $this->assertSame('', $column->getColumnValue(new \stdClass()));
+    }
+
+    public function testEmptyStringCallbackReturnsEmptyString()
+    {
+        $column = new Column('someKey', 'Some Name', '');
+        $this->assertSame('', $column->getColumnValue(new \stdClass()));
+    }
+
+    /**
+     * A string callback is invoked as a method on the item itself.
+     */
+    public function testStringCallbackInvokesMethodOnItem()
+    {
+        $column = new Column('someKey', 'Some Name', 'itemValue');
+        $this->assertSame('item-value', $column->getColumnValue(new ColumnTestCallbackFixture()));
+    }
+
+    /**
+     * An array callback pointing at a static method is invoked with the item
+     * passed as the argument (e.g. NameColumn -> Available::getName).
+     */
+    public function testArrayCallbackInvokesStaticMethodWithItem()
+    {
+        $column = new Column('someKey', 'Some Name', [ColumnTestCallbackFixture::class, 'renderStatic']);
+        $this->assertSame('static:x', $column->getColumnValue('x'));
+    }
+
+    /**
+     * An array callback pointing at a non-static (instance) method is resolved
+     * by instantiating the class first (e.g. FileIDColumn -> getFileID). This
+     * is the PHP 8 path guarded by the is_callable() check in getColumnValue().
+     */
+    public function testArrayCallbackInstantiatesForInstanceMethod()
+    {
+        $column = new Column('someKey', 'Some Name', [ColumnTestCallbackFixture::class, 'renderInstance']);
+        $this->assertSame('instance:x', $column->getColumnValue('x'));
+    }
+}
+
+class ColumnTestCallbackFixture
+{
+    public static function renderStatic($obj)
+    {
+        return 'static:' . $obj;
+    }
+
+    public function renderInstance($obj)
+    {
+        return 'instance:' . $obj;
+    }
+
+    public function itemValue()
+    {
+        return 'item-value';
+    }
+}


### PR DESCRIPTION
The Group ID column (GroupIdColumn) in the Groups dashboard search shipped with an empty getColumnCallback(), so Column::getColumnValue() passed a null method name to call_user_func() and fataled the entire results page whenever the column was displayed. This is the same root-cause defect as the File Manager "Date Added" column (issue #12961 / PR #12962).

- Wire GroupIdColumn to the existing Available::getGroupID(), and make that method static to match its siblings (getGroupName/getType/getMemberCount) so it resolves through the standard static-callback path.
- Harden Column::getColumnValue() to return an empty value when no callback is configured, so any future unwired column degrades to a blank cell instead of fataling the search page.