### PR TITLE
Remove email send call on activate task (duplicated as it's called in triggerActivate)

### DIFF
--- a/concrete/controllers/single_page/dashboard/users/search.php
+++ b/concrete/controllers/single_page/dashboard/users/search.php
@@ -255,29 +255,7 @@ class Search extends DashboardPageController
             case 'activate':
                 $this->setupUser($uID);
                 if ($this->canActivateUser && $this->app->make('helper/validation/token')->validate()) {
-                    if ($this->user->triggerActivate()) {
-                        $mh = $this->app->make('helper/mail');
-                        $mh->to($this->user->getUserEmail());
-                        $config = $this->app->make('config');
-                        if ($config->get('concrete.email.register_notification.address')) {
-                            if ($config->get('concrete.email.register_notification.name')) {
-                                $fromName = $config->get('concrete.email.register_notification.name');
-                            } else {
-                                $fromName = t('Website Registration Notification');
-                            }
-                            $mh->from($config->get('concrete.email.register_notification.address'), $fromName);
-                        } else {
-                            $mh->from($config->get('concrete.email.default.address'), t('Website Registration Notification'));
-                        }
-                        $mh->addParameter('uID', $this->user->getUserID());
-                        $mh->addParameter('user', $this->user);
-                        $mh->addParameter('uName', $this->user->getUserName());
-                        $mh->addParameter('uEmail', $this->user->getUserEmail());
-                        $mh->addParameter('siteName', $this->app->make('site')->getSite()->getSiteName());
-                        $mh->load('user_registered_approval_complete');
-                        $mh->sendMail();
-                    }
-
+                    $this->user->triggerActivate();
                     $this->redirect('/dashboard/users/search', 'edit', $this->user->getUserID(), 'activated');
                 }
                 break;


### PR DESCRIPTION
Fixes: #13014

### Description:

Removes a duplicate user_registered_approval_complete email send from the dashboard user search controller when activating a user. The same email was already being sent by ActivateUserRequest::sendActivationEmail() as part of the user activation workflow.

### Solution

Remove the redundant mail-sending block from concrete/controllers/single_page/dashboard/users/search.php and rely on ActivateUserRequest::sendActivationEmail() as the single source of truth for this notification. This does not affect registration emails from accounts created via the user sign up page