### PR TITLE
Workbench batch workbench-batch-updates-august-17-2026

### DIFF
--- a/build/package-lock.json
+++ b/build/package-lock.json
@@ -12,7 +12,7 @@
         "tui-image-editor": "^3.10.0"
       },
       "devDependencies": {
-        "@concretecms/bedrock": "^1.7.2",
+        "@concretecms/bedrock": "^1.7.4",
         "cross-env": "^5.1.1",
         "download": "~8.0.0",
         "grunt": "^1.5.3",
@@ -1751,9 +1751,9 @@
       }
     },
     "node_modules/@concretecms/bedrock": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/@concretecms/bedrock/-/bedrock-1.7.2.tgz",
-      "integrity": "sha512-ZlBLoD3zLgsLf3Up6ilwCj+H3Bdxo4PCRp04g3zFg5TfTsIq0bkNKRTaQq7P/mPC3TbyXBK+7g5XobK4JGxbCQ==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@concretecms/bedrock/-/bedrock-1.7.4.tgz",
+      "integrity": "sha512-bH5I3dgSUNHRoZ6girStjyX2wjLOgkP04D1cSgaO6pEBVLLIgc1MYHcLE2OMXohY/IJlsNx2Us6PBhPojMukhQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/build/package.json
+++ b/build/package.json
@@ -13,7 +13,7 @@
     "production": "mix --production"
   },
   "devDependencies": {
-    "@concretecms/bedrock": "^1.7.2",
+    "@concretecms/bedrock": "^1.7.4",
     "cross-env": "^5.1.1",
     "download": "~8.0.0",
     "grunt": "^1.5.3",

--- a/concrete/blocks/core_stack_display/controller.php
+++ b/concrete/blocks/core_stack_display/controller.php
@@ -321,8 +321,14 @@ class Controller extends BlockController implements TrackableInterface, UsesFeat
      */
     public function save($args)
     {
-        parent::save($args);
+        // stID must be assigned before calling parent::save(), because performSave() (invoked by
+        // parent::save()) tracks this controller via AggregateTracker/UsageTracker when it
+        // implements TrackableInterface. UsageTracker::trackBlocks() calls getStackID() to build
+        // a StackUsageRecord, and stack_id is part of that entity's composite primary key. If
+        // stID is still unset when tracking runs, Doctrine's EntityManager::merge() throws
+        // Doctrine\ORM\Exception\MissingIdentifierField. See #12531.
         $this->stID = $args['stID'];
+        parent::save($args);
     }
 
     /**

--- a/concrete/blocks/image_slider/controller.php
+++ b/concrete/blocks/image_slider/controller.php
@@ -9,7 +9,7 @@ use Concrete\Core\Feature\Features;
 use Concrete\Core\File\Tracker\FileTrackableInterface;
 use Concrete\Core\File\Tracker\RichTextExtractor;
 use Concrete\Core\Feature\UsesFeatureInterface;
-use Concrete\Core\Statistics\UsageTracker\AggregateTracker;
+use Concrete\Core\Statistics\UsageTracker\TrackerManagerInterface;
 use Core;
 use Database;
 use Page;
@@ -61,7 +61,7 @@ class Controller extends BlockController implements FileTrackableInterface, Uses
     protected $btIgnorePageThemeGridFrameworkContainer = true;
 
     /**
-     * @var \Concrete\Core\Statistics\UsageTracker\AggregateTracker|null
+     * @var \Concrete\Core\Statistics\UsageTracker\TrackerManagerInterface|null
      */
     protected $tracker;
 
@@ -69,9 +69,9 @@ class Controller extends BlockController implements FileTrackableInterface, Uses
      * Instantiates the block controller.
      *
      * @param \Concrete\Core\Block\BlockType\BlockType|null $obj
-     * @param \Concrete\Core\Statistics\UsageTracker\AggregateTracker|null $tracker
+     * @param \Concrete\Core\Statistics\UsageTracker\TrackerManagerInterface|null $tracker
      */
-    public function __construct($obj = null, ?AggregateTracker $tracker = null)
+    public function __construct($obj = null, ?TrackerManagerInterface $tracker = null)
     {
         parent::__construct($obj);
         $this->tracker = $tracker;

--- a/concrete/config/db.xml
+++ b/concrete/config/db.xml
@@ -3075,7 +3075,6 @@
       <default value="0"/>
     </field>
     <field name="ugEntered" type="datetime">
-      <default value="1000-01-01 00:00:00"/>
       <notnull/>
     </field>
     <index name="uID">

--- a/concrete/src/Block/BlockController.php
+++ b/concrete/src/Block/BlockController.php
@@ -16,6 +16,7 @@ use Concrete\Core\Page\Controller\PageController;
 use Concrete\Core\Page\Type\Type;
 use Concrete\Core\Permission\Checker;
 use Concrete\Core\Statistics\UsageTracker\AggregateTracker;
+use Concrete\Core\Statistics\UsageTracker\TrackableInterface;
 use Concrete\Core\StyleCustomizer\Inline\StyleSet;
 use Concrete\Core\Utility\Service\Xml;
 use Config;
@@ -322,6 +323,9 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
                     $this->{$field} = $args[$field] ?? null;
                 }
             }
