### PR TITLE
Render the error view in the express object dashboard

### DIFF
--- a/concrete/controllers/single_page/dashboard/system/express/entities.php
+++ b/concrete/controllers/single_page/dashboard/system/express/entities.php
@@ -174,6 +174,9 @@ class Entities extends DashboardPageController
             return Redirect::to('/dashboard/system/express/entities');
         }
 
+        // Without this the action falls through to the default view, which renders without the
+        // variables view() sets and fatals - so the error above would never reach the user.
+        $this->view();
     }
 
     public function rescan_entries()
@@ -242,6 +245,10 @@ class Entities extends DashboardPageController
             $this->flash('success', t('All Entries were successfully cleared.'));
             return Redirect::to('/dashboard/system/express/entities', 'view_entity', $entity->getId());
         }
+
+        // Without this the action falls through to the default view, which renders without the
+        // variables view() sets and fatals - so the error above would never reach the user.
+        $this->view_entity($this->request->request->get('entity_id'));
     }
 
     /**
@@ -266,6 +273,10 @@ class Entities extends DashboardPageController
             $this->flash('success', t('Entity published successfully.'));
             return Redirect::to('/dashboard/system/express/entities', 'view_entity', $entity->getId());
         }
+
+        // Without this the action falls through to the default view, which renders without the
+        // variables view() sets and fatals - so the error above would never reach the user.
+        $this->view_entity($this->request->request->get('entity_id'));
     }
 
     public function clear_entries($id = null)


### PR DESCRIPTION

fixes #13093 

delete(), delete_entries() and publish() return without a response when their validation fails. Concrete then falls back to the single page's default template, which is written against the variables view() sets, so entities.php:26 runs count($entities) against an unset variable and the request dies with:

  TypeError: count(): Argument #1 ($value) must be of type Countable|array, null given

That means a validation failure turns into a 500 instead of a visible error message.

rescan_entries() in the same file already handles this by calling view_entity() on its error path. Do the same in the other three.
