### PR TITLE
fix #13089: Ask enshrined what it removed instead of diffing its output

### DIFF
--- a/concrete/src/File/Image/Svg/Sanitizer.php
+++ b/concrete/src/File/Image/Svg/Sanitizer.php
@@ -167,18 +167,22 @@ class Sanitizer
         $xml = $this->dataToXml($data);
         $removedNodes = [];
         $this->sanitizeXml($xml, $removedNodes, $options);
-        $preEnshrinedData = $this->xmlToData($xml);
-        $enshrinedData = $this->enshrinedSvgSanitizer->sanitize($preEnshrinedData);
-        if (is_string($enshrinedData) && $enshrinedData !== $preEnshrinedData) {
-            // The enshrined/svg-sanitize library detected and removed additional unsafe
-            // content that our own allowlist/blocklist checks above didn't catch (eg
-            // javascript: URIs). Record it so that reject-mode callers (checkData())
-            // don't silently accept a file that sanitize-mode would have cleaned up.
-            if (isset($removedNodes['enshrined'])) {
-                ++$removedNodes['enshrined'];
-            } else {
-                $removedNodes['enshrined'] = 1;
-            }
+        $enshrinedData = $this->enshrinedSvgSanitizer->sanitize($this->xmlToData($xml));
+        $enshrinedIssues = $this->enshrinedSvgSanitizer->getXmlIssues();
+        if ($enshrinedIssues !== []) {
+            // The enshrined/svg-sanitize library detected and removed additional unsafe content that
+            // our own allowlist/blocklist checks above didn't catch (eg javascript: URIs). Record it
+            // so that reject-mode callers (checkData()) don't silently accept a file that
+            // sanitize-mode would have cleaned up.
+            //
+            // Ask the library what it removed rather than diffing its output against our own. It
+            // re-serializes through its own DOMDocument - preserveWhiteSpace = false, formatOutput
+            // = true, and saveXML() with LIBXML_NOEMPTYTAG - where xmlToData() uses a plain
+            // saveXML() at defaults. So its output differs from ours for every input: <circle/>
+            // comes back as <circle></circle>, the tree is re-indented, and an XML declaration is
+            // added when the source had none. Comparing the strings flagged every SVG, which under
+            // ACTION_REJECT rejected every upload as "potentially harmful".
+            $removedNodes['enshrined'] = count($enshrinedIssues);
         }
 
         return $enshrinedData;

--- a/tests/tests/File/Image/Svg/SanitizerTest.php
+++ b/tests/tests/File/Image/Svg/SanitizerTest.php
@@ -133,4 +133,109 @@ class SanitizerTest extends TestCase
         $sanitizer->sanitizeFile($filename, self::$sanitizerOptions, $filename2);
     }
 
