### PR TITLE
Fix OpenAPI area API scopes to use singular identifiers

### DIFF
--- a/concrete/src/Api/Controller/Areas.php
+++ b/concrete/src/Api/Controller/Areas.php
@@ -36,7 +36,7 @@ class Areas extends ApiController implements ApplicationAwareInterface
      *     operationId="addBlockToPageArea",
      *     summary="Adds a block to a page area.",
      *     security={
-     *         {"authorization": {"pages:areas:add_blocks"}}
+     *         {"authorization": {"pages:areas:add_block"}}
      *     },
      *     @OA\Parameter(
      *         name="pageID",
@@ -103,7 +103,7 @@ class Areas extends ApiController implements ApplicationAwareInterface
      *     operationId="deleteBlockFromPageArea",
      *     summary="Deletes a block from a page area.",
      *     security={
-     *         {"authorization": {"pages:areas:delete_blocks"}}
+     *         {"authorization": {"pages:areas:delete_block"}}
      *     },
      *     @OA\Parameter(
      *         name="pageID",
@@ -190,7 +190,7 @@ class Areas extends ApiController implements ApplicationAwareInterface
      *     operationId="updateBlockInPageArea",
      *     summary="Updates a block within a page area.",
      *     security={
-     *         {"authorization": {"pages:areas:update_blocks"}}
+     *         {"authorization": {"pages:areas:update_block"}}
      *     },
      *     @OA\Parameter(
      *         name="pageID",


### PR DESCRIPTION
## Summary
- Aligns OpenAPI `security` scopes on area API operations in `Areas.php` with the singular identifiers used by route `setScopes()` and the OAuth2 scope registry (`pages:areas:add_block`, `delete_block`, `update_block`).
- Fixes #13019

## Test plan
- [x] Confirm OpenAPI annotations in `concrete/src/Api/Controller/Areas.php` use singular scopes
- [x] Confirm they match `concrete/routes/api/areas.php` `setScopes()` values
- [x] Confirm they match scopes listed in `concrete/src/Api/Controller/Oauth2.php`
- [ ] Optionally regenerate/export OpenAPI docs and verify area endpoints advertise the singular scopes


Made with [Cursor](https://cursor.com)