### PR TITLE
fix: Calendar Event block - issue with calendar not showing events

### DIFF
--- a/concrete/controllers/dialog/choose_event.php
+++ b/concrete/controllers/dialog/choose_event.php
@@ -81,7 +81,7 @@ class ChooseEvent extends BackendInterfaceController
      */
     public function view()
     {
-        $this->requireAsset('fullcalendar');
+        $this->requireAsset('feature/calendar/frontend');
         $this->set('calendar', Calendar::getByID($this->request->query->get('caID', 0)));
     }
 }


### PR DESCRIPTION
Fixes #12955

## Root cause

Duplicate FullCalendar bundle re-patches moment prototype in event chooser

## Changes

- The choose-event dialog now requires the calendar feature asset group (js/features/calendar/frontend.js) instead of the separate js/fullcalendar.js bundle. Both files embed the same FullCalendar 3.10.5 build with moment declared as an external, and FullCalendar captures a copy of moment.fn at load time (oldMomentProto). Loading both on one page makes the second copy capture the already-patched prototype, so oldMomentFormat recurses into FullCalendar's own format() and event/time formatting breaks. Requiring the same asset the page already loads means the library is evaluated only once (ConcreteAssetLoader skips it via the matching src / data-source URL), so the chooser works both when adding and when editing the block.