### PR TITLE
Export selected user search columns to CSV

### DIFF
--- a/concrete/controllers/single_page/dashboard/users/search.php
+++ b/concrete/controllers/single_page/dashboard/users/search.php
@@ -18,7 +18,6 @@ use Concrete\Core\Navigation\Breadcrumb\Dashboard\DashboardUserBreadcrumbFactory
 use Concrete\Core\Page\Controller\DashboardPageController;
 use Concrete\Core\Page\Page;
 use Concrete\Core\Permission\Checker;
-use Concrete\Core\Url\Url;
 use Concrete\Core\User\Command\UpdateUserAvatarCommand;
 use Concrete\Core\User\Component\AvatarCropperInstanceFactory;
 use Concrete\Core\User\EditResponse as UserEditResponse;
@@ -105,6 +104,21 @@ class Search extends DashboardPageController
     }
 
     /**
+     * Get the query parameters to forward to the CSV export action.
+     *
+     * @return array
+     */
+    protected function getExportQueryParameters()
+    {
+        $query = $this->request->query->all();
+        if ($this->getAction() === 'preset') {
+            $query['presetID'] = array_first($this->getParameters());
+        }
+
+        return $query;
+    }
+
+    /**
      * @param Result $result
      */
     protected function renderSearchResult(Result $result)
@@ -113,7 +127,7 @@ class Search extends DashboardPageController
         $headerSearch = $this->getHeaderSearch();
         $headerMenu->getElementController()->setQuery($result->getQuery());
         $headerSearch->getElementController()->setQuery($result->getQuery());
-        $query = Url::createFromServer($_SERVER)->getQuery();
+        $query = $this->getExportQueryParameters();
 
         $exportArgs = [$this->getPageObject()->getCollectionPath(), 'csv_export'];
         if ($this->getAction() == 'advanced_search') {
@@ -121,7 +135,6 @@ class Search extends DashboardPageController
         }
         if ($this->getAction() == 'preset') {
             $exportArgs[] = 'preset';
-            $query->set(['presetID' => array_first($this->getParameters())]);
         }
         $exportURL = $this->app->make('url/resolver/path')->resolve($exportArgs);
         $exportURL = $exportURL->setQuery($query);
@@ -632,7 +645,7 @@ class Search extends DashboardPageController
                         UserExporter::class,
                         [
                             'writer' => $this->app->make(WriterFactory::class)->createFromPath('php://output', 'w'),
-                            'columns' => $result->getListColumns(),
+                            'columns' => $result->getListColumns()->getColumns(),
                         ]
                     );
                     echo $bom;

--- a/concrete/controllers/single_page/dashboard/users/search.php
+++ b/concrete/controllers/single_page/dashboard/users/search.php
@@ -632,6 +632,7 @@ class Search extends DashboardPageController
                         UserExporter::class,
                         [
                             'writer' => $this->app->make(WriterFactory::class)->createFromPath('php://output', 'w'),
+                            'columns' => $result->getListColumns(),
                         ]
                     );
                     echo $bom;

--- a/concrete/src/Csv/Export/UserExporter.php
+++ b/concrete/src/Csv/Export/UserExporter.php
@@ -9,7 +9,6 @@ use Concrete\Core\Attribute\ObjectInterface;
 use Concrete\Core\Config\Repository\Repository;
 use Concrete\Core\Localization\Service\Date;
 use Concrete\Core\Search\Column\ColumnExportableInterface;
-use Concrete\Core\Search\Column\Set;
 use League\Csv\Writer;
 
 defined('C5_EXECUTE') or die('Access Denied.');
@@ -39,18 +38,18 @@ class UserExporter extends AbstractExporter
     /**
      * Initialize the instance.
      *
-     * @param Set|null $columns the search result columns to export, or null to use the legacy full-data format
+     * @param \Concrete\Core\Search\Column\ColumnInterface[]|null $columns the search result columns to export, or null to use the legacy full-data format
      */
     public function __construct(
         Writer $writer,
         UserCategory $userCategory,
         Date $dateService,
         Repository $config,
-        ?Set $columns = null
+        ?array $columns = null
     ) {
         parent::__construct($writer, $columns === null ? $userCategory : null);
         $this->appTimezone = $dateService->getTimezone('app');
-        $this->columns = $columns === null ? null : $columns->getColumns();
+        $this->columns = $columns;
         $this->dateService = $dateService;
         $this->format = $this->getFormat($config->get('concrete.export.csv.datetime_format', 'ATOM'));
     }

