### PR TITLE
Fix accordion header level formatting

### DIFF
--- a/concrete/blocks/accordion/view.css
+++ b/concrete/blocks/accordion/view.css
@@ -1,0 +1,3 @@
+.ccm-block-accordion .accordion-button {
+    font: inherit;
+}

--- a/concrete/themes/elemental/blocks/accordion/view.css
+++ b/concrete/themes/elemental/blocks/accordion/view.css
@@ -1,0 +1,3 @@
+.ccm-block-accordion .accordion-button {
+    font: inherit;
+}


### PR DESCRIPTION
## Summary

Fixes #11930.

Bootstrap sets its own font properties on `.accordion-button`, preventing the visible title from using the selected heading typography.

This CSS-only change makes the accordion control inherit the font from its parent heading in both the default and Elemental views.

## Testing

Tested on Concrete CMS 9.5.x with Atomik and Elemental:

- Verified H1, H2, H6, and Normal text.
- Confirmed font size, weight, line height, and family match the parent.
- Confirmed the correct `view.css` is loaded by both templates.
- Verified Atomik accordions still open and close correctly.
- Confirmed no console errors or changes to saved content.

Elemental's existing collapse issue is unrelated to this change.
