### PR TITLE
Move the methods that only work for pages from Collection to Page

### DIFF
--- a/concrete/src/Page/Collection/Collection.php
+++ b/concrete/src/Page/Collection/Collection.php
@@ -3,17 +3,12 @@
 namespace Concrete\Core\Page\Collection;
 
 use Concrete\Core\Area\Area;
-
 use CacheLocal;
 use CollectionVersion;
-use Concrete\Core\Area\CustomStyleRepository as AreaCustomStyleRepository;
 use Concrete\Core\Block\Block;
-use Concrete\Core\Area\CustomStyle as AreaCustomStyle;
-use Concrete\Core\Area\GlobalArea;
 use Concrete\Core\Attribute\Key\CollectionKey;
 use Concrete\Core\Block\Controller\SaveMode;
 use Concrete\Core\Block\CustomStyle as BlockCustomStyle;
-use Concrete\Core\Block\CustomStyleRepository as BlockCustomStyleRepository;
 use Concrete\Core\Database\Connection\Connection;
 use Concrete\Core\Database\Driver\PDOStatement;
 use Concrete\Core\Entity\Attribute\Value\PageValue;
@@ -21,15 +16,11 @@ use Concrete\Core\Foundation\ConcreteObject;
 use Concrete\Core\Page\Cloner;
 use Concrete\Core\Page\ClonerOptions;
 use Concrete\Core\Page\Collection\Version\VersionList;
-use Concrete\Core\Page\Command\QueuedReindexPageCommand;
-use Concrete\Core\Page\Command\ReindexPageCommand;
 use Concrete\Core\Page\Search\IndexedSearch;
 use Concrete\Core\Page\Summary\Template\Populator;
 use Concrete\Core\Search\Index\IndexManagerInterface;
 use Concrete\Core\Statistics\UsageTracker\TrackableInterface;
-use Concrete\Core\StyleCustomizer\Inline\StyleSet;
 use Concrete\Core\Support\Facade\Application;
-use Concrete\Core\Support\Facade\Facade;
 use Config;
 use Doctrine\DBAL\FetchMode;
 use Loader;