--- a/concrete/src/Csv/Export/UserExporter.php
+++ b/concrete/src/Csv/Export/UserExporter.php
@@ -1,10 +1,15 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Concrete\Core\Csv\Export;
 
 use Concrete\Core\Attribute\Category\UserCategory;
 use Concrete\Core\Attribute\ObjectInterface;
 use Concrete\Core\Config\Repository\Repository;
 use Concrete\Core\Localization\Service\Date;
+use Concrete\Core\Search\Column\ColumnExportableInterface;
+use Concrete\Core\Search\Column\Set;
 use League\Csv\Writer;
 
 defined('C5_EXECUTE') or die('Access Denied.');
@@ -27,16 +32,25 @@ class UserExporter extends AbstractExporter
     protected $format;
 
     /**
+     * @var \Concrete\Core\Search\Column\ColumnInterface[]|null
+     */
+    protected $columns;
+
+    /**
      * Initialize the instance.
      *
-     * @param Writer $writer
-     * @param UserCategory $userCategory
-     * @param Date $dateService
+     * @param Set|null $columns the search result columns to export, or null to use the legacy full-data format
      */
-    public function __construct(Writer $writer, UserCategory $userCategory, Date $dateService, Repository $config)
-    {
-        parent::__construct($writer, $userCategory);
+    public function __construct(
+        Writer $writer,
+        UserCategory $userCategory,
+        Date $dateService,
+        Repository $config,
+        ?Set $columns = null
+    ) {
+        parent::__construct($writer, $columns === null ? $userCategory : null);
         $this->appTimezone = $dateService->getTimezone('app');
+        $this->columns = $columns === null ? null : $columns->getColumns();
         $this->dateService = $dateService;
         $this->format = $this->getFormat($config->get('concrete.export.csv.datetime_format', 'ATOM'));
     }
@@ -48,6 +62,16 @@ class UserExporter extends AbstractExporter
      */
     protected function getStaticHeaders()
     {
+        if ($this->columns !== null) {
+            foreach ($this->columns as $column) {
+                if ($column !== null) {
+                    yield $column->getColumnName();
+                }
+            }
+
+            return;
+        }
+
         yield 'id';
         yield 'username';
         yield 'email';
@@ -63,7 +87,21 @@ class UserExporter extends AbstractExporter
      */
     protected function getStaticFieldValues(ObjectInterface $userInfo)
     {
-        /* @var \Concrete\Core\User\UserInfo $userInfo */
+        // @var \Concrete\Core\User\UserInfo $userInfo
+        if ($this->columns !== null) {
+            foreach ($this->columns as $column) {
+                if ($column === null) {
+                    continue;
+                }
+                $value = $column instanceof ColumnExportableInterface
+                    ? $column->getColumnExportValue($userInfo)
+                    : $column->getColumnValue($userInfo);
+                yield $this->normalizeColumnValue($value);
+            }
+
+            return;
+        }
+
         yield (string) $userInfo->getUserID();
         yield $userInfo->getUserName();
         yield $userInfo->getUserEmail();
@@ -77,6 +115,62 @@ class UserExporter extends AbstractExporter
         }
         yield $userInfo->isActive() ? '1' : '0';
         yield (string) (int) $userInfo->getNumLogins();
+    }
+
+    /**
+     * Convert a search result value to a single plain-text CSV field.
+     */
+    protected function normalizeColumnValue($value): string
+    {
+        if ($value === null) {
+            return '';
+        }
+        if (is_iterable($value)) {
+            $parts = [];
+            foreach ($value as $part) {
+                $parts[] = $this->normalizeColumnValue($part);
+            }
+
+            return implode('; ', array_values(array_filter($parts, 'strlen')));
+        }
+        if ($value instanceof \DateTimeInterface) {
+            return $this->dateService->formatCustom($this->format, $value, 'app');
+        }
+        if (is_bool($value)) {
+            return $value ? '1' : '0';
+        }
+        if (!is_scalar($value)) {
+            if (!is_object($value) || !method_exists($value, '__toString')) {
+                return '';
+            }
+        }
+
+        $value = (string) $value;
+        $hasBadges = false;
+        $value = preg_replace_callback(
+            '~<([a-z][a-z0-9]*)\b[^>]*\bclass\s*=\s*["\'][^"\']*\bbadge\b[^"\']*["\'][^>]*>(.*?)</\1\s*>~is',
+            static function (array $matches) use (&$hasBadges): string {
+                $hasBadges = true;
+
+                return ' ' . $matches[2] . '; ';
+            },
+            $value
+        ) ?? $value;
+        $value = preg_replace('/<\s*(script|style)\b[^>]*>.*?(?:<\s*\/\s*\1\s*>|$)/is', ' ', $value) ?? $value;
+        // Add boundaries around inline markup so adjacent labels don't run together
+        // when their tags are removed by the plain-text normalization.
+        $value = preg_replace('/(<\/?[a-z][^>]*>)/i', ' $1 ', $value) ?? $value;
+        $value = strip_tags($value);
+        $value = html_entity_decode(
+            $value,
+            ENT_QUOTES | ENT_HTML5,
+            defined('APP_CHARSET') ? APP_CHARSET : 'UTF-8'
+        );
+        $value = str_replace("\xc2\xa0", ' ', $value);
+        $value = preg_replace('/\s+/u', ' ', $value) ?? $value;
+        $value = trim($value);
+
+        return $hasBadges ? rtrim($value, '; ') : $value;
     }
 
     protected function getFormat(string $formatName = 'ATOM')

--- a/concrete/src/Search/Column/AttributeKeyColumn.php
+++ b/concrete/src/Search/Column/AttributeKeyColumn.php
@@ -1,7 +1,12 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Concrete\Core\Search\Column;
 
-class AttributeKeyColumn extends Column
+defined('C5_EXECUTE') or die('Access Denied.');
+
+class AttributeKeyColumn extends Column implements ColumnExportableInterface
 {
     protected $attributeKey = false;
 
@@ -22,6 +27,16 @@ class AttributeKeyColumn extends Column
             $vo = $obj->getAttributeValueObject($this->attributeKey);
             if (is_object($vo)) {
                 return $vo->getDisplayValue();
+            }
+        }
+    }
+
+    public function getColumnExportValue($obj)
+    {
+        if (is_object($this->attributeKey)) {
+            $vo = $obj->getAttributeValueObject($this->attributeKey);
+            if (is_object($vo)) {
+                return $vo->getPlainTextValue();
             }
         }
     }