+    /**
+     * SVGs that contain nothing unsafe, in the serialization forms real authoring tools emit.
+     *
+     * @return array
+     */
+    public static function provideCleanSvgData()
+    {
+        return [
+            'indented, self-closing, with declaration' => [
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 100 100\">\n    <circle cx=\"50\" cy=\"50\" r=\"40\"/>\n</svg>\n",
+            ],
+            'minified, no declaration' => [
+                '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="50" cy="50" r="40"/></svg>',
+            ],
+            'no self-closing tags' => [
+                '<svg xmlns="http://www.w3.org/2000/svg"><circle cx="50" cy="50" r="40"></circle></svg>',
+            ],
+            'nested groups and metadata' => [
+                '<svg xmlns="http://www.w3.org/2000/svg"><title>t</title><g id="a"><rect width="10" height="10"/></g></svg>',
+            ],
+        ];
+    }
+
+    /**
+     * checkData() drives ACTION_REJECT in SvgProcessor::validate(), so anything it reports rejects the
+     * upload with "The SVG file contains elements that could be potentially harmful."
+     *
+     * The enshrined library re-serializes through its own DOMDocument - preserveWhiteSpace = false,
+     * formatOutput = true, saveXML() with LIBXML_NOEMPTYTAG - so its output never matches ours byte
+     * for byte. Comparing the two strings flagged every SVG ever uploaded.
+     *
+     * @dataProvider provideCleanSvgData
+     *
+     * @param string $svg
+     */
+    public function testCleanSvgIsNotReportedAsHarmful($svg)
+    {
+        $this->assertSame(
+            [],
+            self::$sanitizer->checkData($svg),
+            'A clean SVG must not be reported as containing anything to remove.'
+        );
+    }
+
+    /**
+     * @return array
+     */
+    public static function provideEnshrinedOnlyThreats()
+    {
+        return [
+            'javascript: href' => [
+                '<svg xmlns="http://www.w3.org/2000/svg"><a href="javascript:alert(1)"><circle r="4"/></a></svg>',
+            ],
+            'javascript: xlink:href' => [
+                '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"><a xlink:href="javascript:alert(1)"><circle r="4"/></a></svg>',
+            ],
+        ];
+    }
+
+    /**
+     * The reason the enshrined check exists: our own allowlist/blocklist pass does not look at URI
+     * schemes, so a javascript: href is reported by the library and by nothing else.
+     *
+     * @dataProvider provideEnshrinedOnlyThreats
+     *
+     * @param string $svg
+     */
+    public function testEnshrinedOnlyThreatIsStillReported($svg)
+    {
+        $removedNodes = self::$sanitizer->checkData($svg);
+
+        $this->assertArrayHasKey(
+            'enshrined',
+            $removedNodes,
+            'A javascript: URI is only caught by the enshrined library, so it must still be reported.'
+        );
+        $this->assertGreaterThan(0, $removedNodes['enshrined']);
+    }
+
+    /**
+     * Threats our own pass does catch must keep being attributed to it, not to the library.
+     */
+    public function testOurOwnPassStillReportsWhatItCatches()
+    {
+        $this->assertSame(
+            ['elements' => ['script' => 1]],
+            self::$sanitizer->checkData('<svg xmlns="http://www.w3.org/2000/svg"><script>alert(1)</script><circle r="4"/></svg>')
+        );
+        $this->assertSame(
+            ['attributes' => ['onload' => 1]],
+            self::$sanitizer->checkData('<svg xmlns="http://www.w3.org/2000/svg" onload="alert(1)"><circle r="4"/></svg>')
+        );
+    }
+
+    /**
+     * Reporting aside, the javascript: URI must actually be gone from the sanitized output.
+     */
+    public function testJavascriptUriIsStrippedFromSanitizedOutput()
+    {
+        $clean = self::$sanitizer->sanitizeData(
+            '<svg xmlns="http://www.w3.org/2000/svg"><a href="javascript:alert(1)"><circle r="4"/></a></svg>'
+        );
+
+        $this->assertStringNotContainsString('javascript:', $clean);
+    }
 }


### PR DESCRIPTION
Fixes #13089

6c53aae06 added a second opinion from enshrined/svg-sanitize so that reject-mode callers don't silently accept a file sanitize-mode would have cleaned. The intent is right - our own allowlist/blocklist pass never looks at URI schemes, so a javascript: href is caught by the library and by nothing else - but the detection compared two strings that are never equal.

xmlToData() is a plain saveXML() on a DOMDocument at defaults. enshrined re-serializes through its own document with preserveWhiteSpace = false, formatOutput = true (minifyXML defaults to false) and saveXML($doc, LIBXML_NOEMPTYTAG). Any one of those diverges on its own: <circle/> comes back as <circle></circle>, the tree is re-indented, and an XML declaration is added when the source had none. The library's output is a fixed point, so the only input that could compare equal is one already in its canonical form, which no authoring tool emits.

So checkData() returned ['enshrined' => 1] for every SVG, and under ACTION_REJECT SvgProcessor::validate() rejected every upload with "The SVG file contains elements that could be potentially harmful." Silent under the default ACTION_SANITIZE, since the returned string was unchanged.

Use getXmlIssues() instead. The library records an entry at every point it removes an element or attribute, and resets the list per sanitize() call. The one removal that records nothing (Sanitizer.php:500) immediately re-sets the same attribute under a lower-cased name, so nothing is dropped there.

Verified against the running application:

```
  clean, indented + self-closing   ACCEPT
  clean, minified                  ACCEPT
  clean, no self-closing tags      ACCEPT
  clean, groups + metadata         ACCEPT
  <script>                         REJECT  {"elements":{"script":1}}
  onload=                          REJECT  {"attributes":{"onload":1}}
  href="javascript:"               REJECT  {"enshrined":1}
  xlink:href="javascript:"         REJECT  {"enshrined":1}
```

The last two are the cases that justify the check: neither is caught by our own pass.
