### PR TITLE
Remove the broken check_queue() action of the legacy jobs controller

### DIFF
--- a/concrete/controllers/frontend/jobs.php
+++ b/concrete/controllers/frontend/jobs.php
@@ -1,7 +1,6 @@
 <?php
 namespace Concrete\Controller\Frontend;
 
-use Concrete\Core\Job\QueueableJob;
 use Controller;
 use stdClass;
 use Job;
@@ -121,68 +120,6 @@ class Jobs extends Controller
                 $response->send();
                 \Core::shutdown();
             }
-        } else {
-            $r->error = t('Access Denied');
-            $response->setStatusCode(Response::HTTP_FORBIDDEN);
-            $response->setContent(json_encode($r));
-            $response->send();
-            \Core::shutdown();
-        }
-    }
-
-    public function check_queue()
-    {
-        if (!ini_get('safe_mode')) {
-            @set_time_limit(0);
-        }
-        //Disable job scheduling so we don't end up in a loop
-        \Config::set('concrete.jobs.enable_scheduling', false);
-
-        $response = new Response();
-        $response->headers->set('Content-Type', 'application/json');
-
-        $r = new stdClass();
-        $r->error = false;
-        $r->results = array();
-
-        if (Job::authenticateRequest($this->request->request->get('auth', $this->request->query->get('auth')))) {
-            $list = Job::getList();
-            foreach ($list as $job) {
-                if ($job->supportsQueue() && $job instanceof QueueableJob) {
-                    $q = $job->getQueueObject();
-                    // don't process queues that are empty
-                    if ($q->count() < 1) {
-                        continue;
-                    }
-                    $obj = new stdClass();
-                    try {
-                        $messages = $q->receive($job->getJobQueueBatchSize());
-                        $job->executeBatch($messages, $q);
-
-                        $totalItems = $q->count();
-                        $obj->totalItems = $totalItems;
-                        $obj->jHandle = $job->getJobHandle();
-                        $obj->jID = $job->getJobID();
-
-                        if ($q->count() == 0) {
-                            $result = $job->finish($q);
-                            $obj = $job->markCompleted(0, $result);
-                            $obj->totalItems = $totalItems;
-                        }
-                    } catch (\Exception $e) {
-                        $obj = $job->markCompleted(Job::JOB_ERROR_EXCEPTION_GENERAL, $e->getMessage());
-                        $obj->message = $obj->result; // needed for progressive library.
-                    }
-
-                    $r->results[] = $obj;
-                    // End when one queue has processed a batch step
-                    break;
-                }
-            }
-            $response->setStatusCode(Response::HTTP_OK);
-            $response->setContent(json_encode($r));
-            $response->send();
-            \Core::shutdown();
         } else {
             $r->error = t('Access Denied');
             $response->setStatusCode(Response::HTTP_FORBIDDEN);


### PR DESCRIPTION
`Concrete\Controller\Frontend\Jobs::check_queue()` can't work: it uses the API of the old job queue (`JobQueue::receive()`, `JobQueue::count()`, `QueueableJob::executeBatch()`) that was removed in 2021, when the jobs were migrated to the tasks (`JobQueue` only has `send()` now, and `run_single()` itself notes that "queueing with jobs is no longer supported").

It's also unreachable: only `view()` and `run_single()` are routed (`/ccm/system/jobs` and `/ccm/system/jobs/run_single`), and they still work, so they are kept.