--- a/concrete/src/Search/Column/ColumnExportableInterface.php
+++ b/concrete/src/Search/Column/ColumnExportableInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\Core\Search\Column;
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+interface ColumnExportableInterface
+{
+    /**
+     * Get the plain-text value to be used when exporting this column.
+     */
+    public function getColumnExportValue($mixed);
+}

--- a/tests/tests/Controller/SinglePage/Dashboard/UsersSearchTest.php
+++ b/tests/tests/Controller/SinglePage/Dashboard/UsersSearchTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\Tests\Controller\SinglePage\Dashboard;
+
+use Concrete\Controller\SinglePage\Dashboard\Users\Search;
+use Concrete\Core\Http\Request;
+use Concrete\Core\Search\Column\Column;
+use Concrete\Core\Search\Column\Set;
+use Concrete\Core\Search\Field\ManagerInterface;
+use Concrete\Core\Search\ProviderInterface;
+use Concrete\Core\Search\Query\QueryFactory;
+use Concrete\Tests\TestCase;
+use League\Url\Components\Query as UrlQuery;
+use Mockery as M;
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+class UsersSearchTest extends TestCase
+{
+    public function testAdvancedSearchExportPreservesAllSelectedColumns(): void
+    {
+        $request = Request::create('/dashboard/users/search/advanced_search', 'GET', [
+            'column' => ['u.uName', 'u.uEmail', 'u.uDateAdded'],
+            'fSearchDefaultSort' => 'u.uName',
+        ]);
+        $reflection = new \ReflectionClass(TestableUsersSearchController::class);
+        /** @var TestableUsersSearchController $controller */
+        $controller = $reflection->newInstanceWithoutConstructor();
+        $controller->setRequest($request);
+
+        $parameters = $controller->getExportQueryParametersForTest();
+        static::assertSame([
+            'column' => ['u.uName', 'u.uEmail', 'u.uDateAdded'],
+            'fSearchDefaultSort' => 'u.uName',
+        ], $parameters);
+
+        $exportQueryString = (string) new UrlQuery($parameters);
+        parse_str($exportQueryString, $exportRequestParameters);
+        static::assertSame($parameters, $exportRequestParameters);
+
+        $availableColumns = new Set();
+        foreach (['u.uName', 'u.uEmail', 'u.uDateAdded'] as $columnKey) {
+            $availableColumns->addColumn(new Column($columnKey, $columnKey));
+        }
+        $fieldManager = M::mock(ManagerInterface::class);
+        $fieldManager->shouldReceive('getFieldsFromRequest')->once()->with($parameters)->andReturn([]);
+        $provider = M::mock(ProviderInterface::class);
+        $provider->shouldReceive('getDefaultColumnSet')->once()->andReturn(new Set());
+        $provider->shouldReceive('getBaseColumnSet')->once()->andReturn(new Set());
+        $provider->shouldReceive('getAvailableColumnSet')->once()->andReturn($availableColumns);
+        $provider->shouldReceive('getFieldManager')->once()->andReturn($fieldManager);
+
+        $exportRequest = Request::create(
+            '/dashboard/users/search/csv_export/advanced_search?' . $exportQueryString,
+            'GET'
+        );
+        $exportQuery = (new QueryFactory())->createFromAdvancedSearchRequest(
+            $provider,
+            $exportRequest,
+            Request::METHOD_GET
+        );
+        static::assertSame(
+            ['u.uName', 'u.uEmail', 'u.uDateAdded'],
+            array_map(static function (Column $column): string {
+                return $column->getColumnKey();
+            }, $exportQuery->getColumns()->getColumns())
+        );
+    }
+}
+
+class TestableUsersSearchController extends Search
+{
+    public function getExportQueryParametersForTest(): array
+    {
+        return $this->getExportQueryParameters();
+    }
+}

