### PR TITLE
Fix the documented types of the attribute value objects

### DIFF
--- a/concrete/attributes/address/controller.php
+++ b/concrete/attributes/address/controller.php
@@ -91,6 +91,13 @@ class Controller extends AttributeTypeController implements
         return AddressValue::class;
     }
 
+    /**
+     * {@inheritdoc}
+     *
+     * @see \Concrete\Core\Attribute\Controller::getAttributeValueObject()
+     *
+     * @return \Concrete\Core\Entity\Attribute\Value\Value\AddressValue|null
+     */
     public function getAttributeValueObject()
     {
         return $this->attributeValue ? $this->entityManager->find(AddressValue::class, $this->attributeValue->getGenericValue()) : null;

--- a/concrete/src/Attribute/AttributeInterface.php
+++ b/concrete/src/Attribute/AttributeInterface.php
@@ -106,7 +106,7 @@ interface AttributeInterface
      * You can reuse this throughout your controllers, but it's used by the getAttributeValueObject()
      * method in the base controller to retrieve the relevant attribute data value object.
      *
-     * @return string
+     * @return string|null NULL or empty string if the attribute type has no associated value entity
      */
     public function getAttributeValueClass();
 

--- a/concrete/src/Attribute/AttributeValueInterface.php
+++ b/concrete/src/Attribute/AttributeValueInterface.php
@@ -10,6 +10,10 @@ interface AttributeValueInterface
      */
     public function getAttributeKey();
     public function getValue($mode = false);
+
+    /**
+     * @return \Concrete\Core\Entity\Attribute\Value\Value\AbstractValue|\Concrete\Core\Attribute\AttributeValueInterface|null
+     */
     public function getValueObject();
     public function getController();
 }

--- a/concrete/src/Attribute/Controller.php
+++ b/concrete/src/Attribute/Controller.php
@@ -33,7 +33,7 @@ class Controller extends AbstractController implements AttributeInterface
     protected $attributeKey;
 
     /**
-     * @var \Concrete\Core\Entity\Attribute\Value\AbstractValue
+     * @var \Concrete\Core\Attribute\AttributeValueInterface|null
      */
     protected $attributeValue;
 
@@ -228,7 +228,7 @@ class Controller extends AbstractController implements AttributeInterface
     }
 
     /**
-     * @param \Concrete\Core\Entity\Attribute\Value\AbstractValue|null $attributeValue
+     * @param \Concrete\Core\Attribute\AttributeValueInterface|null $attributeValue
      */
     public function setAttributeValue($attributeValue)
     {
@@ -246,7 +246,14 @@ class Controller extends AbstractController implements AttributeInterface
     }
 
     /**
-     * @return \Concrete\Core\Entity\Attribute\Value\AbstractValue|null
+     * Get the object holding the value of the attribute this controller was given.
+     *
+     * This normally is a value object, an instance of Value\Value\AbstractValue built by the
+     * attribute type, and that is what the entity manager is queried for.
+     * When the attribute value has no persisted generic value yet there is nothing to query,
+     * and the attribute value itself is handed back instead, hence the AttributeValueInterface.
+     *
+     * @return \Concrete\Core\Entity\Attribute\Value\Value\AbstractValue|\Concrete\Core\Attribute\AttributeValueInterface|null
      */
     public function getAttributeValueObject()
     {
@@ -272,7 +279,7 @@ class Controller extends AbstractController implements AttributeInterface
     /**
      * Create the default attribute value (if needed).
      *
-     * @return \Concrete\Core\Entity\Attribute\Value\AbstractValue|null
+     * @return \Concrete\Core\Entity\Attribute\Value\Value\AbstractValue|null
      */
     public function createDefaultAttributeValue()
     {

--- a/concrete/src/Attribute/ObjectTrait.php
+++ b/concrete/src/Attribute/ObjectTrait.php
@@ -16,10 +16,10 @@ trait ObjectTrait
     abstract public function getObjectAttributeCategory();
 
     /**
-     * @param $ak
+     * @param \Concrete\Core\Attribute\AttributeKeyInterface|string $ak An attribute key instance (or its handle)
      * @param bool $createIfNotExists
      *
-     * @return AttributeValue
+     * @return \Concrete\Core\Attribute\AttributeValueInterface|null
      */
     abstract public function getAttributeValueObject($ak, $createIfNotExists = false);
 
@@ -32,8 +32,9 @@ trait ObjectTrait
     }
 
     /**
-     * @param $ak
-     * @return \Concrete\Core\Entity\Attribute\Value\Value
+     * @param \Concrete\Core\Attribute\AttributeKeyInterface|string $ak An attribute key instance (or its handle)
+     *
+     * @return \Concrete\Core\Attribute\AttributeValueInterface|null
      */
     public function getAttributeValue($ak)
     {
@@ -69,7 +70,8 @@ trait ObjectTrait
      * @param AttributeKeyInterface | string $ak
      * @param mixed $value
      * @param bool $doReindexImmediately
-     * @return \Concrete\Core\Entity\Attribute\Value\Value
+     *
+     * @return \Concrete\Core\Attribute\AttributeValueInterface
      */
     public function setAttribute($ak, $value, $doReindexImmediately = true)
     {

--- a/concrete/src/Entity/Attribute/Value/AbstractValue.php
+++ b/concrete/src/Entity/Attribute/Value/AbstractValue.php
@@ -87,7 +87,15 @@ abstract class AbstractValue implements AttributeValueInterface
     }
 
     /**
-     * @return \Concrete\Core\Entity\Attribute\Value\Value\Value
+     * Get the object that holds the value of this attribute.
+     *
+     * Two unrelated class families share the AbstractValue name: this one represents the attribute
+     * of an object, whereas Value\Value\AbstractValue represents the value itself.
+     * This method normally returns the latter, which is what every attribute controller builds.
+     * It returns an AttributeValueInterface only when the controller falls back to the attribute
+     * value it was handed, that is when the generic value has not been persisted yet.
+     *
+     * @return \Concrete\Core\Entity\Attribute\Value\Value\AbstractValue|\Concrete\Core\Attribute\AttributeValueInterface|null
      */
     final public function getValueObject()
     {


### PR DESCRIPTION
The declared types confused the AttributeValues entity with the value objects, named a class that does not exist, and omitted NULL where it can occur (see [here](https://github.com/concretecms/concretecms/blob/9.5.3/concrete/src/Attribute/Controller.php#L227) and [here](https://github.com/concretecms/concretecms/blob/9.5.3/concrete/src/Attribute/Controller.php#L255)).