### PR TITLE
[Fix] PHP 8 error in Add Workflow dashboard page caused by incorrect View::element argument order

### DIFF
--- a/concrete/single_pages/dashboard/system/permissions/workflows.php
+++ b/concrete/single_pages/dashboard/system/permissions/workflows.php
@@ -63,7 +63,7 @@ $app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
 				<div style="display: none" class="form-group ccm-workflow-type-form" id="ccm-workflow-type-<?=$type->getWorkflowTypeID()?>">
 					<?php
                     if ($type->getPackageID() > 0) {
-                        @View::element('workflow/types/' . $type->getWorkflowTypeHandle()  . '/add_type_form', $type->getPackageHandle(), array('type' => $type));
+                        @View::element('workflow/types/' . $type->getWorkflowTypeHandle() . '/add_type_form', ['type' => $type], $type->getPackageHandle());
                     } else {
                         @View::element('workflow/types/' . $type->getWorkflowTypeHandle() . '/add_type_form', array('type' => $type));
                     }

--- a/concrete/single_pages/dashboard/system/permissions/workflows.php
+++ b/concrete/single_pages/dashboard/system/permissions/workflows.php
@@ -1,7 +1,7 @@
-<?php defined('C5_EXECUTE') or die("Access Denied."); 
+<?php defined('C5_EXECUTE') or die('Access Denied.');
 $app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
 ?>
-<?php $c = Page::getCurrentPage(); ?>
+<?php $c = Page::getCurrentPage() ?>
 
 <?php if (isset($wf)) {
     ?>
@@ -9,75 +9,75 @@ $app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
 <?php if ($this->controller->getTask() == 'edit_details') {
     ?>
 
-<form method="post" action="<?=$view->action('save_workflow_details')?>" method="post">
-<input type="hidden" name="wfID" value="<?=$wf->getWorkflowID()?>" />
-<?=$app->make('helper/validation/token')->output('save_workflow_details')?>
+<form method="post" action="<?= $view->action('save_workflow_details') ?>" method="post">
+<input type="hidden" name="wfID" value="<?= $wf->getWorkflowID() ?>" />
+<?= $app->make('helper/validation/token')->output('save_workflow_details') ?>
 
-<?php View::element("workflow/edit_type_form_required", array('workflow' => $wf));
+<?php View::element('workflow/edit_type_form_required', ['workflow' => $wf]);
     ?>
 
 <div class="ccm-dashboard-form-actions-wrapper">
 <div class="ccm-dashboard-form-actions">
-	<a href="<?=URL::page($c, 'view_detail', $wf->getWorkflowID())?>" class="btn btn-secondary float-start"><?=t("Cancel")?></a>
-	<input type="submit" name="submit" value="<?=t('Save')?>" class="btn btn-primary float-end" />
+	<a href="<?= URL::page($c, 'view_detail', $wf->getWorkflowID()) ?>" class="btn btn-secondary float-start"><?= t('Cancel') ?></a>
+	<input type="submit" name="submit" value="<?= t('Save') ?>" class="btn btn-primary float-end" />
 </div>
 </div>
 </form>
 
-<?php 
+<?php
 } else {
     ?>
 
-	<?php View::element("workflow/type_form_required", array('workflow' => $wf));
+	<?php View::element('workflow/type_form_required', ['workflow' => $wf]);
     ?>
 
-<?php 
+<?php
 }
     ?>
 
 
 
-<?php 
+<?php
 } elseif ($this->controller->getTask() == 'add' || $this->controller->getTask() == 'submit_add') {
     ?>
 
-	<form method="post" action="<?=$view->action('submit_add')?>">
-	<?=$app->make('helper/validation/token')->output('add_workflow')?>
+	<form method="post" action="<?= $view->action('submit_add') ?>">
+	<?= $app->make('helper/validation/token')->output('add_workflow') ?>
 		<fieldset>
 		
-			<legend><?=t('Add Workflow')?></legend>
+			<legend><?= t('Add Workflow') ?></legend>
 			
 			<div class="mb-3">
-                <?=$form->label('wfName', t('Name'))?>
-                <?=$form->text('wfName', $wfName ?? null, ['required' => 'required'])?>
+                <?= $form->label('wfName', t('Name')) ?>
+                <?= $form->text('wfName', $wfName ?? null, ['required' => 'required']) ?>
 			</div>
 			
 			<div class="mb-3">
-                <?=$form->label('wftID', t('Type'))?>
-                <?=$form->select('wftID', $types)?>
+                <?= $form->label('wftID', t('Type')) ?>
+                <?= $form->select('wftID', $types) ?>
 			</div>
 
 			<?php foreach ($typeObjects as $type) {
     ?>
 				
-				<div style="display: none" class="form-group ccm-workflow-type-form" id="ccm-workflow-type-<?=$type->getWorkflowTypeID()?>">
+				<div style="display: none" class="form-group ccm-workflow-type-form" id="ccm-workflow-type-<?= $type->getWorkflowTypeID() ?>">
 					<?php
                     if ($type->getPackageID() > 0) {
                         @View::element('workflow/types/' . $type->getWorkflowTypeHandle() . '/add_type_form', ['type' => $type], $type->getPackageHandle());
                     } else {
-                        @View::element('workflow/types/' . $type->getWorkflowTypeHandle() . '/add_type_form', array('type' => $type));
+                        @View::element('workflow/types/' . $type->getWorkflowTypeHandle() . '/add_type_form', ['type' => $type]);
                     }
     ?>
 				</div>
-			<?php 
+			<?php
 }
     ?>
 		</fieldset>
 		
 		<div class="ccm-dashboard-form-actions-wrapper">
 		<div class="ccm-dashboard-form-actions">
-			<a href="<?=URL::page($c)?>" class="btn btn-secondary float-start"><?=t('Cancel')?></a>
-			<button type="submit" class="btn btn-primary float-end"><?=t('Add')?></button>
+			<a href="<?= URL::page($c) ?>" class="btn btn-secondary float-start"><?= t('Cancel') ?></a>
+			<button type="submit" class="btn btn-primary float-end"><?= t('Add') ?></button>
 		</div>
 		</div>
 			
@@ -93,24 +93,24 @@ $app = \Concrete\Core\Support\Facade\Application::getFacadeApplication();
 	});
 	</script>
 