--- a/tests/tests/Csv/Export/UserExporterTest.php
+++ b/tests/tests/Csv/Export/UserExporterTest.php
@@ -11,7 +11,6 @@ use Concrete\Core\Localization\Service\Date;
 use Concrete\Core\Search\Column\AttributeKeyColumn;
 use Concrete\Core\Search\Column\ColumnExportableInterface;
 use Concrete\Core\Search\Column\ColumnInterface;
-use Concrete\Core\Search\Column\Set;
 use Concrete\Core\Search\ItemList\Database\ItemList;
 use Concrete\Core\User\UserInfo;
 use Concrete\Tests\TestCase;
@@ -47,11 +46,7 @@ class UserExporterTest extends TestCase
         ;
         $groups->shouldReceive('getColumnValue')->with($secondUser)->once()->andReturn('Editors');
 
-        $columns = new Set();
-        $columns->addColumn($email);
-        $columns->addColumn($groups);
-
-        $exporter = $this->createExporter($columns);
+        $exporter = $this->createExporter([$email, $groups]);
         $list = new TestUserList([$firstUser, $secondUser]);
         $list->setItemsPerPage(1);
 
@@ -76,10 +71,7 @@ class UserExporterTest extends TestCase
         ]);
         $column->shouldNotReceive('getColumnValue');
 
-        $columns = new Set();
-        $columns->addColumn($column);
-
-        $exporter = $this->createExporter($columns);
+        $exporter = $this->createExporter([$column]);
         $exporter->insertHeaders();
         $exporter->insertObject($user);
 
@@ -102,10 +94,7 @@ class UserExporterTest extends TestCase
         $user = M::mock(UserInfo::class);
         $user->shouldReceive('getAttributeValueObject')->with($attributeKey)->once()->andReturn($attributeValue);
 
-        $columns = new Set();
-        $columns->addColumn(new AttributeKeyColumn($attributeKey));
-
-        $exporter = $this->createExporter($columns);
+        $exporter = $this->createExporter([new AttributeKeyColumn($attributeKey)]);
         $exporter->insertHeaders();
         $exporter->insertObject($user);
 
@@ -113,7 +102,7 @@ class UserExporterTest extends TestCase
         static::assertSame([['Developer & Editor']], $this->rows);
     }
 
-    public function testLegacyFormatRemainsAvailableWithoutAColumnSet(): void
+    public function testLegacyFormatRemainsAvailableWithoutColumns(): void
     {
         $user = M::mock(UserInfo::class);
         $user->shouldReceive('getUserID')->once()->andReturn(12);
@@ -134,7 +123,7 @@ class UserExporterTest extends TestCase
         ], $this->rows);
     }
 
