### PR TITLE
Package upgrade: ket's clear the OPcache instead of asking users to do that

### DIFF
--- a/concrete/controllers/single_page/dashboard/extend/update.php
+++ b/concrete/controllers/single_page/dashboard/extend/update.php
@@ -2,6 +2,7 @@
 
 namespace Concrete\Controller\SinglePage\Dashboard\Extend;
 
+use Concrete\Core\Cache\OpCache;
 use Concrete\Core\Config\Repository\Repository;
 use Concrete\Core\Error\UserMessageException;
 use Concrete\Core\Foundation\Composer;
@@ -28,8 +29,9 @@ class Update extends DashboardPageController
         $previousVersion = $packageController->getPackageEntity()->getPackageVersion();
         $newVersion = $packageController->getPackageVersion();
         if (version_compare($newVersion, $previousVersion, '<=')) {
+            OpCache::clear();
             $this->error->add(t(
-                'Package "%1$s" was not updated because the loaded package controller still reports version %2$s. Clear the PHP opcode cache and try again.',
+                'Package "%1$s" was not updated because the loaded package controller still reports version %2$s. Try again.',
                 t($packageController->getPackageName()) ?: $packageController->getPackageHandle(),
                 $newVersion
             ));


### PR DESCRIPTION
Most users, when reading "Clear the PHP opcode cache" won't understand what that means and what they should do.

What about clearing the OPcache on our own and simply asking users to retry?