### PR TITLE
Improve and fix keyword search of the file list

### DIFF
--- a/concrete/src/File/FileList.php
+++ b/concrete/src/File/FileList.php
@@ -1,20 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Concrete\Core\File;
 
 use Concrete\Core\Database\Query\LikeBuilder;
-use Concrete\Core\File\StorageLocation\StorageLocationFactory;
 use Concrete\Core\Search\ItemList\Database\AttributedItemList as DatabaseItemList;
 use Concrete\Core\Search\ItemList\Pager\Manager\FileListPagerManager;
 use Concrete\Core\Search\ItemList\Pager\PagerProviderInterface;
 use Concrete\Core\Search\ItemList\Pager\QueryString\VariableFactory;
 use Concrete\Core\Search\Pagination\PaginationProviderInterface;
 use Concrete\Core\Search\StickyRequest;
-use Concrete\Core\User\User;
 use Concrete\Core\Support\Facade\Application;
-use FileAttributeKey;
+use Concrete\Core\User\User;
 use Pagerfanta\Adapter\DoctrineDbalAdapter;
-use Exception;
+
+defined('C5_EXECUTE') or die('Access Denied.');
 
 class FileList extends DatabaseItemList implements PagerProviderInterface, PaginationProviderInterface
 {
@@ -93,7 +94,8 @@ class FileList extends DatabaseItemList implements PagerProviderInterface, Pagin
             ->from('Files', 'f')
             ->innerJoin('f', 'FileVersions', 'fv', 'f.fID = fv.fID and fv.fvIsApproved = 1')
             ->leftJoin('f', 'FileSearchIndexAttributes', 'fsi', 'f.fID = fsi.fID')
-            ->leftJoin('f', 'Users', 'u', 'f.uID = u.uID');
+            ->leftJoin('f', 'Users', 'u', 'f.uID = u.uID')
+        ;
     }
 
     public function getTotalResults()
@@ -105,23 +107,19 @@ class FileList extends DatabaseItemList implements PagerProviderInterface, Pagin
                 'groupBy',
                 'orderBy',
             ])->select('count(distinct f.fID)')->setMaxResults(1)->execute()->fetchColumn();
-        } else {
-            return -1; // unknown
         }
