### PR TITLE
[Feature] Dispatch events on permission assignments, entity changes, and inheritance updates

### DIFF
--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -37,6 +37,7 @@ use Concrete\Core\Permission\Access\Entity\PageOwnerEntity;
 use Concrete\Core\Permission\Access\Entity\UserEntity as UserPermissionAccessEntity;
 use Concrete\Core\Permission\AssignableObjectInterface;
 use Concrete\Core\Permission\AssignableObjectTrait;
+use Concrete\Core\Permission\Event\PermissionInheritanceEvent;
 use Concrete\Core\Permission\Key\PageKey as PagePermissionKey;
 use Concrete\Core\Production\Modes;
 use Concrete\Core\Search\Index\IndexManagerInterface;
@@ -2671,6 +2672,15 @@ EOT
         $this->cInheritPermissionsFromCID = $cpID;
         $this->clearPagePermissions();
         $this->rescanAreaPermissions();
+
+        $app = Application::getFacadeApplication();
+        $u = null;
+        if (!$app->isRunThroughCommandLineInterface() && $app->isInstalled()) {
+            $u = $app->make(User::class);
+        }
+        $event = new PermissionInheritanceEvent($this, 'PARENT', $u);
+        Events::dispatch('on_permission_inheritance_change', $event);
+        Events::dispatch('on_page_permission_inheritance_change', $event);
     }
 
     /**
@@ -2692,6 +2702,15 @@ EOT
                 $this->cInheritPermissionsFromCID = $cpID;
                 $this->clearPagePermissions();
                 $this->rescanAreaPermissions();
+
+                $app = Application::getFacadeApplication();
+                $u = null;
+                if (!$app->isRunThroughCommandLineInterface() && $app->isInstalled()) {
+                    $u = $app->make(User::class);
+                }
+                $event = new PermissionInheritanceEvent($this, 'TEMPLATE', $u);
+                Events::dispatch('on_permission_inheritance_change', $event);
+                Events::dispatch('on_page_permission_inheritance_change', $event);
             }
         }
     }
@@ -2714,6 +2733,15 @@ EOT
             $this->cInheritPermissionsFrom = 'OVERRIDE';
             $this->cInheritPermissionsFromCID = $cpID;
             $this->rescanAreaPermissions();
+
+            $app = Application::getFacadeApplication();
+            $u = null;
+            if (!$app->isRunThroughCommandLineInterface() && $app->isInstalled()) {
+                $u = $app->make(User::class);
+            }
+            $event = new PermissionInheritanceEvent($this, 'OVERRIDE', $u);
+            Events::dispatch('on_permission_inheritance_change', $event);
+            Events::dispatch('on_page_permission_inheritance_change', $event);
         }
     }
 

--- a/concrete/src/Permission/Access/Access.php
+++ b/concrete/src/Permission/Access/Access.php
@@ -7,11 +7,14 @@ use Concrete\Core\Foundation\ConcreteObject;
 use Concrete\Core\Logging\Entry\Permission\Assignment\Assignment as PermissionAssignmentLogEntry;
 use Concrete\Core\Permission\Access\Entity\Entity as PermissionAccessEntity;
 use Concrete\Core\Permission\Duration as PermissionDuration;
+use Concrete\Core\Permission\Event\PermissionAccessEntityEvent;
+use Concrete\Core\Permission\Event\PermissionAssignmentEvent;
 use Concrete\Core\Permission\Key\Key as PermissionKey;
 use Concrete\Core\Permission\Logger;
 use Concrete\Core\Support\Facade\Application;
 use Concrete\Core\User\User;
 use Concrete\Core\Workflow\Workflow;
+use Events;
 use PDO;
 
 /**
@@ -54,21 +57,21 @@ class Access extends ConcreteObject
     /**
      * Get the object associated to the permission (for example, a Page instance).
      *
-     * @return object
+     * @return object|null
      */
     public function getPermissionObject()
     {
-        return $this->pk->getPermissionObject();
+        return isset($this->pk) && is_object($this->pk) ? $this->pk->getPermissionObject() : null;
     }
 
     /**
      * Get the object to be used to check the permission (for example, a Page instance).
      *
-     * @return object
+     * @return object|null
      */
     public function getPermissionObjectToCheck()
     {
-        return $this->pk->getPermissionObjectToCheck();
+        return isset($this->pk) && is_object($this->pk) ? $this->pk->getPermissionObjectToCheck() : null;
     }
 
     /**
@@ -289,9 +292,22 @@ class Access extends ConcreteObject
         $db->executeQuery('update PermissionAccess set paIsInUse = 1 where paID = ?', [$this->paID]);
         $this->paIsInUse = true;
 
+        $u = null;
+        if (!$app->isRunThroughCommandLineInterface() && $app->isInstalled()) {
+            $u = $app->make(User::class);
+        }
+
+        $event = new PermissionAssignmentEvent(
+            isset($this->pk) ? $this->pk : null,
+            $this,
+            $this->getPermissionObject(),
+            $u
+        );
+        Events::dispatch('on_permission_assignment_assign', $event);
+
         $logger = $app->make(Logger::class);
         $entry = $app->make(PermissionAssignmentLogEntry::class, [
-           'applier' => $app->make(User::class),
+           'applier' => $u ?: $app->make(User::class),
            'key' => $this->pk,
            'access' => $this,
         ]);
@@ -324,6 +340,22 @@ class Access extends ConcreteObject
             ['paID', 'peID'],
             false
         );
+
+        $u = null;
+        if (!$app->isRunThroughCommandLineInterface() && $app->isInstalled()) {
+            $u = $app->make(User::class);
+        }
+
+        $event = new PermissionAccessEntityEvent(
+            $this,
+            $pae,
+            $durationObject instanceof PermissionDuration ? $durationObject : null,
+            (int) $accessType,
+            $u,
+            isset($this->pk) ? $this->pk : null,
+            $this->getPermissionObject()
+        );
+        Events::dispatch('on_permission_access_entity_add', $event);
     }
 
     /**
@@ -337,6 +369,22 @@ class Access extends ConcreteObject
             'delete from PermissionAccessList where peID = ? and paID = ?',
             [$pe->getAccessEntityID(), $this->getPermissionAccessID()]
         );
+
+        $u = null;
+        if (!$app->isRunThroughCommandLineInterface() && $app->isInstalled()) {
+            $u = $app->make(User::class);
+        }
+
+        $event = new PermissionAccessEntityEvent(
+            $this,
+            $pe,
+            null,
+            PermissionKey::ACCESS_TYPE_INCLUDE,
+            $u,
+            isset($this->pk) ? $this->pk : null,
+            $this->getPermissionObject()
+        );
+        Events::dispatch('on_permission_access_entity_remove', $event);
     }
 
     /**

--- a/concrete/src/Permission/Assignment/AreaAssignment.php
+++ b/concrete/src/Permission/Assignment/AreaAssignment.php
@@ -213,6 +213,7 @@ class AreaAssignment extends Assignment
         $area = $this->getPermissionObject();
         $c = $area->getAreaCollectionObject();
         $db->executeQuery('update AreaPermissionAssignments set paID = 0 where pkID = ? and cID = ? and arHandle = ?', [$this->pk->getPermissionKeyID(), $c->getCollectionID(), $area->getAreaHandle()]);
+        $this->dispatchClearEvent();
     }
 
     /**

--- a/concrete/src/Permission/Assignment/Assignment.php
+++ b/concrete/src/Permission/Assignment/Assignment.php
@@ -4,7 +4,10 @@ namespace Concrete\Core\Permission\Assignment;
 
 use Concrete\Core\Database\Connection\Connection;
 use Concrete\Core\Permission\Access\Access;
+use Concrete\Core\Permission\Event\PermissionAssignmentEvent;
 use Concrete\Core\Support\Facade\Application;
+use Concrete\Core\User\User;
+use Events;
 use PermissionKeyCategory;
 
 class Assignment
@@ -72,11 +75,29 @@ class Assignment
         return $akc->getTaskURL($task, $options);
     }
 
+    protected function dispatchClearEvent()
+    {
+        $app = Application::getFacadeApplication();
+        $u = null;
+        if (!$app->isRunThroughCommandLineInterface() && $app->isInstalled()) {
+            $u = $app->make(User::class);
+        }
+
+        $event = new PermissionAssignmentEvent(
+            $this->pk,
+            null,
+            $this->getPermissionObject(),
+            $u
+        );
+        Events::dispatch('on_permission_assignment_clear', $event);
+    }
+
     public function clearPermissionAssignment()
     {
         $app = Application::getFacadeApplication();
         $db = $app->make(Connection::class);
         $db->executeQuery('update PermissionAssignments set paID = 0 where pkID = ?', [$this->pk->getPermissionKeyID()]);
+        $this->dispatchClearEvent();
     }
 
     /**

--- a/concrete/src/Permission/Assignment/BasicWorkflowAssignment.php
+++ b/concrete/src/Permission/Assignment/BasicWorkflowAssignment.php
@@ -20,6 +20,7 @@ class BasicWorkflowAssignment extends Assignment
     {
         $db = Loader::db();
         $db->Execute('update BasicWorkflowPermissionAssignments set paID = 0 where pkID = ? and wfID = ?', array($this->pk->getPermissionKeyID(), $this->getPermissionObject()->getWorkflowID()));
+        $this->dispatchClearEvent();
     }
 
     public function assignPermissionAccess(Access $pa)

--- a/concrete/src/Permission/Assignment/BlockAssignment.php
+++ b/concrete/src/Permission/Assignment/BlockAssignment.php
@@ -99,6 +99,7 @@ class BlockAssignment extends Assignment
         $db = Database::connection();
         $co = $this->permissionObject->getBlockCollectionObject();
         $db->Execute('update BlockPermissionAssignments set paID = 0 where pkID = ? and bID = ? and cvID = ? and cID = ?', array($this->pk->getPermissionKeyID(), $this->permissionObject->getBlockID(), $co->getVersionID(), $co->getCollectionID()));
+        $this->dispatchClearEvent();
     }
 
     public function assignPermissionAccess(Access $pa)

--- a/concrete/src/Permission/Assignment/BoardAssignment.php
+++ b/concrete/src/Permission/Assignment/BoardAssignment.php
@@ -73,6 +73,7 @@ class BoardAssignment extends Assignment
         $db = \Database::connection();
         $board = $this->getPermissionObject();
         $db->Execute('update BoardPermissionAssignments set paID = 0 where pkID = ? and boardID = ?', array($this->pk->getPermissionKeyID(), $board->getBoardID()));
+        $this->dispatchClearEvent();
     }
 
     public function assignPermissionAccess(Access $pa)

--- a/concrete/src/Permission/Assignment/CalendarAssignment.php
+++ b/concrete/src/Permission/Assignment/CalendarAssignment.php
@@ -77,6 +77,7 @@ class CalendarAssignment extends Assignment
         $db = \Database::connection();
         $calendar = $this->getPermissionObject();
         $db->Execute('update CalendarPermissionAssignments set paID = 0 where pkID = ? and caID = ?', array($this->pk->getPermissionKeyID(), $calendar->getID()));
+        $this->dispatchClearEvent();
     }
 
     public function assignPermissionAccess(Access $pa)

--- a/concrete/src/Permission/Assignment/ConversationAssignment.php
+++ b/concrete/src/Permission/Assignment/ConversationAssignment.php
@@ -54,6 +54,7 @@ class ConversationAssignment extends Assignment
             'update ConversationPermissionAssignments set paID = 0 where pkID = ? and cnvID = ?',
             array($this->pk->getPermissionKeyID(), $cnvID)
         );
+        $this->dispatchClearEvent();
     }
 
     public function assignPermissionAccess(Access $pa)

--- a/concrete/src/Permission/Assignment/FileAssignment.php
+++ b/concrete/src/Permission/Assignment/FileAssignment.php
@@ -86,6 +86,7 @@ class FileAssignment extends TreeNodeAssignment
     {
         $db = Database::connection();
         $db->Execute('update FilePermissionAssignments set paID = 0 where pkID = ? and fID = ?', array($this->pk->getPermissionKeyID(), $this->permissionObject->getFileID()));
+        $this->dispatchClearEvent();
     }
 
     public function assignPermissionAccess(Access $pa)

--- a/concrete/src/Permission/Assignment/PageAssignment.php
+++ b/concrete/src/Permission/Assignment/PageAssignment.php
@@ -89,6 +89,8 @@ class PageAssignment extends Assignment
             $this->getPermissionObject()->getPermissionObjectIdentifier()
         );
         $cache->delete($identifier);
+
+        $this->dispatchClearEvent();
     }
 
     /**

--- a/concrete/src/Permission/Assignment/PageTypeAssignment.php
+++ b/concrete/src/Permission/Assignment/PageTypeAssignment.php
@@ -20,6 +20,7 @@ class PageTypeAssignment extends Assignment
     {
         $db = Loader::db();
         $db->Execute('update PageTypePermissionAssignments set paID = 0 where pkID = ? and ptID = ?', array($this->pk->getPermissionKeyID(), $this->permissionObject->getPageTypeID()));
+        $this->dispatchClearEvent();
     }
 
     public function assignPermissionAccess(Access $pa)

--- a/concrete/src/Permission/Assignment/TreeNodeAssignment.php
+++ b/concrete/src/Permission/Assignment/TreeNodeAssignment.php
@@ -31,6 +31,7 @@ class TreeNodeAssignment extends Assignment
     {
         $db = Loader::db();
         $db->Execute('update TreeNodePermissionAssignments set paID = 0 where pkID = ? and treeNodeID = ?', array($this->pk->getPermissionKeyID(), $this->permissionObject->getTreeNodeID()));
+        $this->dispatchClearEvent();
     }
 
     public function assignPermissionAccess(Access $pa)

--- a/concrete/src/Permission/Event/PermissionAccessEntityEvent.php
+++ b/concrete/src/Permission/Event/PermissionAccessEntityEvent.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Concrete\Core\Permission\Event;
+
+use Concrete\Core\Permission\Access\Access;
+use Concrete\Core\Permission\Access\Entity\Entity;
+use Concrete\Core\Permission\Duration;
+use Concrete\Core\Permission\Key\Key;
+use Concrete\Core\Permission\ObjectInterface;
+use Concrete\Core\User\User;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class PermissionAccessEntityEvent extends Event
+{
+    /**
+     * @var Access
+     */
+    protected $permissionAccess;
+
+    /**
+     * @var Entity
+     */
+    protected $accessEntity;
+
+    /**
+     * @var Duration|null
+     */
+    protected $duration;
+
+    /**
+     * @var int
+     */
+    protected $accessType;
+
+    /**
+     * @var Key|null
+     */
+    protected $permissionKey;
+
+    /**
+     * @var ObjectInterface|null
+     */
+    protected $permissionObject;
+
+    /**
+     * @var User|null
+     */
+    protected $applier;
+
+    public function __construct(
+        Access $permissionAccess,
+        Entity $accessEntity,
+        ?Duration $duration = null,
+        int $accessType = Key::ACCESS_TYPE_INCLUDE,
+        ?User $applier = null,
+        ?Key $permissionKey = null,
+        ?ObjectInterface $permissionObject = null
+    ) {
+        $this->permissionAccess = $permissionAccess;
+        $this->accessEntity = $accessEntity;
+        $this->duration = $duration;
+        $this->accessType = $accessType;
+        $this->applier = $applier;
+        $this->permissionKey = $permissionKey ?: $permissionAccess->getPermissionKeyObject();
+        $this->permissionObject = $permissionObject ?: ($this->permissionKey ? $this->permissionKey->getPermissionObject() : null);
+    }
+
+    public function getPermissionAccess(): Access
+    {
+        return $this->permissionAccess;
+    }
+
+    public function getPermissionAccessObject(): Access
+    {
+        return $this->permissionAccess;
+    }
+
+    public function getAccessEntity(): Entity
+    {
+        return $this->accessEntity;
+    }
+
+    public function getAccessEntityObject(): Entity
+    {
+        return $this->accessEntity;
+    }
+
+    public function getDuration(): ?Duration
+    {
+        return $this->duration;
+    }
+
+    public function getDurationObject(): ?Duration
+    {
+        return $this->duration;
+    }
+
+    public function getAccessType(): int
+    {
+        return $this->accessType;
+    }
+
+    public function getPermissionKey(): ?Key
+    {
+        return $this->permissionKey;
+    }
+
+    public function getPermissionKeyObject(): ?Key
+    {
+        return $this->permissionKey;
+    }
+
+    public function getPermissionObject(): ?ObjectInterface
+    {
+        return $this->permissionObject;
+    }
+
+    public function getApplier(): ?User
+    {
+        return $this->applier;
+    }
+
+    public function getUser(): ?User
+    {
+        return $this->applier;
+    }
+
+    public function getUserObject(): ?User
+    {
+        return $this->applier;
+    }
+}

