### PR TITLE
Add a new API route to add a new page version to edit

### DIFF
--- a/concrete/routes/api/versions.php
+++ b/concrete/routes/api/versions.php
@@ -19,6 +19,11 @@ $router->get('/page_versions/{pageID}', '\Concrete\Core\Api\Controller\Versions:
     ->setScopes('pages:versions:read')
 ;
 
+$router->post('/page_versions/{pageID}', '\Concrete\Core\Api\Controller\Versions::add')
+    ->setRequirement('pageID', '[0-9]+')
+    ->setScopes('pages:versions:add')
+;
+
 $router->delete('/page_versions/{pageID}/{versionID}', '\Concrete\Core\Api\Controller\Versions::delete')
     ->setRequirement('pageID', '[0-9]+')
     ->setRequirement('versionID', '[0-9]+')

--- a/concrete/src/Api/Controller/Oauth2.php
+++ b/concrete/src/Api/Controller/Oauth2.php
@@ -41,6 +41,7 @@ namespace Concrete\Core\Api\Controller;
  *             "pages:areas:delete_block": "Delete blocks from a page area",
  *             "pages:areas:update_block": "Updates a block in a page area",
  *             "pages:versions:read": "View page versions",
+ *             "pages:versions:add": "Create editable page version drafts",
  *             "pages:versions:update": "Update page versions",
  *             "pages:versions:delete": "Delete page versions",
  *             "blocks:read": "View site blocks",

--- a/concrete/src/Api/Controller/Versions.php
+++ b/concrete/src/Api/Controller/Versions.php
@@ -144,6 +144,76 @@ class Versions extends ApiController
     }
 
     /**
+     * @OA\Post(
+     *     path="/ccm/api/1.0/page_versions/{pageID}",
+     *     tags={"page_versions"},
+     *     operationId="addPageVersionByPageId",
+     *     summary="Create or return an editable RECENT draft page version.",
+     *     description="Matches Collection::getVersionToModify() semantics: if the current RECENT version is already a draft (isNew), it is returned unchanged; otherwise a new draft is cloned (blocks remain aliases until edited). After cloning, read blocks with version=recent. Approving or publishing is out of scope — use the update endpoint.",
+     *     security={
+     *         {"authorization": {"pages:versions:add"}}
+     *     },
+     *     @OA\Parameter(
+     *         name="pageID",
+     *         in="path",
+     *         description="ID of page",
+     *         required=true,
+     *         @OA\Schema(
+     *             type="integer",
+     *             format="int64"
+     *         )
+     *     ),
+     *     @OA\RequestBody(ref="#/components/requestBodies/NewPageVersion"),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Successful operation",
+     *         @OA\JsonContent(ref="#/components/schemas/PageVersion"),
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="You do not have the proper permissions to create a draft for this page."
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         description="Page not found"
+     *     ),
+     * )
+     */
+    public function add($pageID)
+    {
+        $cache = $this->app->make('cache/request');
+        $cache->disable();
+
+        $page = Page::getByID($pageID, 'RECENT');
+        if (!$page) {
+            return $this->error(t('Page not found'), 404);
+        }
+        if ($page->isError() && $page->getError() == COLLECTION_NOT_FOUND) {
+            return $this->error(t('Page not found'), 404);
+        }
+
+        $checker = new Checker($page);
+        if (!$checker->canEditPageContents()) {
+            return $this->error(t('You do not have access to create a draft version of this page.'), 401);
+        }
+
+        $versionComments = null;
+        $body = json_decode($this->request->getContent(), true);
+        if (is_array($body) && isset($body['comments']) && is_string($body['comments'])) {
+            $versionComments = $body['comments'];
+        }
+
+        // Match Collection::getVersionToModify(), with optional clone comments.
+        $version = $page->getVersionObject();
+        if (!$page->isMasterCollection() && !$version->isNew()) {
+            $page = $page->cloneVersion($versionComments);
+            $version = $page->getVersionObject();
+        }
+
+        return $this->transform($version, new CollectionVersionTransformer(), Resources::RESOURCE_PAGE_VERSIONS);
+    }
+
+    /**
      * @OA\Delete(
      *     path="/ccm/api/1.0/page_versions/{pageID}/{versionID}",
      *     tags={"page_versions"},

--- a/concrete/src/Api/Fractal/Transformer/CollectionVersionTransformer.php
+++ b/concrete/src/Api/Fractal/Transformer/CollectionVersionTransformer.php
@@ -12,6 +12,8 @@ class CollectionVersionTransformer extends TransformerAbstract
         $data = [];
         $data['id'] = $version->getVersionID();
         $data['is_approved'] = $version->isApproved();
+        $data['is_new'] = $version->isNew();
+        $data['comments'] = $version->getVersionComments(false);
         $data['date_created'] = $version->getVersionDateCreated();
         $data['date_approved'] = $version->getVersionDateApproved();
         $data['publish_end_date'] = $version->getPublishEndDate();

--- a/concrete/src/Api/Model/NewPageVersion.php
+++ b/concrete/src/Api/Model/NewPageVersion.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Concrete\Core\Api\Model;
+
+/**
+ * @OA\Schema(
+ *     title="NewPageVersion model",
+ *     description="Optional payload when creating an editable page version draft"
+ * )
+ */
+class NewPageVersion
+{
+
+    /**
+     * @OA\Property(type="string", title="Version Comments", description="Comments stored on the cloned draft version. Ignored when a RECENT draft already exists.")
+     *
+     * @var string
+     */
+    private $comments;
+
+}

--- a/concrete/src/Api/Model/NewPageVersionRequestBody.php
+++ b/concrete/src/Api/Model/NewPageVersionRequestBody.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Concrete\Core\Api\Model;
+
+/**
+ * @OA\RequestBody(
+ *     request="NewPageVersion",
+ *     description="Optional fields when creating a page version draft. An empty body is allowed.",
+ *     required=false,
+ *     @OA\JsonContent(ref="#/components/schemas/NewPageVersion"),
+ * )
+ */
+class NewPageVersionRequestBody
+{
+
+
+
+}

--- a/concrete/src/Api/Model/PageVersion.php
+++ b/concrete/src/Api/Model/PageVersion.php
@@ -26,6 +26,24 @@ class PageVersion
     private $is_approved;
 
     /**
+     * @OA\Property(
+     *     format="boolean",
+     *     title="Is New Draft",
+     *     description="Whether this version is an unapproved draft (cvIsNew).",
+     * )
+     *
+     * @var bool
+     */
+    private $is_new;
+
+    /**
+     * @OA\Property(type="string", title="Version Comments")
+     *
+     * @var string
+     */
+    private $comments;
+
+    /**
      * @OA\Property(type="date", title="Date page created")
      *
      * @var string


### PR DESCRIPTION
Adds `POST /ccm/api/1.0/page_versions/{pageID}` to create or return an editable RECENT draft (`getVersionToModify` semantics), with optional version comments, `pages:versions:add` scope, OpenAPI docs, and `is_new` / `comments` on page version responses.

Fixes #13021