-<?php 
+<?php
 } else {
     ?>
 
 	<div class="ccm-dashboard-header-buttons">
-		<a href="<?=URL::to('/dashboard/system/permissions/workflows', 'add')?>" class="btn btn-primary"><?=t('Add Workflow')?></a>
+		<a href="<?= URL::to('/dashboard/system/permissions/workflows', 'add') ?>" class="btn btn-primary"><?= t('Add Workflow') ?></a>
 	</div>
 	
-	<h4><?=t2('%d Workflow', '%d Workflows', count($workflows))?></h4>
+	<h4><?= t2('%d Workflow', '%d Workflows', count($workflows)) ?></h4>
 	
 	<ul class="item-select-list">
 	<?php foreach ($workflows as $workflow) {
     ?>
-		<li><a href="<?=$view->url('/dashboard/system/permissions/workflows', 'view_detail', $workflow->getWorkflowID())?>"><i class="fas fa-exchange-alt"></i> <?=$workflow->getWorkflowDisplayName()?></a></li>
-	<?php 
+		<li><a href="<?= $view->url('/dashboard/system/permissions/workflows', 'view_detail', $workflow->getWorkflowID()) ?>"><i class="fas fa-exchange-alt"></i> <?= $workflow->getWorkflowDisplayName() ?></a></li>
+	<?php
 }
     ?>
 	</ul>
 
-<?php 
+<?php
 } ?>


### PR DESCRIPTION
#### Summary
Fixed a 500 error on the "Add Workflow" dashboard page (`/dashboard/system/permissions/workflows/add`) that occurred when a package-based workflow type was present and the site was running on PHP 8+.

#### The Problem
When navigating to the Add Workflow page, if there are workflow types belonging to a package (such as the "Advanced Workflow" package), the system attempts to render their specific "Add" forms. In the `workflows.php` view file, the `View::element()` call for these forms had the second and third arguments swapped.

Specifically, the code was:
`@View::element($element, $pkgHandle, $args)`

However, the `View::element` signature is:
`public static function element($_file, $args = null, $_pkgHandle = null)`

In PHP 8, passing a string (the package handle) as the second argument causes an `Uncaught Error: Cannot access offset of type string on string` when the system attempts to process the `$args` variable as an array.

#### The Solution
Swapped the arguments in `concrete/single_pages/dashboard/system/permissions/workflows.php` to correctly pass the data array as the second argument and the package handle as the third.

#### How to Test
1. Use PHP 8.x.
2. Install a package that provides a custom workflow type (e.g., Advanced Workflow).
3. Navigate to `Dashboard > System & Permissions > Tasks > Workflows`.
4. Click "Add Workflow".
5. Observe the 500 error before the fix, and the correctly rendered page after the fix.