### PR TITLE
Test mail settings: show email sender, add links to configuration pages

### DIFF
--- a/concrete/controllers/single_page/dashboard/system/mail/method/test.php
+++ b/concrete/controllers/single_page/dashboard/system/mail/method/test.php
@@ -1,15 +1,114 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Concrete\Controller\SinglePage\Dashboard\System\Mail\Method;
 
+use Concrete\Core\Config\Repository\Repository;
+use Concrete\Core\Error\UserMessageException;
+use Concrete\Core\Http\ResponseFactoryInterface;
+use Concrete\Core\Mail\Service as MailService;
 use Concrete\Core\Page\Controller\DashboardPageController;
-use Exception;
+use Concrete\Core\Page\Page;
+use Concrete\Core\Permission\Checker;
+use Concrete\Core\Site\Service as SiteService;
+use Concrete\Core\Url\Resolver\Manager\ResolverManagerInterface;
+use Concrete\Core\User\User;
+use Concrete\Core\User\UserInfoRepository;
 use Concrete\Core\Validator\String\EmailValidator;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\Response;
+
+defined('C5_EXECUTE') or die('Access Denied.');
 
 class Test extends DashboardPageController
 {
-    protected function describeSmtpEncryption($value): string
+    public function view(): ?Response
     {
-        $value = strtoupper(trim((string) $value));
+        $config = $this->app->make(Repository::class);
+        $this->set('emailEnabled', (bool) $config->get('concrete.email.enabled'));
+        $me = $this->app->make(User::class);
+        $myInfo = $me->isRegistered() ? $this->app->make(UserInfoRepository::class)->getByID($me->getUserID()) : null;
+        $this->set('myEmailAddress', $myInfo ? $myInfo->getUserEmail() : '');
+        $this->set('settingsPageUrl', $this->getPageInfo('/dashboard/system/mail/method')['url'] ?? '');
+        $this->set('senderEmailAddress', (string) $config->get('concrete.email.default.address'));
+        $this->set('senderEmailName', (string) $config->get('concrete.email.default.name'));
+        $this->set('systemEmailAddressesPage', $this->getPageInfo('/dashboard/system/mail/addresses'));
+
+        return null;
+    }
+
+    public function send_test_email(): JsonResponse
+    {
+        if (!$this->token->validate('send_test_email')) {
+            throw new UserMessageException($this->token->getErrorMessage());
+        }
+        $config = $this->app->make(Repository::class);
+        if (!$config->get('concrete.email.enabled')) {
+            throw new UserMessageException(t('The mail system is disabled.'));
+        }
+        $emailRecipient = $this->request->request->get('emailRecipient');
+        if (!is_string($emailRecipient) || $emailRecipient === '') {
+            throw new UserMessageException(t('The recipient address of the test email has not been specified.'));
+        }
+        if (!$this->app->make(EmailValidator::class)->isValid($emailRecipient)) {
+            throw new UserMessageException(t('The recipient address is not valid.'));
+        }
+        $numEmails = $this->request->request->getInt('numEmails');
+        if ($numEmails < 1) {
+            throw new UserMessageException(t('Please specify an integer greater than zero for the number of the emails to be sent'));
+        }
+        $baseSubject = t(/* i18n: %s is the site name */'Test message from %s', $this->app->make(SiteService::class)->getSite()->getSiteName());
+        $mail = $this->app->make(MailService::class);
+        for ($cycle = 1; $cycle <= $numEmails; $cycle++) {
+            $mail->setTesting(true);
+            if ($numEmails > 1) {
+                $mail->setSubject("{$baseSubject} [{$cycle}/{$numEmails}]");
+            } else {
+                $mail->setSubject($baseSubject);
+            }
+            $mail->to($emailRecipient);
+            $mail->setBody($this->buildMessageBody());
+            try {
+                $mail->sendMail();
+            } catch (\Throwable $x) {
+                throw new UserMessageException(t('The following error was found while trying to send the test email:') . "\n" . $x->getMessage());
+            }
+        }
+
+        return $this->app->make(ResponseFactoryInterface::class)->json(true);
+    }
+
+    private function buildMessageBody(): string
+    {
+        $config = $this->app->make(Repository::class);
+        $lines = [
+            t('This is a test message.'),
+            '',
+            t('Configuration:'),
+            '- ' . t('Send mail method: %s', $config->get('concrete.mail.method')),
+        ];
+        switch ($config->get('concrete.mail.method')) {
+            case 'smtp':
+                $lines[] = '- ' . t('SMTP Server: %s', $config->get('concrete.mail.methods.smtp.server'));
+                $lines[] = '- ' . t('SMTP Port: %s', $config->get('concrete.mail.methods.smtp.port', tc('SMTP Port', 'default')));
+                $lines[] = '- ' . t('SMTP Encryption: %s', $this->describeSmtpEncryption((string) $config->get('concrete.mail.methods.smtp.encryption')));
+                $lines[] = '- ' . t(/* i18n: %1%s is HELO, %2$s is the domain */'SMTP %1$s Domain: %2$s', 'HELO', $config->get('concrete.mail.methods.smtp.helo_domain'));
+                if (!$config->get('concrete.mail.methods.smtp.username')) {
+                    $lines[] = '- ' . t('SMTP Authentication: none');
+                } else {
+                    $lines[] = '- ' . t('SMTP Username: %s', $config->get('concrete.mail.methods.smtp.username'));
+                    $lines[] = '- ' . t('SMTP Password: %s', tc('Password', '<hidden>'));
+                }
+                break;
+        }
+
+        return implode("\n", $lines);
+    }
+
+    private function describeSmtpEncryption(string $value): string
+    {
+        $value = strtoupper(trim($value));
         switch ($value) {
             case 'STARTTLS':
                 return t('STARTTLS');
@@ -21,80 +120,19 @@ class Test extends DashboardPageController
         }
     }
 
-    public function view()
+    /**
+     * @return array{name:string,url:string}|null
+     */
+    private function getPageInfo(string $path): ?array
     {
-        $config = $this->app->make('config');
-        $this->set('emailEnabled', (bool) $config->get('concrete.email.enabled'));
-    }
-
-    public function do_test()
-    {
-        if ($this->token->validate('test')) {
-            $config = $this->app->make('config');
-            if (!$config->get('concrete.email.enabled')) {
-                $this->error->add(t('The mail system is disabled.'));
-            } else {
-                $mailRecipient = $this->post('mailRecipient');
-                if (!is_string($mailRecipient)) {
-                    $mailRecipient = '';
-                }
-                if ($mailRecipient === '') {
-                    $this->error->add(t('The recipient address of the test email has not been specified.'));
-                } else {
-                    $this->app->make(EmailValidator::class, ['testMXRecord' => true])->isValid($mailRecipient, $this->error);
-                }
-                $numEmails = $this->post('numEmails');
-                if (!$this->app->make('helper/validation/numbers')->integer($numEmails) || ($numEmails = (int) $numEmails) < 1) {
-                    $this->error->add(t('Please specify an integer greater than zero for the number of the emails to be sent'));
-                }
-                if (!$this->error->has()) {
-                    try {
-                        $baseSubject = t(/*i18n: %s is the site name*/'Test message from %s', $this->app->make('site')->getSite()->getSiteName());
-                        $mail = $this->app->make('helper/mail');
-                        /* @var \Concrete\Core\Mail\Service $mail */
-                        for ($cycle = 1; $cycle <= $numEmails; ++$cycle) {
-                            $mail->setTesting(true);
-                            if ($numEmails > 1) {
-                                $mail->setSubject($baseSubject . " [$cycle/$numEmails]");
-                            } else {
-                                $mail->setSubject($baseSubject);
-                            }
-                            $mail->to($mailRecipient);
-                            $body = t('This is a test message.');
-                            $body .= "\n\n" . t('Configuration:');
-                            $body .= "\n- " . t('Send mail method: %s', $config->get('concrete.mail.method'));
-                            switch ($config->get('concrete.mail.method')) {
-                                case 'smtp':
-                                    $body .= "\n- " . t('SMTP Server: %s', $config->get('concrete.mail.methods.smtp.server'));
-                                    $body .= "\n- " . t('SMTP Port: %s', $config->get('concrete.mail.methods.smtp.port', tc('SMTP Port', 'default')));
-                                    $body .= "\n- " . t('SMTP Encryption: %s', $this->describeSmtpEncryption($config->get('concrete.mail.methods.smtp.encryption')));
-                                    $body .= "\n- " . t(/*i18n: %1%s is HELO, %2$s is the domain*/'SMTP %1$s Domain: %2$s', 'HELO', $config->get('concrete.mail.methods.smtp.helo_domain'));
-                                    if (!$config->get('concrete.mail.methods.smtp.username')) {
-                                        $body .= "\n- " . t('SMTP Authentication: none');
-                                    } else {
-                                        $body .= "\n- " . t('SMTP Username: %s', $config->get('concrete.mail.methods.smtp.username'));
-                                        $body .= "\n- " . t('SMTP Password: %s', tc('Password', '<hidden>'));
-                                    }
-                                    break;
-                            }
-                            $mail->setBody($body);
-                            $mail->sendMail();
-                        }
-                        $this->flash('numEmails', $numEmails);
-                        $this->flash('mailRecipient', $mailRecipient);
-                        $this->flash('success',
-                            t('The test email has been successfully sent to %s.', $mailRecipient)
-                            . "\n" . t('You will receive a test message from %s', $config->get('concrete.email.default.address'))
-                        );
-                        $this->redirect($this->action(''));
-                    } catch (Exception $x) {
-                        $this->error->add(t('The following error was found while trying to send the test email:') . "\n" . $x->getMessage());
-                    }
-                }
-            }
-        } else {
-            $this->error->add($this->token->getErrorMessage());
+        $page = Page::getByPath($path);
+        if (!$page || $page->isError()) {
+            return null;
         }
-        $this->view();
+
+        return [
+            'name' => t($page->getCollectionName()),
+            'url' => (new Checker($page))->canViewPage() ? (string) $this->app->make(ResolverManagerInterface::class)->resolve([$page]) : '',
+        ];
     }
 }

--- a/concrete/single_pages/dashboard/system/mail/method/test.php
+++ b/concrete/single_pages/dashboard/system/mail/method/test.php
@@ -1,58 +1,166 @@
 <?php
-use Concrete\Core\User\UserInfoRepository;
+
+declare(strict_types=1);
 
 defined('C5_EXECUTE') or die('Access Denied.');
 
-// Arguments
-/* @var bool $emailEnabled */
-/* @var string $mailRecipient [optional] */
-/* @var int $numEmails [optional] */
+/**
+ * @var Concrete\Controller\SinglePage\Dashboard\System\Mail\Method\Test $controller
+ * @var Concrete\Core\Page\View\PageView $view
+ * @var Concrete\Core\Validation\CSRF\Token $token
+ * @var bool $emailEnabled
+ * @var string $senderEmailAddress
+ * @var string $senderEmailName
+ * @var string $myEmailAddress
+ * @var string $settingsPageUrl
+ * @var array{name:string,url:string}|null $systemEmailAddressesPage
+ */
 
-if (!isset($mailRecipient)) {
-    $mailRecipient = '';
-    $me = Core::make(Concrete\Core\User\User::class);
-    if ($me->isRegistered()) {
-        $myInfo = Core::make(UserInfoRepository::class)->getByID($me->getUserID());
-        if ($myInfo !== null) {
-            $mailRecipient = $myInfo->getUserEmail();
+if (!$emailEnabled) {
+    ?>
+    <div class="alert alert-info">
+        <?= t(/* i18n: %1$s is a configuration name, %2$s is a configuration value */'It\'s not possible to test the settings since the mail system is disabled (the setting %1$s is set to %2$s in the configuration).', '<code>concrete.email.enabled</code>', '<code>false</code>') ?>
+        <?php
+        if ($settingsPageUrl !== '') {
+            ?>
+            <div class="mt-3">
+                <a href="<?= h($settingsPageUrl) ?>" class="btn btn-secondary"><?= t('Change Settings') ?></a>
+            </div>
+            <?php
         }
-    }
-}
-if (!isset($numEmails)) {
-    $numEmails = 1;
+        ?>
+    </div>
+    <?php
+    return;
 }
 ?>
 
-<form method="post" action="<?= $view->action('do_test') ?>" id="mail-settings-test-form">
-    <?php
-    if (!$emailEnabled) {
-        ?>
-        <div class="alert alert-info">
-            <?= t(/*i18n: %1$s is a configuration name, %2$s is a configuration value*/'It\'s not possible to test the settings since the mail system is disabled (the setting %1$s is set to %2$s in the configuration).', '<b>concrete.email.enabled</b>', '<b>false</b>') ?>
-        </div>
+<form id="mail-settings-test-form" v-cloak @submit.prevent="submit()">
+    <div class="form-group">
+        <label class="form-label" for="emailSender"><?= t('Sender') ?></label>
+        <input type="text" class="form-control" id="emailSender" readonly="readonly" :value="senderEmailName ? `${senderEmailName} <${senderEmailAddress}>`: senderEmailAddress" />
         <?php
-    } else {
+        if ($systemEmailAddressesPage !== null) {
+            ?>
+            <div class="form-text">
+                <?= t(
+                    'You can change the sender in the %s page',
+                    $systemEmailAddressesPage['url']
+                    ? '<a href="' . h($systemEmailAddressesPage['url']) . '">' . h($systemEmailAddressesPage['name']) . '</a>'
+                    : h($systemEmailAddressesPage['name'])
+                ) ?>
+            </div>
+            <?php
+        }
         ?>
-        <?php $token->output('test') ?>
-        <div class="form-group">
-            <?= $form->label('mailRecipient', t('Recipient email address')) ?>
-            <?= $form->email('mailRecipient', $mailRecipient, ['required' => 'required']) ?>
+    </div>
+    <div class="form-group">
+        <label class="form-label" for="emailRecipient"><?= t('Recipient email address') ?></label>
+        <input type="email" class="form-control" id="emailRecipient" required="required" v-model.trim="emailRecipient" :readonly="busy" />
+        <div class="form-text" v-if="myEmailAddress" :class="emailRecipient === myEmailAddress ? 'invisible' : ''">
+            <a href="#" @click.prevent="emailRecipient = myEmailAddress"><?= t('Use your email address') ?></a>
         </div>
-        <div class="form-group">
-            <?= $form->label('numEmails', t('Number of messages to send')) ?>
-            <?= $form->number('numEmails', $numEmails, ['required' => 'required', 'min' => 1]) ?>
-        </div>
-        <?php
-    }
-    ?>
+    </div>
+    <div class="form-group">
+        <label class="form-label" for="numEmails"><?= t('Number of messages to send') ?></label>
+        <input type="number" class="form-control" id="numEmails" required="required" min="1" v-model.number="numEmails" :readonly="busy" />
+    </div>
+    <div v-if="outcome" class="alert" :class="outcome.success ? 'alert-success' : 'alert-danger'">
+        <div v-if="outcome.isHtml" v-html="outcome.message"></div>
+        <div v-else style="white-space: pre-wrap">{{ outcome.message }}</div>
+    </div>
     <div class="ccm-dashboard-form-actions-wrapper">
         <div class="ccm-dashboard-form-actions">
-            <a href="<?= URL::to('/dashboard/system/mail/method') ?>" class="btn btn-secondary float-start"><?= t('Change Settings') ?></a>
             <?php
-            if ($emailEnabled) {
-                echo $interface->submit(t('Send'), 'mail-settings-test-form', 'right', 'btn-primary');
+            if ($settingsPageUrl !== '') {
+                ?>
+                <a href="<?= h($settingsPageUrl) ?>" class="btn btn-secondary"><?= t('Change Settings') ?></a>
+                <?php
             }
             ?>
+            <input type="submit" class="btn btn-primary float-end" value="<?= t('Send') ?>" :disabled="busy" />
         </div>
     </div>
 </form>
+
+<script>
+$(document).ready(() => {
+    Concrete.Vue.activateContext('cms', (Vue, config) => {
+        new Vue({
+            el: '#mail-settings-test-form',
+            data() {
+                return {
+                    senderEmailAddress: <?= json_encode($senderEmailAddress) ?>,
+                    senderEmailName: <?= json_encode($senderEmailName) ?>,
+                    myEmailAddress: <?= json_encode($myEmailAddress) ?>,
+                    emailRecipient: <?= json_encode($myEmailAddress) ?>,
+                    numEmails: 1,
+                    busy: false,
+                    outcome: null,
+                };
+            },
+            mounted() {
+                window.addEventListener('beforeunload', (e) => {
+                    if (this.busy) {
+                        e.preventDefault();
+                        return e.returnValue = 'confirm';
+                    }
+                });
+            },
+            watch: {
+                emailRecipient() {
+                    this.outcome = null;
+                },
+                busy() {
+                    if (this.busy) {
+                        window.NProgress.start()
+                    } else {
+                        window.NProgress.done()
+                    }
+                },
+            },
+            methods: {
+                submit() {
+                    if (this.busy) {
+                        return;
+                    }
+                    this.busy = true;
+                    this.outcome = null;
+                    $.ajax({
+                        method: 'POST',
+                        dataType: 'json',
+                        url: <?= json_encode((string) $view->action('send_test_email')) ?>,
+                        data: {
+                            <?= json_encode($token::DEFAULT_TOKEN_NAME) ?>: <?= json_encode($token->generate('send_test_email')) ?>,
+                            emailRecipient: this.emailRecipient,
+                            numEmails: this.numEmails,
+                        },
+                    }).done(() => {
+                        this.outcome = {
+                            success: true,
+                            isHtml: false,
+                            message: <?= json_encode(t('The test email has been successfully sent to %s.')) ?>.replace('%s', this.emailRecipient),
+                        };
+                    }).fail((xhr, status, error) => {
+                        if (xhr?.responseJSON?.errors instanceof Array && typeof xhr.responseJSON.errors[0] === 'string') {
+                            this.outcome = {
+                                success: false,
+                                isHtml: false,
+                                message: xhr.responseJSON.errors[0],
+                            };
+                        } else {
+                            this.outcome = {
+                                success: false,
+                                isHtml: xhr.responseJSON ? true : false,
+                                message: xhr.responseJSON ? ConcreteAjaxRequest.renderJsonError(xhr) : xhr.responseText,
+                            };
+                        }
+                    }).always(() => {
+                        this.busy = false;
+                    });
+                },
+            },
+        });
+    });
+});
+</script>


### PR DESCRIPTION
Improvements for the System & Settings > Email > SMTP Method > Test Mail Settings dashboard page:

- display the sender email address (and name, if configured)
- add a link to where the default sender can be configured
- allow reverting to "my email address" with a click
- uses Vue instead of setting variables in the controller

Screenshot:

<img width="561" height="645" alt="Screenshot" src="https://github.com/user-attachments/assets/a1870b67-9cc2-4e32-a853-a04abd5199b8" />