@@ -368,34 +359,6 @@ class Collection extends ConcreteObject implements TrackableInterface
     }
 
     /**
-     * Create a new Collection instance, using the same theme as this instance (if it's a Page instance).
-     *
-     * @param array $data {
-     *
-     *     @var int|null $cID The ID of the collection to create (if unspecified or NULL: database autoincrement value)
-     *     @var string $handle The collection handle (default: NULL)
-     *     @var string $name The collection name (default: empty string)
-     *     @var string $cDescription The collection description (default: NULL)
-     *     @var string $cDatePublic The collection publish date/time in format 'YYYY-MM-DD hh:mm:ss' (default: now)
-     *     @var bool $cvIsApproved Is the collection version approved (default: true)
-     *     @var bool $cvIsNew Is the collection to be considered "new"? (default: true if $cvIsApproved is false, false if $cvIsApproved is true)
-     *     @var int|null $pTemplateID The collection template ID (default: NULL)
-     *     @var int|null $uID The ID of the collection author (default: NULL)
-     * }
-     *
-     * @return \Concrete\Core\Page\Collection\Collection
-     */
-    public function addCollection($data)
-    {
-        $data['pThemeID'] = 0;
-        if (isset($this) && $this instanceof Page) {
-            $data['pThemeID'] = $this->getCollectionThemeID();
-        }
-
-        return static::createCollection($data);
-    }
-
-    /**
      * Load a specific collection version (you can retrieve it with the getVersionObject() method).
      *
      * @param string|int $cvID the collection version ('RECENT' for the most recent version, 'ACTIVE' for the currently published version, 'SCHEDULED' for the currently scheduled version, or an integer to retrieve a specific version ID)
@@ -403,23 +366,6 @@ class Collection extends ConcreteObject implements TrackableInterface
     public function loadVersionObject($cvID = 'ACTIVE')
     {
         $this->vObj = CollectionVersion::get($this, $cvID);
-    }
-
-    /**
-     * Get the Collection instance to be modified (this instance if it's a new or master Collection, a clone otherwise).
-     *
-     * @return $this|\Concrete\Core\Page\Page
-     */
-    public function getVersionToModify()
-    {
-        $vObj = $this->getVersionObject();
-        if ($this->isMasterCollection() || ($vObj->isNew())) {
-            return $this;
-        } else {
-            $nc = $this->cloneVersion(null);
-
-            return $nc;
-        }
     }
 
     /**
@@ -433,21 +379,6 @@ class Collection extends ConcreteObject implements TrackableInterface
         $cvID = $c->getVersionID();
 
         return t('Version %d', $cvID + 1);
-    }
-
-    public function reindex($doReindexImmediately = true)
-    {
-        if ($this->isAlias() && !$this->isExternalLink()) {
-            return false;
-        }
-
-        if ($doReindexImmediately) {
-            $command = new ReindexPageCommand($this->getCollectionID());
-        } else {
-            $command = new QueuedReindexPageCommand($this->getCollectionID());
-        }
-        $app = Facade::getFacadeApplication();
-        $app->executeCommand($command);
     }
 
 
@@ -538,7 +469,9 @@ class Collection extends ConcreteObject implements TrackableInterface
                 ->setParameter('cvID', $this->getVersionID())
                 ->execute();
         }
-        $this->reindex();
+        if ($this instanceof Page) {
+            $this->reindex();
+        }
     }
 
     /**
@@ -624,50 +557,6 @@ class Collection extends ConcreteObject implements TrackableInterface
     }
 
     /**
-     * Get the custom style of an area in the currently loaded collection version.
-     *
-     * @param \Concrete\Core\Area\Area $area the area for which you want the custom styles
-     * @param bool $force Set to true to retrieve a CustomStyle even if the area does not define any custom style
-     *
-     * @return \Concrete\Core\Area\CustomStyle|null return NULL if the area does not have any custom style and $force is false, a CustomStyle instance otherwise
-     */
-    public function getAreaCustomStyle($area, $force = false)
-    {
-        $areac = $area->getAreaCollectionObject();
-        if ($areac instanceof Stack) {
-            // this fixes the problem of users applying design to the main area on the page, and then that trickling into any
-            // stacks that have been added to other areas of the page.
-            return null;
-        }
-        $result = null;
-        $styleSet = null;
-        $areaHandle = $area->getAreaHandle();
-        if ($area->isGlobalArea()) {
-            /**
-             * @var $area GlobalArea
-             */
-            $stack = Stack::getGlobalAreaStackFromName($this, $area->getAreaHandle());
-            if ($stack) {
-                $styles = $stack->getVersionObject()->getCustomAreaStyles();
-                if (isset($styles[STACKS_AREA_NAME])) {
-                    $styleSet = StyleSet::getByID($styles[STACKS_AREA_NAME]);
-                }
-            }
-        } else {
-            $styles = $this->vObj->getCustomAreaStyles();
-            if (isset($styles[$areaHandle])) {
-                $styleSet = StyleSet::getByID($styles[$areaHandle]);
-            }
-        }
-
-        if ($styleSet || $force) {
-            $result = new AreaCustomStyle($styleSet, $area, $this->getCollectionThemeObject());
-        }
-
-        return $result;
-    }
-
-    /**
      * Set the custom style of an area in the currently loaded collection version.
      *
      * @param \Concrete\Core\Area\Area $area
@@ -729,62 +618,6 @@ class Collection extends ConcreteObject implements TrackableInterface
             ->setParameter('cvID', $this->getVersionID())
             ->setParameter('arHandle', $area->isGlobalArea() ? STACKS_AREA_NAME : $area->getAreaHandle())
             ->execute();
-    }
-
-    /**
-     * Retrieve all custom style rules that should be inserted into the header on a page, whether they are defined in areas or blocks.
-     *
-     * @param bool $return set to true to return the HTML that defines the styles, false to add it to the current View instance
-     *
-     * @return string|null
-     */
-    public function outputCustomStyleHeaderItems($return = false)
-    {
-        $app = Application::getFacadeApplication();
-        if (!$app['config']->get('concrete.design.enable_custom')) {
-            return $return ? '' : null;
-        }
-
-        $psss = [];
-        /** @var BlockCustomStyleRepository $blockCustomStyleRepository */
-        $blockCustomStyleRepository = $app->make(BlockCustomStyleRepository::class);
-        /** @var AreaCustomStyleRepository $areaCustomStyleRepository */
-        $areaCustomStyleRepository = $app->make(AreaCustomStyleRepository::class);
-
-        foreach ($blockCustomStyleRepository->getCollectionVersionBlockStyles($this) as $blockStyle) {
-            $psss[] = $blockStyle;
-        }
-        foreach ($areaCustomStyleRepository->getCollectionVersionAreaStyles($this) as $areaStyle) {
-            $psss[] = $areaStyle;
-        }
-
-        // grab all the header block style rules for items in global areas on this page
-        $applicableStacks = $this->getGlobalStacksForCollection();
-        foreach ($applicableStacks as $s) {
-            foreach ($blockCustomStyleRepository->getStackBlockStyles($s, $this->getCollectionThemeObject()) as $blockStyle) {
-                $psss[] = $blockStyle;
-            }
-            foreach ($areaCustomStyleRepository->getStackAreaStyles($s, $this->getCollectionThemeObject()) as $areaStyle) {
-                $psss[] = $areaStyle;
-            }
-        }
-
-        $styleHeader = '';
-        foreach ($psss as $st) {
-            $css = $st->getCSS();
-            if ($css !== '') {
-                $styleHeader .= $st->getStyleWrapper($css);
-            }
-        }
-
-        if (strlen(trim($styleHeader))) {
-            if ($return == true) {
-                return $styleHeader;
-            } else {
-                $v = \View::getInstance();
-                $v->addHeaderItem($styleHeader);
-            }
-        }
     }
 
     /**
@@ -1313,27 +1146,6 @@ class Collection extends ConcreteObject implements TrackableInterface
         $newCollection = $cloner->cloneCollection($this, $clonerOptions);
 
         return $newCollection;
-    }
-
-    /**
-     * Clone the currently loaded version and returns a Page instance containing the new version.
-     *
-     * @param string|null $versionComments the comments to be associated to the new Version
-     * @param bool $createEmpty set to true to create a Version without any blocks/area styles, false to clone them too
-     *
-     * @return \Concrete\Core\Page\Page
-     */
-    public function cloneVersion($versionComments, $createEmpty = false)
-    {
-        $app = Application::getFacadeApplication();
-        $cloner = $app->make(Cloner::class);
-        $clonerOptions = $app->make(ClonerOptions::class)
-            ->setVersionComments($versionComments)
-            ->setCopyContents($createEmpty ? false : true)
-        ;
-        $newVersion = $cloner->cloneCollectionVersion($this->getVersionObject(), $this, $clonerOptions);
-
-        return Page::getByID($newVersion->getCollectionID(), $newVersion->getVersionID());
     }
 
     /**

--- a/concrete/src/Page/Page.php
+++ b/concrete/src/Page/Page.php
@@ -3,9 +3,13 @@
 namespace Concrete\Core\Page;
 
 use Concrete\Core\Area\Area;
+use Concrete\Core\Area\CustomStyle as AreaCustomStyle;
+use Concrete\Core\Area\CustomStyleRepository as AreaCustomStyleRepository;
+use Concrete\Core\Area\GlobalArea;
 use Block;
 use CacheLocal;
 use Concrete\Core\Block\Controller\SaveMode;
+use Concrete\Core\Block\CustomStyleRepository as BlockCustomStyleRepository;
 use Concrete\Core\Entity\Page\Summary\CustomPageTemplateCollection;
 use Concrete\Core\Localization\Service\Date;
 use Concrete\Core\Page\Collection\Collection;
@@ -22,6 +26,8 @@ use Concrete\Core\Localization\Locale\Service as LocaleService;
 use Concrete\Core\Logging\Channels;
 use Concrete\Core\Multilingual\Page\Section\Section;
 use Concrete\Core\Package\PackageList;
+use Concrete\Core\Page\Command\QueuedReindexPageCommand;
+use Concrete\Core\Page\Command\ReindexPageCommand;
 use Concrete\Core\Page\Controller\PageController;
 use Concrete\Core\Page\Search\ColumnSet\DefaultSet;
 use Concrete\Core\Page\Stack\Stack;
@@ -42,6 +48,7 @@ use Concrete\Core\Production\Modes;
 use Concrete\Core\Search\Index\IndexManagerInterface;
 use Concrete\Core\Site\SiteAggregateInterface;
 use Concrete\Core\Site\Tree\TreeInterface;
+use Concrete\Core\StyleCustomizer\Inline\StyleSet;
 use Concrete\Core\StyleCustomizer\Skin\SkinInterface;
 use Concrete\Core\Summary\Category\CategoryMemberInterface;
 use Concrete\Core\Support\Facade\Application;
@@ -3788,7 +3795,7 @@ EOT
             $data['pTemplateID'] = $template->getPageTemplateID();
         }
 
-        $cobj = parent::addCollection($data);
+        $cobj = $this->addCollection($data);
         $cID = $cobj->getCollectionID();
 
         //$this->rescanChildrenDisplayOrder();
@@ -4429,5 +4436,183 @@ EOT
         }
 
         return $pkHandles;
+    }
+
+    /**
+     * Create a new Collection instance, using the same theme as this instance (if it's a Page instance).
+     *
+     * @param array $data {
+     *
+     *     @var int|null $cID The ID of the collection to create (if unspecified or NULL: database autoincrement value)
+     *     @var string $handle The collection handle (default: NULL)
+     *     @var string $name The collection name (default: empty string)
+     *     @var string $cDescription The collection description (default: NULL)
+     *     @var string $cDatePublic The collection publish date/time in format 'YYYY-MM-DD hh:mm:ss' (default: now)
+     *     @var bool $cvIsApproved Is the collection version approved (default: true)
+     *     @var bool $cvIsNew Is the collection to be considered "new"? (default: true if $cvIsApproved is false, false if $cvIsApproved is true)
+     *     @var int|null $pTemplateID The collection template ID (default: NULL)
+     *     @var int|null $uID The ID of the collection author (default: NULL)
+     * }
+     *
+     * @return \Concrete\Core\Page\Collection\Collection
+     */
+    public function addCollection($data)
+    {
+        $data['pThemeID'] = $this->getCollectionThemeID();
+
+        return static::createCollection($data);
+    }
+
+    /**
+     * Get the Collection instance to be modified (this instance if it's a new or master Collection, a clone otherwise).
+     *
+     * @return $this|\Concrete\Core\Page\Page
+     */
+    public function getVersionToModify()
+    {
+        $vObj = $this->getVersionObject();
+        if ($this->isMasterCollection() || ($vObj->isNew())) {
+            return $this;
+        } else {
+            $nc = $this->cloneVersion(null);
+
+            return $nc;
+        }
+    }
+
+    public function reindex($doReindexImmediately = true)
+    {
+        if ($this->isAlias() && !$this->isExternalLink()) {
+            return false;
+        }
+
+        if ($doReindexImmediately) {
+            $command = new ReindexPageCommand($this->getCollectionID());
+        } else {
+            $command = new QueuedReindexPageCommand($this->getCollectionID());
+        }
+        $app = Facade::getFacadeApplication();
+        $app->executeCommand($command);
+    }
+
+    /**
+     * Get the custom style of an area in the currently loaded collection version.
+     *
+     * @param \Concrete\Core\Area\Area $area the area for which you want the custom styles
+     * @param bool $force Set to true to retrieve a CustomStyle even if the area does not define any custom style
+     *
+     * @return \Concrete\Core\Area\CustomStyle|null return NULL if the area does not have any custom style and $force is false, a CustomStyle instance otherwise
+     */
+    public function getAreaCustomStyle($area, $force = false)
+    {
+        $areac = $area->getAreaCollectionObject();
+        if ($areac instanceof Stack) {
+            // this fixes the problem of users applying design to the main area on the page, and then that trickling into any
+            // stacks that have been added to other areas of the page.
+            return null;
+        }
+        $result = null;
+        $styleSet = null;
+        $areaHandle = $area->getAreaHandle();
+        if ($area->isGlobalArea()) {
+            /**
+             * @var $area GlobalArea
+             */
+            $stack = Stack::getGlobalAreaStackFromName($this, $area->getAreaHandle());
+            if ($stack) {
+                $styles = $stack->getVersionObject()->getCustomAreaStyles();
+                if (isset($styles[STACKS_AREA_NAME])) {
+                    $styleSet = StyleSet::getByID($styles[STACKS_AREA_NAME]);
+                }
+            }
+        } else {
+            $styles = $this->vObj->getCustomAreaStyles();
+            if (isset($styles[$areaHandle])) {
+                $styleSet = StyleSet::getByID($styles[$areaHandle]);
+            }
+        }
+
+        if ($styleSet || $force) {
+            $result = new AreaCustomStyle($styleSet, $area, $this->getCollectionThemeObject());
+        }
+
+        return $result;
+    }
+
+    /**
+     * Retrieve all custom style rules that should be inserted into the header on a page, whether they are defined in areas or blocks.
+     *
+     * @param bool $return set to true to return the HTML that defines the styles, false to add it to the current View instance
+     *
+     * @return string|null
+     */
+    public function outputCustomStyleHeaderItems($return = false)
+    {
+        $app = Application::getFacadeApplication();
+        if (!$app['config']->get('concrete.design.enable_custom')) {
+            return $return ? '' : null;
+        }
+
+        $psss = [];
+        /** @var BlockCustomStyleRepository $blockCustomStyleRepository */
+        $blockCustomStyleRepository = $app->make(BlockCustomStyleRepository::class);
+        /** @var AreaCustomStyleRepository $areaCustomStyleRepository */
+        $areaCustomStyleRepository = $app->make(AreaCustomStyleRepository::class);
+
+        foreach ($blockCustomStyleRepository->getCollectionVersionBlockStyles($this) as $blockStyle) {
+            $psss[] = $blockStyle;
+        }
+        foreach ($areaCustomStyleRepository->getCollectionVersionAreaStyles($this) as $areaStyle) {
+            $psss[] = $areaStyle;
+        }
+
+        // grab all the header block style rules for items in global areas on this page
+        $applicableStacks = $this->getGlobalStacksForCollection();
+        foreach ($applicableStacks as $s) {
+            foreach ($blockCustomStyleRepository->getStackBlockStyles($s, $this->getCollectionThemeObject()) as $blockStyle) {
+                $psss[] = $blockStyle;
+            }
+            foreach ($areaCustomStyleRepository->getStackAreaStyles($s, $this->getCollectionThemeObject()) as $areaStyle) {
+                $psss[] = $areaStyle;
+            }
+        }
+
+        $styleHeader = '';
+        foreach ($psss as $st) {
+            $css = $st->getCSS();
+            if ($css !== '') {
+                $styleHeader .= $st->getStyleWrapper($css);
+            }
+        }
+
+        if (strlen(trim($styleHeader))) {
+            if ($return == true) {
+                return $styleHeader;
+            } else {
+                $v = \View::getInstance();
+                $v->addHeaderItem($styleHeader);
+            }
+        }
+    }
+
+    /**
+     * Clone the currently loaded version and returns a Page instance containing the new version.
+     *
+     * @param string|null $versionComments the comments to be associated to the new Version
+     * @param bool $createEmpty set to true to create a Version without any blocks/area styles, false to clone them too
+     *
+     * @return \Concrete\Core\Page\Page
+     */
+    public function cloneVersion($versionComments, $createEmpty = false)
+    {
+        $app = Application::getFacadeApplication();
+        $cloner = $app->make(Cloner::class);
+        $clonerOptions = $app->make(ClonerOptions::class)
+            ->setVersionComments($versionComments)
+            ->setCopyContents($createEmpty ? false : true)
+        ;
+        $newVersion = $cloner->cloneCollectionVersion($this->getVersionObject(), $this, $clonerOptions);
+
+        return Page::getByID($newVersion->getCollectionID(), $newVersion->getVersionID());
     }
 }


### PR DESCRIPTION
`Concrete\Core\Page\Collection\Collection` defines some methods that can't work for plain collections, because they need what only `Concrete\Core\Page\Page` has (the theme, the alias/master flags, the page cache, the page search index):

- `getVersionToModify()` and `cloneVersion()` check `isMasterCollection()`/`isAlias()` and clone pages;
- `reindex()` dispatches the page reindex commands;
- `getAreaCustomStyle()` and `outputCustomStyleHeaderItems()` need the theme of the page;
- `addCollection()` sets the theme of the new collection: it checked `$this instanceof Page`, but when called on a plain collection it would silently create a collection without a theme, so the same call would have had different effects (and lost data) depending on the receiver.

The core only ever calls these methods on `Page` (or `Stack`) instances. This PR moves them to `Page`, unchanged except for the now-useless `instanceof` check of `addCollection()`. The `reindex()` call inside `Collection::clearCollectionAttributes()` is kept for pages only, and the imports that are no longer needed by `Collection` are removed.

`clearCollectionAttributes()` itself is never called by the core (nor by the tests): it could be moved to `Page` as well (its `reindex()` call only makes sense there), or removed altogether.
That's left for a follow-up, to keep this PR a pure move.
