### PR TITLE
Fix the time-dependent PackageRepositoryTest::testRequestAuthentication test

### DIFF
--- a/concrete/src/Marketplace/PackageRepository.php
+++ b/concrete/src/Marketplace/PackageRepository.php
@@ -396,6 +396,10 @@ final class PackageRepository implements PackageRepositoryInterface
         string $algo = 'sha256'
     ): RequestInterface {
         $now = new \DateTimeImmutable('', new \DateTimeZone('UTC'));
+        // Beware: 'h' is the 12-hour format (not 'H', the 24-hour one), so $time is not simply the
+        // current time truncated to the minute: from 13:00 to 00:59 UTC it's shifted by 12 hours, and
+        // the same nonce is generated twice a day (for instance at 03:30 and at 15:30 UTC).
+        // This must be kept in sync with the way the marketplace server recomputes the nonce.
         $time = $now->setTime((int) $now->format('h'), (int) $now->format('i'));
         $nonce = $algo . ',' . hash_hmac($algo, (string) $time->getTimestamp(), $connection->getPrivate());
 

--- a/tests/tests/Marketplace/PackageRepositoryTest.php
+++ b/tests/tests/Marketplace/PackageRepositoryTest.php
@@ -148,18 +148,46 @@ class PackageRepositoryTest extends TestCase
 
         $connection = new Connection('public', 'private');
 
+        $before = new \DateTimeImmutable('', new \DateTimeZone('UTC'));
         /** @var Request $sha256 */
         $sha256 = $method->invoke($repository, new Request('GET', new Uri()), $connection);
         /** @var Request $sha512 */
         $sha512 = $method->invoke($repository, new Request('GET', new Uri()), $connection, 'sha512');
+        $after = new \DateTimeImmutable('', new \DateTimeZone('UTC'));
 
-        $now = new \DateTimeImmutable();
-        $time = $now->setTime((int) $now->format('h'), (int) $now->format('i'));
-        $sha256Nonce = 'sha256,' . hash_hmac('sha256', (string) $time->getTimestamp(), $connection->getPrivate());
-        $sha512Nonce = 'sha512,' . hash_hmac('sha512', (string) $time->getTimestamp(), $connection->getPrivate());
+        $this->assertContains(
+            $sha256->getUri()->getUserInfo(),
+            $this->expectedUserInfos('sha256', $connection, $before, $after)
+        );
+        $this->assertContains(
+            $sha512->getUri()->getUserInfo(),
+            $this->expectedUserInfos('sha512', $connection, $before, $after)
+        );
+    }
 
-        $this->assertEquals('public:' . $sha256Nonce, $sha256->getUri()->getUserInfo());
-        $this->assertEquals('public:' . $sha512Nonce, $sha512->getUri()->getUserInfo());
+    /**
+     * Build the user info values that authenticate() may have generated between two instants.
+     *
+     * The nonce is built from the current time truncated to the minute: if the minute changed while
+     * the nonce was being generated, both the previous and the next values are acceptable.
+     *
+     * @return string[]
+     */
+    private function expectedUserInfos(
+        string $algo,
+        ConnectionInterface $connection,
+        \DateTimeImmutable $before,
+        \DateTimeImmutable $after
+    ): array {
+        $result = [];
+        foreach ([$before, $after] as $moment) {
+            // Same truncation performed by PackageRepository::authenticate()
+            $time = $moment->setTime((int) $moment->format('h'), (int) $moment->format('i'));
+            $nonce = $algo . ',' . hash_hmac($algo, (string) $time->getTimestamp(), $connection->getPrivate());
+            $result[] = $connection->getPublic() . ':' . $nonce;
+        }
+
+        return array_values(array_unique($result));
     }
 
     public function testValidate(): void


### PR DESCRIPTION
The test recomputed the authentication nonce using the local timezone, while PackageRepository::authenticate() uses UTC, so it failed during part of the day depending on the machine timezone.
It also computed its own timestamp after the tested code did, so it failed when the minute changed in between.

While looking into it: the nonce timestamp is truncated with the 'h' (12-hour) format instead of 'H', so it's shifted by 12 hours from 13:00 to 00:59 UTC and the same nonce is generated twice a day.
That's left untouched, since it has to match how the marketplace server recomputes the nonce, but it's now documented with a comment.
