### PR TITLE
Show validation errors for blocks in stacks

### DIFF
--- a/concrete/blocks/core_stack_display/controller.php
+++ b/concrete/blocks/core_stack_display/controller.php
@@ -12,6 +12,7 @@ use Concrete\Core\Page\Stack\Stack;
 use Concrete\Core\Permission\Checker;
 use Concrete\Core\Statistics\UsageTracker\TrackableInterface;
 use Concrete\Core\Utility\Service\Xml;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * The controller for the stack display block. This is an internal proxy block that is inserted when a stack's contents are displayed in a page.
@@ -160,8 +161,20 @@ class Controller extends BlockController implements TrackableInterface, UsesFeat
         }
 
         $controller = $b->getController();
+        $response = $controller->runAction($action, $parameters);
+        if ($response instanceof Response) {
+            return $response;
+        }
 
-        return $controller->runAction($action, $parameters);
+        $c = Page::getCurrentPage();
+        if (is_object($c) && !$c->isError()) {
+            $pageController = $c->getPageController();
+            if ($pageController) {
+                $controller->setPassThruBlockController($pageController);
+            }
+        }
+
+        return $response;
     }
 
     /**


### PR DESCRIPTION
When a block inside a stack handled a page action, core_stack_display delegated to the nested controller but never registered it as a passthru controller. BlockView then rendered a fresh controller, so values set in action methods (such as Express form validation errors) were lost.

Fixes: #5941 
