### PR TITLE
Reject API tokens for deactivated, deleted, or password-reset users

### DIFF
--- a/concrete/src/Api/OAuth/Grant/RefreshTokenGrant.php
+++ b/concrete/src/Api/OAuth/Grant/RefreshTokenGrant.php
@@ -2,7 +2,7 @@
 
 namespace Concrete\Core\Api\OAuth\Grant;
 
-use Concrete\Core\Entity\User\User as UserEntity;
+use Concrete\Core\Api\OAuth\UserStatusValidator;
 use League\OAuth2\Server\Exception\OAuthServerException;
 use League\OAuth2\Server\Grant\RefreshTokenGrant as BaseRefreshTokenGrant;
 use League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface;
@@ -12,10 +12,20 @@ use Psr\Http\Message\ServerRequestInterface;
 
 class RefreshTokenGrant extends BaseRefreshTokenGrant
 {
-    public function __construct(RefreshTokenRepositoryInterface $refreshTokenRepository, UserRepositoryInterface $userRepository)
-    {
+
+    /**
+     * @var \Concrete\Core\Api\OAuth\UserStatusValidator
+     */
+    private $userStatusValidator;
+
+    public function __construct(
+        RefreshTokenRepositoryInterface $refreshTokenRepository,
+        UserRepositoryInterface $userRepository,
+        UserStatusValidator $userStatusValidator
+    ) {
         parent::__construct($refreshTokenRepository);
         $this->setUserRepository($userRepository);
+        $this->userStatusValidator = $userStatusValidator;
     }
 
     /**
@@ -29,9 +39,14 @@ class RefreshTokenGrant extends BaseRefreshTokenGrant
     {
         $refreshTokenData = parent::validateOldRefreshToken($request, $clientId);
 
-        $user = $this->userRepository->find($refreshTokenData['user_id']);
+        if (!$this->userStatusValidator->isValid($refreshTokenData['user_id'])) {
+            // Revoke before throwing. The parent only revokes the old tokens further along in
+            // respondToAccessTokenRequest(), so bailing out here would otherwise leave both the refresh
+            // token and the access token it was paired with live - retryable indefinitely, and usable
+            // again if the account is ever reactivated.
+            $this->refreshTokenRepository->revokeRefreshToken($refreshTokenData['refresh_token_id']);
+            $this->accessTokenRepository->revokeAccessToken($refreshTokenData['access_token_id']);
 
-        if (!$user instanceof UserEntity || !$user->isUserActive()) {
             $this->getEmitter()->emit(new RequestEvent(RequestEvent::USER_AUTHENTICATION_FAILED, $request));
             throw OAuthServerException::invalidRefreshToken('Token is not linked to an active user');
         }

--- a/concrete/src/Api/OAuth/Server/IdTokenResponse.php
+++ b/concrete/src/Api/OAuth/Server/IdTokenResponse.php
@@ -2,6 +2,7 @@
 
 namespace Concrete\Core\Api\OAuth\Server;
 
+use Concrete\Core\Api\OAuth\UserStatusValidator;
 use Concrete\Core\Application\Application;
 use Concrete\Core\Application\ApplicationAwareInterface;
 use Concrete\Core\Site\Service;
@@ -48,11 +49,23 @@ class IdTokenResponse extends BearerTokenResponse
      */
     protected $userInfoRepository;
 
-    public function __construct(Service $site, ClaimsSetFactory $claimFactory, UserInfoRepository $userInfoRepository)
-    {
+    /**
+     * Decides whether the user is still permitted to authenticate
+     *
+     * @var \Concrete\Core\Api\OAuth\UserStatusValidator
+     */
+    protected $userStatusValidator;
+
+    public function __construct(
+        Service $site,
+        ClaimsSetFactory $claimFactory,
+        UserInfoRepository $userInfoRepository,
+        UserStatusValidator $userStatusValidator
+    ) {
         $this->site = $site;
         $this->claimFactory = $claimFactory;
         $this->userInfoRepository = $userInfoRepository;
+        $this->userStatusValidator = $userStatusValidator;
     }
 
     /**
@@ -69,9 +82,13 @@ class IdTokenResponse extends BearerTokenResponse
 
         // If this is an OIDC request, pack a new id token into it
         if ($this->isOidcRequest($accessToken->getScopes())) {
-            $user = $this->userInfoRepository->getByID($accessToken->getUserIdentifier());
+            $userIdentifier = $accessToken->getUserIdentifier();
+            $user = $this->userInfoRepository->getByID($userIdentifier);
 
-            if ($user) {
+            // An id token is an assertion to the relying party that this user authenticated, so it
+            // must not be minted for an account that can no longer log in. Auth codes stay redeemable
+            // for a day, which is ample time for the account to be deactivated in between.
+            if ($user && $this->userStatusValidator->isValid($userIdentifier)) {
                 $params['id_token'] = (string) $this->createIdToken($accessToken, $this->claimFactory->createFromUserInfo($user));
             }
         }

--- a/concrete/src/Api/OAuth/UserStatusValidator.php
+++ b/concrete/src/Api/OAuth/UserStatusValidator.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Concrete\Core\Api\OAuth;
+
+use Concrete\Core\Entity\User\User as UserEntity;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Determines whether the user an OAuth token was issued to may still use the API.
+ *
+ * Tokens outlive the state of the account they were issued to - an access token is good for an hour,
+ * an auth code for a day, a refresh token for a month - and the League server never re-checks the user
+ * once a token has been issued. This is the single place that decides what "still a valid API user"
+ * means, so that every point which turns a token back into API authority agrees on the answer.
+ *
+ * The checks mirror those \Concrete\Core\User\User::checkLogin() applies to a web session, minus the
+ * uLastPasswordChange comparison: that one is made against a value stored in the session at login, and
+ * no equivalent issue time is recorded against a token.
+ */
+class UserStatusValidator
+{
+
+    /**
+     * @var \Doctrine\ORM\EntityManagerInterface
+     */
+    protected $entityManager;
+
+    public function __construct(EntityManagerInterface $entityManager)
+    {
+        $this->entityManager = $entityManager;
+    }
+
+    /**
+     * Is the user with the given ID still allowed to authenticate against the API?
+     *
+     * @param int|string|null $userIdentifier The user ID a token was issued to. Tokens issued through
+     *                                        the client credentials grant have no user; callers should
+     *                                        not consult this validator for those.
+     *
+     * @return bool
+     */
+    public function isValid($userIdentifier)
+    {
+        if (!$userIdentifier) {
+            return false;
+        }
+
+        $user = $this->entityManager->find(UserEntity::class, (int) $userIdentifier);
+
+        if (!$user instanceof UserEntity) {
+            // The account has been deleted.
+            return false;
+        }
+
+        if (!$user->isUserActive()) {
+            return false;
+        }
+
+        if ($user->isUserPasswordReset()) {
+            // The account is flagged for a password reset and cannot log in through the web UI, so it
+            // should not retain API access either.
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/concrete/src/Api/OAuth/Validator/DefaultValidator.php
+++ b/concrete/src/Api/OAuth/Validator/DefaultValidator.php
@@ -2,11 +2,13 @@
 
 namespace Concrete\Core\Api\OAuth\Validator;
 
+use Concrete\Core\Api\OAuth\UserStatusValidator;
 use Concrete\Core\Application\Application;
 use Concrete\Core\User\User;
 use League\OAuth2\Server\AuthorizationValidators\AuthorizationValidatorInterface;
 use League\OAuth2\Server\AuthorizationValidators\BearerTokenValidator;
 use League\OAuth2\Server\CryptKey;
+use League\OAuth2\Server\Exception\OAuthServerException;
 use Psr\Http\Message\ServerRequestInterface;
 
 class DefaultValidator implements AuthorizationValidatorInterface
@@ -18,10 +20,17 @@ class DefaultValidator implements AuthorizationValidatorInterface
     /** @var \Concrete\Core\Application\Application */
     private $app;
 
-    public function __construct(BearerTokenValidator $validator, Application $app)
-    {
+    /** @var \Concrete\Core\Api\OAuth\UserStatusValidator */
+    private $userStatusValidator;
+
+    public function __construct(
+        BearerTokenValidator $validator,
+        Application $app,
+        UserStatusValidator $userStatusValidator
+    ) {
         $this->validator = $validator;
         $this->app = $app;
+        $this->userStatusValidator = $userStatusValidator;
     }
 
     /**
@@ -54,7 +63,20 @@ class DefaultValidator implements AuthorizationValidatorInterface
         */
 
         // Delegate the rest to the passed in validator
-        return $this->validator->validateAuthorization($request);
+        $request = $this->validator->validateAuthorization($request);
+
+        // A valid bearer token only proves that a token was issued and has not expired or been
+        // revoked - it says nothing about the state of the account it was issued to. Re-check the user
+        // here so that deactivated, deleted and password-reset accounts lose API access immediately
+        // rather than for the remaining lifetime of the token. Tokens issued through the client
+        // credentials grant are not tied to a user and carry an empty subject.
+        $userIdentifier = $request->getAttribute('oauth_user_id');
+
+        if ($userIdentifier && !$this->userStatusValidator->isValid($userIdentifier)) {
+            throw OAuthServerException::accessDenied('Token is not linked to an active user');
+        }
+
+        return $request;
     }
 
     /**

--- a/tests/helpers/Api/OAuth/InMemoryAccessTokenRepository.php
+++ b/tests/helpers/Api/OAuth/InMemoryAccessTokenRepository.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Concrete\TestHelpers\Api\OAuth;
+
+use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
+use League\OAuth2\Server\Entities\ClientEntityInterface;
+use League\OAuth2\Server\Repositories\AccessTokenRepositoryInterface;
+
+/**
+ * An access token repository that actually remembers what has been revoked.
+ *
+ * @see \Concrete\TestHelpers\Api\OAuth\InMemoryRefreshTokenRepository
+ */
+class InMemoryAccessTokenRepository implements AccessTokenRepositoryInterface
+{
+
+    /**
+     * Token IDs known to this repository.
+     *
+     * @var bool[]
+     */
+    protected $tokens = [];
+
+    /**
+     * Token IDs that have been revoked, in the order they were revoked.
+     *
+     * @var string[]
+     */
+    public $revoked = [];
+
+    /**
+     * @param string ...$tokenIds token IDs that start out live
+     */
+    public function __construct(...$tokenIds)
+    {
+        foreach ($tokenIds as $tokenId) {
+            $this->tokens[$tokenId] = true;
+        }
+    }
+
+    /**
+     * Not exercised by these tests - access tokens are seeded through the constructor.
+     */
+    public function getNewToken(ClientEntityInterface $clientEntity, array $scopes, $userIdentifier = null)
+    {
+        return null;
+    }
+
+    /**
+     * Not exercised by these tests.
+     */
+    public function persistNewAccessToken(AccessTokenEntityInterface $accessTokenEntity)
+    {
+    }
+
+    public function revokeAccessToken($tokenId)
+    {
+        unset($this->tokens[$tokenId]);
+        $this->revoked[] = $tokenId;
+    }
+
+    public function isAccessTokenRevoked($tokenId)
+    {
+        return !isset($this->tokens[$tokenId]);
+    }
+}

--- a/tests/helpers/Api/OAuth/InMemoryRefreshTokenRepository.php
+++ b/tests/helpers/Api/OAuth/InMemoryRefreshTokenRepository.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Concrete\TestHelpers\Api\OAuth;
+
+use League\OAuth2\Server\Entities\RefreshTokenEntityInterface;
+use League\OAuth2\Server\Repositories\RefreshTokenRepositoryInterface;
+
+/**
+ * A refresh token repository that actually remembers what has been revoked.
+ *
+ * Revocation has to persist between calls for a test to be able to show that a rejected refresh token
+ * is genuinely dead rather than merely refused once.
+ */
+class InMemoryRefreshTokenRepository implements RefreshTokenRepositoryInterface
+{
+
+    /**
+     * Token IDs known to this repository.
+     *
+     * @var bool[]
+     */
+    protected $tokens = [];
+
+    /**
+     * Token IDs that have been revoked, in the order they were revoked.
+     *
+     * @var string[]
+     */
+    public $revoked = [];
+
+    /**
+     * @param string ...$tokenIds token IDs that start out live
+     */
+    public function __construct(...$tokenIds)
+    {
+        foreach ($tokenIds as $tokenId) {
+            $this->tokens[$tokenId] = true;
+        }
+    }
+
+    /**
+     * Not exercised by these tests - refresh tokens are seeded through the constructor.
+     */
+    public function getNewRefreshToken()
+    {
+        return null;
+    }
+
+    /**
+     * Not exercised by these tests.
+     */
+    public function persistNewRefreshToken(RefreshTokenEntityInterface $refreshTokenEntity)
+    {
+    }
+
+    public function revokeRefreshToken($tokenId)
+    {
+        unset($this->tokens[$tokenId]);
+        $this->revoked[] = $tokenId;
+    }
+
+    public function isRefreshTokenRevoked($tokenId)
+    {
+        return !isset($this->tokens[$tokenId]);
+    }
+}

--- a/tests/tests/Api/OAuth/Grant/RefreshTokenGrantTest.php
+++ b/tests/tests/Api/OAuth/Grant/RefreshTokenGrantTest.php
@@ -1,0 +1,228 @@
+<?php
+
+namespace Concrete\Tests\Api\OAuth\Grant;
+
+use Concrete\Core\Api\OAuth\Grant\RefreshTokenGrant;
+use Concrete\Core\Api\OAuth\UserStatusValidator;
+use Concrete\Tests\TestCase;
+use Concrete\TestHelpers\Api\OAuth\InMemoryAccessTokenRepository;
+use Concrete\TestHelpers\Api\OAuth\InMemoryRefreshTokenRepository;
+use Defuse\Crypto\Key;
+use GuzzleHttp\Psr7\ServerRequest;
+use League\OAuth2\Server\Exception\OAuthServerException;
+use League\OAuth2\Server\Repositories\UserRepositoryInterface;
+use Mockery as M;
+use ReflectionMethod;
+
+/**
+ * Refresh tokens live for a month by default, so a token issued before a user was deactivated is the
+ * longest-lived way back into the API.
+ *
+ * The refresh token in these tests is always well formed and unexpired, and is presented by the client
+ * it was issued to - everything the stock League grant checks. Only the state of the account differs.
+ *
+ * @covers \Concrete\Core\Api\OAuth\Grant\RefreshTokenGrant
+ */
+class RefreshTokenGrantTest extends TestCase
+{
+
+    const CLIENT_ID = 'client-id';
+    const REFRESH_TOKEN_ID = 'refresh-token-id';
+    const ACCESS_TOKEN_ID = 'access-token-id';
+    const USER_ID = 42;
+
+    /** @var \Concrete\Core\Api\OAuth\Grant\RefreshTokenGrant */
+    protected $grant;
+
+    /** @var \Concrete\TestHelpers\Api\OAuth\InMemoryRefreshTokenRepository */
+    protected $refreshTokenRepository;
+
+    /** @var \Concrete\TestHelpers\Api\OAuth\InMemoryAccessTokenRepository */
+    protected $accessTokenRepository;
+
+    /** @var \Concrete\Core\Api\OAuth\UserStatusValidator|\Mockery\Mock */
+    protected $userStatusValidator;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->refreshTokenRepository = new InMemoryRefreshTokenRepository(self::REFRESH_TOKEN_ID);
+        $this->accessTokenRepository = new InMemoryAccessTokenRepository(self::ACCESS_TOKEN_ID);
+        $this->userStatusValidator = M::mock(UserStatusValidator::class);
+
+        $this->grant = new RefreshTokenGrant(
+            $this->refreshTokenRepository,
+            M::mock(UserRepositoryInterface::class),
+            $this->userStatusValidator
+        );
+        $this->grant->setAccessTokenRepository($this->accessTokenRepository);
+        $this->grant->setEncryptionKey(Key::createNewRandomKey());
+    }
+
+    /**
+     * Build the encrypted refresh token a client would present, using the grant's own crypto.
+     *
+     * @param array $overrides
+     *
+     * @return string
+     */
+    protected function encryptedRefreshToken(array $overrides = [])
+    {
+        $payload = array_merge([
+            'client_id' => self::CLIENT_ID,
+            'refresh_token_id' => self::REFRESH_TOKEN_ID,
+            'access_token_id' => self::ACCESS_TOKEN_ID,
+            'scopes' => [],
+            'user_id' => self::USER_ID,
+            'expire_time' => time() + 3600,
+        ], $overrides);
+
+        $encrypt = new ReflectionMethod($this->grant, 'encrypt');
+        $encrypt->setAccessible(true);
+
+        return $encrypt->invoke($this->grant, json_encode($payload));
+    }
+
+    /**
+     * Present a refresh token to the grant the way the token endpoint would.
+     *
+     * @param string $encryptedRefreshToken
+     *
+     * @return array the decoded refresh token payload
+     */
+    protected function presentRefreshToken($encryptedRefreshToken)
+    {
+        $request = (new ServerRequest('POST', 'https://example.com/oauth/2.0/token'))
+            ->withParsedBody([
+                'grant_type' => 'refresh_token',
+                'client_id' => self::CLIENT_ID,
+                'refresh_token' => $encryptedRefreshToken,
+            ]);
+
+        $validate = new ReflectionMethod($this->grant, 'validateOldRefreshToken');
+        $validate->setAccessible(true);
+
+        return $validate->invoke($this->grant, $request, self::CLIENT_ID);
+    }
+
+    /**
+     * The check must not break the normal case.
+     */
+    public function testRefreshTokenForActiveUserIsAccepted()
+    {
+        $this->userStatusValidator->shouldReceive('isValid')->once()->with(self::USER_ID)->andReturn(true);
+
+        $payload = $this->presentRefreshToken($this->encryptedRefreshToken());
+
+        $this->assertSame(self::REFRESH_TOKEN_ID, $payload['refresh_token_id']);
+        $this->assertSame(self::USER_ID, $payload['user_id']);
+        $this->assertSame([], $this->refreshTokenRepository->revoked, 'A valid refresh token must not be revoked.');
+        $this->assertSame([], $this->accessTokenRepository->revoked, 'A valid access token must not be revoked.');
+    }
+
+    /**
+     * Findings #1 and #3: the account behind the token is no longer allowed to authenticate, so the
+     * token must not be exchangeable for a fresh access token.
+     */
+    public function testRefreshTokenForInactiveUserIsRejected()
+    {
+        $this->userStatusValidator->shouldReceive('isValid')->with(self::USER_ID)->andReturn(false);
+
+        try {
+            $this->presentRefreshToken($this->encryptedRefreshToken());
+            $this->fail('A refresh token belonging to an inactive user was accepted.');
+        } catch (OAuthServerException $e) {
+            $this->assertSame('invalid_request', $e->getErrorType());
+            $this->assertSame(401, $e->getHttpStatusCode());
+            $this->assertSame('Token is not linked to an active user', $e->getHint());
+        }
+    }
+
+    /**
+     * Finding #4: the rejection threw before the parent grant reached its own revocation step, so the
+     * refused refresh token - and the access token it was paired with - were both left live.
+     */
+    public function testRejectedRefreshTokenIsRevoked()
+    {
+        $this->userStatusValidator->shouldReceive('isValid')->with(self::USER_ID)->andReturn(false);
+
+        try {
+            $this->presentRefreshToken($this->encryptedRefreshToken());
+        } catch (OAuthServerException $e) {
+            // Asserted in testRefreshTokenForInactiveUserIsRejected().
+        }
+
+        $this->assertSame(
+            [self::REFRESH_TOKEN_ID],
+            $this->refreshTokenRepository->revoked,
+            'The refused refresh token must be revoked rather than left retryable.'
+        );
+        $this->assertSame(
+            [self::ACCESS_TOKEN_ID],
+            $this->accessTokenRepository->revoked,
+            'The access token the refresh token was paired with must be revoked too - it is still live otherwise.'
+        );
+    }
+
+    /**
+     * Finding #4, the consequence: without revocation the refused token could be retried indefinitely,
+     * and would start working again the moment the account was reactivated.
+     *
+     * Here the account IS reactivated between the two attempts, and the token still fails - because it
+     * no longer exists, not because the user is inactive.
+     */
+    public function testRejectedRefreshTokenCannotBeRetriedEvenIfTheAccountIsReactivated()
+    {
+        $encrypted = $this->encryptedRefreshToken();
+
+        // First attempt: the account is deactivated, so the token is refused and revoked.
+        $this->userStatusValidator->shouldReceive('isValid')->once()->with(self::USER_ID)->andReturn(false);
+
+        try {
+            $this->presentRefreshToken($encrypted);
+            $this->fail('A refresh token belonging to an inactive user was accepted.');
+        } catch (OAuthServerException $e) {
+            $this->assertSame('Token is not linked to an active user', $e->getHint());
+        }
+
+        // Second attempt with the very same token, with the account now active again.
+        $this->userStatusValidator->shouldReceive('isValid')->with(self::USER_ID)->andReturn(true);
+
+        try {
+            $this->presentRefreshToken($encrypted);
+            $this->fail('A revoked refresh token was accepted on a retry.');
+        } catch (OAuthServerException $e) {
+            $this->assertSame(
+                'Token has been revoked',
+                $e->getHint(),
+                'The retry must fail because the token is gone, not merely because the user was inactive.'
+            );
+        }
+    }
+
+    /**
+     * The user check must run in addition to the stock checks, not instead of them: a token presented
+     * by a client it was not issued to must still be refused, and must not be revoked on the strength
+     * of another client's say-so.
+     */
+    public function testTokenPresentedByTheWrongClientIsStillRejected()
+    {
+        $this->userStatusValidator->shouldNotReceive('isValid');
+
+        $encrypted = $this->encryptedRefreshToken(['client_id' => 'a-different-client']);
+
+        try {
+            $this->presentRefreshToken($encrypted);
+            $this->fail('A refresh token issued to another client was accepted.');
+        } catch (OAuthServerException $e) {
+            $this->assertSame('Token is not linked to client', $e->getHint());
+        }
+
+        $this->assertSame(
+            [],
+            $this->refreshTokenRepository->revoked,
+            'A token must not be revoked because an unrelated client presented it.'
+        );
+    }
+}

--- a/tests/tests/Api/OAuth/Server/IdTokenResponseTest.php
+++ b/tests/tests/Api/OAuth/Server/IdTokenResponseTest.php
@@ -1,0 +1,190 @@
+<?php
+
+namespace Concrete\Tests\Api\OAuth\Server;
+
+use Concrete\Core\Api\OAuth\Server\ClaimsSetFactory;
+use Concrete\Core\Api\OAuth\Server\IdTokenResponse;
+use Concrete\Core\Api\OAuth\UserStatusValidator;
+use Concrete\Core\Site\Service;
+use Concrete\Core\User\UserInfo;
+use Concrete\Core\User\UserInfoRepository;
+use Concrete\Tests\TestCase;
+use DateTimeImmutable;
+use League\OAuth2\Server\CryptKey;
+use League\OAuth2\Server\Entities\AccessTokenEntityInterface;
+use League\OAuth2\Server\Entities\ClientEntityInterface;
+use League\OAuth2\Server\Entities\ScopeEntityInterface;
+use League\OpenIdConnectClaims\ClaimsSet;
+use Mockery as M;
+use ReflectionMethod;
+
+/**
+ * An id_token is an assertion to a relying party that the user authenticated. Unlike an access token
+ * it is not re-validated against this site on use, so it must not be minted for an account that can no
+ * longer log in - the relying party would simply sign the user in.
+ *
+ * Auth codes are redeemable for a day, which is ample time for an account to be deactivated in between
+ * the authorization and the redemption.
+ *
+ * @covers \Concrete\Core\Api\OAuth\Server\IdTokenResponse
+ */
+class IdTokenResponseTest extends TestCase
+{
+
+    const USER_ID = 42;
+    const CLIENT_ID = 'client-id';
+
+    /**
+     * @var string
+     */
+    protected static $privateKeyPem;
+
+    /** @var \Concrete\Core\Api\OAuth\UserStatusValidator|\Mockery\Mock */
+    protected $userStatusValidator;
+
+    /** @var \Concrete\Core\Api\OAuth\Server\IdTokenResponse */
+    protected $response;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        $resource = openssl_pkey_new([
+            'private_key_bits' => 2048,
+            'private_key_type' => OPENSSL_KEYTYPE_RSA,
+        ]);
+        openssl_pkey_export($resource, self::$privateKeyPem);
+    }
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $site = M::mock(Service::class);
+        // No site: createIdToken() falls back to a literal issuer, which keeps this test off the
+        // site/locale machinery entirely.
+        $site->shouldReceive('getSite')->andReturn(null);
+
+        $claimsSet = new ClaimsSet();
+        $claimsSet->setIdentifier(self::USER_ID);
+
+        $claimFactory = M::mock(ClaimsSetFactory::class);
+        $claimFactory->shouldReceive('createFromUserInfo')->andReturn($claimsSet);
+
+        $userInfoRepository = M::mock(UserInfoRepository::class);
+        $userInfoRepository->shouldReceive('getByID')->with(self::USER_ID)->andReturn(M::mock(UserInfo::class));
+
+        $this->userStatusValidator = M::mock(UserStatusValidator::class);
+
+        $this->response = new IdTokenResponse(
+            $site,
+            $claimFactory,
+            $userInfoRepository,
+            $this->userStatusValidator
+        );
+        $this->response->setPrivateKey(new CryptKey(self::$privateKeyPem));
+    }
+
+    /**
+     * Build the access token the response type is asked to describe.
+     *
+     * @param string[] $scopeIdentifiers
+     *
+     * @return \League\OAuth2\Server\Entities\AccessTokenEntityInterface
+     */
+    protected function accessToken(array $scopeIdentifiers)
+    {
+        $scopes = [];
+        foreach ($scopeIdentifiers as $identifier) {
+            $scope = M::mock(ScopeEntityInterface::class);
+            $scope->shouldReceive('getIdentifier')->andReturn($identifier);
+            $scopes[] = $scope;
+        }
+
+        $client = M::mock(ClientEntityInterface::class);
+        $client->shouldReceive('getIdentifier')->andReturn(self::CLIENT_ID);
+
+        $accessToken = M::mock(AccessTokenEntityInterface::class);
+        $accessToken->shouldReceive('getScopes')->andReturn($scopes);
+        $accessToken->shouldReceive('getUserIdentifier')->andReturn(self::USER_ID);
+        $accessToken->shouldReceive('getClient')->andReturn($client);
+        $accessToken->shouldReceive('getExpiryDateTime')->andReturn(new DateTimeImmutable('+1 hour'));
+
+        return $accessToken;
+    }
+
+    /**
+     * @param \League\OAuth2\Server\Entities\AccessTokenEntityInterface $accessToken
+     *
+     * @return array
+     */
+    protected function getExtraParams(AccessTokenEntityInterface $accessToken)
+    {
+        $method = new ReflectionMethod($this->response, 'getExtraParams');
+        $method->setAccessible(true);
+
+        return $method->invoke($this->response, $accessToken);
+    }
+
+    /**
+     * Decode a JWT payload without verifying it - these tests care about the claims, not the signature.
+     *
+     * @param string $jwt
+     *
+     * @return array
+     */
+    protected function decodeClaims($jwt)
+    {
+        $segments = explode('.', $jwt);
+        $this->assertCount(3, $segments, 'The id_token should be a well formed JWT.');
+
+        return json_decode(base64_decode(strtr($segments[1], '-_', '+/')), true);
+    }
+
+    /**
+     * Finding #2: the auth code grant never consults the user repository, so a code issued before the
+     * account was deactivated stayed redeemable - and handed back a signed assertion that the user had
+     * just authenticated.
+     */
+    public function testIdTokenIsNotIssuedForInactiveUser()
+    {
+        $this->userStatusValidator->shouldReceive('isValid')->once()->with(self::USER_ID)->andReturn(false);
+
+        $params = $this->getExtraParams($this->accessToken(['openid', 'site']));
+
+        $this->assertArrayNotHasKey(
+            'id_token',
+            $params,
+            'An id_token must not be minted for an account that can no longer log in.'
+        );
+    }
+
+    /**
+     * The check must not break OpenID Connect for everyone else.
+     */
+    public function testIdTokenIsIssuedForActiveUser()
+    {
+        $this->userStatusValidator->shouldReceive('isValid')->once()->with(self::USER_ID)->andReturn(true);
+
+        $params = $this->getExtraParams($this->accessToken(['openid', 'site']));
+
+        $this->assertArrayHasKey('id_token', $params, 'An active user must still receive an id_token.');
+
+        $claims = $this->decodeClaims($params['id_token']);
+        $this->assertSame((string) self::USER_ID, $claims['sub']);
+        $this->assertSame(self::CLIENT_ID, $claims['aud']);
+    }
+
+    /**
+     * A plain API token request carries no openid scope and never produced an id_token to begin with.
+     * It must not start paying for a user lookup either.
+     */
+    public function testNonOidcRequestIsUnaffected()
+    {
+        $this->userStatusValidator->shouldNotReceive('isValid');
+
+        $params = $this->getExtraParams($this->accessToken(['site']));
+
+        $this->assertArrayNotHasKey('id_token', $params);
+    }
+}

--- a/tests/tests/Api/OAuth/UserStatusValidatorTest.php
+++ b/tests/tests/Api/OAuth/UserStatusValidatorTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace Concrete\Tests\Api\OAuth;
+
+use Concrete\Core\Api\OAuth\UserStatusValidator;
+use Concrete\Core\Entity\User\User as UserEntity;
+use Concrete\TestHelpers\User\UserTestCase;
+use Core;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Covers the predicate that every OAuth entry point consults to decide whether the user a token was
+ * issued to may still use the API.
+ *
+ * @covers \Concrete\Core\Api\OAuth\UserStatusValidator
+ */
+class UserStatusValidatorTest extends UserTestCase
+{
+
+    /**
+     * @var \Concrete\Core\Api\OAuth\UserStatusValidator
+     */
+    protected $validator;
+
+    /**
+     * @var \Doctrine\ORM\EntityManagerInterface
+     */
+    protected $entityManager;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->entityManager = Core::make(EntityManagerInterface::class);
+        $this->validator = Core::make(UserStatusValidator::class);
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+        $this->truncateTables();
+    }
+
+    /**
+     * Persist a user in a given state and return its ID.
+     *
+     * @param bool $isActive
+     * @param bool $isPasswordReset
+     *
+     * @return int
+     */
+    protected function createUserEntity($isActive = true, $isPasswordReset = false)
+    {
+        $user = new UserEntity();
+        $user->setUserName('u' . uniqid());
+        $user->setUserEmail(uniqid() . '@example.com');
+        $user->setUserPassword('irrelevant-for-these-tests');
+        $user->setUserIsActive($isActive);
+        $user->setUserIsPasswordReset($isPasswordReset);
+
+        $this->entityManager->persist($user);
+        $this->entityManager->flush();
+
+        $uID = $user->getUserID();
+
+        // Read back through a clean identity map, the way a fresh API request would.
+        $this->entityManager->clear();
+
+        return $uID;
+    }
+
+    public function testActiveUserIsValid()
+    {
+        $uID = $this->createUserEntity(true, false);
+
+        $this->assertTrue(
+            $this->validator->isValid($uID),
+            'An active user with no password reset flag should retain API access.'
+        );
+    }
+
+    /**
+     * Finding #1: a deactivated user must lose API access immediately, not when their token expires.
+     */
+    public function testDeactivatedUserIsRejected()
+    {
+        $uID = $this->createUserEntity(true, false);
+        $this->assertTrue($this->validator->isValid($uID), 'Precondition: user starts out valid.');
+
+        // Deactivate exactly as UserInfo::deactivate() does - a straight write to uIsActive, with no
+        // token revocation of any kind.
+        $this->entityManager->getConnection()->executeQuery(
+            'update Users set uIsActive = 0 where uID = ?',
+            [$uID]
+        );
+        $this->entityManager->clear();
+
+        $this->assertFalse(
+            $this->validator->isValid($uID),
+            'A deactivated user must not be able to authenticate against the API.'
+        );
+    }
+
+    /**
+     * Finding #3: uIsActive is only part of what checkLogin() gates on. A user locked out of the web UI
+     * by uIsPasswordReset must not keep API access.
+     */
+    public function testPasswordResetFlaggedUserIsRejected()
+    {
+        $uID = $this->createUserEntity(true, false);
+        $this->assertTrue($this->validator->isValid($uID), 'Precondition: user starts out valid.');
+
+        // Flag for reset exactly as UserInfo::markAsPasswordReset() does.
+        $this->entityManager->getConnection()->executeQuery(
+            'UPDATE Users SET uIsPasswordReset = 1 WHERE uID = ?',
+            [$uID]
+        );
+        $this->entityManager->clear();
+
+        $this->assertFalse(
+            $this->validator->isValid($uID),
+            'A user flagged for a password reset cannot log in through the web UI and must not keep API access.'
+        );
+    }
+
+    public function testDeletedUserIsRejected()
+    {
+        $uID = $this->createUserEntity(true, false);
+        $this->assertTrue($this->validator->isValid($uID), 'Precondition: user starts out valid.');
+
+        $this->entityManager->getConnection()->executeQuery('delete from Users where uID = ?', [$uID]);
+        $this->entityManager->clear();
+
+        $this->assertFalse(
+            $this->validator->isValid($uID),
+            'A token issued to a since-deleted user must not authenticate.'
+        );
+    }
+
+    /**
+     * Tokens issued through the client credentials grant carry no user. Callers guard against this
+     * before consulting the validator, but the validator itself must never treat "no user" as valid.
+     *
+     * @dataProvider provideEmptyIdentifiers
+     */
+    public function testEmptyIdentifierIsRejected($identifier)
+    {
+        $this->assertFalse(
+            $this->validator->isValid($identifier),
+            'An empty user identifier must never be treated as a valid user.'
+        );
+    }
+
+    public static function provideEmptyIdentifiers()
+    {
+        return [
+            'null' => [null],
+            'empty string' => [''],
+            'zero' => [0],
+            'string zero' => ['0'],
+        ];
+    }
+}

--- a/tests/tests/Api/OAuth/Validator/DefaultValidatorTest.php
+++ b/tests/tests/Api/OAuth/Validator/DefaultValidatorTest.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace Concrete\Tests\Api\OAuth\Validator;
+
+use Concrete\Core\Api\OAuth\UserStatusValidator;
+use Concrete\Core\Api\OAuth\Validator\DefaultValidator;
+use Concrete\Core\Application\Application;
+use Concrete\Core\User\User;
+use Concrete\Tests\TestCase;
+use GuzzleHttp\Psr7\ServerRequest;
+use League\OAuth2\Server\AuthorizationValidators\BearerTokenValidator;
+use League\OAuth2\Server\Exception\OAuthServerException;
+use Mockery as M;
+
+/**
+ * Every authenticated API request passes through this validator, so it is where a token issued before
+ * a user was deactivated has to be stopped.
+ *
+ * The bearer token in these tests is always perfectly valid - correctly signed, unexpired, and still
+ * present in OAuth2AccessToken. That is the whole point: BearerTokenValidator is happy, and without a
+ * separate check on the account the request would be served.
+ *
+ * @covers \Concrete\Core\Api\OAuth\Validator\DefaultValidator
+ */
+class DefaultValidatorTest extends TestCase
+{
+
+    /** @var \League\OAuth2\Server\AuthorizationValidators\BearerTokenValidator|\Mockery\Mock */
+    protected $bearerTokenValidator;
+
+    /** @var \Concrete\Core\Api\OAuth\UserStatusValidator|\Mockery\Mock */
+    protected $userStatusValidator;
+
+    /** @var \Concrete\Core\Api\OAuth\Validator\DefaultValidator */
+    protected $validator;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->bearerTokenValidator = M::mock(BearerTokenValidator::class);
+        $this->userStatusValidator = M::mock(UserStatusValidator::class);
+
+        $app = M::mock(Application::class);
+        $app->shouldReceive('make')->andReturn(M::mock(User::class));
+
+        $this->validator = new DefaultValidator($this->bearerTokenValidator, $app, $this->userStatusValidator);
+    }
+
+    /**
+     * Build the request BearerTokenValidator hands back once it has accepted a token.
+     *
+     * @param string $userIdentifier the "sub" claim; empty for client credentials tokens
+     *
+     * @return \Psr\Http\Message\ServerRequestInterface
+     */
+    protected function validatedRequest($userIdentifier)
+    {
+        return (new ServerRequest('GET', 'https://example.com/api/1.0/system/info'))
+            ->withAttribute('oauth_access_token_id', 'access-token-id')
+            ->withAttribute('oauth_client_id', 'client-id')
+            ->withAttribute('oauth_user_id', $userIdentifier)
+            ->withAttribute('oauth_scopes', ['site']);
+    }
+
+    /**
+     * Finding #1: an access token issued before the user was deactivated kept working for the rest of
+     * its life - an hour, or a day for tokens minted from an auth code.
+     */
+    public function testAccessTokenForDeactivatedUserIsRejected()
+    {
+        $this->bearerTokenValidator->shouldReceive('validateAuthorization')
+            ->once()
+            ->andReturn($this->validatedRequest('42'));
+
+        // The account has since been deactivated, deleted, or flagged for a password reset.
+        $this->userStatusValidator->shouldReceive('isValid')->once()->with('42')->andReturn(false);
+
+        try {
+            $this->validator->validateAuthorization(new ServerRequest('GET', 'https://example.com/api/1.0/system/info'));
+            $this->fail('A token belonging to an inactive user was accepted.');
+        } catch (OAuthServerException $e) {
+            $this->assertSame('access_denied', $e->getErrorType());
+            $this->assertSame(401, $e->getHttpStatusCode());
+            $this->assertSame('Token is not linked to an active user', $e->getHint());
+        }
+    }
+
+    /**
+     * The check must not break the normal case.
+     */
+    public function testAccessTokenForActiveUserIsAccepted()
+    {
+        $validated = $this->validatedRequest('42');
+
+        $this->bearerTokenValidator->shouldReceive('validateAuthorization')->once()->andReturn($validated);
+        $this->userStatusValidator->shouldReceive('isValid')->once()->with('42')->andReturn(true);
+
+        $result = $this->validator->validateAuthorization(
+            new ServerRequest('GET', 'https://example.com/api/1.0/system/info')
+        );
+
+        $this->assertSame($validated, $result, 'The validated request must be returned untouched.');
+        $this->assertSame('42', $result->getAttribute('oauth_user_id'));
+        $this->assertSame('access-token-id', $result->getAttribute('oauth_access_token_id'));
+        $this->assertSame(['site'], $result->getAttribute('oauth_scopes'));
+    }
+
+    /**
+     * Tokens issued through the client credentials grant are not tied to a user at all and carry an
+     * empty subject. They must keep working, and must not be run through the user check.
+     */
+    public function testClientCredentialsTokenIsUnaffected()
+    {
+        $validated = $this->validatedRequest('');
+
+        $this->bearerTokenValidator->shouldReceive('validateAuthorization')->once()->andReturn($validated);
+        $this->userStatusValidator->shouldNotReceive('isValid');
+
+        $result = $this->validator->validateAuthorization(
+            new ServerRequest('GET', 'https://example.com/api/1.0/system/info')
+        );
+
+        $this->assertSame($validated, $result, 'A client credentials token must still authenticate.');
+    }
+
+    /**
+     * A token the bearer validator itself rejects (bad signature, expired, revoked) must keep failing
+     * the way it always did, without the user check swallowing or masking the error.
+     */
+    public function testBearerTokenValidatorRejectionIsPropagated()
+    {
+        $this->bearerTokenValidator->shouldReceive('validateAuthorization')
+            ->once()
+            ->andThrow(OAuthServerException::accessDenied('Access token could not be verified'));
+
+        $this->userStatusValidator->shouldNotReceive('isValid');
+
+        $this->expectException(OAuthServerException::class);
+        $this->validator->validateAuthorization(
+            new ServerRequest('GET', 'https://example.com/api/1.0/system/info')
+        );
+    }
+}


### PR DESCRIPTION
Fixes #13091

Access tokens, auth codes, and refresh tokens are checked for signature and expiry, but nothing re-verifies the state of the underlying account once a token has been issued. A token issued before a user was deactivated keeps working until it naturally expires.

Add UserStatusValidator as a single predicate for "is this user still allowed to authenticate," mirroring the checks User::checkLogin() applies to a web session, and consult it from:

- DefaultValidator, so a live bearer token stops authenticating immediately once the account is deactivated
- IdTokenResponse, so an auth code can't be exchanged for a signed OIDC assertion about a deactivated user
- RefreshTokenGrant, which now also revokes the refused refresh token and its paired access token before throwing, rather than leaving both retryable