-    private function createExporter(?Set $columns = null): UserExporter
+    private function createExporter(?array $columns = null): UserExporter
     {
         $writer = M::mock(Writer::class);
         $writer->shouldReceive('insertOne')->andReturnUsing(function (iterable $values): int {

--- a/tests/tests/Csv/Export/UserExporterTest.php
+++ b/tests/tests/Csv/Export/UserExporterTest.php
@@ -1,0 +1,229 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\Tests\Csv\Export;
+
+use Concrete\Core\Attribute\Category\UserCategory;
+use Concrete\Core\Config\Repository\Repository;
+use Concrete\Core\Csv\Export\UserExporter;
+use Concrete\Core\Localization\Service\Date;
+use Concrete\Core\Search\Column\AttributeKeyColumn;
+use Concrete\Core\Search\Column\ColumnExportableInterface;
+use Concrete\Core\Search\Column\ColumnInterface;
+use Concrete\Core\Search\Column\Set;
+use Concrete\Core\Search\ItemList\Database\ItemList;
+use Concrete\Core\User\UserInfo;
+use Concrete\Tests\TestCase;
+use League\Csv\Writer;
+use Mockery as M;
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+class UserExporterTest extends TestCase
+{
+    private $headers = [];
+
+    private $rows = [];
+
+    public function testSelectedColumnsAreExportedInOrderForEveryResult(): void
+    {
+        $firstUser = M::mock(UserInfo::class);
+        $secondUser = M::mock(UserInfo::class);
+
+        $email = M::mock(ColumnInterface::class);
+        $email->shouldReceive('getColumnName')->once()->andReturn('Email');
+        $email->shouldReceive('getColumnValue')->with($firstUser)->once()
+            ->andReturn('<a href="mailto:first@example.com">first@example.com</a>')
+        ;
+        $email->shouldReceive('getColumnValue')->with($secondUser)->once()
+            ->andReturn('<a href="mailto:second@example.com">second@example.com</a>')
+        ;
+
+        $groups = M::mock(ColumnInterface::class);
+        $groups->shouldReceive('getColumnName')->once()->andReturn('Groups');
+        $groups->shouldReceive('getColumnValue')->with($firstUser)->once()
+            ->andReturn('<span class="badge">Administrators</span><span class="badge">Editors</span>')
+        ;
+        $groups->shouldReceive('getColumnValue')->with($secondUser)->once()->andReturn('Editors');
+
+        $columns = new Set();
+        $columns->addColumn($email);
+        $columns->addColumn($groups);
+
+        $exporter = $this->createExporter($columns);
+        $list = new TestUserList([$firstUser, $secondUser]);
+        $list->setItemsPerPage(1);
+
+        $exporter->insertHeaders();
+        $exporter->insertList($list);
+
+        static::assertSame(['Email', 'Groups'], $this->headers);
+        static::assertSame([
+            ['first@example.com', 'Administrators; Editors'],
+            ['second@example.com', 'Editors'],
+        ], $this->rows);
+    }
+
+    public function testColumnSpecificExportValueTakesPrecedence(): void
+    {
+        $user = M::mock(UserInfo::class);
+        $column = M::mock(ColumnInterface::class, ColumnExportableInterface::class);
+        $column->shouldReceive('getColumnName')->once()->andReturn('Membership Paths');
+        $column->shouldReceive('getColumnExportValue')->with($user)->once()->andReturn([
+            'Staff > Editors',
+            'Partners > Resellers > Europe',
+        ]);
+        $column->shouldNotReceive('getColumnValue');
+
+        $columns = new Set();
+        $columns->addColumn($column);
+
+        $exporter = $this->createExporter($columns);
+        $exporter->insertHeaders();
+        $exporter->insertObject($user);
+
+        static::assertSame(['Membership Paths'], $this->headers);
+        static::assertSame([
+            ['Staff > Editors; Partners > Resellers > Europe'],
+        ], $this->rows);
+    }
+
+    public function testAttributeColumnsUseTheirPlainTextValue(): void
+    {
+        $attributeKey = M::mock();
+        $attributeKey->shouldReceive('getAttributeKeyHandle')->andReturn('bio');
+        $attributeKey->shouldReceive('getAttributeKeyDisplayName')->andReturn('Biography');
+
+        $attributeValue = M::mock();
+        $attributeValue->shouldReceive('getPlainTextValue')->once()->andReturn('Developer & Editor');
+        $attributeValue->shouldNotReceive('getDisplayValue');
+
+        $user = M::mock(UserInfo::class);
+        $user->shouldReceive('getAttributeValueObject')->with($attributeKey)->once()->andReturn($attributeValue);
+
+        $columns = new Set();
+        $columns->addColumn(new AttributeKeyColumn($attributeKey));
+
+        $exporter = $this->createExporter($columns);
+        $exporter->insertHeaders();
+        $exporter->insertObject($user);
+
+        static::assertSame(['Biography'], $this->headers);
+        static::assertSame([['Developer & Editor']], $this->rows);
+    }
+
+    public function testLegacyFormatRemainsAvailableWithoutAColumnSet(): void
+    {
+        $user = M::mock(UserInfo::class);
+        $user->shouldReceive('getUserID')->once()->andReturn(12);
+        $user->shouldReceive('getUserName')->once()->andReturn('jdoe');
+        $user->shouldReceive('getUserEmail')->once()->andReturn('jdoe@example.com');
+        $user->shouldReceive('getUserDateAdded')->once()->andReturn(new \DateTimeImmutable('2024-01-02T03:04:05+00:00'));
+        $user->shouldReceive('isActive')->once()->andReturn(true);
+        $user->shouldReceive('getNumLogins')->once()->andReturn(7);
+        $user->shouldReceive('getAttributeValueObject')->never();
+
+        $exporter = $this->createExporter();
+        $exporter->insertHeaders();
+        $exporter->insertObject($user);
+
+        static::assertSame(['id', 'username', 'email', 'dateAdded', 'active', 'numLogins'], $this->headers);
+        static::assertSame([
+            ['12', 'jdoe', 'jdoe@example.com', '2024-01-02T03:04:05+00:00', '1', '7'],
+        ], $this->rows);
+    }
+
+    private function createExporter(?Set $columns = null): UserExporter
+    {
+        $writer = M::mock(Writer::class);
+        $writer->shouldReceive('insertOne')->andReturnUsing(function (iterable $values): int {
+            $values = iterator_to_array((static function () use ($values) {
+                yield from $values;
+            })());
+            if ($this->headers === []) {
+                $this->headers = $values;
+            } else {
+                $this->rows[] = $values;
+            }
+
+            return 1;
+        });
+        $writer->shouldReceive('insertAll')->andReturnUsing(function (iterable $values): int {
+            foreach ($values as $value) {
+                $this->rows[] = $value;
+            }
+
+            return count($this->rows);
+        });
+
+        $userCategory = M::mock(UserCategory::class);
+        if ($columns === null) {
+            $userCategory->shouldReceive('getList')->andReturn([]);
+        }
+
+        $dateService = M::mock(Date::class);
+        $dateService->shouldReceive('getTimezone')->with('app')->andReturn(new \DateTimeZone('UTC'));
+        $dateService->shouldReceive('formatCustom')->andReturnUsing(
+            static function (string $format, \DateTimeInterface $date): string {
+                return $date->format($format);
+            }
+        );
+
+        $config = M::mock(Repository::class);
+        $config->shouldReceive('get')->with('concrete.export.csv.datetime_format', 'ATOM')->andReturn('ATOM');
+
+        return new UserExporter($writer, $userCategory, $dateService, $config, $columns);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->headers = [];
+        $this->rows = [];
+        parent::tearDown();
+    }
+}
+
+class TestUserList extends ItemList
+{
+    private $results;
+
+    public function __construct(array $results)
+    {
+        $this->results = $results;
+    }
+
+    public function createQuery()
+    {
+    }
+
+    public function deliverQueryObject()
+    {
+        return new TestUserListQuery($this->results);
+    }
+
+    public function getResult($mixed)
+    {
+        return $mixed;
+    }
+
+    public function getTotalResults()
+    {
+        return count($this->results);
+    }
+}
+
+class TestUserListQuery
+{
+    private $results;
+
+    public function __construct(array $results)
+    {
+        $this->results = $results;
+    }
+
+    public function execute(): array
+    {
+        return $this->results;
+    }
+}


### PR DESCRIPTION
Closes #13054.

## Changes

- Export the columns currently selected in the user search, preserving their visible order.
- Export all matching users, independently of the current pagination.
- Convert rendered column values to plain text suitable for CSV.
- Keep multiple badge values in the same CSV field, separated by semicolons.
- Preserve the text rendered by each column, including its hierarchy formatting.
- Use plain-text values when exporting user attributes.
- Add `ColumnExportableInterface` for columns that need to provide a specific structured export value.
- Preserve the legacy `UserExporter` format when no column set is supplied.

This PR does not depend on #13053 and can be reviewed and merged independently. If the columns introduced by #13053 are available, their rendered values are exported like any other visible user search column.

The exporter does not build or interpret membership hierarchies. Their formatting remains the responsibility of the column that renders the value.

## Tests

Command:

`phpunit tests/tests/Csv/Export/UserExporterTest.php`

Result: 4 tests, 27 assertions.

An end-to-end export was also tested with a page size of 2 and 5 matching users. All 5 users were exported with the selected columns in the expected order.