### PR TITLE
Fix the generation of the URLs of the named routes

### DIFF
--- a/concrete/src/Url/Resolver/RouterUrlResolver.php
+++ b/concrete/src/Url/Resolver/RouterUrlResolver.php
@@ -3,7 +3,9 @@
 namespace Concrete\Core\Url\Resolver;
 
 use Concrete\Core\Routing\Router;
+use Symfony\Component\Routing\Generator\UrlGenerator;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\RouteCollection;
 
 class RouterUrlResolver implements UrlResolverInterface
@@ -25,13 +27,14 @@ class RouterUrlResolver implements UrlResolverInterface
     }
 
     /**
-     * Get the url generator from the router.
+     * Get the url generator for the routes of the router.
      *
      * @return \Symfony\Component\Routing\Generator\UrlGeneratorInterface
      */
     public function getGenerator()
     {
-        return $this->router->getGenerator();
+        // The generator only builds the paths of the routes: the path resolver turns them into URLs (with the base path of the site)
+        return new UrlGenerator($this->router->getRoutes(), new RequestContext());
     }
 
     /**
@@ -81,7 +84,10 @@ class RouterUrlResolver implements UrlResolverInterface
             if (is_string($route_handle) &&
                 strtolower(substr($route_handle, 0, 6)) == 'route/' &&
                 is_array($route_parameters)) {
-                $resolved = $this->resolveRoute(substr($route_handle, 6), $route_parameters);
+                $url = $this->resolveRoute(substr($route_handle, 6), $route_parameters);
+                if ($url !== null) {
+                    $resolved = $url;
+                }
             }
         }
 

--- a/tests/tests/Url/Resolver/RouterUrlResolverTest.php
+++ b/tests/tests/Url/Resolver/RouterUrlResolverTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Concrete\Tests\Url\Resolver;
+
+use Concrete\Core\Routing\Route;
+use Concrete\Core\Routing\Router;
+use Concrete\Core\Support\Facade\Application;
+use Concrete\Core\Url\Resolver\PathUrlResolver;
+use Concrete\Core\Url\Resolver\RouterUrlResolver;
+use Concrete\TestHelpers\Url\Resolver\ResolverTestCase;
+
+defined('C5_EXECUTE') or die('Access Denied.');
+
+class RouterUrlResolverTest extends ResolverTestCase
+{
+    /**
+     * @var \Concrete\Core\Routing\Router
+     */
+    protected $router;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $app = Application::getFacadeApplication();
+        $this->router = $app->make(Router::class);
+        $this->urlResolver = new RouterUrlResolver($app->make(PathUrlResolver::class), $this->router);
+    }
+
+    /**
+     * Make sure that we can actually resolve a basic route.
+     */
+    public function testRoute()
+    {
+        $path = '/named/route/path';
+        $name = 'named_route';
+        $this->router->getRoutes()->add($name, new Route($path));
+        $url = $this->canonicalUrlWithPath($path);
+        static::assertEquals((string) $url, (string) $this->urlResolver->resolve(["route/{$name}"]));
+    }
+
+    /**
+     * Test routes that have inline parameters.
+     */
+    public function testRouteWithParameters()
+    {
+        $path = '/named/{parameter}/route';
+        $name = 'named_route';
+        $value = uniqid();
+        $this->router->getRoutes()->add($name, new Route($path));
+        $url = $this->canonicalUrlWithPath(str_replace('{parameter}', $value, $path));
+        static::assertEquals((string) $url, (string) $this->urlResolver->resolve(["route/{$name}", ['parameter' => $value]]));
+    }
+
+    /**
+     * Test not finding a named route in the list.
+     */
+    public function testRouteMiss()
+    {
+        $resolved = uniqid();
+        static::assertEquals($resolved, $this->urlResolver->resolve(['route/miss'], $resolved));
+    }
+
+    /**
+     * Test not matching the expected syntax.
+     */
+    public function testNoMatch()
+    {
+        $resolved = uniqid();
+        static::assertEquals($resolved, $this->urlResolver->resolve(['no match'], $resolved));
+    }
+}


### PR DESCRIPTION
`Concrete\Core\Url\Resolver\RouterUrlResolver` is the resolver behind `URL::to('route/<name>', [...])`: given the name of a registered route (and its parameters), it should return the URL of that route.

It asked the router for a Symfony URL generator, but `Router::getGenerator()` was removed in 742d6f936cdf4fa090cfd954759301a94286ca91 (August 2018, the new router): since then, resolving an existing named route fails with a fatal error, while an unknown one silently returns `null`.

Nobody noticed because the core never generates URLs from route names (it always resolves paths), and routes keep working in the other direction (URL → action, handled by the router's matcher). Only third-party code using the documented `route/` syntax was affected.

This PR:
- builds the generator from the route collection of the router (no performance impact: it's only created when `route/` is resolved, and only the requested route gets compiled);
- keeps the result of the previous resolvers when the named route doesn't exist, like the deprecated `RouteUrlResolver` does;
- adds the tests of `RouterUrlResolver` (the same ones of the deprecated resolver).

An alternative to this PR could be to remove `RouterUrlResolver` (together with the deprecated `RouteUrlResolver` and the `concrete.route` resolver registration): if no one has noticed this problem, it is probably because no one uses this feature (or tried it, hit the fatal error and gave up).
