### PR TITLE
Fix Rescan Locale deleting content links, losing block relation fixes, and crashing on stacks

### DIFF
--- a/concrete/src/Page/Command/RescanMultilingualPageCommandHandler.php
+++ b/concrete/src/Page/Command/RescanMultilingualPageCommandHandler.php
@@ -1,27 +1,60 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Concrete\Core\Page\Command;
 
-use Concrete\Core\Multilingual\Page\Section\Processor\ReplaceBlockPageRelationsTask;
-use Concrete\Core\Multilingual\Page\Section\Processor\ReplaceContentLinksTask;
 use Concrete\Core\Multilingual\Page\Section\Section;
 use Concrete\Core\Page\Page;
+use Concrete\Core\Page\Stack\Stack;
+
+defined('C5_EXECUTE') or die('Access Denied.');
 
 class RescanMultilingualPageCommandHandler
 {
+    public function __invoke(RescanMultilingualPageCommand $command)
+    {
+        $page = Page::getByID($command->getPageID());
+        if (!$page || $page->isError()) {
+            return;
+        }
+        $section = $this->getSection($page);
+        if (!$section) {
+            return;
+        }
+        $isApproved = $page->getVersionObject()->isApproved();
+        $nvc = $page->getVersionToModify();
+        $this->replaceBlockPageRelations($page, $nvc, $section);
+        $this->replaceContentLinks($page, $nvc, $section);
+        if ($isApproved) {
+            $nvc->getVersionObject()->approve();
+        }
+    }
 
-    protected function replaceBlockPageRelations(Page $c, Page $section)
+    /**
+     * Stacks live outside the site trees, so they resolve their section through the Stacks table.
+     */
+    protected function getSection(Page $page): ?Section
+    {
+        if ($page->getPageTypeHandle() === STACKS_PAGE_TYPE) {
+            $stack = Stack::getByID($page->getCollectionID());
+
+            return $stack ? $stack->getMultilingualSection() : null;
+        }
+        $section = Section::getBySectionOfSite($page);
+
+        return $section ?: null;
+    }
+
+    protected function replaceBlockPageRelations(Page $c, Page $nvc, Section $section)
     {
         $db = \Database::connection();
-        $blocks = $c->getBlocks();
-        $nvc = $c->getVersionToModify();
-        $isApproved = $c->getVersionObject()->isApproved();
-        foreach ($blocks as $b) {
+        foreach ($c->getBlocks() as $b) {
             $controller = $b->getController();
             $pageColumns = $controller->getBlockTypeExportPageColumns();
             if (count($pageColumns)) {
                 $columns = $db->MetaColumnNames($controller->getBlockTypeDatabaseTable());
-                $data = array();
+                $data = [];
                 $record = $controller->getBlockControllerData();
                 foreach ($columns as $key) {
                     $data[$key] = $record->{$key};
@@ -31,11 +64,9 @@ class RescanMultilingualPageCommandHandler
                     $cID = $data[$column];
                     if ($cID > 0) {
                         $link = Page::getByID($cID, 'ACTIVE');
-                        if (is_object($section)) {
-                            $relatedID = $section->getTranslatedPageID($link);
-                            if ($relatedID) {
-                                $data[$column] = $relatedID;
-                            }
+                        $relatedID = $section->getTranslatedPageID($link);
+                        if ($relatedID) {
+                            $data[$column] = $relatedID;
                         }
                     }
                 }
@@ -53,61 +84,40 @@ class RescanMultilingualPageCommandHandler
                 $b2->update($data);
             }
         }
-        if ($isApproved) {
-            $nvc->getVersionObject()->approve();
-        }
     }
 
-    public function replaceContentLinks(Page $c, Page $section)
+    protected function replaceContentLinks(Page $c, Page $nvc, Section $section)
     {
-        $blocks = $c->getBlocks();
-        $nvc = $c->getVersionToModify();
-        $isApproved = $c->getVersionObject()->isApproved();
-        foreach ($blocks as $b) {
+        foreach ($c->getBlocks() as $b) {
             if ($b->getBlockTypeHandle() == 'content') {
                 $content = $b->getController()->content;
                 $content = preg_replace_callback(
                     '/{CCM:CID_([0-9]+)}/i',
-                    function ($matches) {
-                        $cID = $matches[1];
+                    static function ($matches) use ($section) {
+                        $cID = (int) $matches[1];
                         if ($cID > 0) {
                             $link = Page::getByID($cID, 'ACTIVE');
-                            if (is_object($section)) {
-                                $relatedID = $section->getTranslatedPageID($link);
-                                if ($relatedID) {
-                                    return sprintf('{CCM:CID_%s}', $relatedID);
-                                }
+                            $relatedID = $section->getTranslatedPageID($link);
+                            if ($relatedID) {
+                                return sprintf('{CCM:CID_%s}', $relatedID);
                             }
                         }
+
+                        // Leave links to untranslated pages alone rather than stripping them.
+                        return $matches[0];
                     },
-                    $content);
+                    $content
+                );
                 $ob = $b;
                 // replace the block with the version of the block in the later version (if applicable)
                 $b2 = \Block::getByID($b->getBlockID(), $nvc, $b->getAreaHandle());
-
                 if ($b2->isAlias()) {
                     $nb = $ob->duplicate($nvc);
                     $b2->deleteBlock();
                     $b2 = clone $nb;
                 }
-                $data = array('content' => $content);
-                $b2->update($data);
+                $b2->update(['content' => $content]);
             }
         }
-        if ($isApproved) {
-            $nvc->getVersionObject()->approve();
-        }
     }
-
-    public function __invoke(RescanMultilingualPageCommand $command)
-    {
-        $page = Page::getByID($command->getPageID());
-        if ($page && !$page->isError()) {
-            $section = Section::getBySectionOfSite($page);
-            $this->replaceBlockPageRelations($page, $section);
-            $this->replaceContentLinks($page, $section);
-        }
-    }
-
-
 }


### PR DESCRIPTION
Fixes #13082

`RescanMultilingualPageCommandHandler` had three problems, all from the 9.0 port of the 8.x processor tasks onto the command bus:

- The `preg_replace_callback` closure in `replaceContentLinks()` never captured `$section`, so it returned null for every match and `preg_replace_callback` deleted every `{CCM:CID_nnn}` token on every rescanned page. The 8.x version had `use ($subject, $target)`.
- Both passes called `getVersionToModify()` on the same stale page object, so the second pass cloned the uncorrected version and approved it over the first pass's block-relation fixes. 8.x re-fetched the page per task.
- Stack pages have no site tree, so `Section::getBySectionOfSite()` returned null and the `Page $section` type hint threw a `TypeError`. 8.x used the dashboard's selected section rather than deriving it from the page.

The handler now resolves the section once in `__invoke()`, using `Stack::getMultilingualSection()` for stack pages and returning early if there's still no section. It creates one new version, runs both passes against it, and approves once. The two pass methods take the target version and the section as arguments and no longer create or approve versions themselves. `replaceContentLinks()` was public but nothing in core calls it; both passes are `protected` now.

One deliberate behavior change: when a linked page has no translation in the target locale, the closure now returns the original token instead of falling through to null. Before (including in 8.x) those links were stripped too. Leaving a link pointing at the untranslated page seems clearly better than an empty `href`.

Also removed the two `use` imports for the 8.x processor classes that no longer exist.

Verified by calling the handler directly on a test page with a content block linking to page A and to home, an autonav pointing at A, and a `MultilingualPageRelations` row mapping A to B in the target locale. Before: two new versions, the approved one with `href=""` for both links and the autonav back on A. After: one new approved version with both links intact (A rewritten to B, home untouched) and the autonav on B. A locale-neutral stack page runs without an exception.

Beyond the scripted check, I have the same handler running as an `application/`-level override on a real two-locale 9.5.3 site (English plus a freshly copied Spanish tree, with locale stacks). Rescan Locale from the dashboard now does what it says: links repointed to the Spanish pages, page lists and autonavs retargeted, one new version per page, nothing in the failed queue.

The file is identical on `10.0.x`, so this should merge forward cleanly.