--- a/concrete/src/Permission/Event/PermissionAssignmentEvent.php
+++ b/concrete/src/Permission/Event/PermissionAssignmentEvent.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace Concrete\Core\Permission\Event;
+
+use Concrete\Core\Permission\Access\Access;
+use Concrete\Core\Permission\Key\Key;
+use Concrete\Core\Permission\ObjectInterface;
+use Concrete\Core\User\User;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class PermissionAssignmentEvent extends Event
+{
+    /**
+     * @var Key|null
+     */
+    protected $permissionKey;
+
+    /**
+     * @var Access|null
+     */
+    protected $permissionAccess;
+
+    /**
+     * @var ObjectInterface|null
+     */
+    protected $permissionObject;
+
+    /**
+     * @var User|null
+     */
+    protected $applier;
+
+    public function __construct(
+        ?Key $permissionKey = null,
+        ?Access $permissionAccess = null,
+        ?ObjectInterface $permissionObject = null,
+        ?User $applier = null
+    ) {
+        $this->permissionKey = $permissionKey;
+        $this->permissionAccess = $permissionAccess;
+        $this->permissionObject = $permissionObject;
+        $this->applier = $applier;
+    }
+
+    public function getPermissionKey(): ?Key
+    {
+        return $this->permissionKey;
+    }
+
+    public function getPermissionKeyObject(): ?Key
+    {
+        return $this->permissionKey;
+    }
+
+    public function setPermissionKey(?Key $permissionKey): void
+    {
+        $this->permissionKey = $permissionKey;
+    }
+
+    public function getPermissionAccess(): ?Access
+    {
+        return $this->permissionAccess;
+    }
+
+    public function getPermissionAccessObject(): ?Access
+    {
+        return $this->permissionAccess;
+    }
+
+    public function setPermissionAccess(?Access $permissionAccess): void
+    {
+        $this->permissionAccess = $permissionAccess;
+    }
+
+    public function getPermissionObject(): ?ObjectInterface
+    {
+        if ($this->permissionObject !== null) {
+            return $this->permissionObject;
+        }
+        if ($this->permissionKey !== null) {
+            return $this->permissionKey->getPermissionObject();
+        }
+
+        return null;
+    }
+
+    public function setPermissionObject(?ObjectInterface $permissionObject): void
+    {
+        $this->permissionObject = $permissionObject;
+    }
+
+    public function getApplier(): ?User
+    {
+        return $this->applier;
+    }
+
+    public function setApplier(?User $applier): void
+    {
+        $this->applier = $applier;
+    }
+
+    public function getUser(): ?User
+    {
+        return $this->applier;
+    }
+
+    public function getUserObject(): ?User
+    {
+        return $this->applier;
+    }
+}