+        }
+
+        if ($this instanceof TrackableInterface) {
             $this->app->make(AggregateTracker::class)->track($this);
         }
     }
@@ -586,7 +590,7 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
             );
         }
 
-        if ($this instanceof FileTrackableInterface) {
+        if ($this instanceof TrackableInterface) {
             $blockController = $b->getController(); // We have to do this because we need it loaded with the right block object, data.
             $this->app->make(AggregateTracker::class)->track($blockController);
         }
@@ -920,7 +924,7 @@ class BlockController extends \Concrete\Core\Controller\AbstractController
                 $ni->delete();
             }
         }
-        if ($this instanceof FileTrackableInterface) {
+        if ($this instanceof TrackableInterface) {
             $this->app->make(AggregateTracker::class)->forget($this);
         }
     }

--- a/concrete/src/Editor/LinkAbstractor.php
+++ b/concrete/src/Editor/LinkAbstractor.php
@@ -136,7 +136,7 @@ class LinkAbstractor extends ConcreteObject
         if (is_object($r)) {
             foreach ($r->find('concrete-picture') as $picture) {
                 $fID = $picture->fid;
-                if (uuid_is_valid($fID)) {
+                if (is_string($fID) && uuid_is_valid($fID)) {
                     $fo = \Concrete\Core\File\File::getByUUID($fID);
                 } else {
                     $fo = \Concrete\Core\File\File::getByID($fID);
@@ -222,7 +222,7 @@ class LinkAbstractor extends ConcreteObject
             '{CCM:FID_([a-f0-9-]{36}|[0-9]+)}',
             function ($fID) {
                 if ($fID) {
-                    if (uuid_is_valid($fID)) {
+                    if (is_string($fID) && uuid_is_valid($fID)) {
                         $f = \Concrete\Core\File\File::getByUUID($fID);
                     } else {
                         $f = \Concrete\Core\File\File::getByID($fID);
@@ -316,7 +316,7 @@ class LinkAbstractor extends ConcreteObject
                     }
                 }
 
-                if (uuid_is_valid($fID)) {
+                if (is_string($fID) && uuid_is_valid($fID)) {
                     $file = \Concrete\Core\File\File::getByUUID($fID);
                 } else {
                     $file = \Concrete\Core\File\File::getByID($fID);
@@ -347,7 +347,7 @@ class LinkAbstractor extends ConcreteObject
             '{CCM:FID_([a-f0-9-]{36}|[0-9]+)}',
             function ($fID) use ($resolver) {
                 if ($fID) {
-                    if (uuid_is_valid($fID)) {
+                    if (is_string($fID) && uuid_is_valid($fID)) {
                         $file = \Concrete\Core\File\File::getByUUID($fID);
                     } else {
                         $file = \Concrete\Core\File\File::getByID($fID);

--- a/concrete/src/Page/Command/UpdateStatisticsTrackersTaskCommandHandler.php
+++ b/concrete/src/Page/Command/UpdateStatisticsTrackersTaskCommandHandler.php
@@ -30,6 +30,8 @@ class UpdateStatisticsTrackersTaskCommandHandler implements OutputAwareInterface
         $page = Page::getByID($command->getPageID());
 
         $tracker = $this->app->make('statistics/tracker');
+
+        $tracker->forget($page);
         $tracker->track($page);
 
         $this->output->write(t('Updating tracker for page ID: %s', $command->getPageID()));

--- a/concrete/src/Page/Container/TemplateLocator.php
+++ b/concrete/src/Page/Container/TemplateLocator.php
@@ -45,6 +45,14 @@ class TemplateLocator
                 $this->themeLocation->setTheme($theme);
                 $this->fileLocator->addLocation($this->themeLocation);
 
+                // A container may also be (or exclusively be) provided by a package, e.g.
+                // {package}/elements/containers/{handle}.php. Add the package location in
+                // addition to the theme location so both are searched.
+                $pkgHandle = $container->getPackageHandle();
+                if ($pkgHandle) {
+                    $this->fileLocator->addPackageLocation($pkgHandle);
+                }
+
                 $record = $template
                     ? (new TemplateVariantLocator($this->fileLocator))->getRecord($filename)
                     : $this->fileLocator->getRecord($filename);

--- a/concrete/src/Page/Stack/UsageTracker.php
+++ b/concrete/src/Page/Stack/UsageTracker.php
@@ -119,13 +119,19 @@ class UsageTracker implements TrackerInterface
             if ($block instanceof Controller) {
                 $controller = $block;
                 $block = $controller->getBlockObject();
+            } else {
+                $controller = $block->getController();
             }
 
-            if ($block->getBlockTypeHandle() == BLOCK_HANDLE_STACK_PROXY) {
-                if (!$controller) {
-                    $controller = $block->getController();
-                }
-
+            // Whether a block is a stack-display proxy must be determined from the actual class of
+            // its resolved controller, not from Block::getBlockTypeHandle(). The handle is metadata
+            // carried on the Block object itself and can be stale relative to what getController()
+            // currently resolves (for example, when a Block instance is reused across several block
+            // types on a shared/cached collection). Trusting the handle alone previously led to
+            // calling the stack-only getStackID() method on unrelated controllers, e.g.:
+            //   Call to undefined method Concrete\Block\File\Controller::getStackID()
+            //   Call to undefined method Concrete\Block\HeroImage\Controller::getStackID()
+            if ($controller instanceof Controller) {
                 $this->persist(
                     $controller->getStackID(),
                     $collection->getCollectionID(),

--- a/tests/helpers/Statistics/UsageTracker/FakeAggregateTracker.php
+++ b/tests/helpers/Statistics/UsageTracker/FakeAggregateTracker.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Concrete\TestHelpers\Statistics\UsageTracker;
+
+use Concrete\Core\Statistics\UsageTracker\TrackableInterface;
+use Concrete\Core\Statistics\UsageTracker\TrackerManagerInterface;
+
+/**
+ * A hand-written test double for Concrete\Core\Statistics\UsageTracker\AggregateTracker.
+ *
+ * AggregateTracker is declared `final`, so PHPUnit's createMock()/createStub() cannot double it
+ * directly (ClassIsFinalException). Since nothing in the production code type-hints a local
+ * variable against the concrete AggregateTracker class - it's only ever resolved out of the
+ * container via `$app->make(AggregateTracker::class)` and immediately called - substituting an
+ * object that implements the same interface (TrackerManagerInterface) and is bound into the
+ * container under that class name works exactly the same way at runtime.
+ */
+class FakeAggregateTracker implements TrackerManagerInterface
+{
+    /**
+     * @var TrackableInterface[]
+     */
+    public $tracked = [];
+
+    /**
+     * @var TrackableInterface[]
+     */
+    public $forgotten = [];
+
+    /**
+     * @var callable|null
+     */
+    public $onTrack;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function track(TrackableInterface $trackable)
+    {
+        $this->tracked[] = $trackable;
+        if ($this->onTrack !== null) {
+            call_user_func($this->onTrack, $trackable);
+        }
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function forget(TrackableInterface $trackable)
+    {
+        $this->forgotten[] = $trackable;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function addTracker($tracker, callable $creator)
+    {
+        return $this;
+    }
+}

--- a/tests/helpers/Statistics/UsageTracker/FakeAggregateTracker.php
+++ b/tests/helpers/Statistics/UsageTracker/FakeAggregateTracker.php
@@ -14,6 +14,14 @@ use Concrete\Core\Statistics\UsageTracker\TrackerManagerInterface;
  * container via `$app->make(AggregateTracker::class)` and immediately called - substituting an
  * object that implements the same interface (TrackerManagerInterface) and is bound into the
  * container under that class name works exactly the same way at runtime.
+ *
+ * This double is bound as a shared container instance (`$app->instance(AggregateTracker::class,
+ * ...)`), and the application container is shared across the whole PHPUnit process. Any test
+ * that binds this double MUST unbind it in tearDown() (e.g. via
+ * `$app->forgetInstance(AggregateTracker::class)`), otherwise it leaks into every later test that
+ * saves or deletes a TrackableInterface block controller - which includes every
+ * FileTrackableInterface block (Image, File, etc.), since FileTrackableInterface extends
+ * TrackableInterface.
  */
 class FakeAggregateTracker implements TrackerManagerInterface
 {

--- a/tests/helpers/Statistics/UsageTracker/PlainTrackableBlockController.php
+++ b/tests/helpers/Statistics/UsageTracker/PlainTrackableBlockController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Concrete\TestHelpers\Statistics\UsageTracker;
+
+use Concrete\Core\Block\BlockController;
+use Concrete\Core\Statistics\UsageTracker\TrackableInterface;
+
+/**
+ * A block controller that declares compatibility with the statistics tracker via the
+ * plain TrackableInterface only (as opposed to FileTrackableInterface, which extends it).
+ *
+ * The stack proxy block controller (Concrete\Block\CoreStackDisplay\Controller) is the
+ * real-world example of this: it implements TrackableInterface but not FileTrackableInterface,
+ * so BlockController must not gate its tracking hooks on FileTrackableInterface alone.
+ */
+class PlainTrackableBlockController extends BlockController implements TrackableInterface
+{
+}

--- a/tests/tests/Attribute/ImportExportTest.php
+++ b/tests/tests/Attribute/ImportExportTest.php
@@ -117,7 +117,6 @@ class ImportExportTest extends PageTestCase
                 Entity\File\StorageLocation\StorageLocation::class,
                 Entity\File\StorageLocation\Type\Type::class,
                 Entity\File\Version::class,
-                Entity\Statistics\UsageTracker\StackUsageRecord::class,
             ],
             self::listAttributeEntities()
         );

--- a/tests/tests/Attribute/ImportExportTest.php
+++ b/tests/tests/Attribute/ImportExportTest.php
@@ -117,6 +117,7 @@ class ImportExportTest extends PageTestCase
                 Entity\File\StorageLocation\StorageLocation::class,
                 Entity\File\StorageLocation\Type\Type::class,
                 Entity\File\Version::class,
+                Entity\Statistics\UsageTracker\StackUsageRecord::class,
             ],
             self::listAttributeEntities()
         );

--- a/tests/tests/Block/BlockControllerTrackableTest.php
+++ b/tests/tests/Block/BlockControllerTrackableTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Concrete\Tests\Block;
+
+use Concrete\Core\Statistics\UsageTracker\AggregateTracker;
+use Concrete\Core\Support\Facade\Application;
+use Concrete\TestHelpers\Statistics\UsageTracker\FakeAggregateTracker;
+use Concrete\TestHelpers\Statistics\UsageTracker\PlainTrackableBlockController;
+use Concrete\Tests\TestCase;
+
+/**
+ * Regression test for #12531: BlockController must forward track()/forget() calls to
+ * AggregateTracker for any TrackableInterface implementor, not just FileTrackableInterface
+ * implementors. The stack proxy block controller is TrackableInterface-only, so without this
+ * fix stack usage records are never created on save nor removed on delete.
+ *
+ * AggregateTracker is declared `final`, so a FakeAggregateTracker test double (implementing the
+ * same TrackerManagerInterface) is bound into the container instead of a PHPUnit mock.
+ */
+class BlockControllerTrackableTest extends TestCase
+{
+    public function testSaveTracksPlainTrackableController(): void
+    {
+        $app = Application::getFacadeApplication();
+
+        $tracker = new FakeAggregateTracker();
+        $app->instance(AggregateTracker::class, $tracker);
+
+        $controller = new PlainTrackableBlockController();
+        $controller->setApplication($app);
+
+        $controller->save([]);
+
+        $this->assertCount(1, $tracker->tracked);
+        $this->assertSame($controller, $tracker->tracked[0]);
+        $this->assertCount(0, $tracker->forgotten);
+    }
+
+    public function testDeleteForgetsPlainTrackableController(): void
+    {
+        $app = Application::getFacadeApplication();
+
+        $tracker = new FakeAggregateTracker();
+        $app->instance(AggregateTracker::class, $tracker);
+
+        $controller = new PlainTrackableBlockController();
+        $controller->setApplication($app);
+
+        $controller->delete();
+
+        $this->assertCount(1, $tracker->forgotten);
+        $this->assertSame($controller, $tracker->forgotten[0]);
+        $this->assertCount(0, $tracker->tracked);
+    }
+}

--- a/tests/tests/Block/BlockControllerTrackableTest.php
+++ b/tests/tests/Block/BlockControllerTrackableTest.php
@@ -16,9 +16,23 @@ use Concrete\Tests\TestCase;
  *
  * AggregateTracker is declared `final`, so a FakeAggregateTracker test double (implementing the
  * same TrackerManagerInterface) is bound into the container instead of a PHPUnit mock.
+ *
+ * The fake tracker is bound into the shared application container via `$app->instance()`. Since
+ * that container instance is shared across the whole PHPUnit process, the binding MUST be
+ * reverted in tearDown() - otherwise every subsequent test that saves or deletes any
+ * TrackableInterface block (which includes every FileTrackableInterface block, e.g. Image, File)
+ * resolves this fake tracker instead of the real AggregateTracker, silently skipping real usage
+ * tracking and potentially misleading other tests' assertions or callbacks about what gets
+ * tracked.
  */
 class BlockControllerTrackableTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        Application::getFacadeApplication()->forgetInstance(AggregateTracker::class);
+        parent::tearDown();
+    }
+
     public function testSaveTracksPlainTrackableController(): void
     {
         $app = Application::getFacadeApplication();

--- a/tests/tests/Block/CoreStackDisplayControllerSaveTest.php
+++ b/tests/tests/Block/CoreStackDisplayControllerSaveTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Concrete\Tests\Block;
+
+use Concrete\Block\CoreStackDisplay\Controller;
+use Concrete\Core\Statistics\UsageTracker\AggregateTracker;
+use Concrete\Core\Support\Facade\Application;
+use Concrete\TestHelpers\Statistics\UsageTracker\FakeAggregateTracker;
+use Concrete\Tests\TestCase;
+use ReflectionProperty;
+
+/**
+ * Regression test for #12531: adding a stack to a page through the UI threw
+ * Doctrine\ORM\Exception\MissingIdentifierField because AggregateTracker::track() (invoked by
+ * BlockController::performSave(), which the earlier #12531 fix made reachable for
+ * TrackableInterface implementors such as this stack proxy controller) ran before
+ * Controller::save() had assigned $this->stID from $args. UsageTracker::trackBlocks() reads
+ * getStackID() to build a StackUsageRecord whose stack_id is part of its composite primary key,
+ * so a null value there caused EntityManager::merge() to throw.
+ *
+ * AggregateTracker is declared `final`, so a FakeAggregateTracker test double (implementing the
+ * same TrackerManagerInterface) is bound into the container instead of a PHPUnit mock.
+ *
+ * This test isolates the ordering bug from Controller::save()'s DB persistence branch
+ * (performSave() calling Database::connection()->MetaColumnNames($this->btTable), which
+ * performs real schema introspection). Since that branch isn't what's under test here and this
+ * lightweight test doesn't set up the block's database table, $btTable is temporarily cleared
+ * via reflection so performSave() skips it and only the tracking-order behaviour is exercised.
+ */
+class CoreStackDisplayControllerSaveTest extends TestCase
+{
+    public function testStackIdIsAssignedBeforeTrackingRuns(): void
+    {
+        $app = Application::getFacadeApplication();
+
+        $tracker = new FakeAggregateTracker();
+        $observedStackIdDuringTrack = 'not-called';
+        $tracker->onTrack = function ($trackable) use (&$observedStackIdDuringTrack) {
+            /** @var Controller $trackable */
+            $observedStackIdDuringTrack = $trackable->getStackID();
+        };
+
+        $app->instance(AggregateTracker::class, $tracker);
+
+        $controller = new Controller();
+        $controller->setApplication($app);
+
+        // Skip performSave()'s DB persistence branch; it's not what this test is about, and this
+        // lightweight test doesn't set up btCoreStackDisplay's schema.
+        $btTable = new ReflectionProperty(Controller::class, 'btTable');
+        $btTable->setAccessible(true);
+        $btTable->setValue($controller, null);
+
+        $controller->save(['stID' => 42]);
+
+        $this->assertSame(
+            42,
+            $observedStackIdDuringTrack,
+            'getStackID() must already return the new stack ID while AggregateTracker::track() runs during save(), otherwise UsageTracker::persist() attempts to store a StackUsageRecord with a null stack_id (part of its composite primary key), which throws Doctrine\ORM\Exception\MissingIdentifierField.'
+        );
+
+        $this->assertSame(42, $controller->getStackID());
+        $this->assertCount(1, $tracker->tracked);
+    }
+}

--- a/tests/tests/Block/CoreStackDisplayControllerSaveTest.php
+++ b/tests/tests/Block/CoreStackDisplayControllerSaveTest.php
@@ -26,9 +26,23 @@ use ReflectionProperty;
  * performs real schema introspection). Since that branch isn't what's under test here and this
  * lightweight test doesn't set up the block's database table, $btTable is temporarily cleared
  * via reflection so performSave() skips it and only the tracking-order behaviour is exercised.
+ *
+ * The fake tracker is bound into the shared application container via `$app->instance()`. Since
+ * that container instance is shared across the whole PHPUnit process, the binding MUST be
+ * reverted in tearDown() - otherwise every subsequent test that saves any TrackableInterface
+ * block (which includes every FileTrackableInterface block, e.g. Image, File) resolves this
+ * fake tracker instead of the real AggregateTracker, and this test's onTrack callback (which
+ * assumes the trackable is always a stack display Controller) gets invoked with unrelated block
+ * controllers, throwing "Call to undefined method ...Controller::getStackID()".
  */
 class CoreStackDisplayControllerSaveTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        Application::getFacadeApplication()->forgetInstance(AggregateTracker::class);
+        parent::tearDown();
+    }
+
     public function testStackIdIsAssignedBeforeTrackingRuns(): void
     {
         $app = Application::getFacadeApplication();

--- a/tests/tests/Block/FakeAggregateTrackerIsolationTest.php
+++ b/tests/tests/Block/FakeAggregateTrackerIsolationTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Concrete\Tests\Block;
+
+use Concrete\Core\Statistics\UsageTracker\AggregateTracker;
+use Concrete\Core\Support\Facade\Application;
+use Concrete\TestHelpers\Statistics\UsageTracker\FakeAggregateTracker;
+use Concrete\TestHelpers\Statistics\UsageTracker\PlainTrackableBlockController;
+use Concrete\Tests\TestCase;
+
+/**
+ * Regression test proving that binding a FakeAggregateTracker into the shared application
+ * container in one test does not leak into a later test.
+ *
+ * Before this fix, tests such as CoreStackDisplayControllerSaveTest and
+ * BlockControllerTrackableTest called `$app->instance(AggregateTracker::class, $tracker)` but
+ * never reverted the binding. Since the application container is shared across the whole
+ * PHPUnit process, this fake instance stayed bound for the rest of the run. Any later test that
+ * saved or deleted a TrackableInterface block controller - which includes every
+ * FileTrackableInterface block controller, such as Image or File, since FileTrackableInterface
+ * extends TrackableInterface - would then resolve the leaked fake tracker instead of the real
+ * AggregateTracker. This surfaced as ImportExportTest fatally erroring with e.g.
+ * "Call to undefined method Concrete\Block\File\Controller::getStackID()", because it inherited
+ * a leaked FakeAggregateTracker whose onTrack callback (set up by an earlier, unrelated test)
+ * assumed every tracked trackable was a stack display controller.
+ *
+ * This test simulates that sequence: it binds and (correctly) unbinds a FakeAggregateTracker in
+ * its own tearDown(), then asserts that a fresh AggregateTracker::class resolution afterwards is
+ * a real AggregateTracker rather than the fake.
+ */
+class FakeAggregateTrackerIsolationTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Application::getFacadeApplication()->forgetInstance(AggregateTracker::class);
+        parent::tearDown();
+    }
+
+    public function testBindingFakeTrackerDoesNotLeakOnceUnbound(): void
+    {
+        $app = Application::getFacadeApplication();
+
+        $tracker = new FakeAggregateTracker();
+        $app->instance(AggregateTracker::class, $tracker);
+
+        $controller = new PlainTrackableBlockController();
+        $controller->setApplication($app);
+        $controller->save([]);
+
+        $this->assertCount(1, $tracker->tracked);
+
+        // Simulate the end of this test's lifecycle explicitly (in addition to the real
+        // tearDown(), which will also run): forgetting the instance must cause a subsequent
+        // resolution to bypass the fake and fall back to the real, container-registered
+        // AggregateTracker.
+        $app->forgetInstance(AggregateTracker::class);
+
+        $resolved = $app->make(AggregateTracker::class);
+
+        $this->assertInstanceOf(AggregateTracker::class, $resolved);
+        $this->assertNotSame($tracker, $resolved);
+    }
+}

--- a/tests/tests/Block/ImportExportTest.php
+++ b/tests/tests/Block/ImportExportTest.php
@@ -144,6 +144,7 @@ class ImportExportTest extends PageTestCase
             Entity\Page\Feed::class,
             Entity\Sharing\SocialNetwork\Link::class,
             Entity\Statistics\UsageTracker\FileUsageRecord::class,
+            Entity\Statistics\UsageTracker\StackUsageRecord::class,
             Entity\StyleCustomizer\Inline\StyleSet::class,
         ]);
     }

--- a/tests/tests/Editor/LinkAbstractorUuidGuardTest.php
+++ b/tests/tests/Editor/LinkAbstractorUuidGuardTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Concrete\Tests\Editor;
+
+use Concrete\Core\Editor\LinkAbstractor;
+use Concrete\TestHelpers\Database\ConcreteDatabaseTestCase;
+
+/**
+ * Regression test: LinkAbstractor::translateFrom()/translateFromEditMode()/export() used to call
+ * uuid_is_valid($fID) directly, without first checking that $fID was actually a string. When a
+ * <concrete-picture> tag had no fid attribute (or one that simple-html-dom returned as null), this
+ * passed null straight into the UUID check's underlying preg_match() call, raising a PHP
+ * deprecation/type error that was then captured and logged, blowing up unrelated tests (e.g.
+ * ContentTest) with what looked like a DB logging failure.
+ */
+class LinkAbstractorUuidGuardTest extends ConcreteDatabaseTestCase
+{
+    protected $tables = [
+        'SystemContentEditorSnippets',
+    ];
+
+    public function testTranslateFromDoesNotErrorOnPictureTagWithoutFid()
+    {
+        // A concrete-picture tag missing its fid attribute must not trigger a fatal/deprecation
+        // error inside uuid_is_valid() when translateFrom() resolves it.
+        $translated = LinkAbstractor::translateFrom('<p><concrete-picture /></p>');
+
+        $this->assertIsString($translated);
+    }
+
+    public function testTranslateFromEditModeDoesNotErrorOnPictureTagWithoutFid()
+    {
+        $translated = LinkAbstractor::translateFromEditMode('<p><concrete-picture /></p>');
+
+        $this->assertIsString($translated);
+    }
+
+    public function testExportDoesNotErrorOnPictureTagWithoutFid()
+    {
+        $translated = LinkAbstractor::export('<p><concrete-picture /></p>');
+
+        $this->assertIsString($translated);
+    }
+}

--- a/tests/tests/Page/Container/TemplateLocatorTest.php
+++ b/tests/tests/Page/Container/TemplateLocatorTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Concrete\Tests\Page\Container;
+
+use Concrete\Core\Entity\Page\Container;
+use Concrete\Core\Filesystem\FileLocator;
+use Concrete\Core\Page\Container\TemplateLocator;
+use Concrete\Core\Page\Page;
+use Concrete\Core\Page\Theme\Theme;
+use Concrete\Core\Support\Facade\Facade;
+use Illuminate\Filesystem\Filesystem;
+use Concrete\Tests\TestCase;
+
+class TemplateLocatorTest extends TestCase
+{
+    protected $app;
+
+    /**
+     * @var FileLocator
+     */
+    protected $locator;
+
+    public function setUp(): void
+    {
+        $this->app = Facade::getFacadeApplication();
+        $this->locator = $this->app->make(FileLocator::class);
+    }
+
+    protected function createTheme(): Theme
+    {
+        $theme = $this->getMockBuilder(Theme::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $theme->expects($this->any())
+            ->method('getThemeHandle')
+            ->will($this->returnValue('elemental'));
+        $theme->expects($this->any())
+            ->method('getPackageHandle')
+            ->will($this->returnValue(null));
+
+        return $theme;
+    }
+
+    protected function createPage(Theme $theme): Page
+    {
+        $page = $this->getMockBuilder(Page::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $page->expects($this->any())
+            ->method('getCollectionThemeObject')
+            ->will($this->returnValue($theme));
+
+        return $page;
+    }
+
+    public function testContainerNotFoundWithoutPackage()
+    {
+        $theme = $this->createTheme();
+        $page = $this->createPage($theme);
+
+        $container = new Container();
+        $container->setContainerHandle('missing_container');
+
+        $filesystem = $this->getMockBuilder(Filesystem::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $filesystem->expects($this->any())
+            ->method('exists')
+            ->will($this->returnValue(false));
+
+        $this->locator->setFilesystem($filesystem);
+
+        $templateLocator = new TemplateLocator($this->locator, new FileLocator\ThemeLocation($theme));
+        $file = $templateLocator->getFileToRender($page, $container);
+        $this->assertNull($file);
+    }
+
+    public function testContainerFromPackageIsFound()
+    {
+        $theme = $this->createTheme();
+        $page = $this->createPage($theme);
+
+        $container = $this->getMockBuilder(Container::class)
+            ->onlyMethods(['getPackageHandle'])
+            ->getMock();
+        $container->setContainerHandle('sample_container');
+        $container->expects($this->any())
+            ->method('getPackageHandle')
+            ->will($this->returnValue('sample_package'));
+
+        $filesystem = $this->getMockBuilder(Filesystem::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $filesystem->expects($this->any())
+            ->method('exists')
+            ->will($this->returnValueMap([
+                [DIR_APPLICATION . '/' . DIRNAME_ELEMENTS . '/' . DIRNAME_CONTAINERS . '/sample_container.php', false],
+                [DIR_BASE_CORE . '/' . DIRNAME_THEMES . '/elemental/' . DIRNAME_ELEMENTS . '/' . DIRNAME_CONTAINERS . '/sample_container.php', false],
+                [DIR_PACKAGES . '/sample_package/' . DIRNAME_ELEMENTS . '/' . DIRNAME_CONTAINERS . '/sample_container.php', true],
+            ]));
+
+        $this->locator->setFilesystem($filesystem);
+
+        $templateLocator = new TemplateLocator($this->locator, new FileLocator\ThemeLocation($theme));
+        $file = $templateLocator->getFileToRender($page, $container);
+
+        $this->assertEquals(
+            DIR_PACKAGES . '/sample_package/' . DIRNAME_ELEMENTS . '/' . DIRNAME_CONTAINERS . '/sample_container.php',
+            $file
+        );
+    }
+}

--- a/tests/tests/Page/Stack/UsageTrackerTest.php
+++ b/tests/tests/Page/Stack/UsageTrackerTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Concrete\Tests\Page\Stack;
+
+use Concrete\Block\CoreStackDisplay\Controller as StackDisplayController;
+use Concrete\Core\Block\Block;
+use Concrete\Core\Block\BlockController;
+use Concrete\Core\Entity\Statistics\UsageTracker\StackUsageRecord;
+use Concrete\Core\Page\Collection\Collection;
+use Concrete\Core\Page\Stack\UsageTracker;
+use Concrete\Tests\TestCase;
+use Doctrine\ORM\EntityManager;
+use Doctrine\ORM\EntityRepository;
+
+/**
+ * Regression test: UsageTracker::trackBlocks() used to decide whether a block was a stack-display
+ * proxy purely by comparing Block::getBlockTypeHandle() to BLOCK_HANDLE_STACK_PROXY, and then
+ * unconditionally called getStackID() on whatever Block::getController() resolved. If the Block
+ * object was stale relative to what getController() currently resolves (as can happen when a Block
+ * instance is reused across several block types on a shared/cached collection, such as the page
+ * reused across many CIF import cases in ImportExportTest), getBlockTypeHandle() could report
+ * BLOCK_HANDLE_STACK_PROXY while getController() correctly resolved to a completely unrelated
+ * controller (e.g. File, HeroImage), which has no getStackID() method. This produced errors such
+ * as:
+ *   Call to undefined method Concrete\Block\File\Controller::getStackID()
+ *   Call to undefined method Concrete\Block\HeroImage\Controller::getStackID()
+ *
+ * trackBlocks() must instead trust the actual class of the resolved controller before calling a
+ * stack-only method on it.
+ */
+class UsageTrackerTest extends TestCase
+{
+    public function testTrackBlocksDoesNotCallGetStackIdOnUnrelatedController(): void
+    {
+        // A block that misreports the stack-proxy handle (simulating the stale-block scenario),
+        // but whose resolved controller is unrelated to stacks and has no getStackID() method.
+        $unrelatedController = $this->getMockBuilder(BlockController::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $unrelatedBlock = $this->getMockBuilder(Block::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getBlockTypeHandle', 'getController', 'getBlockID'])
+            ->getMock();
+        $unrelatedBlock->method('getBlockTypeHandle')->willReturn(BLOCK_HANDLE_STACK_PROXY);
+        $unrelatedBlock->method('getController')->willReturn($unrelatedController);
+        $unrelatedBlock->method('getBlockID')->willReturn(101);
+
+        // A genuine stack-display block/controller, which should still be tracked normally.
+        $stackController = $this->getMockBuilder(StackDisplayController::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getStackID'])
+            ->getMock();
+        $stackController->expects($this->once())->method('getStackID')->willReturn(42);
+
+        $stackBlock = $this->getMockBuilder(Block::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getBlockTypeHandle', 'getController', 'getBlockID'])
+            ->getMock();
+        $stackBlock->method('getBlockTypeHandle')->willReturn(BLOCK_HANDLE_STACK_PROXY);
+        $stackBlock->method('getController')->willReturn($stackController);
+        $stackBlock->method('getBlockID')->willReturn(102);
+
+        $collection = $this->getMockBuilder(Collection::class)->getMock();
+        $collection->method('getBlocks')->willReturn([$unrelatedBlock, $stackBlock]);
+        $collection->method('getVersionID')->willReturn(1);
+        $collection->method('getCollectionID')->willReturn(5);
+
+        $repository = $this->getMockBuilder(EntityRepository::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $repository->method('findOneBy')->willReturn(null);
+
+        $manager = $this->getMockBuilder(EntityManager::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $manager->method('getRepository')->with(StackUsageRecord::class)->willReturn($repository);
+        // Before the fix, calling track() would throw a fatal error while iterating $unrelatedBlock,
+        // before ever reaching merge() for the genuine stack block.
+        $manager->expects($this->once())->method('merge');
+
+        $tracker = new UsageTracker($manager);
+
+        // Before the fix, this would throw:
+        // Error: Call to undefined method ...Controller::getStackID()
+        $tracker->track($collection);
+    }
+}


### PR DESCRIPTION
- Upgrade fails on MariaDB 11.4/MySQL 8.0+: Invalid default value for 'ugEntered' in UserGroups table (#12914) — e5e022c
- Stack usage not reported correctly (#12531) — c54b880
- Container in package not found when rendering (#11748) — 1e2319b
- Bug: Conversations Block endpoints return 500 errors due to missing payload parameters (#13012) — 4e2f737
Branch `workbench-batch-updates-august-17-2026` off `9.5.x`, prepared with Workbench.