### PR TITLE
Allow selecting file folders by clicking labels

### DIFF
--- a/concrete/src/Form/Service/Widget/FileFolderSelector.php
+++ b/concrete/src/Form/Service/Widget/FileFolderSelector.php
@@ -1,14 +1,16 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Concrete\Core\Form\Service\Widget;
 
 use Concrete\Core\File\Filesystem;
-use Concrete\Core\Tree\Node\Type\FileFolder;
 use Concrete\Core\Utility\Service\Identifier;
-use Symfony\Component\HttpFoundation\JsonResponse;
+
+defined('C5_EXECUTE') or die('Access Denied.');
 
 class FileFolderSelector
 {
-
     public function selectFileFolder($field, $folder = null, $updateSelectionOnPost = true)
     {
         $identifier = new Identifier();
@@ -23,7 +25,7 @@ class FileFolderSelector
             $selected = is_object($folder) ? $folder->getTreeNodeID() : $folder;
         } elseif ($_SERVER['REQUEST_METHOD'] == 'POST' && $updateSelectionOnPost) {
             if (isset($_POST[$field])) {
-                $selected = intval($_POST[$field]);
+                $selected = (int) ($_POST[$field]);
             }
         }
 
@@ -34,50 +36,58 @@ class FileFolderSelector
         $nameDescendingLabel = h(t('Name (Z-A)'));
 
         $html = <<<EOL
-        <input type="hidden" name="{$field}" value="{$selected}">
-        <div class="d-flex align-items-center gap-2 mb-2">
-            <label for="file-folder-selector-sort-{$identifier}" class="form-label mb-0">{$sortByLabel}</label>
-            <select id="file-folder-selector-sort-{$identifier}" class="form-select form-select-sm w-auto" data-file-folder-selector-sort="{$identifier}">
-                <option value="">{$systemOrderLabel}</option>
-                <option value="name_asc">{$nameAscendingLabel}</option>
-                <option value="name_desc">{$nameDescendingLabel}</option>
-            </select>
-        </div>
-        <div data-file-folder-selector="{$identifier}"></div>
-        <script type="text/javascript">
-        $(function() {
-            var ajaxData = {
-                displayOnly: 'file_folder'
-            };
-            var treeElement = $('[data-file-folder-selector={$identifier}]');
-            treeElement.concreteTree({
-                    ajaxData: ajaxData,
-                    treeNodeParentID: {$rootTreeNodeID},
-                    selectNodesByKey: [{$selected}],
-                    onSelect : function(nodes) {
-                        if (nodes.length) {
-                            $('input[name={$field}]').val(nodes[0]);
+                <input type="hidden" name="{$field}" value="{$selected}">
+                <div class="d-flex align-items-center gap-2 mb-2">
+                    <label for="file-folder-selector-sort-{$identifier}" class="form-label mb-0">{$sortByLabel}</label>
+                    <select id="file-folder-selector-sort-{$identifier}" class="form-select form-select-sm w-auto" data-file-folder-selector-sort="{$identifier}">
+                        <option value="">{$systemOrderLabel}</option>
+                        <option value="name_asc">{$nameAscendingLabel}</option>
+                        <option value="name_desc">{$nameDescendingLabel}</option>
+                    </select>
+                </div>
+                <div data-file-folder-selector="{$identifier}"></div>
+                <script type="text/javascript">
+                $(function() {
+                    var ajaxData = {
+                        displayOnly: 'file_folder'
+                    };
+                    var treeElement = $('[data-file-folder-selector={$identifier}]');
+                    treeElement.concreteTree({
+                            ajaxData: ajaxData,
+                            treeNodeParentID: {$rootTreeNodeID},
+                            selectNodesByKey: [{$selected}],
+                            onSelect : function(nodes) {
+                                if (nodes.length) {
+                                    $('input[name={$field}]').val(nodes[0]);
+                                } else {
+                                    $('input[name={$field}]').val('');
+                                }
+                            },
+                            onClick: function(node, event) {
+                                var target = event.originalEvent.target;
+                                if (target && $(target).hasClass('fancytree-title')) {
+                                    node.setSelected(true);
+                                    return false;
+                                }
+                                return true;
+                            },
+                            chooseNodeInForm: 'single'
+                    });
+                    $('[data-file-folder-selector-sort={$identifier}]').on('change', function() {
+                        var orderBy = $(this).val();
+                        if (orderBy) {
+                            ajaxData.orderBy = orderBy;
                         } else {
-                            $('input[name={$field}]').val('');
+                            delete ajaxData.orderBy;
                         }
-                    },
-                    chooseNodeInForm: 'single'
-            });
-            $('[data-file-folder-selector-sort={$identifier}]').on('change', function() {
-                var orderBy = $(this).val();
-                if (orderBy) {
-                    ajaxData.orderBy = orderBy;
-                } else {
-                    delete ajaxData.orderBy;
-                }
-                var tree = $.ui.fancytree.getTree(treeElement);
-                tree.reload($.extend({}, tree.options.source, {
-                    data: ajaxData
-                }));
-            });
-        });
-        </script>
-EOL;
+                        var tree = $.ui.fancytree.getTree(treeElement);
+                        tree.reload($.extend({}, tree.options.source, {
+                            data: ajaxData
+                        }));
+                    });
+                });
+                </script>
+        EOL;
 
         return $html;
     }


### PR DESCRIPTION
Closes #10586

## Summary

In file folder selectors, folders could previously be selected only by clicking their checkbox. Clicking the folder label did not select the folder, which made the interaction less intuitive.

This pull request makes folder labels selectable while preserving the existing behavior of checkboxes, expanders, folder icons, and single-folder selection.

## Implementation

A scoped `onClick` handler has been added to the `FileFolderSelector` tree configuration.

When the clicked element is a folder title, the corresponding node is selected through Fancytree's existing `setSelected()` API. The handler then prevents the default title-click behavior from interfering with the selection.

The change is limited to file folder selectors and does not modify the global Concrete tree component or the behavior of other tree-based interfaces.

## Testing

The change was tested in the single-file "Move to Folder" dialog:

- clicking a folder label selects the folder;
- clicking another label updates the selected folder;
- clicking the selected label again keeps the selection consistent;
- checkbox-based selection continues to work;
- selecting one folder deselects the previous folder;
- clicking expanders or folder icons does not change the selected destination;
- folder sorting continues to reload the tree without changing the stored destination;
- the dialog and File Manager load without JavaScript or server errors.

The following checks were also completed:

- Concrete PHP CS Fixer
- PHP syntax validation
- `git diff --check`