--- a/concrete/src/Permission/Event/PermissionInheritanceEvent.php
+++ b/concrete/src/Permission/Event/PermissionInheritanceEvent.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Concrete\Core\Permission\Event;
+
+use Concrete\Core\Permission\ObjectInterface;
+use Concrete\Core\User\User;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class PermissionInheritanceEvent extends Event
+{
+    /**
+     * @var ObjectInterface|mixed
+     */
+    protected $permissionObject;
+
+    /**
+     * @var string
+     */
+    protected $inheritanceMode;
+
+    /**
+     * @var User|null
+     */
+    protected $applier;
+
+    public function __construct(
+        $permissionObject,
+        string $inheritanceMode,
+        ?User $applier = null
+    ) {
+        $this->permissionObject = $permissionObject;
+        $this->inheritanceMode = $inheritanceMode;
+        $this->applier = $applier;
+    }
+
+    public function getPermissionObject()
+    {
+        return $this->permissionObject;
+    }
+
+    public function getInheritanceMode(): string
+    {
+        return $this->inheritanceMode;
+    }
+
+    public function getMode(): string
+    {
+        return $this->inheritanceMode;
+    }
+
+    public function getApplier(): ?User
+    {
+        return $this->applier;
+    }
+
+    public function getUser(): ?User
+    {
+        return $this->applier;
+    }
+
+    public function getUserObject(): ?User
+    {
+        return $this->applier;
+    }
+}

