### PR TITLE
Add password visibility toggle to login form

### DIFF
--- a/concrete/authentication/concrete/form.php
+++ b/concrete/authentication/concrete/form.php
@@ -1,7 +1,7 @@
-<?php defined('C5_EXECUTE') or die('Access denied.');
+<?php defined('C5_EXECUTE') or die('Access Denied.');
 $form = Core::make('helper/form');
-$dh = Core::make('helper/date');  /* @var $dh \Concrete\Core\Localization\Service\Date */
-/* @var Concrete\Core\Form\Service\Form $form */
+$dh = Core::make('helper/date');  /** @var \Concrete\Core\Localization\Service\Date $dh */
+/** @var Concrete\Core\Form\Service\Form $form */
 
 $loggedIn = isset($user) && $user->isRegistered();
 ?>
@@ -9,11 +9,11 @@ $loggedIn = isset($user) && $user->isRegistered();
 <?php
 if (!$loggedIn) {
     ?>
-    <form class="concrete-login-form" method="post" action="<?= URL::to('/login', 'authenticate', $this->getAuthenticationTypeHandle()); ?>">
+    <form class="concrete-login-form" method="post" action="<?= URL::to('/login', 'authenticate', $this->getAuthenticationTypeHandle()) ?>">
 
         <div class="mb-3 row">
             <label class="col-sm-3 col-form-label" for="uName">
-                <?=Config::get('concrete.user.registration.email_registration') ? t('Email Address') : t('User Name'); ?>
+                <?= Config::get('concrete.user.registration.email_registration') ? t('Email Address') : t('User Name') ?>
             </label>
             <div class="col-sm-9">
                 <input name="uName" id="uName" class="form-control" autofocus="autofocus" />
@@ -21,29 +21,38 @@ if (!$loggedIn) {
         </div>
         <div class="mb-3 row">
             <label class="col-sm-3 col-form-label" for="uPassword">
-                <?=t('Password'); ?>
+                <?= t('Password') ?>
             </label>
             <div class="col-sm-9">
-                <input name="uPassword" id="uPassword" class="form-control" type="password" autocomplete="off" />
+                <div class="input-group">
+                    <input name="uPassword" id="uPassword" class="form-control" type="password" autocomplete="off" />
+                    <button
+                        type="button"
+                        id="toggle-password-visibility"
+                        class="btn btn-outline-secondary"
+                        title="<?= t('Show password') ?>"
+                        aria-label="<?= t('Show password') ?>"
+                    ><i class="fas fa-eye" aria-hidden="true"></i></button>
+                </div>
             </div>
         </div>
         <div class="mb-3 row">
             <label class="col-sm-3 col-form-label" for="uPassword">
             </label>
             <div class="col-sm-9 text-end">
-                <a href="<?= URL::to('/login', 'concrete', 'forgot_password'); ?>" class="btn-link"><?= t('Forgot Password'); ?></a>
+                <a href="<?= URL::to('/login', 'concrete', 'forgot_password') ?>" class="btn-link"><?= t('Forgot Password') ?></a>
             </div>
         </div>
         <?php
         if (Config::get('concrete.session.remember_me.lifetime') > 0) {
             ?>
             <div class="mb-3 row">
-                <div class="col-sm-3 col-form-label pt-0"><?=t('Remember Me'); ?></div>
+                <div class="col-sm-3 col-form-label pt-0"><?= t('Remember Me') ?></div>
                 <div class="col-sm-9">
                     <div class="form-check">
                         <input class="form-check-input" type="checkbox" id="uMaintainLogin" name="uMaintainLogin" value="1">
                         <label class="form-check-label form-check-remember-me" for="uMaintainLogin">
-                            <?php echo t('Stay signed in for %s', $dh->describeInterval(Config::get('concrete.session.remember_me.lifetime'))); ?>
+                            <?= t('Stay signed in for %s', $dh->describeInterval(Config::get('concrete.session.remember_me.lifetime'))) ?>
                         </label>
                     </div>
                 </div>
@@ -54,17 +63,17 @@ if (!$loggedIn) {
         if (isset($locales) && is_array($locales) && count($locales) > 0) {
             ?>
             <div class="mb-3">
-                <label for="USER_LOCALE" class="control-label form-label"><?= t('Language'); ?></label>
-                <?= $form->select('USER_LOCALE', $locales); ?>
+                <label for="USER_LOCALE" class="control-label form-label"><?= t('Language') ?></label>
+                <?= $form->select('USER_LOCALE', $locales) ?>
             </div>
             <?php
         }
         ?>
         <div class="mb-3 row">
             <div class="col-sm-12 text-end">
-                <a href="<?= \URL::to('/'); ?>" class="btn btn-secondary"> <?= t('Cancel'); ?> </a>
-                <button class="btn btn-primary"><?= t('Sign In'); ?></button>
-                <?php Core::make('helper/validation/token')->output('login_' . $this->getAuthenticationTypeHandle()); ?>
+                <a href="<?= \URL::to('/') ?>" class="btn btn-secondary"> <?= t('Cancel') ?> </a>
+                <button class="btn btn-primary"><?= t('Sign In') ?></button>
+                <?php Core::make('helper/validation/token')->output('login_' . $this->getAuthenticationTypeHandle()) ?>
             </div>
         </div>
 
@@ -73,13 +82,32 @@ if (!$loggedIn) {
             ?>
             <hr/>
             <div class="text-center sign-up-container">
-                <?=t("Don't have an account?"); ?>
-                <a href="<?=URL::to('/register'); ?>" class="btn-link"><?=t('Sign up'); ?></a>
+                <?= t("Don't have an account?") ?>
+                <a href="<?= URL::to('/register') ?>" class="btn-link"><?= t('Sign up') ?></a>
             </div>
             <?php
         }
         ?>
     </form>
+    <script>
+    $(function() {
+        $('#toggle-password-visibility').on('click', function() {
+            var $button = $(this);
+            var $password = $('#uPassword');
+            var showPassword = $password.attr('type') === 'password';
+            var label = showPassword ? <?= json_encode(t('Hide password')) ?> : <?= json_encode(t('Show password')) ?>;
+
+            $password.attr('type', showPassword ? 'text' : 'password');
+            $button
+                .attr('title', label)
+                .attr('aria-label', label)
+                .find('i')
+                .toggleClass('fa-eye', !showPassword)
+                .toggleClass('fa-eye-slash', showPassword)
+            ;
+        });
+    });
+    </script>
     <?php
 } else {
     ?>


### PR DESCRIPTION
Closes #12731

This pull request adds a show/hide password button to the standard Concrete authentication login form.

The password remains masked by default. Activating the button toggles the input between `password` and `text` and updates:

- the Font Awesome icon between `fa-eye` and `fa-eye-slash`;
- the translated `title`;
- the translated `aria-label`.

The implementation follows the existing Concrete CMS authentication form pattern and uses a native `button` element, providing keyboard support for Enter and Space.

Offering users the option to display a password during entry is explicitly recommended by [NIST SP 800-63B](https://pages.nist.gov/800-63-4/sp800-63b.html) to help reduce password entry errors.

No authentication or server-side password handling has been changed. The toggle only changes the client-side input type.

### Testing

- [x] PHP CS Fixer completed successfully using the Concrete CMS coding-style rules.
- [x] PHP syntax check passed.
- [x] `git diff --check` passed.
- [x] Login page responds successfully with the toggle markup.
- [x] Password is masked by default.
- [x] Verified show/hide behavior with mouse.
- [x] Verified show/hide behavior with keyboard.
- [x] Verified successful login with the password hidden and visible.