+
+        return -1; // unknown
     }
 
     public function getPaginationAdapter()
     {
-        $adapter = new DoctrineDbalAdapter($this->deliverQueryObject(), function ($query) {
+        return new DoctrineDbalAdapter($this->deliverQueryObject(), static function ($query) {
             $query->resetQueryParts(['groupBy', 'orderBy'])->select('count(distinct f.fID)')->setMaxResults(1);
         });
-
-        return $adapter;
     }
 
     /**
-     * @param $queryRow
-     *
      * @return \Concrete\Core\Entity\File\File
      */
     public function getResult($queryRow)
@@ -137,9 +135,9 @@ class FileList extends DatabaseItemList implements PagerProviderInterface, Pagin
         if (isset($this->permissionsChecker)) {
             if ($this->permissionsChecker === -1) {
                 return true;
-            } else {
-                return call_user_func_array($this->permissionsChecker, [$mixed]);
             }
+
+            return call_user_func_array($this->permissionsChecker, [$mixed]);
         }
 
         $fp = new \Permissions($mixed);
@@ -179,13 +177,14 @@ class FileList extends DatabaseItemList implements PagerProviderInterface, Pagin
      *
      * @param \Concrete\Core\Entity\File\StorageLocation\StorageLocation|int $storageLocation storage location object
      */
-    public function filterByStorageLocation($storageLocation) {
+    public function filterByStorageLocation($storageLocation)
+    {
         if ($storageLocation instanceof \Concrete\Core\Entity\File\StorageLocation\StorageLocation) {
             $this->filterByStorageLocationID($storageLocation->getID());
         } elseif (!is_object($storageLocation)) {
             $this->filterByStorageLocationID($storageLocation);
         } else {
-            throw new Exception(t('Invalid file storage location.'));
+            throw new \Exception(t('Invalid file storage location.'));
         }
     }
 
@@ -217,7 +216,7 @@ class FileList extends DatabaseItemList implements PagerProviderInterface, Pagin
         /** @var LikeBuilder $likeBuilder */
         $likeBuilder = Application::getFacadeApplication()->make(LikeBuilder::class);
         $expr = $this->query->expr();
-        $attributeKeys = FileAttributeKey::getSearchableIndexedList();
+        $attributeKeys = \FileAttributeKey::getSearchableIndexedList();
         foreach ($words as $word) {
             // filterByKeywords may be called more than once: every word must have its own parameter
             $parameter = 'keywords_' . $this->keywordsCounter++;
@@ -286,8 +285,11 @@ class FileList extends DatabaseItemList implements PagerProviderInterface, Pagin
      */
     public function filterByDateAdded($date, $comparison = '=')
     {
-        $this->query->andWhere($this->query->expr()->comparison('f.fDateAdded', $comparison,
-            $this->query->createNamedParameter($date)));
+        $this->query->andWhere($this->query->expr()->comparison(
+            'f.fDateAdded',
+            $comparison,
+            $this->query->createNamedParameter($date)
+        ));
     }
 
     /**

--- a/concrete/src/File/FileList.php
+++ b/concrete/src/File/FileList.php
@@ -2,6 +2,7 @@
 
 namespace Concrete\Core\File;
 
+use Concrete\Core\Database\Query\LikeBuilder;
 use Concrete\Core\File\StorageLocation\StorageLocationFactory;
 use Concrete\Core\Search\ItemList\Database\AttributedItemList as DatabaseItemList;
 use Concrete\Core\Search\ItemList\Pager\Manager\FileListPagerManager;
@@ -37,6 +38,15 @@ class FileList extends DatabaseItemList implements PagerProviderInterface, Pagin
         'fv.fvSize',
         'totalDownloads',
     ];
+
+    /**
+     * The number of keywords used so far by the filterByKeywords method.
+     *
+     * @var int
+     *
+     * @see \Concrete\Core\File\FileList::filterByKeywords()
+     */
+    private $keywordsCounter = 0;
 
     public function __construct(?StickyRequest $req = null)
     {
@@ -199,22 +209,36 @@ class FileList extends DatabaseItemList implements PagerProviderInterface, Pagin
      */
     public function filterByKeywords($keywords)
     {
-        $expressions = [
-            $this->query->expr()->like('fv.fvFilename', ':keywords'),
-            $this->query->expr()->like('fv.fvDescription', ':keywords'),
-            $this->query->expr()->like('fv.fvTitle', ':keywords'),
-            $this->query->expr()->like('fv.fvTags', ':keywords'),
-            $this->query->expr()->eq('uName', ':keywords'),
-        ];
-
-        $keys = FileAttributeKey::getSearchableIndexedList();
-        foreach ($keys as $ak) {
-            $cnt = $ak->getController();
-            $expressions[] = $cnt->searchKeywords($keywords, $this->query);
+        $words = preg_split('/\s+/', (string) $keywords, -1, PREG_SPLIT_NO_EMPTY);
+        if ($words === []) {
+            return;
         }
+        $words = array_values(array_unique(array_map('mb_strtolower', $words)));
+        /** @var LikeBuilder $likeBuilder */
+        $likeBuilder = Application::getFacadeApplication()->make(LikeBuilder::class);
         $expr = $this->query->expr();
-        $this->query->andWhere(call_user_func_array([$expr, 'orX'], $expressions));
-        $this->query->setParameter('keywords', '%' . $keywords . '%');
+        $attributeKeys = FileAttributeKey::getSearchableIndexedList();
+        foreach ($words as $word) {
+            // filterByKeywords may be called more than once: every word must have its own parameter
+            $parameter = 'keywords_' . $this->keywordsCounter++;
+            $expressions = [
+                $expr->like('fv.fvFilename', ":{$parameter}"),
+                $expr->like('fv.fvDescription', ":{$parameter}"),
+                $expr->like('fv.fvTitle', ":{$parameter}"),
+                $expr->like('fv.fvTags', ":{$parameter}"),
+                $expr->like('u.uName', ":{$parameter}"),
+            ];
+            foreach ($attributeKeys as $attributeKey) {
+                $attributeExpression = (string) $attributeKey->getController()->searchKeywords($word, $this->query);
+                if ($attributeExpression !== '') {
+                    // the attribute controllers build their expressions around the :keywords placeholder
+                    $expressions[] = preg_replace('/:keywords\b/', ":{$parameter}", $attributeExpression);
+                }
+            }
+            // every word must be found, but not necessarily in the same field as the other ones
+            $this->query->andWhere(call_user_func_array([$expr, 'orX'], $expressions));
+            $this->query->setParameter($parameter, $likeBuilder->escapeForLike($word));
+        }
     }
 
     public function filterBySet($fs)

--- a/tests/tests/File/FileListKeywordsTest.php
+++ b/tests/tests/File/FileListKeywordsTest.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\Tests\File;
+
+use Concrete\Core\Attribute\Key\Category;
+use Concrete\Core\Attribute\Type as AttributeType;
+use Concrete\Core\Database\Connection\Connection;
+use Concrete\Core\Entity\Attribute\Key\FileKey as FileKeyEntity;
+use Concrete\Core\Entity\User\User as UserEntity;
+use Concrete\Core\File\FileList;
+use Concrete\Core\File\Filesystem;
+use Concrete\Core\File\Import\FileImporter;
+use Concrete\Core\Permission\Access\Entity\Type as PermissionAccessEntityType;
+use Concrete\TestHelpers\File\FileStorageTestCase;
+use Doctrine\ORM\EntityManagerInterface;
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+/**
+ * Tests the keyword filtering of the file list.
+ *
+ * @see \Concrete\Core\File\FileList::filterByKeywords()
+ */
+class FileListKeywordsTest extends FileStorageTestCase
+{
+    /**
+     * The name of the user that uploads the files.
+     *
+     * @var string
+     */
+    private const UPLOADER = 'admin';
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\TestHelpers\Database\ConcreteDatabaseTestCase::getTables()
+     */
+    protected function getTables()
+    {
+        return array_merge(parent::getTables(), [
+            'ConfigStore',
+            'FileSets',
+            'FileSetFiles',
+            'FileVersionLog',
+            'Logs',
+            'PermissionAccessEntities',
+            'PermissionAccessEntityGroups',
+            'PermissionAccessEntityTypes',
+            'UserGroups',
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\TestHelpers\Database\ConcreteDatabaseTestCase::getEntityClassNames()
+     */
+    protected function getEntityClassNames(): array
+    {
+        return array_merge(parent::getEntityClassNames(), [
+            'Concrete\Core\Entity\Attribute\Category',
+            'Concrete\Core\Entity\Attribute\Key\Key',
+            'Concrete\Core\Entity\Attribute\Key\FileKey',
+            'Concrete\Core\Entity\Attribute\Key\Settings\Settings',
+            'Concrete\Core\Entity\Attribute\Key\Settings\EmptySettings',
+            'Concrete\Core\Entity\Attribute\Key\Settings\TextSettings',
+            'Concrete\Core\Entity\Attribute\Type',
+            'Concrete\Core\Entity\Attribute\Value\FileValue',
+            'Concrete\Core\Entity\Attribute\Value\Value\Value',
+            'Concrete\Core\Entity\Attribute\Value\Value\TextValue',
+            'Concrete\Core\Entity\File\Image\Thumbnail\Type\TypeFileSet',
+            'Concrete\Core\Entity\User\User',
+        ]);
+    }
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        app(Filesystem::class)->create();
+        $category = Category::add('file');
+        PermissionAccessEntityType::add('file_uploader', 'File Uploader');
+
+        // a searchable attribute: the keywords are looked for in the indexed attributes too
+        $attributeKey = new FileKeyEntity();
+        $attributeKey->setAttributeKeyHandle('notes');
+        $attributeKey->setAttributeKeyName('Notes');
+        $attributeKey->setIsAttributeKeyContentIndexed(true);
+        $category->add(AttributeType::add('text', 'Text'), $attributeKey);
+
+        $self = new static();
+        if (!is_dir($self->getStorageDirectory())) {
+            mkdir($self->getStorageDirectory());
+        }
+        $self->getStorageLocation();
+
+        $sample = DIR_TESTS . '/assets/File/StorageLocation/sample.txt';
+        $importer = app(FileImporter::class);
+        $version = $importer->importLocalFile($sample, 'recipe-1.txt');
+        $version->updateTitle('Pizzoccheri della Valtellina');
+        $version = $importer->importLocalFile($sample, 'recipe-2.txt');
+        $version->updateTitle('Risotto allo zafferano');
+        $version->updateDescription('A dish from Milan');
+        $version = $importer->importLocalFile($sample, 'shopping-list.txt');
+        $version->updateTags("cheese\nbutter");
+        $version->getFile()->setAttribute('notes', 'Ask for gnocchi');
+
+        // the files must belong to a user, so that they can be searched by the name of who uploaded them
+        $user = new UserEntity();
+        $user->setUserName(self::UPLOADER);
+        $user->setUserEmail('admin@example.com');
+        $user->setUserPassword('');
+        $user->setUserDateAdded(new \DateTime());
+        $user->setUserLastPasswordChange(new \DateTime());
+        $entityManager = app(EntityManagerInterface::class);
+        $entityManager->persist($user);
+        $entityManager->flush();
+        app(Connection::class)->executeStatement('update Files set uID = ?', [$user->getUserID()]);
+    }
+
+    public static function providerKeywords(): array
+    {
+        return [
+            // a word is looked for in every searchable field
+            'a part of a title' => ['pizzoccher', ['recipe-1.txt']],
+            'a part of a file name' => ['recipe', ['recipe-1.txt', 'recipe-2.txt']],
+            'a part of a description' => ['Milan', ['recipe-2.txt']],
+            'a tag' => ['butter', ['shopping-list.txt']],
+            'a word of a searchable attribute' => ['gnocchi', ['shopping-list.txt']],
+            'an any-characters wildcard' => ['%', []],
+            'a one-character wildcard' => ['_', []],
+            'a wildcard in a word' => ['recipe_1', []],
+            'an attribute and a file name' => ['gnocchi shopping', ['shopping-list.txt']],
+            'an attribute and another file' => ['gnocchi recipe', []],
+            'the name of the uploader' => [self::UPLOADER, ['recipe-1.txt', 'recipe-2.txt', 'shopping-list.txt']],
+            // every word must be found, each one in any field
+            'the uploader and a part of a title' => ['admin pizzoccher', ['recipe-1.txt']],
+            'a file name and a title' => ['recipe risotto', ['recipe-2.txt']],
+            'two words of the same title' => ['della pizzoccheri', ['recipe-1.txt']],
+            'words found in different files' => ['pizzoccheri risotto', []],
+            'a word no file has' => ['pizzoccheri lasagna', []],
+            // the words are normalized
+            'the same word twice' => ['risotto Risotto', ['recipe-2.txt']],
+            'a title in capitals' => ['RISOTTO', ['recipe-2.txt']],
+            'blanks between the words' => ["  recipe \t risotto  ", ['recipe-2.txt']],
+            // an empty search is not a search
+            'nothing' => ['', ['recipe-1.txt', 'recipe-2.txt', 'shopping-list.txt']],
+            'blanks' => ["  \t ", ['recipe-1.txt', 'recipe-2.txt', 'shopping-list.txt']],
+        ];
+    }
+
+    /**
+     * @dataProvider providerKeywords
+     *
+     * @param string[] $expectedFilenames
+     */
+    public function testFilterByKeywords(string $keywords, array $expectedFilenames): void
+    {
+        $list = new FileList();
+        $list->ignorePermissions();
+        $list->filterByKeywords($keywords);
+
+        static::assertSame($expectedFilenames, $this->getFilenames($list));
+    }
+
+    public function testFilterByKeywordsCalledMoreThanOnce(): void
+    {
+        $list = new FileList();
+        $list->ignorePermissions();
+        $list->filterByKeywords('recipe');
+        $list->filterByKeywords('admin');
+
+        static::assertSame(['recipe-1.txt', 'recipe-2.txt'], $this->getFilenames($list));
+
+        $list = new FileList();
+        $list->ignorePermissions();
+        $list->filterByKeywords('pizzoccheri');
+        $list->filterByKeywords('risotto');
+
+        static::assertSame([], $this->getFilenames($list));
+    }
+
+    /**
+     * @return string[]
+     */
+    private function getFilenames(FileList $list): array
+    {
+        $result = [];
+        foreach ($list->getResults() as $file) {
+            $result[] = $file->getApprovedVersion()->getFileName();
+        }
+        sort($result);
+
+        return $result;
+    }
+}


### PR DESCRIPTION
The keywords were used as a single string, so searching for two words found only the files having both of them in the same field.

Now every word must be found, but each one can be in any searchable field: searching for `admin pizzoccheri` finds the files uploaded by `admin` whose title contains `pizzoccheri`.

Furthermore:
- the `uName` criterion never matched, since the column was compared with an exact match (`uName = '%search%'`) instead of a `LIKE`
- the `%` and `_` characters in the searched text are now escaped with `LikeBuilder`, so that they aren't used as wildcards
- the query parameters are numbered progressively, so that calling `filterByKeywords` more than once doesn't overwrite the previous parameters