--- a/tests/tests/Permission/PermissionEventsTest.php
+++ b/tests/tests/Permission/PermissionEventsTest.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Concrete\Tests\Permission;
+
+use Concrete\Core\Permission\Access\Access;
+use Concrete\Core\Permission\Access\Entity\GroupEntity;
+use Concrete\Core\Permission\Access\Entity\Type as AccessEntityType;
+use Concrete\Core\Permission\Category as PermissionCategory;
+use Concrete\Core\Permission\Event\PermissionAccessEntityEvent;
+use Concrete\Core\Permission\Event\PermissionAssignmentEvent;
+use Concrete\Core\Permission\Event\PermissionInheritanceEvent;
+use Concrete\Core\Permission\Key\Key as PermissionKey;
+use Concrete\Core\Permission\Key\PageKey;
+use Concrete\TestHelpers\Page\PageTestCase;
+use Events;
+use Group;
+use Page;
+
+class PermissionEventsTest extends PageTestCase
+{
+    protected function getTables()
+    {
+        return array_merge(parent::getTables(), [
+            'UserGroups',
+            'Groups',
+            'TreeTypes',
+            'Trees',
+            'TreeNodes',
+            'TreeNodeTypes',
+            'TreeGroupNodes',
+            'AreaPermissionAssignments',
+            'PermissionAccess',
+            'PermissionAccessEntities',
+            'PermissionAccessEntityGroups',
+            'PermissionAccessList',
+            'PermissionKeyCategories',
+            'PermissionKeys',
+        ]);
+    }
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        if (!AccessEntityType::getByHandle('group')) {
+            AccessEntityType::add('group', 'Group');
+        }
+        if (!PermissionCategory::getByHandle('page')) {
+            PermissionCategory::add('page');
+        }
+        if (!PermissionKey::getByHandle('view_page')) {
+            PermissionKey::add('page', 'view_page', 'View Page', '', 0, 0);
+        }
+    }
+
+    public function testPermissionAssignmentEvents()
+    {
+        $page = self::createPage('Permission Test Page');
+        $pk = PageKey::getByHandle('view_page');
+        $this->assertNotNull($pk, 'Permission key view_page should exist');
+        $pk->setPermissionObject($page);
+
+        $pa = Access::create($pk);
+        $group = Group::getByID(GUEST_GROUP_ID);
+        if (!is_object($group)) {
+            $group = Group::add('Guest', '');
+        }
+        $entity = GroupEntity::getOrCreate($group);
+
+        $addEntityFired = false;
+        $removeEntityFired = false;
+        $assignFired = false;
+        $clearFired = false;
+
+        Events::addListener('on_permission_access_entity_add', function ($event) use (&$addEntityFired, $entity) {
+            $this->assertInstanceOf(PermissionAccessEntityEvent::class, $event);
+            $this->assertEquals($entity->getAccessEntityID(), $event->getAccessEntity()->getAccessEntityID());
+            $addEntityFired = true;
+        });
+
+        Events::addListener('on_permission_access_entity_remove', function ($event) use (&$removeEntityFired, $entity) {
+            $this->assertInstanceOf(PermissionAccessEntityEvent::class, $event);
+            $this->assertEquals($entity->getAccessEntityID(), $event->getAccessEntity()->getAccessEntityID());
+            $removeEntityFired = true;
+        });
+
+        Events::addListener('on_permission_assignment_assign', function ($event) use (&$assignFired, $pk) {
+            $this->assertInstanceOf(PermissionAssignmentEvent::class, $event);
+            if ($event->getPermissionKey() && $event->getPermissionKey()->getPermissionKeyHandle() === 'view_page') {
+                $assignFired = true;
+            }
+        });
+
+        Events::addListener('on_permission_assignment_clear', function ($event) use (&$clearFired, $pk) {
+            $this->assertInstanceOf(PermissionAssignmentEvent::class, $event);
+            if ($event->getPermissionKey() && $event->getPermissionKey()->getPermissionKeyHandle() === 'view_page') {
+                $clearFired = true;
+            }
+        });
+
+        $pa->addListItem($entity);
+        $this->assertTrue($addEntityFired, 'on_permission_access_entity_add should fire when adding list item');
+
+        $pt = $pk->getPermissionAssignmentObject();
+        $pt->assignPermissionAccess($pa);
+        $this->assertTrue($assignFired, 'on_permission_assignment_assign should fire when assigning permission access');
+
+        $pt->clearPermissionAssignment();
+        $this->assertTrue($clearFired, 'on_permission_assignment_clear should fire when clearing assignment');
+
+        $pa->removeListItem($entity);
+        $this->assertTrue($removeEntityFired, 'on_permission_access_entity_remove should fire when removing list item');
+
+        $page->delete();
+    }
+
+    public function testPermissionInheritanceEvent()
+    {
+        $page = self::createPage('Permission Inheritance Test Page');
+
+        $inheritanceFired = false;
+        $firedMode = null;
+
+        Events::addListener('on_permission_inheritance_change', function ($event) use (&$inheritanceFired, &$firedMode, $page) {
+            $this->assertInstanceOf(PermissionInheritanceEvent::class, $event);
+            $this->assertEquals($page->getCollectionID(), $event->getPermissionObject()->getCollectionID());
+            $inheritanceFired = true;
+            $firedMode = $event->getInheritanceMode();
+        });
+
+        $page->setPermissionsToManualOverride();
+        $this->assertTrue($inheritanceFired, 'on_permission_inheritance_change should fire when overriding permissions');
+        $this->assertEquals('OVERRIDE', $firedMode);
+
+        $inheritanceFired = false;
+        $page->inheritPermissionsFromParent();
+        $this->assertTrue($inheritanceFired, 'on_permission_inheritance_change should fire when inheriting from parent');
+        $this->assertEquals('PARENT', $firedMode);
+
+        $page->delete();
+    }
+}


