### PR TITLE
Prevent duplicate saved search preset names

### DIFF
--- a/concrete/controllers/dialog/search/advanced_search.php
+++ b/concrete/controllers/dialog/search/advanced_search.php
@@ -6,6 +6,7 @@ use Concrete\Controller\Element\Search\SearchFieldSelector;
 use Concrete\Core\Foundation\Serializer\JsonSerializer;
 use Concrete\Core\Search\Query\QueryFactory;
 use Concrete\Core\Search\Result\ResultFactory;
+use Concrete\Core\Search\SavedSearchPresetNameValidator;
 use Concrete\Core\Support\Facade\Application;
 use Concrete\Controller\Element\Search\CustomizeResults;
 use Concrete\Core\Entity\Search\Query;
@@ -118,6 +119,11 @@ abstract class AdvancedSearch extends BackendInterfaceController
     public function savePreset()
     {
         if ($this->validateAction() && $this->supportsSavedSearch) {
+            $securityHelper = $this->app->make('helper/security');
+            $presetName = trim((string) $securityHelper->sanitizeString($this->request->request->get('presetName')));
+            if ($presetName === '') {
+                throw new Exception(t('Please specify a name for the search preset.'));
+            }
             $provider = $this->getSearchProvider();
             $query = $this->app->make(QueryFactory::class)
                 ->createFromAdvancedSearchRequest($provider, $this->request, Request::METHOD_POST);
@@ -125,8 +131,12 @@ abstract class AdvancedSearch extends BackendInterfaceController
                 $em = $this->app->make(EntityManager::class);
                 $search = $provider->getSavedSearch();
                 if (is_object($search)) {
+                    $nameValidator = $this->app->make(SavedSearchPresetNameValidator::class);
+                    if (!$nameValidator->isUnique($search, $presetName)) {
+                        throw new Exception(t('A search preset with that name already exists.'));
+                    }
                     $search->setQuery($query);
-                    $search->setPresetName($this->request->request->get('presetName'));
+                    $search->setPresetName($presetName);
                     $em->persist($search);
                     $em->flush();
 

--- a/concrete/controllers/dialog/search/preset/edit.php
+++ b/concrete/controllers/dialog/search/preset/edit.php
@@ -4,6 +4,7 @@ namespace Concrete\Controller\Dialog\Search\Preset;
 use Concrete\Controller\Backend\UserInterface;
 use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\Application\EditResponse;
+use Concrete\Core\Search\SavedSearchPresetNameValidator;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Doctrine\ORM\EntityManager;
 
@@ -39,7 +40,7 @@ abstract class Edit extends UserInterface
             $app = Application::getFacadeApplication();
             $securityHelper = $app->make('helper/security');
             $presetID = $securityHelper->sanitizeInt($this->request->request->get('presetID'));
-            $newPresetName = $securityHelper->sanitizeString($this->request->request->get('presetName'));
+            $newPresetName = trim((string) $securityHelper->sanitizeString($this->request->request->get('presetName')));
             if (!empty($presetID) && !empty($newPresetName)) {
                 $searchEntity = $this->getSavedSearchEntity();
                 if (is_object($searchEntity)) {
@@ -48,6 +49,12 @@ abstract class Edit extends UserInterface
                         $this->error->add(t('Invalid search preset.'));
                     }
                     if (!$this->error->has()) {
+                        $nameValidator = $this->app->make(SavedSearchPresetNameValidator::class);
+                        if (!$nameValidator->isUnique($searchPreset, $newPresetName)) {
+                            $this->error->add(t('A search preset with that name already exists.'));
+
+                            return new JsonResponse($this->error);
+                        }
                         $response = new EditResponse();
                         $response->setMessage(t('%s edited successfully.', h($newPresetName)));
                         $response->setAdditionalDataAttribute('presetID', $presetID);

--- a/concrete/src/Search/SavedSearchPresetNameValidator.php
+++ b/concrete/src/Search/SavedSearchPresetNameValidator.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\Core\Search;
+
+use Concrete\Core\Entity\Search\SavedExpressSearch;
+use Concrete\Core\Entity\Search\SavedSearch;
+use Doctrine\Common\Util\ClassUtils;
+use Doctrine\ORM\EntityManagerInterface;
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+class SavedSearchPresetNameValidator
+{
+    /**
+     * @var \Doctrine\ORM\EntityManagerInterface
+     */
+    protected $entityManager;
+
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        $this->entityManager = $entityManager;
+    }
+
+    public function isUnique(SavedSearch $search, string $presetName): bool
+    {
+        $criteria = ['presetName' => $presetName];
+        if ($search instanceof SavedExpressSearch) {
+            $criteria['entity'] = $search->getEntity();
+        }
+
+        $currentID = $search->getID();
+        $repository = $this->entityManager->getRepository(ClassUtils::getClass($search));
+        foreach ($repository->findBy($criteria) as $existingSearch) {
+            if ($currentID === null || (string) $existingSearch->getID() !== (string) $currentID) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/tests/tests/Search/SavedSearchPresetNameValidatorTest.php
+++ b/tests/tests/Search/SavedSearchPresetNameValidatorTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\Tests\Search;
+
+use Concrete\Core\Entity\Express\Entity as ExpressEntity;
+use Concrete\Core\Entity\Search\SavedExpressSearch;
+use Concrete\Core\Entity\Search\SavedUserSearch;
+use Concrete\Core\Search\SavedSearchPresetNameValidator;
+use Concrete\Tests\TestCase;
+use Doctrine\Common\Persistence\ObjectRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Mockery as M;
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+class SavedSearchPresetNameValidatorTest extends TestCase
+{
+    public function testNewRegularPresetNameIsUniqueWhenNoMatchesExist()
+    {
+        $search = new SavedUserSearch();
+        $validator = $this->createValidator(
+            SavedUserSearch::class,
+            ['presetName' => 'Example'],
+            []
+        );
+
+        static::assertTrue($validator->isUnique($search, 'Example'));
+    }
+
+    public function testNewRegularPresetNameIsNotUniqueWhenAMatchExists()
+    {
+        $search = new SavedUserSearch();
+        $existingSearch = new SavedUserSearch();
+        self::setNonPublicPropertyValue($existingSearch, 'id', 1);
+        $validator = $this->createValidator(
+            SavedUserSearch::class,
+            ['presetName' => 'Example'],
+            [$existingSearch]
+        );
+
+        static::assertFalse($validator->isUnique($search, 'Example'));
+    }
+
+    public function testExistingPresetDoesNotConflictWithItself()
+    {
+        $search = new SavedUserSearch();
+        self::setNonPublicPropertyValue($search, 'id', 1);
+        $validator = $this->createValidator(
+            SavedUserSearch::class,
+            ['presetName' => 'Example'],
+            [$search]
+        );
+
+        static::assertTrue($validator->isUnique($search, 'Example'));
+    }
+
+    public function testExistingPresetConflictsWithAnotherMatchingPreset()
+    {
+        $search = new SavedUserSearch();
+        self::setNonPublicPropertyValue($search, 'id', 1);
+        $existingSearch = new SavedUserSearch();
+        self::setNonPublicPropertyValue($existingSearch, 'id', 2);
+        $validator = $this->createValidator(
+            SavedUserSearch::class,
+            ['presetName' => 'Example'],
+            [$search, $existingSearch]
+        );
+
+        static::assertFalse($validator->isUnique($search, 'Example'));
+    }
+
+    public function testExpressPresetNamesAreScopedByEntity()
+    {
+        $entity = M::mock(ExpressEntity::class);
+        $search = new SavedExpressSearch();
+        $search->setEntity($entity);
+        $validator = $this->createValidator(
+            SavedExpressSearch::class,
+            ['presetName' => 'Example', 'entity' => $entity],
+            []
+        );
+
+        static::assertTrue($validator->isUnique($search, 'Example'));
+    }
+
+    private function createValidator(string $className, array $criteria, array $matches): SavedSearchPresetNameValidator
+    {
+        $repository = M::mock(ObjectRepository::class);
+        $repository->shouldReceive('findBy')->once()->with($criteria)->andReturn($matches);
+
+        $entityManager = M::mock(EntityManagerInterface::class);
+        $entityManager->shouldReceive('getRepository')->once()->with($className)->andReturn($repository);
+
+        return new SavedSearchPresetNameValidator($entityManager);
+    }
+}


### PR DESCRIPTION
Fixes #13056

### Summary

This PR prevents saved search presets from being created or renamed using a name that is already in use.

The validation applies to all supported saved search types:

- User
- Group
- File
- Page
- Log
- Express

Regular preset names are checked within their corresponding search type. Express preset names are scoped to the associated Express entity, allowing the same name to be used by different entities.

Preset names are sanitized and trimmed before validation. Name comparison follows the database collation, so names that differ only by letter case are considered duplicates on the standard configuration.

### Implementation

A shared preset-name validator is used by both the creation and rename flows.

Validation is performed at the application level without adding database constraints or migrations. Existing installations containing duplicate names are therefore not modified and upgrades are not blocked.

### Testing

Added PHPUnit coverage for:

- Accepting an unused preset name
- Rejecting a duplicate name
- Excluding the preset being edited from its own uniqueness check
- Rejecting a rename when another matching preset exists
- Scoping Express preset names by entity

Manual end-to-end testing on 9.5.2 covered:

- Creating a new preset
- Rejecting an exact duplicate
- Rejecting a duplicate with different letter casing
- Rejecting a rename to an existing name
- Removing the test preset

PHPUnit result: 5 tests, 15 assertions.

### Screenshot

<img width="583" height="656" alt="error_message_on_duplicate_preset_name_attempt" src="https://github.com/user-attachments/assets/b6455c25-d5e9-4cd9-8e17-0d6ad9ef7ef0" />
