### PR TITLE
Fix page list block location filtering for blocks copied from page type defaults

### DIFF
--- a/concrete/blocks/page_list/controller.php
+++ b/concrete/blocks/page_list/controller.php
@@ -478,7 +478,7 @@ class Controller extends BlockController implements UsesFeatureInterface
 
         $this->list->filterByExcludePageList(false);
 
-        if ((int) ($this->cParentID) != 0) {
+        if ((int) ($this->cParentID) !== 0 || (int) ($this->cThis) !== 0 || (int) ($this->cThisParent) !== 0) {
             $cParentID = ($this->cThis) ? $this->cID : (($this->cThisParent) ? $this->cPID : $this->cParentID);
             if ($this->includeAllDescendents) {
                 $this->list->filterByPath(Page::getByID($cParentID)->getCollectionPath());


### PR DESCRIPTION
## Summary

The "Beneath this page" and "At the current level" location filters of the Page List block do not apply when the block is added from a page type default (master collection), so "related pages" components defined on a page type cannot filter by location.

## Root cause

When a Page List block is configured on a page type default, the block is saved with `cParentID = 0`, while the chosen location mode is still recorded via the `cThis` / `cThisParent` flags. At render time, the location filtering block in `concrete/blocks/page_list/controller.php` only runs when `cParentID` is non-zero, so the filter is silently skipped:

```php
if ((int) ($this->cParentID) != 0) {
```

## Fix

Extend the guard so it also runs when `cThis` or `cThisParent` is set (the condition proposed by @hissy and confirmed by @aembler in #11370):

```php
if ((int) ($this->cParentID) !== 0 || (int) ($this->cThis) !== 0 || (int) ($this->cThisParent) !== 0) {
```

Inside the block, `$cParentID` is already resolved from `cThis` / `cThisParent` to the current page's ID or parent ID at render time, so no other change is needed.

This does not change behavior for any currently working case: "Everywhere" still skips filtering (all three flags are zero), and "Beneath another page" / normal page cases are unchanged.

Fixes #11370