### PR DESCRIPTION
### Summary
We're adding auditing features for one of our clients to track permission changes. However, Concrete CMS does not dispatch events when permissions are assigned, modified, or cleared, or when permission inheritance modes are changed. This makes it difficult for external packages, audit logging tools to monitor permission updates.

This pull request introduces standard Concrete CMS core events dispatched during permission lifecycle changes, following the `on_permission_*` naming conventions and providing typed event objects.

---

### New Events Introduced

1. **`on_permission_assignment_assign`**
   - **Event Class:** `Concrete\Core\Permission\Event\PermissionAssignmentEvent`
   - **Dispatched:** When a `PermissionAccess` object is assigned to a `PermissionKey` (`Access::assignPermissionAccess()`).
   - **Payload:** `PermissionKey`, `PermissionAccess`, target object (`PermissionObject`), and acting `User`.

2. **`on_permission_assignment_clear`**
   - **Event Class:** `Concrete\Core\Permission\Event\PermissionAssignmentEvent`
   - **Dispatched:** When permission assignments are cleared (`Assignment::clearPermissionAssignment()` and all category-specific assignment subclasses: `PageAssignment`, `FileAssignment`, `AreaAssignment`, `BlockAssignment`, `TreeNodeAssignment`, etc.).
   - **Payload:** `PermissionKey`, target object (`PermissionObject`), and acting `User`.

3. **`on_permission_access_entity_add`**
   - **Event Class:** `Concrete\Core\Permission\Event\PermissionAccessEntityEvent`
   - **Dispatched:** When an access entity (user, group, combination) is added to a permission access list (`Access::addListItem()`).
   - **Payload:** `PermissionAccess`, `PermissionAccessEntity`, `Duration`, access type (`ACCESS_TYPE_INCLUDE` / `ACCESS_TYPE_EXCLUDE`), `PermissionKey`, `PermissionObject`, and acting `User`.

4. **`on_permission_access_entity_remove`**
   - **Event Class:** `Concrete\Core\Permission\Event\PermissionAccessEntityEvent`
   - **Dispatched:** When an access entity is removed from a permission access list (`Access::removeListItem()`).
   - **Payload:** `PermissionAccess`, `PermissionAccessEntity`, `PermissionKey`, `PermissionObject`, and acting `User`.

5. **`on_permission_inheritance_change`**
   - **Event Class:** `Concrete\Core\Permission\Event\PermissionInheritanceEvent`
   - **Dispatched:** When page permission inheritance is modified (`Page::setPermissionsToOverride()`, `Page::setPermissionsToInheritFromParent()`, `Page::setPermissionsToInheritFromTemplate()`).
   - **Payload:** Target `Page` object, new `inheritanceMode` (`OVERRIDE`, `PARENT`, `TEMPLATE`), and acting `User`.
